### PR TITLE
feat(collab): agent delegation handshake + sponsor_contact_id + cascades (D1)

### DIFF
--- a/changelog.d/2048-agent-delegation.md
+++ b/changelog.d/2048-agent-delegation.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Cross-user agent delegation (D1)**: agents can delegate project work to another user's agent. A `sponsor_contact_id` column on the agent registry links a sponsored identity to its sponsor, a `delegation_request` envelope routes through the peer inbox into a scope-validated delegation handler, and each project gains an `auto_approve_delegation` knob (default off — otherwise a manual Decisions card gates the delegation). Sponsored agents get a conservative default scope (`a2a_send`, `a2a_receive`, `project_tasks`, `canvas_read`, `registry_feeds_read`) with `files_write` and `decisions_write` hard-denied at scope validation. Revoking a contact or membership cascades to revoke all sponsored identities and unassign their board tasks (#2048).

--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -602,6 +602,15 @@ async def test_mint_collab_invite(store):
     assert result["record"]["status"] == "pending"
     assert len(result["pin"]) == 4
 
+    # Verify redeem works with correct pin.
+    record = await store.redeem(result["record"]["invite_id"], result["pin"])
+    assert record["status"] == "claimed"
+
+    # mark_accepted should work from claimed for collab invites.
+    await store.mark_accepted(result["record"]["invite_id"], "hub:hogne")
+    row = await store.get(result["record"]["invite_id"])
+    assert row["status"] == "redeemed"
+
 
 @pytest.mark.asyncio
 async def test_mint_collab_invite_no_pin_required(store):
@@ -616,6 +625,14 @@ async def test_mint_collab_invite_no_pin_required(store):
         contact_id="hub:hogne",
     )
     assert result["record"]["pin_required"] == 0
+
+    # pin_required=False: redeem MUST succeed with any pin (A2 fix #2048).
+    record = await store.redeem(result["record"]["invite_id"], "")
+    assert record["status"] == "claimed"
+
+    # Redeem again — already claimed, so InviteAlreadyRedeemedError expected.
+    with pytest.raises(InviteAlreadyRedeemedError):
+        await store.redeem(result["record"]["invite_id"], "9999")
 
 
 @pytest.mark.asyncio
@@ -643,6 +660,10 @@ async def test_default_kind_is_agent(store):
     assert result["record"]["kind"] == "agent"
     assert result["record"]["pin_required"] == 1
     assert result["record"]["contact_id"] is None
+
+    # Agent-kind with pin_required=True: redeem needs correct pin.
+    record = await store.redeem(result["record"]["invite_id"], result["pin"])
+    assert record["status"] == "claimed"
 
 
 @pytest.mark.asyncio
@@ -816,3 +837,41 @@ async def test_boot_migration_adds_kind_pin_required_contact_id(tmp_path):
     assert row.get("pin_required") == 1
     assert row.get("contact_id") is None
     await store.close()
+
+
+# ---------------------------------------------------------------------------
+# A2 e2e: mint + redeem with pin_required=False (issue #2048)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mint_redeem_pin_not_required_e2e(store):
+    """End-to-end: mint an invite with pin_required=False, redeem with any
+    pin, and verify the invite is claimed. This kills A1 (mint returns pin
+    even when not required) + A2 (redeem skips PIN verification when
+    pin_required=False) in one test."""
+    result = await store.mint(
+        project_id="prj-e2e",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+        pin_required=False,
+    )
+    assert result["record"]["pin_required"] == 0
+
+    # Redeem with empty string — must succeed even though PIN was never
+    # communicated to the invitee (A2 fix).
+    record = await store.redeem(result["record"]["invite_id"], "")
+    assert record["status"] == "claimed"
+    assert record["project_id"] == "prj-e2e"
+
+    # Redeem again with any other string — already claimed.
+    with pytest.raises(InviteAlreadyRedeemedError):
+        await store.redeem(result["record"]["invite_id"], "0000")
+
+    # Also verify: a wrong-PIN attempt on the same invite (already claimed)
+    # raises InviteAlreadyRedeemedError, not InvitePinError — the status
+    # guard fires before the PIN check.
+    with pytest.raises(InviteAlreadyRedeemedError):
+        await store.redeem(result["record"]["invite_id"], "wrong")

--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -847,9 +847,9 @@ async def test_boot_migration_adds_kind_pin_required_contact_id(tmp_path):
 @pytest.mark.asyncio
 async def test_mint_redeem_pin_not_required_e2e(store):
     """End-to-end: mint an invite with pin_required=False, redeem with any
-    pin, and verify the invite is claimed. This kills A1 (mint returns pin
-    even when not required) + A2 (redeem skips PIN verification when
-    pin_required=False) in one test."""
+    pin, and verify the invite is claimed.  Covers two #2048 regressions in
+    one path: mint returns a ``pin_required=0`` record when the flag is False,
+    and redeem skips PIN verification when ``pin_required=False``."""
     result = await store.mint(
         project_id="prj-e2e",
         scopes=["a2a_send"],
@@ -861,17 +861,13 @@ async def test_mint_redeem_pin_not_required_e2e(store):
     assert result["record"]["pin_required"] == 0
 
     # Redeem with empty string — must succeed even though PIN was never
-    # communicated to the invitee (A2 fix).
+    # communicated to the invitee (pin_required=False skips PIN verification).
     record = await store.redeem(result["record"]["invite_id"], "")
     assert record["status"] == "claimed"
     assert record["project_id"] == "prj-e2e"
 
-    # Redeem again with any other string — already claimed.
+    # Redeem again — already claimed, so any further redeem (with any pin)
+    # raises InviteAlreadyRedeemedError, not InvitePinError: the status guard
+    # fires before the PIN check.
     with pytest.raises(InviteAlreadyRedeemedError):
         await store.redeem(result["record"]["invite_id"], "0000")
-
-    # Also verify: a wrong-PIN attempt on the same invite (already claimed)
-    # raises InviteAlreadyRedeemedError, not InvitePinError — the status
-    # guard fires before the PIN check.
-    with pytest.raises(InviteAlreadyRedeemedError):
-        await store.redeem(result["record"]["invite_id"], "wrong")

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -468,7 +468,11 @@ class TestSetSponsorGuard:
     """
 
     @pytest.mark.asyncio
-    async def test_set_sponsor_skips_when_already_set(self, tmp_path):
+    async def test_set_sponsor_reparents_to_different_sponsor(self, tmp_path):
+        """Re-parenting an identity to a different sponsor (cross-project
+        reuse via handle) must now SUCCEED — the old immutability guard
+        was removed so cascade_sponsor_revoke(B) can find identities
+        sponsored by B even when the handle was first sponsored by A."""
         from tinyagentos.agent_registry_store import AgentRegistryStore
 
         db_path = tmp_path / "test_registry.db"
@@ -480,17 +484,44 @@ class TestSetSponsorGuard:
             display_name="Agent With Sponsor",
             user_id="user-1",
             origin="external-selfjoin",
-            handle="sponsored-reuse",
-            sponsor_contact_id="hub:original-sponsor",
+            handle="sponsored-reparent",
+            sponsor_contact_id="hub:sponsor-a",
         )
         cid = reg["canonical_id"]
 
-        # Try to re-parent — the guard in set_sponsor must block this.
-        await store.set_sponsor(cid, "hub:new-sponsor")
+        # Re-parent to a different sponsor — must succeed now.
+        result = await store.set_sponsor(cid, "hub:sponsor-b")
+        assert result is not None
+        assert result["sponsor_contact_id"] == "hub:sponsor-b"
 
-        # Sponsor must still be the original — guard blocked re-parenting.
+        # Verify the store agrees.
         agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] == "hub:original-sponsor"
+        assert agent["sponsor_contact_id"] == "hub:sponsor-b"
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_set_sponsor_noop_on_same_sponsor(self, tmp_path):
+        """Setting the same sponsor that is already set must be a no-op
+        (returns the current record without a write)."""
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        reg = await store.register(
+            framework="test",
+            display_name="Agent",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="same-sponsor",
+            sponsor_contact_id="hub:sponsor-a",
+        )
+        cid = reg["canonical_id"]
+
+        result = await store.set_sponsor(cid, "hub:sponsor-a")
+        assert result is not None
+        assert result["sponsor_contact_id"] == "hub:sponsor-a"
         await store.close()
 
     @pytest.mark.asyncio

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -148,20 +148,21 @@ class TestSponsorRegistryMethods:
         store = AgentRegistryStore(db_path)
         await store.init()
 
-        # Register with sponsor
+        # Register, then record a sponsorship association (D1 rework: the
+        # sponsor is a per-(identity, project) association, not a column).
         reg = await store.register(
             framework="test",
             display_name="Sponsored Agent",
             user_id="user-1",
             origin="external-selfjoin",
             handle="sponsored-agent",
-            sponsor_contact_id="hub:hogne",
         )
         canonical_id = reg["canonical_id"]
-        # List by sponsor
+        assert await store.set_sponsorship(canonical_id, "prj-1", "hub:hogne") is True
+
+        # List by sponsor — resolves through the association.
         sponsored = await store.list_by_sponsor("hub:hogne")
-        assert len(sponsored) == 1
-        assert sponsored[0]["sponsor_contact_id"] == "hub:hogne"
+        assert [r["canonical_id"] for r in sponsored] == [canonical_id]
 
         # List by different sponsor — empty
         other = await store.list_by_sponsor("hub:other")
@@ -176,17 +177,17 @@ class TestSponsorRegistryMethods:
         store = AgentRegistryStore(db_path)
         await store.init()
 
-        await store.register(
+        reg = await store.register(
             framework="test",
             display_name="Active Sponsored",
             user_id="user-1",
             origin="external-selfjoin",
             handle="active-sponsor",
-            sponsor_contact_id="hub:hogne",
         )
-        # Only active agents
+        await store.set_sponsorship(reg["canonical_id"], "prj-1", "hub:hogne")
+        # Only active agents (external-selfjoin starts pending)
         active = await store.list_by_sponsor("hub:hogne", status="active")
-        assert len(active) == 0  # external-selfjoin starts pending
+        assert len(active) == 0
 
         # With no status filter, shows all
         all_sponsored = await store.list_by_sponsor("hub:hogne")
@@ -194,7 +195,7 @@ class TestSponsorRegistryMethods:
         await store.close()
 
     @pytest.mark.asyncio
-    async def test_set_sponsor(self, tmp_path):
+    async def test_set_sponsorship(self, tmp_path):
         from tinyagentos.agent_registry_store import AgentRegistryStore
 
         db_path = tmp_path / "test_registry.db"
@@ -210,19 +211,26 @@ class TestSponsorRegistryMethods:
         )
         cid = reg["canonical_id"]
 
-        # Initially NULL
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] is None
+        # Initially no sponsorship association.
+        assert await store.list_sponsorships_for_identity(cid) == []
 
-        # Set sponsor
-        await store.set_sponsor(cid, "hub:hogne")
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] == "hub:hogne"
+        # First write for (identity, project) wins.
+        assert await store.set_sponsorship(cid, "prj-1", "hub:hogne") is True
+        # A second write for the SAME (identity, project) is ignored.
+        assert await store.set_sponsorship(cid, "prj-1", "hub:other") is False
+        rows = await store.list_sponsorships_for_identity(cid)
+        assert len(rows) == 1
+        assert rows[0]["sponsor_contact_id"] == "hub:hogne"
+        assert rows[0]["project_id"] == "prj-1"
 
-        # Clear sponsor
-        await store.set_sponsor(cid, None)
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] is None
+        # A different project is a distinct association.
+        assert await store.set_sponsorship(cid, "prj-2", "hub:other") is True
+        assert len(await store.list_sponsorships_for_identity(cid)) == 2
+
+        # Remove one association.
+        await store.remove_sponsorship(cid, "prj-1")
+        remaining = await store.list_sponsorships_for_identity(cid)
+        assert [r["project_id"] for r in remaining] == ["prj-2"]
         await store.close()
 
     @pytest.mark.asyncio
@@ -265,6 +273,72 @@ class TestSponsorRegistryMethods:
         await _migration_v7_add_sponsor_contact_id(conn)
 
         await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_backfill_reproduces_single_sponsor_cascade(self, tmp_path):
+        """Acceptance #4 — the v8 backfill must reproduce the old single-sponsor
+        cascade for a pre-change identity stamped with a legacy
+        ``sponsor_contact_id`` but no association row.
+
+        The legacy column carried a sponsor but no project binding, so the
+        backfilled association is keyed to the empty project_id sentinel.
+        ``list_by_sponsor`` must find the identity through that association,
+        and a cascade revoke of that one contact must revoke the identity
+        (no rows remain) — exactly the pre-rework behaviour.
+        """
+        from types import SimpleNamespace
+
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            _LEGACY_SPONSORSHIP_PROJECT,
+            _migration_v8_backfill_sponsorship,
+        )
+        from tinyagentos.delegation_handler import cascade_sponsor_revoke
+
+        store = AgentRegistryStore(tmp_path / "registry.db")
+        await store.init()
+
+        # Register an identity and mark it active, then stamp the legacy
+        # sponsor_contact_id column directly — simulating a pre-change DB row
+        # that carries a sponsor but no agent_sponsorship association.
+        reg = await store.register(
+            framework="test",
+            display_name="Legacy Sponsored",
+            user_id="u",
+            origin="external-selfjoin",
+            handle="legacy-sponsored",
+        )
+        cid = reg["canonical_id"]
+        await store.set_status(cid, "active")
+        await store._db.execute(
+            "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
+            ("hub:legacy", cid),
+        )
+        await store._db.commit()
+
+        # Run the backfill.
+        await _migration_v8_backfill_sponsorship(store._db)
+
+        # The association row is keyed to the empty project_id sentinel.
+        rows = await store.list_sponsorships_for_identity(cid)
+        assert len(rows) == 1
+        assert rows[0]["project_id"] == _LEGACY_SPONSORSHIP_PROJECT
+        assert rows[0]["sponsor_contact_id"] == "hub:legacy"
+
+        # list_by_sponsor resolves the identity through the association.
+        assert [r["canonical_id"] for r in await store.list_by_sponsor("hub:legacy")] == [cid]
+
+        # The single-sponsor cascade revokes the identity (last row removed).
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(agent_registry=store))
+        )
+        result = await cascade_sponsor_revoke(request, contact_id="hub:legacy")
+        assert result["status"] == "revoked"
+        assert result["revoked_ids"] == [cid]
+        assert (await store.get(cid))["status"] == "revoked"
+        assert await store.list_sponsorships_for_identity(cid) == []
+
+        await store.close()
 
 
 # ---------------------------------------------------------------------------
@@ -406,32 +480,192 @@ class TestMintReturnShape:
         await store.close()
 
 
-class TestCascadeSponsorRevokeFailClosed:
-    """🟠 MAJOR: project-scoped revoke with missing project_store must fail closed."""
+class TestPerProjectSponsorshipCascade:
+    """Acceptance #1 — two contacts, two projects, one handle.
+
+    The association model must let each contact's cascade find exactly what
+    THEY sponsored in their own project.  Revoking A kills A's sponsorship
+    while the identity survives under B's sponsorship; revoking B then kills
+    the identity outright.  A single-contact test cannot catch this — the
+    whole point is the second contact's sponsorship keeps the identity alive
+    after the first contact's revoke.
+    """
 
     @pytest.mark.asyncio
-    async def test_cascade_with_project_id_and_no_store_fails(self, tmp_path):
-        from unittest.mock import AsyncMock, MagicMock
+    async def test_two_contacts_two_projects_survive_then_die(self, tmp_path):
+        from types import SimpleNamespace
+
+        from tinyagentos.agent_registry_store import AgentRegistryStore
         from tinyagentos.delegation_handler import cascade_sponsor_revoke
 
-        # Mock request with registry but NO project_store
-        request = MagicMock()
-        mock_registry = AsyncMock()
-        mock_registry.list_by_sponsor.return_value = [
-            {"canonical_id": "agent-1", "sponsor_contact_id": "hub:sponsor"}
-        ]
-        request.app.state.agent_registry = mock_registry
-        request.app.state.project_store = None  # missing!
+        store = AgentRegistryStore(tmp_path / "registry.db")
+        await store.init()
 
-        result = await cascade_sponsor_revoke(
-            request,
-            contact_id="hub:sponsor",
-            project_id="prj-1",
+        # One identity, reused by handle across two projects, sponsored by two
+        # different contacts.
+        reg = await store.register(
+            framework="test",
+            display_name="Shared Agent",
+            user_id="u",
+            origin="external-selfjoin",
+            handle="shared-agent",
+        )
+        cid = reg["canonical_id"]
+        await store.set_status(cid, "active")
+        assert await store.set_sponsorship(cid, "prj-1", "hub:A") is True
+        assert await store.set_sponsorship(cid, "prj-2", "hub:B") is True
+
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(agent_registry=store))
         )
 
-        # Must fail closed — project_store absent with project_id set is an error
-        assert result["status"] == "error"
-        assert "project store not available" in result["error"]
+        # A's revoke: A's association is gone, but the identity survives
+        # because B still sponsors it in P2.
+        result_a = await cascade_sponsor_revoke(request, contact_id="hub:A")
+        assert result_a["status"] == "revoked"
+        assert result_a["revoked_ids"] == []  # identity NOT revoked yet
+        assert await store.list_by_sponsor("hub:A") == []
+        assert [r["canonical_id"] for r in await store.list_by_sponsor("hub:B")] == [cid]
+        agent = await store.get(cid)
+        assert agent["status"] == "active"  # survives A's revoke
+
+        # B's revoke: last association gone -> identity revoked outright.
+        result_b = await cascade_sponsor_revoke(request, contact_id="hub:B")
+        assert result_b["status"] == "revoked"
+        assert result_b["revoked_ids"] == [cid]
+        assert await store.list_by_sponsor("hub:B") == []
+        agent = await store.get(cid)
+        assert agent["status"] == "revoked"
+
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_project_scoped_revoke_spares_other_projects(self, tmp_path):
+        from types import SimpleNamespace
+
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+        from tinyagentos.delegation_handler import cascade_sponsor_revoke
+
+        store = AgentRegistryStore(tmp_path / "registry.db")
+        await store.init()
+
+        reg = await store.register(
+            framework="test", display_name="A", user_id="u",
+            origin="external-selfjoin", handle="multi-proj",
+        )
+        cid = reg["canonical_id"]
+        await store.set_status(cid, "active")
+        await store.set_sponsorship(cid, "prj-1", "hub:A")
+        await store.set_sponsorship(cid, "prj-2", "hub:A")
+
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(agent_registry=store))
+        )
+
+        # Membership-revoke scoped to prj-1 removes only that association; the
+        # prj-2 association keeps the identity alive.
+        result = await cascade_sponsor_revoke(
+            request, contact_id="hub:A", project_id="prj-1"
+        )
+        assert result["status"] == "revoked"
+        assert result["revoked_ids"] == []
+        rows = await store.list_sponsorships_for_identity(cid)
+        assert [r["project_id"] for r in rows] == ["prj-2"]
+        agent = await store.get(cid)
+        assert agent["status"] == "active"
+
+        # Revoking the remaining association kills the identity.
+        await cascade_sponsor_revoke(request, contact_id="hub:A", project_id="prj-2")
+        assert (await store.get(cid))["status"] == "revoked"
+
+        await store.close()
+
+
+class TestKillSwitchAuthPath:
+    """Acceptance #2 — the per-contact kill-switch must be observable through the
+    AUTH path (a live bearer the registry now refuses), not by counting rows in
+    ``list_by_sponsor``.
+
+    ``kill_switch_per_contact`` revokes the contact's sponsorships; a single
+    sponsored identity therefore becomes 'revoked' in the registry and its
+    still-cryptographically-valid token is rejected by
+    ``agent_token_auth._verify_agent_scope`` with 403.  This is the behaviour a
+    human operator actually depends on when they hit the kill-switch.
+    """
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_revokes_live_bearer(self, tmp_path):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock
+
+        from fastapi import HTTPException
+
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            mint_registry_token,
+        )
+        from tinyagentos.agent_token_auth import _verify_agent_scope
+        from tinyagentos.delegation_handler import kill_switch_per_contact
+        from tinyagentos.store_signing import generate_signing_keypair
+
+        registry = AgentRegistryStore(tmp_path / "registry.db")
+        await registry.init()
+        grants = AgentGrantsStore(tmp_path / "grants.db")
+        await grants.init()
+        priv, _pub = generate_signing_keypair()
+
+        reg = await registry.register(
+            framework="test",
+            display_name="Kill Switch Agent",
+            user_id="u",
+            origin="external-selfjoin",
+            handle="kill-switch-agent",
+        )
+        cid = reg["canonical_id"]
+        await registry.set_status(cid, "active")
+        assert await registry.set_sponsorship(cid, "prj-1", "hub:A") is True
+        await grants.add_grant(cid, "a2a_receive")
+        token = mint_registry_token(cid, priv, user_id="u", framework="test")
+
+        # A contacts_store mock so kill_switch_per_contact does not fail-closed
+        # on a missing store (it tries to revoke the peer link first).
+        contacts = AsyncMock()
+        contacts.revoke_peer_link = AsyncMock()
+
+        def make_request():
+            return SimpleNamespace(
+                headers={"Authorization": f"Bearer {token}"},
+                app=SimpleNamespace(
+                    state=SimpleNamespace(
+                        agent_registry=registry,
+                        agent_grants=grants,
+                        agent_registry_keypair=(priv, _pub),
+                        contacts_store=contacts,
+                    )
+                ),
+            )
+
+        # Before the kill-switch, the bearer is LIVE: the auth path accepts it.
+        live_cid, _payload = await _verify_agent_scope(make_request(), "a2a_receive")
+        assert live_cid == cid
+
+        # Hit the per-contact kill-switch: revokes the sponsorship, which
+        # revokes the (single-sponsored) identity.
+        result = await kill_switch_per_contact(make_request(), contact_id="hub:A")
+        assert result["status"] == "paused"
+        assert (await registry.get(cid))["status"] == "revoked"
+
+        # The bearer is now REFUSED by the auth path (403), even though the
+        # token signature is still valid — the kill-switch is observable as a
+        # dead bearer, not merely an empty list_by_sponsor.
+        with pytest.raises(HTTPException) as exc:
+            await _verify_agent_scope(make_request(), "a2a_receive")
+        assert exc.value.status_code == 403
+        assert "not active" in exc.value.detail
+
+        await registry.close()
+        await grants.close()
 
 
 class TestProjectStoreSettingsGuard:
@@ -460,19 +694,15 @@ class TestProjectStoreSettingsGuard:
         await store.close()
 
 
-class TestSetSponsorGuard:
-    """🟡 MINOR: set_sponsor must not re-parent an existing sponsored identity.
-
-    Tests the guard in AgentRegistryStore.set_sponsor directly — the guard
-    is now IN the production code, so direct calls ARE the real path (N1 fix).
+class TestPerProjectSponsorshipStore:
+    """Sponsorship is now a per-(identity, project) association, not a single
+    column.  Two contacts can sponsor the SAME identity in DIFFERENT projects
+    without one overwriting the other — the exact shape the old single column
+    could not represent.
     """
 
     @pytest.mark.asyncio
-    async def test_set_sponsor_reparents_to_different_sponsor(self, tmp_path):
-        """Re-parenting an identity to a different sponsor (cross-project
-        reuse via handle) must now SUCCEED — the old immutability guard
-        was removed so cascade_sponsor_revoke(B) can find identities
-        sponsored by B even when the handle was first sponsored by A."""
+    async def test_two_contacts_coexist_in_distinct_projects(self, tmp_path):
         from tinyagentos.agent_registry_store import AgentRegistryStore
 
         db_path = tmp_path / "test_registry.db"
@@ -481,28 +711,29 @@ class TestSetSponsorGuard:
 
         reg = await store.register(
             framework="test",
-            display_name="Agent With Sponsor",
+            display_name="Agent With Sponsors",
             user_id="user-1",
             origin="external-selfjoin",
-            handle="sponsored-reparent",
-            sponsor_contact_id="hub:sponsor-a",
+            handle="sponsored-shared",
         )
         cid = reg["canonical_id"]
 
-        # Re-parent to a different sponsor — must succeed now.
-        result = await store.set_sponsor(cid, "hub:sponsor-b")
-        assert result is not None
-        assert result["sponsor_contact_id"] == "hub:sponsor-b"
+        # A sponsors in P1, B sponsors in P2 — both survive independently.
+        assert await store.set_sponsorship(cid, "prj-1", "hub:sponsor-a") is True
+        assert await store.set_sponsorship(cid, "prj-2", "hub:sponsor-b") is True
 
-        # Verify the store agrees.
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] == "hub:sponsor-b"
+        assert [r["canonical_id"] for r in await store.list_by_sponsor("hub:sponsor-a")] == [cid]
+        assert [r["canonical_id"] for r in await store.list_by_sponsor("hub:sponsor-b")] == [cid]
+
+        rows = await store.list_sponsorships_for_identity(cid)
+        assert {(r["project_id"], r["sponsor_contact_id"]) for r in rows} == {
+            ("prj-1", "hub:sponsor-a"),
+            ("prj-2", "hub:sponsor-b"),
+        }
         await store.close()
 
     @pytest.mark.asyncio
-    async def test_set_sponsor_noop_on_same_sponsor(self, tmp_path):
-        """Setting the same sponsor that is already set must be a no-op
-        (returns the current record without a write)."""
+    async def test_same_project_second_writer_ignored(self, tmp_path):
         from tinyagentos.agent_registry_store import AgentRegistryStore
 
         db_path = tmp_path / "test_registry.db"
@@ -510,48 +741,18 @@ class TestSetSponsorGuard:
         await store.init()
 
         reg = await store.register(
-            framework="test",
-            display_name="Agent",
-            user_id="user-1",
-            origin="external-selfjoin",
-            handle="same-sponsor",
-            sponsor_contact_id="hub:sponsor-a",
+            framework="test", display_name="Agent", user_id="u",
+            origin="external-selfjoin", handle="same-proj",
         )
         cid = reg["canonical_id"]
 
-        result = await store.set_sponsor(cid, "hub:sponsor-a")
-        assert result is not None
-        assert result["sponsor_contact_id"] == "hub:sponsor-a"
-        await store.close()
-
-    @pytest.mark.asyncio
-    async def test_set_sponsor_clearing_allowed(self, tmp_path):
-        """Clearing sponsor via set_sponsor(cid, None) must still work
-        (revoke cascades depend on it)."""
-        from tinyagentos.agent_registry_store import AgentRegistryStore
-
-        db_path = tmp_path / "test_registry.db"
-        store = AgentRegistryStore(db_path)
-        await store.init()
-
-        reg = await store.register(
-            framework="test",
-            display_name="Agent",
-            user_id="user-1",
-            origin="external-selfjoin",
-            handle="clear-test",
-            sponsor_contact_id="hub:sponsor",
-        )
-        cid = reg["canonical_id"]
-
-        # Set initial sponsor
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] == "hub:sponsor"
-
-        # Clear with None — must work
-        await store.set_sponsor(cid, None)
-        agent = await store.get(cid)
-        assert agent["sponsor_contact_id"] is None
+        # First writer for (identity, project) wins; a later writer for the
+        # SAME project is a no-op (deterministic first-writer-wins).
+        assert await store.set_sponsorship(cid, "prj-1", "hub:sponsor-a") is True
+        assert await store.set_sponsorship(cid, "prj-1", "hub:sponsor-b") is False
+        rows = await store.list_sponsorships_for_identity(cid)
+        assert len(rows) == 1
+        assert rows[0]["sponsor_contact_id"] == "hub:sponsor-a"
         await store.close()
 
 
@@ -888,12 +1089,19 @@ class TestApprovalMembershipFailClosed:
         await store.close()
 
 
-class TestSetSponsorAtomicGuard:
-    """Blockers #4 — set_sponsor immutability must be enforced in the UPDATE
-    predicate, not a read->check->write race."""
+class TestSetSponsorshipAtomicGuard:
+    """Acceptance #3 — concurrency: two concurrent sponsorship writes for the
+    same (identity, project) leave exactly one row with a deterministic
+    first-writer-wins winner.
+
+    The atomic discipline (formerly the UPDATE predicate on the column) now
+    lives on the association's PRIMARY KEY: ``INSERT OR IGNORE`` makes exactly
+    one writer win and the loser a no-op, deterministically — the surviving
+    row is whichever INSERT actually inserted, never a racing overwrite.
+    """
 
     @pytest.mark.asyncio
-    async def test_concurrent_set_sponsor_reparents_once(self, tmp_path):
+    async def test_concurrent_same_project_writes_leave_one_row(self, tmp_path):
         import asyncio
 
         from tinyagentos.agent_registry_store import AgentRegistryStore
@@ -914,24 +1122,24 @@ class TestSetSponsorAtomicGuard:
         )
         cid = reg["canonical_id"]
 
-        # Concurrent re-parent attempts: whichever wins, the identity ends up
-        # with exactly one sponsor.  Re-parenting to a different sponsor is now
-        # allowed (cross-project identity reuse), so a later set_sponsor to C
-        # must succeed.
-        await asyncio.gather(
-            store_a.set_sponsor(cid, "hub:A"),
-            store_b.set_sponsor(cid, "hub:B"),
+        # Two concurrent writes for the SAME (identity, project). Exactly one
+        # wins (INSERT OR IGNORE); the loser is a no-op.  The winner is
+        # deterministic: it is whichever INSERT actually inserted the row, so
+        # the surviving sponsor must equal the writer whose call returned True.
+        results = await asyncio.gather(
+            store_a.set_sponsorship(cid, "prj-1", "hub:A"),
+            store_b.set_sponsorship(cid, "prj-1", "hub:B"),
         )
 
-        agent = await store_a.get(cid)
-        assert agent["sponsor_contact_id"] in ("hub:A", "hub:B")
+        # Exactly one insert succeeded, the other was ignored.
+        assert sorted(results) == [False, True]
+        winner = "hub:A" if results[0] is True else "hub:B"
 
-        # Re-parent to a third sponsor must now succeed.
-        result = await store_a.set_sponsor(cid, "hub:C")
-        assert result is not None
-        assert result["sponsor_contact_id"] == "hub:C"
-        agent = await store_a.get(cid)
-        assert agent["sponsor_contact_id"] == "hub:C"
+        rows = await store_a.list_sponsorships_for_identity(cid)
+        assert len(rows) == 1
+        assert rows[0]["sponsor_contact_id"] == winner
+        assert rows[0]["project_id"] == "prj-1"
+
         await store_a.close()
         await store_b.close()
 

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -1,0 +1,300 @@
+"""Tests for cross-user collab D1 — agent delegation handshake + sponsor_contact_id."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Scope denylist tests
+# ---------------------------------------------------------------------------
+
+class TestDelegationScopeValidation:
+    def test_hard_denies_files_write(self):
+        from tinyagentos.delegation_handler import validate_delegation_scopes
+
+        granted, denied = validate_delegation_scopes(
+            ["a2a_send", "files_write", "project_tasks"]
+        )
+        assert "files_write" in denied
+        assert "files_write" not in granted
+        assert "a2a_send" in granted
+        assert "project_tasks" in granted
+
+    def test_hard_denies_decisions_write(self):
+        from tinyagentos.delegation_handler import validate_delegation_scopes
+
+        granted, denied = validate_delegation_scopes(
+            ["decisions_write", "canvas_read"]
+        )
+        assert "decisions_write" in denied
+        assert "decisions_write" not in granted
+        assert "canvas_read" in granted
+
+    def test_allows_default_scopes(self):
+        from tinyagentos.delegation_handler import validate_delegation_scopes
+        from tinyagentos.delegation_handler import SPONSORED_DEFAULT_SCOPES
+
+        granted, denied = validate_delegation_scopes(list(SPONSORED_DEFAULT_SCOPES))
+        assert len(denied) == 0
+        assert set(granted) == SPONSORED_DEFAULT_SCOPES
+
+    def test_empty_request_returns_no_scopes(self):
+        from tinyagentos.delegation_handler import validate_delegation_scopes
+
+        granted, denied = validate_delegation_scopes([])
+        assert granted == []
+        assert denied == []
+
+
+# ---------------------------------------------------------------------------
+# Envelope body validation tests
+# ---------------------------------------------------------------------------
+
+class TestDelegationEnvelopeValidation:
+    def test_valid_envelope_body(self):
+        from tinyagentos.delegation_handler import _validate_delegation_envelope_body
+
+        ok, err, parsed = _validate_delegation_envelope_body({
+            "agent_slug": "grok-taos",
+            "display_name": "Grok TAOS",
+            "requested_scopes": ["a2a_send", "project_tasks"],
+            "project_id": "prj-123",
+        })
+        assert ok is True
+        assert err == ""
+        assert parsed is not None
+        assert parsed["agent_slug"] == "grok-taos"
+        assert parsed["display_name"] == "Grok TAOS"
+        assert parsed["project_id"] == "prj-123"
+
+    def test_missing_field(self):
+        from tinyagentos.delegation_handler import _validate_delegation_envelope_body
+
+        ok, err, parsed = _validate_delegation_envelope_body({
+            "agent_slug": "grok-taos",
+            "display_name": "Grok TAOS",
+        })
+        assert ok is False
+        assert "missing required field" in err
+        assert parsed is None
+
+    def test_empty_scopes(self):
+        from tinyagentos.delegation_handler import _validate_delegation_envelope_body
+
+        ok, err, parsed = _validate_delegation_envelope_body({
+            "agent_slug": "grok-taos",
+            "display_name": "Grok TAOS",
+            "requested_scopes": [],
+            "project_id": "prj-123",
+        })
+        assert ok is False
+        assert "must not be empty" in err
+
+    def test_scopes_not_a_list(self):
+        from tinyagentos.delegation_handler import _validate_delegation_envelope_body
+
+        ok, err, parsed = _validate_delegation_envelope_body({
+            "agent_slug": "grok-taos",
+            "display_name": "Grok TAOS",
+            "requested_scopes": "not-a-list",
+            "project_id": "prj-123",
+        })
+        assert ok is False
+        assert "must be a list" in err
+
+    def test_empty_agent_slug(self):
+        from tinyagentos.delegation_handler import _validate_delegation_envelope_body
+
+        ok, err, parsed = _validate_delegation_envelope_body({
+            "agent_slug": "",
+            "display_name": "Grok TAOS",
+            "requested_scopes": ["a2a_send"],
+            "project_id": "prj-123",
+        })
+        assert ok is False
+        assert "must be a non-empty string" in err
+
+
+# ---------------------------------------------------------------------------
+# Sponsor list / set tests
+# ---------------------------------------------------------------------------
+
+class TestSponsorRegistryMethods:
+    @pytest.mark.asyncio
+    async def test_list_by_sponsor_empty(self, tmp_path):
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        sponsored = await store.list_by_sponsor("hub:hogne")
+        assert sponsored == []
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_list_by_sponsor_with_registration(self, tmp_path):
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        # Register with sponsor
+        reg = await store.register(
+            framework="test",
+            display_name="Sponsored Agent",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="sponsored-agent",
+            sponsor_contact_id="hub:hogne",
+        )
+        canonical_id = reg["canonical_id"]
+        # List by sponsor
+        sponsored = await store.list_by_sponsor("hub:hogne")
+        assert len(sponsored) == 1
+        assert sponsored[0]["sponsor_contact_id"] == "hub:hogne"
+
+        # List by different sponsor — empty
+        other = await store.list_by_sponsor("hub:other")
+        assert other == []
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_list_by_sponsor_filter_by_status(self, tmp_path):
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        await store.register(
+            framework="test",
+            display_name="Active Sponsored",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="active-sponsor",
+            sponsor_contact_id="hub:hogne",
+        )
+        # Only active agents
+        active = await store.list_by_sponsor("hub:hogne", status="active")
+        assert len(active) == 0  # external-selfjoin starts pending
+
+        # With no status filter, shows all
+        all_sponsored = await store.list_by_sponsor("hub:hogne")
+        assert len(all_sponsored) == 1  # pending agent
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_set_sponsor(self, tmp_path):
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        reg = await store.register(
+            framework="test",
+            display_name="Agent",
+            user_id="user-1",
+            origin="taos-deployed",
+            handle="test-agent",
+        )
+        cid = reg["canonical_id"]
+
+        # Initially NULL
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] is None
+
+        # Set sponsor
+        await store.set_sponsor(cid, "hub:hogne")
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] == "hub:hogne"
+
+        # Clear sponsor
+        await store.set_sponsor(cid, None)
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] is None
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_adds_sponsor_column(self, tmp_path):
+        from tinyagentos.agent_registry_store import _migration_v5_add_sponsor_contact_id
+
+        import aiosqlite
+
+        db_path = tmp_path / "test_registry.db"
+        # Simulate pre-migration DB with agent_registry but no sponsor_contact_id
+        conn = await aiosqlite.connect(db_path)
+        await conn.execute("""
+            CREATE TABLE agent_registry (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                canonical_id TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL DEFAULT '',
+                framework TEXT NOT NULL DEFAULT '',
+                user_id TEXT NOT NULL DEFAULT '',
+                origin TEXT NOT NULL DEFAULT 'taos-deployed',
+                handle TEXT NOT NULL DEFAULT '',
+                role TEXT,
+                capabilities TEXT NOT NULL DEFAULT '[]',
+                created_ts TEXT NOT NULL,
+                revoked_at TEXT,
+                status TEXT NOT NULL DEFAULT 'active'
+            )
+        """)
+        await conn.commit()
+
+        # Migration should add the column
+        await _migration_v5_add_sponsor_contact_id(conn)
+
+        # Verify column exists
+        cols = {row[1] for row in await (await conn.execute(
+            "PRAGMA table_info(agent_registry)"
+        )).fetchall()}
+        assert "sponsor_contact_id" in cols
+
+        # Idempotent
+        await _migration_v5_add_sponsor_contact_id(conn)
+
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Invite metadata tests
+# ---------------------------------------------------------------------------
+
+class TestInviteMetadata:
+    @pytest.mark.asyncio
+    async def test_row_to_dict_deserializes_metadata(self, tmp_path):
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        db_path = tmp_path / "test_invites.db"
+        store = ProjectInviteStore(db_path)
+        await store.init()
+
+        metadata = {
+            "kind": "delegation_sponsored",
+            "sponsor_contact_id": "hub:hogne",
+            "agent_slug": "grok-taos",
+        }
+
+        result = await store.mint(
+            project_id="prj-test",
+            scopes=["project_tasks", "a2a_send"],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="hub:hogne",
+            metadata=metadata,
+        )
+
+        invite_id = result["record"]["invite_id"]
+        invite = await store.get(invite_id)
+        # metadata should be deserialized to a dict
+        assert isinstance(invite["metadata"], dict)
+        assert invite["metadata"]["kind"] == "delegation_sponsored"
+        assert invite["metadata"]["sponsor_contact_id"] == "hub:hogne"
+        await store.close()

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -298,3 +298,291 @@ class TestInviteMetadata:
         assert invite["metadata"]["kind"] == "delegation_sponsored"
         assert invite["metadata"]["sponsor_contact_id"] == "hub:hogne"
         await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for CodeRabbit findings (#2048) — rewritten to test
+# through real production paths (N1 fix).
+# ---------------------------------------------------------------------------
+
+
+class TestMintReturnShape:
+    """🔴 CRITICAL: delegation_handler must read invite_id from correct path.
+
+    Tests process_delegation_request end-to-end so the handler's
+    invite["record"]["invite_id"] path is exercised — not just the store.
+    """
+
+    @pytest.mark.asyncio
+    async def test_process_delegation_request_returns_invite_id(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import process_delegation_request
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        db_path = tmp_path / "test_invites.db"
+        store = ProjectInviteStore(db_path)
+        await store.init()
+
+        # Project store mock: member check → True, auto_approve → True
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+        project_store.get_project_setting.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_store = project_store
+        request.app.state.project_invite_store = store
+
+        envelope_body = {
+            "agent_slug": "sponsored-agent",
+            "display_name": "Sponsored Agent",
+            "requested_scopes": ["a2a_send", "project_tasks"],
+            "project_id": "prj-test",
+        }
+
+        result = await process_delegation_request(
+            request,
+            contact_id="hub:sponsor",
+            envelope_body=envelope_body,
+        )
+
+        # Handler must return invite_id from invite["record"]["invite_id"]
+        # (not invite["id"] or any flat key — this was the A1 bug).
+        assert result["status"] == "approved"
+        invite_id = result["invite_id"]
+        assert isinstance(invite_id, str)
+        assert len(invite_id) == 6  # 6-digit invite ID
+
+        # The invite must actually exist in the store and be redeemable.
+        invite_row = await store.get(invite_id)
+        assert invite_row is not None
+        assert invite_row["pin_required"] == 0  # pin_required=False
+        assert invite_row["status"] == "pending"
+
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_mint_pin_required_false_persisted_through_handler(self, tmp_path):
+        """pin_required=False must be a TOP-LEVEL mint arg (not metadata)
+        so the column is actually written (N1+A2 regression guard)."""
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import process_delegation_request
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        db_path = tmp_path / "test_invites.db"
+        store = ProjectInviteStore(db_path)
+        await store.init()
+
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+        project_store.get_project_setting.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_store = project_store
+        request.app.state.project_invite_store = store
+
+        result = await process_delegation_request(
+            request,
+            contact_id="hub:sponsor",
+            envelope_body={
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "requested_scopes": ["a2a_send"],
+                "project_id": "prj-pin",
+            },
+        )
+        assert result["status"] == "approved"
+
+        invite = await store.get(result["invite_id"])
+        assert invite["pin_required"] == 0  # persisted as 0
+
+        # Redeem with empty pin — must succeed (A2 fix: pin_required=False
+        # skips PIN verification).
+        record = await store.redeem(result["invite_id"], "")
+        assert record["status"] == "claimed"
+        await store.close()
+
+
+class TestCascadeSponsorRevokeFailClosed:
+    """🟠 MAJOR: project-scoped revoke with missing project_store must fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_cascade_with_project_id_and_no_store_fails(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import cascade_sponsor_revoke
+
+        # Mock request with registry but NO project_store
+        request = MagicMock()
+        mock_registry = AsyncMock()
+        mock_registry.list_by_sponsor.return_value = [
+            {"canonical_id": "agent-1", "sponsor_contact_id": "hub:sponsor"}
+        ]
+        request.app.state.agent_registry = mock_registry
+        request.app.state.project_store = None  # missing!
+
+        result = await cascade_sponsor_revoke(
+            request,
+            contact_id="hub:sponsor",
+            project_id="prj-1",
+        )
+
+        # Must fail closed — project_store absent with project_id set is an error
+        assert result["status"] == "error"
+        assert "project store not available" in result["error"]
+
+
+class TestProjectStoreSettingsGuard:
+    """🟡 MINOR: get_project_setting must handle non-dict settings."""
+
+    @pytest.mark.asyncio
+    async def test_get_setting_non_dict_returns_default(self, tmp_path):
+        from tinyagentos.projects.project_store import ProjectStore
+
+        db_path = tmp_path / "test_settings.db"
+        store = ProjectStore(db_path)
+        await store.init()
+
+        # Create a project with settings as a list (malformed)
+        import json, time
+        await store._db.execute(
+            "INSERT INTO projects (id, name, slug, created_by, created_at, updated_at, settings) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("prj-bad", "Bad Project", "bad-project", "test-user",
+             time.time(), time.time(), json.dumps(["not-a-dict"])),
+        )
+        await store._db.commit()
+
+        result = await store.get_project_setting("prj-bad", "some_key", default="fallback")
+        assert result == "fallback"
+        await store.close()
+
+
+class TestSetSponsorGuard:
+    """🟡 MINOR: set_sponsor must not re-parent an existing sponsored identity.
+
+    Tests the guard in AgentRegistryStore.set_sponsor directly — the guard
+    is now IN the production code, so direct calls ARE the real path (N1 fix).
+    """
+
+    @pytest.mark.asyncio
+    async def test_set_sponsor_skips_when_already_set(self, tmp_path):
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        reg = await store.register(
+            framework="test",
+            display_name="Agent With Sponsor",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="sponsored-reuse",
+            sponsor_contact_id="hub:original-sponsor",
+        )
+        cid = reg["canonical_id"]
+
+        # Try to re-parent — the guard in set_sponsor must block this.
+        await store.set_sponsor(cid, "hub:new-sponsor")
+
+        # Sponsor must still be the original — guard blocked re-parenting.
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] == "hub:original-sponsor"
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_set_sponsor_clearing_allowed(self, tmp_path):
+        """Clearing sponsor via set_sponsor(cid, None) must still work
+        (revoke cascades depend on it)."""
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "test_registry.db"
+        store = AgentRegistryStore(db_path)
+        await store.init()
+
+        reg = await store.register(
+            framework="test",
+            display_name="Agent",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="clear-test",
+            sponsor_contact_id="hub:sponsor",
+        )
+        cid = reg["canonical_id"]
+
+        # Set initial sponsor
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] == "hub:sponsor"
+
+        # Clear with None — must work
+        await store.set_sponsor(cid, None)
+        agent = await store.get(cid)
+        assert agent["sponsor_contact_id"] is None
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# E2E: mint through delegation_handler → redeem (A1 + A2 killed together)
+# ---------------------------------------------------------------------------
+
+class TestDelegationE2E:
+    """End-to-end: process_delegation_request with auto_approve on, then
+    redeem the resulting invite.  This single test proves A1 (invite_id
+    is read from the correct path) and A2 (pin_required=False skips PIN
+    verification) together."""
+
+    @pytest.mark.asyncio
+    async def test_mint_and_redeem_e2e(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import process_delegation_request
+        from tinyagentos.projects.invite_store import (
+            ProjectInviteStore,
+            InviteAlreadyRedeemedError,
+        )
+
+        db_path = tmp_path / "test_invites.db"
+        store = ProjectInviteStore(db_path)
+        await store.init()
+
+        # Auto-approve path: member check passes, auto_approve_delegation=True
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+        project_store.get_project_setting.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_store = project_store
+        request.app.state.project_invite_store = store
+
+        # Step 1: process delegation request (auto-approve)
+        result = await process_delegation_request(
+            request,
+            contact_id="hub:hogne",
+            envelope_body={
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "requested_scopes": ["a2a_send", "project_tasks", "files_write"],
+                "project_id": "prj-e2e",
+            },
+        )
+
+        assert result["status"] == "approved"
+        invite_id = result["invite_id"]
+        assert len(invite_id) == 6
+
+        # Step 2: verify invite in store
+        invite = await store.get(invite_id)
+        assert invite["status"] == "pending"
+        assert invite["pin_required"] == 0
+        scopes = invite["scopes"]
+        assert "a2a_send" in scopes
+        assert "project_tasks" in scopes
+        assert "files_write" not in scopes  # hard-denied
+
+        # Step 3: redeem with empty pin (pin_required=False)
+        record = await store.redeem(invite_id, "")
+        assert record["status"] == "claimed"
+
+        # Step 4: already claimed → error, not PIN error (A2 proof)
+        with pytest.raises(InviteAlreadyRedeemedError):
+            await store.redeem(invite_id, "9999")
+
+        await store.close()

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -1178,3 +1178,142 @@ class TestDelegationStatusLandingPlace:
 
         await decision_store.close()
 
+
+class TestDelegationStatusIdempotency:
+    """Kilo re-review: a retried delegation_status (distinct nonce, same
+    invite_id) must not mint a duplicate decision — the handler is idempotent
+    on invite_id."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_delivery_returns_existing_decision(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.routes.peer import _handle_delegation_status
+
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        request = MagicMock()
+        request.app.state.decision_store = decision_store
+
+        body = {"invite_id": "inv-dup", "agent_slug": "grok", "project_id": "prj-1"}
+
+        first = await _handle_delegation_status(request, "hub:sponsor", {}, body)
+        assert first["dispatched"] is True
+        first_id = first["decision_id"]
+
+        second = await _handle_delegation_status(request, "hub:sponsor", {}, body)
+        assert second["dispatched"] is True
+        assert second.get("duplicate") is True
+        assert second["decision_id"] == first_id
+
+        # Exactly one decision row records this invite_id (no duplicate).
+        all_decisions = await decision_store.list(limit=500)
+        assert len(all_decisions) == 1
+        matches = await decision_store.find_by_metadata("invite_id", "inv-dup")
+        assert len(matches) == 1
+
+        await decision_store.close()
+
+    @pytest.mark.asyncio
+    async def test_decision_is_project_scoped_and_system_attributed(self, tmp_path):
+        """The decision must carry project_id + owner user_id and be tagged as a
+        system notification (not a request from the peer)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.routes.peer import _handle_delegation_status
+
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        project_store = AsyncMock()
+        project_store.get_project.return_value = {"id": "prj-1", "user_id": "owner-1"}
+
+        request = MagicMock()
+        request.app.state.decision_store = decision_store
+        request.app.state.project_store = project_store
+
+        result = await _handle_delegation_status(
+            request, "hub:sponsor", {},
+            {"invite_id": "inv-p", "agent_slug": "grok", "project_id": "prj-1"},
+        )
+
+        decision = await decision_store.get(result["decision_id"])
+        assert decision["project_id"] == "prj-1"
+        assert decision["user_id"] == "owner-1"
+        assert decision["from_agent"] == "system:delegation"
+        # Originating contact stays in metadata, not the from_agent.
+        assert decision["metadata"]["contact_id"] == "hub:sponsor"
+
+        await decision_store.close()
+
+
+class TestSendEnvelopeGuards:
+    """Kilo re-review: send_envelope must fail loudly on a wrong contact-id
+    shape and keep endpoint ordering deterministic."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_hub_contact_id(self, tmp_path):
+        import pytest
+
+        from tinyagentos.contacts_store import ContactsStore
+        from tinyagentos.peer import send_envelope
+
+        store = ContactsStore(tmp_path / "contacts.db")
+        await store.init()
+
+        # A non-hub id (e.g. peer:abc) must raise, not silently produce a
+        # hub:peer:abc envelope that the receiver 403s.
+        with pytest.raises(ValueError, match="hub:<username>"):
+            await send_envelope(
+                store, from_username="jaylfc", to_contact_id="peer:abc",
+                kind="chat", body={},
+            )
+
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_orders_dict_endpoints_by_priority(self, tmp_path):
+        import httpx as _httpx
+        import respx
+
+        from tinyagentos.contacts_store import ContactsStore, generate_peer_token
+        from tinyagentos.peer import send_envelope
+
+        store = ContactsStore(tmp_path / "contacts.db")
+        await store.init()
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+            endpoints=[
+                {"url": "https://primary.example.com", "priority": 1},
+                {"url": "https://fallback.example.com", "priority": 99},
+            ],
+        )
+
+        with respx.mock as mock:
+            primary = mock.post("https://primary.example.com/api/peer/inbox").mock(
+                return_value=_httpx.Response(200, json={"status": "received"}))
+            fallback = mock.post("https://fallback.example.com/api/peer/inbox").mock(
+                return_value=_httpx.Response(200, json={"status": "received"}))
+
+            delivered, err = await send_envelope(
+                store, from_username="jaylfc", to_contact_id="hub:hogne",
+                kind="delegation_status", body={},
+            )
+
+            assert delivered is True
+            # Priority 1 endpoint was tried first and succeeded, so the
+            # fallback was never reached.
+            assert primary.called
+            assert not fallback.called
+
+        await store.close()
+

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -16,37 +16,41 @@ class TestDelegationScopeValidation:
     def test_hard_denies_files_write(self):
         from tinyagentos.delegation_handler import validate_delegation_scopes
 
-        granted, denied = validate_delegation_scopes(
+        tier, elevated, denied = validate_delegation_scopes(
             ["a2a_send", "files_write", "project_tasks"]
         )
         assert "files_write" in denied
-        assert "files_write" not in granted
-        assert "a2a_send" in granted
-        assert "project_tasks" in granted
+        assert "files_write" not in tier
+        assert "a2a_send" in tier
+        assert "project_tasks" in tier
+        assert elevated == []
 
     def test_hard_denies_decisions_write(self):
         from tinyagentos.delegation_handler import validate_delegation_scopes
 
-        granted, denied = validate_delegation_scopes(
+        tier, elevated, denied = validate_delegation_scopes(
             ["decisions_write", "canvas_read"]
         )
         assert "decisions_write" in denied
-        assert "decisions_write" not in granted
-        assert "canvas_read" in granted
+        assert "decisions_write" not in tier
+        assert "canvas_read" in tier
+        assert elevated == []
 
     def test_allows_default_scopes(self):
         from tinyagentos.delegation_handler import validate_delegation_scopes
         from tinyagentos.delegation_handler import SPONSORED_DEFAULT_SCOPES
 
-        granted, denied = validate_delegation_scopes(list(SPONSORED_DEFAULT_SCOPES))
+        tier, elevated, denied = validate_delegation_scopes(list(SPONSORED_DEFAULT_SCOPES))
         assert len(denied) == 0
-        assert set(granted) == SPONSORED_DEFAULT_SCOPES
+        assert elevated == []
+        assert set(tier) == SPONSORED_DEFAULT_SCOPES
 
     def test_empty_request_returns_no_scopes(self):
         from tinyagentos.delegation_handler import validate_delegation_scopes
 
-        granted, denied = validate_delegation_scopes([])
-        assert granted == []
+        tier, elevated, denied = validate_delegation_scopes([])
+        assert tier == []
+        assert elevated == []
         assert denied == []
 
 
@@ -350,7 +354,7 @@ class TestMintReturnShape:
         assert result["status"] == "approved"
         invite_id = result["invite_id"]
         assert isinstance(invite_id, str)
-        assert len(invite_id) == 6  # 6-digit invite ID
+        assert len(invite_id) >= 20  # token_urlsafe id (PIN-free invite)
 
         # The invite must actually exist in the store and be redeemable.
         invite_row = await store.get(invite_id)
@@ -566,7 +570,7 @@ class TestDelegationE2E:
 
         assert result["status"] == "approved"
         invite_id = result["invite_id"]
-        assert len(invite_id) == 6
+        assert len(invite_id) >= 20  # token_urlsafe id (PIN-free invite)
 
         # Step 2: verify invite in store
         invite = await store.get(invite_id)
@@ -718,4 +722,233 @@ class TestManualApprovalWiring:
 
         await invite_store.close()
         await decision_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Security blockers (jaylfc Aug 17 14:16 re-review) — red-first regression tests.
+# ---------------------------------------------------------------------------
+
+
+class TestSponsoredInviteMetadata:
+    """Blockers #1 — sponsored-invite metadata must carry sponsor_contact_id."""
+
+    @pytest.mark.asyncio
+    async def test_process_delegation_request_writes_sponsor_metadata(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import process_delegation_request
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        store = ProjectInviteStore(tmp_path / "invites.db")
+        await store.init()
+
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+        project_store.get_project_setting.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_store = project_store
+        request.app.state.project_invites = store
+
+        result = await process_delegation_request(
+            request,
+            contact_id="hub:sponsor",
+            envelope_body={
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "requested_scopes": ["a2a_send"],
+                "project_id": "prj-test",
+            },
+        )
+        assert result["status"] == "approved"
+
+        invite = await store.get(result["invite_id"])
+        assert invite["metadata"]["sponsor_contact_id"] == "hub:sponsor"
+        await store.close()
+
+
+class TestScopeTierVsElevated:
+    """Blockers #2 — tier (allowlist) vs elevated scopes must be split."""
+
+    def test_validate_splits_tier_from_elevated(self):
+        from tinyagentos.delegation_handler import validate_delegation_scopes
+
+        tier, elevated, denied = validate_delegation_scopes(
+            ["a2a_send", "tools_execute"]
+        )
+        assert "a2a_send" in tier
+        assert "tools_execute" in elevated
+        assert "tools_execute" not in tier
+        assert denied == []
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_never_grants_elevated(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+        from tinyagentos.delegation_handler import process_delegation_request
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+        from tinyagentos.decisions.decision_store import DecisionStore
+
+        store = ProjectInviteStore(tmp_path / "invites.db")
+        await store.init()
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+        project_store.get_project_setting.return_value = True  # auto-approve ON
+
+        request = MagicMock()
+        request.app.state.project_store = project_store
+        request.app.state.project_invites = store
+        request.app.state.decision_store = decision_store
+
+        result = await process_delegation_request(
+            request,
+            contact_id="hub:sponsor",
+            envelope_body={
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "requested_scopes": ["a2a_send", "tools_execute"],
+                "project_id": "prj-test",
+            },
+        )
+        # An elevated scope must never be auto-granted: the request must route
+        # to manual approval, not mint an invite containing tools_execute.
+        assert result["status"] == "pending_approval"
+        # And no invite may have been minted on the auto path.
+        invites = await store.list_for_project("prj-test")
+        assert invites == []
+        await store.close()
+        await decision_store.close()
+
+
+class TestApprovalMembershipFailClosed:
+    """Blockers #3 — approval-time membership re-check must fail closed."""
+
+    @pytest.mark.asyncio
+    async def test_complete_approval_fails_closed_without_project_store(self, tmp_path):
+        from unittest.mock import MagicMock
+        from tinyagentos.delegation_handler import complete_delegation_approval
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        store = ProjectInviteStore(tmp_path / "invites.db")
+        await store.init()
+
+        request = MagicMock()
+        request.app.state.project_store = None  # missing -> must fail closed
+        request.app.state.project_invites = store
+
+        result = await complete_delegation_approval(
+            request,
+            decision_metadata={
+                "contact_id": "hub:sponsor",
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "granted_scopes": ["a2a_send"],
+                "project_id": "prj-test",
+            },
+        )
+        # Failing closed: a missing project_store must yield an error, not a
+        # silently minted invite (the old code failed OPEN and minted anyway).
+        assert result["status"] == "error"
+        assert "project store" in result["error"]
+        # And no invite may have been minted.
+        invites = await store.list_for_project("prj-test")
+        assert invites == []
+        await store.close()
+
+
+class TestSetSponsorAtomicGuard:
+    """Blockers #4 — set_sponsor immutability must be enforced in the UPDATE
+    predicate, not a read->check->write race."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_set_sponsor_reparents_once(self, tmp_path):
+        import asyncio
+
+        from tinyagentos.agent_registry_store import AgentRegistryStore
+
+        db_path = tmp_path / "registry.db"
+        # Two stores over the same file = two connections = a real race window.
+        store_a = AgentRegistryStore(db_path)
+        await store_a.init()
+        store_b = AgentRegistryStore(db_path)
+        await store_b.init()
+
+        reg = await store_a.register(
+            framework="test",
+            display_name="Race Agent",
+            user_id="user-1",
+            origin="external-selfjoin",
+            handle="race-agent",
+        )
+        cid = reg["canonical_id"]
+
+        # Concurrent re-parent attempts: whichever wins, the identity ends up
+        # with exactly one sponsor and cannot be re-parented a second time.
+        await asyncio.gather(
+            store_a.set_sponsor(cid, "hub:A"),
+            store_b.set_sponsor(cid, "hub:B"),
+        )
+
+        agent = await store_a.get(cid)
+        assert agent["sponsor_contact_id"] in ("hub:A", "hub:B")
+
+        # A later re-parent to a third sponsor must be refused.
+        await store_a.set_sponsor(cid, "hub:C")
+        agent = await store_a.get(cid)
+        assert agent["sponsor_contact_id"] != "hub:C"
+        await store_a.close()
+        await store_b.close()
+
+
+class TestUnassignAgentTasks:
+    """Blockers #5 — cascade revoke must release claimed tasks via the store's
+    real release path (claimed -> open), not a non-existent in_progress/assignee
+    vocabulary."""
+
+    @pytest.mark.asyncio
+    async def test_unassign_releases_claimed_task(self, tmp_path):
+        from tinyagentos.delegation_handler import _unassign_agent_tasks
+        from tinyagentos.projects.task_store import ProjectTaskStore
+
+        store = ProjectTaskStore(tmp_path / "tasks.db")
+        await store.init()
+
+        task = await store.create_task("prj-1", "Fix bug", "alice")
+        tid = task["id"]
+        claimed = await store.claim_task(tid, "agent-1")
+        assert claimed is True
+
+        count = await _unassign_agent_tasks(store, "agent-1", project_id="prj-1")
+        assert count == 1
+
+        fetched = await store.get_task(tid)
+        assert fetched["status"] == "open"
+        assert fetched["claimed_by"] is None
+        await store.close()
+
+
+class TestPinFreeInviteIdEntropy:
+    """Blockers #6 — PIN-free invite IDs must be high-entropy, not 6 digits."""
+
+    @pytest.mark.asyncio
+    async def test_pin_free_invite_id_is_high_entropy(self, tmp_path):
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+
+        store = ProjectInviteStore(tmp_path / "invites.db")
+        await store.init()
+
+        result = await store.mint(
+            project_id="prj-1",
+            scopes=["a2a_send"],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+            pin_required=False,
+        )
+        invite_id = result["record"]["invite_id"]
+        # token_urlsafe-class id, not a guessable 6-digit numeric credential.
+        assert len(invite_id) >= 20
+        assert not invite_id.isdigit()
+        await store.close()
 

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -330,7 +330,7 @@ class TestMintReturnShape:
 
         request = MagicMock()
         request.app.state.project_store = project_store
-        request.app.state.project_invite_store = store
+        request.app.state.project_invites = store
 
         envelope_body = {
             "agent_slug": "sponsored-agent",
@@ -378,7 +378,7 @@ class TestMintReturnShape:
 
         request = MagicMock()
         request.app.state.project_store = project_store
-        request.app.state.project_invite_store = store
+        request.app.state.project_invites = store
 
         result = await process_delegation_request(
             request,
@@ -550,7 +550,7 @@ class TestDelegationE2E:
 
         request = MagicMock()
         request.app.state.project_store = project_store
-        request.app.state.project_invite_store = store
+        request.app.state.project_invites = store
 
         # Step 1: process delegation request (auto-approve)
         result = await process_delegation_request(

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -223,7 +223,7 @@ class TestSponsorRegistryMethods:
 
     @pytest.mark.asyncio
     async def test_migration_adds_sponsor_column(self, tmp_path):
-        from tinyagentos.agent_registry_store import _migration_v5_add_sponsor_contact_id
+        from tinyagentos.agent_registry_store import _migration_v7_add_sponsor_contact_id
 
         import aiosqlite
 
@@ -249,7 +249,7 @@ class TestSponsorRegistryMethods:
         await conn.commit()
 
         # Migration should add the column
-        await _migration_v5_add_sponsor_contact_id(conn)
+        await _migration_v7_add_sponsor_contact_id(conn)
 
         # Verify column exists
         cols = {row[1] for row in await (await conn.execute(
@@ -258,7 +258,7 @@ class TestSponsorRegistryMethods:
         assert "sponsor_contact_id" in cols
 
         # Idempotent
-        await _migration_v5_add_sponsor_contact_id(conn)
+        await _migration_v7_add_sponsor_contact_id(conn)
 
         await conn.close()
 
@@ -586,3 +586,136 @@ class TestDelegationE2E:
             await store.redeem(invite_id, "9999")
 
         await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Manual approval path (the WIRED path): approving a collab_delegation_gate
+# decision must actually mint the sponsored invite via complete_delegation_approval.
+# ---------------------------------------------------------------------------
+
+class TestManualApprovalWiring:
+    """Regression guard for the dead manual path: a delegation request that
+    lands in a Decisions card (kind collab_delegation_gate) must, on approval,
+    actually mint the sponsored project invite.  Previously nothing read the
+    decision's metadata kind, so approval was a no-op."""
+
+    @pytest.mark.asyncio
+    async def test_approve_delegation_gate_mints_invite(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+        from tinyagentos.routes.decisions import AnswerIn, answer_decision
+
+        invite_store = ProjectInviteStore(tmp_path / "invites.db")
+        await invite_store.init()
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        # The contact must still be a human collaborator at approval time.
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_invites = invite_store
+        request.app.state.project_store = project_store
+        request.app.state.decision_store = decision_store
+
+        decision = await decision_store.create(
+            from_agent="hub:sponsor",
+            question=(
+                "hub:sponsor wants to delegate agent 'Grok TAOS' (grok-taos) "
+                "to this project. Requested scopes: a2a_send, project_tasks."
+            ),
+            type="approve_deny",
+            priority="blocking",
+            project_id="prj-test",
+            user_id="admin-user",
+            metadata={
+                "kind": "collab_delegation_gate",
+                "contact_id": "hub:sponsor",
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "granted_scopes": ["a2a_send", "project_tasks"],
+                "denied_scopes": [],
+                "project_id": "prj-test",
+            },
+        )
+
+        user = MagicMock()
+        user.is_admin = True
+        user.user_id = "admin-user"
+
+        updated = await answer_decision(
+            decision["id"], AnswerIn(value="approve"), request, user
+        )
+
+        assert updated["status"] == "answered"
+
+        # The delegation must have actually minted a project invite.
+        invites = await invite_store.list_for_project("prj-test")
+        assert len(invites) == 1
+        minted = invites[0]
+        assert minted["display_name"] == "Grok TAOS"
+        assert minted["created_by"] == "hub:sponsor"
+        scopes = minted["scopes"]
+        assert "a2a_send" in scopes
+        assert "project_tasks" in scopes
+
+        await invite_store.close()
+        await decision_store.close()
+
+    @pytest.mark.asyncio
+    async def test_deny_delegation_gate_mints_nothing(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.projects.invite_store import ProjectInviteStore
+        from tinyagentos.routes.decisions import AnswerIn, answer_decision
+
+        invite_store = ProjectInviteStore(tmp_path / "invites.db")
+        await invite_store.init()
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_invites = invite_store
+        request.app.state.project_store = project_store
+        request.app.state.decision_store = decision_store
+
+        decision = await decision_store.create(
+            from_agent="hub:sponsor",
+            question="delegation gate",
+            type="approve_deny",
+            priority="blocking",
+            project_id="prj-test",
+            user_id="admin-user",
+            metadata={
+                "kind": "collab_delegation_gate",
+                "contact_id": "hub:sponsor",
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "granted_scopes": ["a2a_send"],
+                "denied_scopes": [],
+                "project_id": "prj-test",
+            },
+        )
+
+        user = MagicMock()
+        user.is_admin = True
+        user.user_id = "admin-user"
+
+        updated = await answer_decision(
+            decision["id"], AnswerIn(value="deny"), request, user
+        )
+
+        assert updated["status"] == "answered"
+        invites = await invite_store.list_for_project("prj-test")
+        assert invites == []
+
+        await invite_store.close()
+        await decision_store.close()
+

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -915,7 +915,9 @@ class TestSetSponsorAtomicGuard:
         cid = reg["canonical_id"]
 
         # Concurrent re-parent attempts: whichever wins, the identity ends up
-        # with exactly one sponsor and cannot be re-parented a second time.
+        # with exactly one sponsor.  Re-parenting to a different sponsor is now
+        # allowed (cross-project identity reuse), so a later set_sponsor to C
+        # must succeed.
         await asyncio.gather(
             store_a.set_sponsor(cid, "hub:A"),
             store_b.set_sponsor(cid, "hub:B"),
@@ -924,10 +926,12 @@ class TestSetSponsorAtomicGuard:
         agent = await store_a.get(cid)
         assert agent["sponsor_contact_id"] in ("hub:A", "hub:B")
 
-        # A later re-parent to a third sponsor must be refused.
-        await store_a.set_sponsor(cid, "hub:C")
+        # Re-parent to a third sponsor must now succeed.
+        result = await store_a.set_sponsor(cid, "hub:C")
+        assert result is not None
+        assert result["sponsor_contact_id"] == "hub:C"
         agent = await store_a.get(cid)
-        assert agent["sponsor_contact_id"] != "hub:C"
+        assert agent["sponsor_contact_id"] == "hub:C"
         await store_a.close()
         await store_b.close()
 

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -987,3 +987,194 @@ class TestPinFreeInviteIdEntropy:
         assert not invite_id.isdigit()
         await store.close()
 
+
+# ---------------------------------------------------------------------------
+# Delivery path (jaylfc 08-28 merge-blocker): the delegation invite must
+# actually reach the requester.  send_envelope / _deliver_delegation_invite
+# had zero coverage, which is why the three delivery bugs (envelope double
+# prefix, endpoint shape mismatch, no durable landing place) survived green.
+# ---------------------------------------------------------------------------
+
+class TestDelegationDeliveryPath:
+    """Exercises the real outbound delivery path: send_envelope and
+    _deliver_delegation_invite against a stub peer inbox."""
+
+    @pytest.mark.asyncio
+    async def test_send_envelope_delivers_to_string_endpoint_without_double_prefix(
+        self, tmp_path
+    ):
+        """send_envelope must (a) accept plain string endpoints (the canonical
+        shape written by establish_peer_link) and (b) address the envelope to
+        ``hub:<user>``, not ``hub:hub:<user>``."""
+        import httpx as _httpx
+        import respx
+        from tinyagentos.contacts_store import ContactsStore, generate_peer_token
+        from tinyagentos.peer import send_envelope
+
+        store = ContactsStore(tmp_path / "contacts.db")
+        await store.init()
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+            endpoints=["https://hogne.example.com:6969"],
+        )
+
+        with respx.mock as mock:
+            route = mock.post(
+                "https://hogne.example.com:6969/api/peer/inbox"
+            ).mock(return_value=_httpx.Response(200, json={"status": "received"}))
+
+            delivered, err = await send_envelope(
+                store,
+                from_username="jaylfc",
+                to_contact_id="hub:hogne",
+                kind="delegation_status",
+                body={"invite_id": "inv-123", "agent_slug": "grok", "project_id": "prj-1"},
+            )
+
+            assert delivered is True
+            assert err == ""
+            assert route.called
+            assert len(route.calls) == 1
+            envelope = json.loads(route.calls[0].request.content)["envelope"]
+            assert envelope["to"] == "hub:hogne"  # NOT hub:hub:hogne
+            assert envelope["from"] == "hub:jaylfc"
+
+        await store.close()
+
+    @pytest.mark.asyncio
+    async def test_deliver_delegation_invite_reaches_stub_inbox(self, tmp_path, monkeypatch):
+        """_deliver_delegation_invite must build a correctly-addressed envelope
+        and POST it to the requester's peer inbox (assert delivered via a
+        stub inbox, not a mock of send_envelope)."""
+        import httpx as _httpx
+        import respx
+        from unittest.mock import MagicMock
+
+        from tinyagentos.contacts_store import ContactsStore, generate_peer_token
+        from tinyagentos.routes.decisions import _deliver_delegation_invite
+
+        store = ContactsStore(tmp_path / "contacts.db")
+        await store.init()
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+            endpoints=["https://hogne.example.com:6969"],
+        )
+
+        # Avoid the hub-identity filesystem lookup; the delivery path only
+        # needs a local id to derive from_username.
+        monkeypatch.setattr(
+            "tinyagentos.peer.resolve_local_identity_id",
+            lambda data_dir=None: "hub:testnode",
+        )
+
+        request = MagicMock()
+        request.app.state.contacts_store = store
+        request.app.state.data_dir = str(tmp_path)
+
+        with respx.mock as mock:
+            route = mock.post(
+                "https://hogne.example.com:6969/api/peer/inbox"
+            ).mock(return_value=_httpx.Response(200, json={"status": "received"}))
+
+            # Returns None and never raises (best-effort delivery).
+            await _deliver_delegation_invite(
+                request,
+                {
+                    "contact_id": "hub:hogne",
+                    "agent_slug": "grok-taos",
+                    "project_id": "prj-1",
+                },
+                "inv-abc123",
+            )
+
+            assert route.called
+            envelope = json.loads(route.calls[0].request.content)["envelope"]
+            assert envelope["to"] == "hub:hogne"
+            assert envelope["kind"] == "delegation_status"
+            assert envelope["body"]["invite_id"] == "inv-abc123"
+            assert envelope["body"]["agent_slug"] == "grok-taos"
+
+        await store.close()
+
+
+class TestDelegationStatusLandingPlace:
+    """The receiver of a delegation_status envelope must persist a durable
+    decision record (invite_id in metadata) so the requester's agent runner
+    can poll for and redeem it — not merely log and drop it."""
+
+    @pytest.mark.asyncio
+    async def test_delegation_status_persists_decision_with_invite_id(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.routes.peer import _handle_delegation_status
+
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        request = MagicMock()
+        request.app.state.decision_store = decision_store
+
+        result = await _handle_delegation_status(
+            request,
+            contact_id="hub:sponsor",
+            envelope={},
+            body_data={
+                "invite_id": "inv-abc123",
+                "agent_slug": "grok-taos",
+                "project_id": "prj-1",
+            },
+        )
+
+        assert result["status"] == "received"
+        assert result["dispatched"] is True
+        assert result["invite_id"] == "inv-abc123"
+
+        decision_id = result["decision_id"]
+        decision = await decision_store.get(decision_id)
+        assert decision is not None
+        assert decision["metadata"]["invite_id"] == "inv-abc123"
+        assert decision["metadata"]["agent_slug"] == "grok-taos"
+        assert decision["metadata"]["project_id"] == "prj-1"
+        assert decision["metadata"]["envelope_kind"] == "delegation_status"
+
+        await decision_store.close()
+
+    @pytest.mark.asyncio
+    async def test_delegation_status_missing_invite_id_no_record(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.routes.peer import _handle_delegation_status
+
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        request = MagicMock()
+        request.app.state.decision_store = decision_store
+
+        result = await _handle_delegation_status(
+            request,
+            contact_id="hub:sponsor",
+            envelope={},
+            body_data={"agent_slug": "grok-taos", "project_id": "prj-1"},
+        )
+
+        assert result["dispatched"] is False
+        decisions = await decision_store.list(limit=500)
+        assert decisions == []
+
+        await decision_store.close()
+

--- a/tests/test_collab_d1_delegation.py
+++ b/tests/test_collab_d1_delegation.py
@@ -841,7 +841,7 @@ class TestManualApprovalWiring:
 
         from tinyagentos.decisions.decision_store import DecisionStore
         from tinyagentos.projects.invite_store import ProjectInviteStore
-        from tinyagentos.routes.decisions import AnswerIn, answer_decision
+        from tinyagentos.routes.decisions import SERVER_RAISED_KEY, AnswerIn, answer_decision
 
         invite_store = ProjectInviteStore(tmp_path / "invites.db")
         await invite_store.init()
@@ -868,6 +868,7 @@ class TestManualApprovalWiring:
             project_id="prj-test",
             user_id="admin-user",
             metadata={
+                SERVER_RAISED_KEY: True,
                 "kind": "collab_delegation_gate",
                 "contact_id": "hub:sponsor",
                 "agent_slug": "grok-taos",
@@ -907,6 +908,68 @@ class TestManualApprovalWiring:
 
         from tinyagentos.decisions.decision_store import DecisionStore
         from tinyagentos.projects.invite_store import ProjectInviteStore
+        from tinyagentos.routes.decisions import SERVER_RAISED_KEY, AnswerIn, answer_decision
+
+        invite_store = ProjectInviteStore(tmp_path / "invites.db")
+        await invite_store.init()
+        decision_store = DecisionStore(tmp_path / "decisions.db")
+        await decision_store.init()
+
+        project_store = AsyncMock()
+        project_store.is_project_member.return_value = True
+
+        request = MagicMock()
+        request.app.state.project_invites = invite_store
+        request.app.state.project_store = project_store
+        request.app.state.decision_store = decision_store
+
+        decision = await decision_store.create(
+            from_agent="hub:sponsor",
+            question="delegation gate",
+            type="approve_deny",
+            priority="blocking",
+            project_id="prj-test",
+            user_id="admin-user",
+            metadata={
+                SERVER_RAISED_KEY: True,
+                "kind": "collab_delegation_gate",
+                "contact_id": "hub:sponsor",
+                "agent_slug": "grok-taos",
+                "display_name": "Grok TAOS",
+                "granted_scopes": ["a2a_send"],
+                "denied_scopes": [],
+                "project_id": "prj-test",
+            },
+        )
+
+        user = MagicMock()
+        user.is_admin = True
+        user.user_id = "admin-user"
+
+        updated = await answer_decision(
+            decision["id"], AnswerIn(value="deny"), request, user
+        )
+
+        assert updated["status"] == "answered"
+        invites = await invite_store.list_for_project("prj-test")
+        assert invites == []
+
+        await invite_store.close()
+        await decision_store.close()
+
+    @pytest.mark.asyncio
+    async def test_gate_card_without_server_provenance_mints_nothing(self, tmp_path):
+        """tsk-mul5pa provenance (post-#2748): a collab_delegation_gate decision
+        whose metadata lacks the server-stamped `_server_raised` marker — the
+        shape a caller could persist through the public create path, which
+        strips the marker but does not restrict `kind` — must NOT mint a
+        sponsored invite on approval.  This mirrors the red direction of the
+        other four `_apply_*_grant` guards; it exists so a future drop of the
+        guard in `_apply_collab_delegation_grant` fails this test."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tinyagentos.decisions.decision_store import DecisionStore
+        from tinyagentos.projects.invite_store import ProjectInviteStore
         from tinyagentos.routes.decisions import AnswerIn, answer_decision
 
         invite_store = ProjectInviteStore(tmp_path / "invites.db")
@@ -922,6 +985,8 @@ class TestManualApprovalWiring:
         request.app.state.project_store = project_store
         request.app.state.decision_store = decision_store
 
+        # Deliberately NO _server_raised marker — this is what a caller-supplied
+        # card looks like after the create route strips it.
         decision = await decision_store.create(
             from_agent="hub:sponsor",
             question="delegation gate",
@@ -945,7 +1010,7 @@ class TestManualApprovalWiring:
         user.user_id = "admin-user"
 
         updated = await answer_decision(
-            decision["id"], AnswerIn(value="deny"), request, user
+            decision["id"], AnswerIn(value="approve"), request, user
         )
 
         assert updated["status"] == "answered"

--- a/tests/test_decision_store.py
+++ b/tests/test_decision_store.py
@@ -165,3 +165,33 @@ async def test_create_retries_on_id_collision(store, monkeypatch):
     )
     assert d2["id"] == fresh_id
     assert call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_find_by_metadata_exact_match(store):
+    """find_by_metadata returns only decisions whose metadata[key] == value."""
+    await store.create(
+        "@a", "q1", "free_text", user_id="u1",
+        metadata={"invite_id": "inv-abc", "agent_slug": "grok"},
+    )
+    await store.create(
+        "@a", "q2", "free_text", user_id="u1",
+        metadata={"invite_id": "inv-xyz", "agent_slug": "grok"},
+    )
+    await store.create("@a", "q3", "free_text", user_id="u1", metadata={})
+
+    hits = await store.find_by_metadata("invite_id", "inv-abc")
+    assert len(hits) == 1
+    assert hits[0]["metadata"]["invite_id"] == "inv-abc"
+    # A missing key must not match (json_extract returns NULL, not equal).
+    assert await store.find_by_metadata("invite_id", "inv-absent") == []
+
+
+@pytest.mark.asyncio
+async def test_find_by_metadata_distinguishes_similar_values(store):
+    """An exact JSON-key equality must not substring-match (inv-abc vs inv-abcd)."""
+    await store.create(
+        "@a", "q1", "free_text", user_id="u1",
+        metadata={"invite_id": "inv-abc"},
+    )
+    assert await store.find_by_metadata("invite_id", "inv-abcd") == []

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -729,6 +729,43 @@ async def test_device_bearer_delegation_gate_refused(client, app):
 
 
 @pytest.mark.asyncio
+async def test_device_bearer_collab_delegation_gate_refused(client, app):
+    """A device bearer must not approve a collab_delegation_gate decision.
+
+    This is the D1 cross-user delegation card: approving it mints a sponsored
+    project invite that grants a remote agent the default scope tier.  It is a
+    privileged grant, so the phone (a notification surface, not an approval
+    channel) must get a 409 — the same invariant that guards execution_gate,
+    delegation_gate and app_grant.  If ``collab_delegation_gate`` ever falls out
+    of GATE_DECISION_KINDS again this test returns 200 instead of 409, so it is
+    coverage against a re-drift, not a tautology."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "hub:sponsor",
+        "question": "hub:sponsor wants to delegate agent 'assistant' (assistant) to this project",
+        "type": "approve_deny",
+        "priority": "blocking",
+        "metadata": {"kind": "collab_delegation_gate",
+                     "contact_id": "hub:sponsor",
+                     "agent_slug": "assistant",
+                     "display_name": "assistant",
+                     "granted_scopes": ["a2a_send"],
+                     "elevated_scopes": [],
+                     "denied_scopes": [],
+                     "project_id": None},
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_device_bearer_ordinary_consent_still_answered(client, app):
     """Control: a device bearer can still answer a non-gate consent decision
     (e.g. a plain approve_deny with no gate kind)."""

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -50,6 +50,19 @@ CREATE TABLE IF NOT EXISTS agent_registry (
     status              TEXT    NOT NULL DEFAULT 'active',
     sponsor_contact_id  TEXT
 );
+
+-- Per-(identity, project) sponsorship association (D1 rework, #2048).
+-- A single agent identity can be reused BY HANDLE across projects, and each
+-- project's delegating contact sponsors the identity independently.  One row
+-- per (canonical_id, project_id) describes exactly one sponsorship, so each
+-- contact's cascade finds exactly what they sponsored in their own project.
+CREATE TABLE IF NOT EXISTS agent_sponsorship (
+    canonical_id        TEXT    NOT NULL,
+    project_id          TEXT    NOT NULL,
+    sponsor_contact_id  TEXT    NOT NULL,
+    created_at          REAL    NOT NULL,
+    PRIMARY KEY (canonical_id, project_id)
+);
 """
 
 # Partial unique index: at most ONE active agent may own any given non-empty
@@ -274,6 +287,48 @@ async def _migration_v7_add_sponsor_contact_id(conn) -> None:
             "ALTER TABLE agent_registry ADD COLUMN sponsor_contact_id TEXT"
         )
         await conn.commit()
+
+
+# Sentinel project_id used when backfilling the association from the legacy
+# sponsor_contact_id column.  Pre-association rows carry a sponsor but no
+# project binding (the old column could not record one), so the backfilled
+# association is keyed to this empty project_id.  It is deliberately distinct
+# from any real project_id, which is always a non-empty string validated by
+# the delegation flow.
+_LEGACY_SPONSORSHIP_PROJECT = ""
+
+
+async def _migration_v8_backfill_sponsorship(conn) -> None:
+    """Backfill agent_sponsorship from the legacy sponsor_contact_id column.
+
+    Databases created before the per-(identity, project) association carried
+    sponsorship on ``agent_registry.sponsor_contact_id``.  This migration
+    copies each stamped identity into an association row (idempotent via
+    INSERT OR IGNORE) so a pre-existing single-sponsor identity reproduces the
+    old cascade result exactly: ``list_by_sponsor`` finds it, and revoking the
+    one association leaves no rows, so the identity is revoked.
+
+    The legacy column is retained READ-ONLY for one release; new sponsorships
+    are written to ``agent_sponsorship`` only.  The column is dropped in a
+    later release.
+    """
+    rows = await (
+        await conn.execute(
+            "SELECT canonical_id, sponsor_contact_id FROM agent_registry "
+            "WHERE sponsor_contact_id IS NOT NULL AND sponsor_contact_id != ''"
+        )
+    ).fetchall()
+    if not rows:
+        return
+    now = time.time()
+    for canonical_id, sponsor_contact_id in rows:
+        await conn.execute(
+            "INSERT OR IGNORE INTO agent_sponsorship "
+            "(canonical_id, project_id, sponsor_contact_id, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (canonical_id, _LEGACY_SPONSORSHIP_PROJECT, sponsor_contact_id, now),
+        )
+    await conn.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -554,6 +609,7 @@ class AgentRegistryStore(BaseStore):
         await _migration_v5_add_token_min_iat(self._db)
         await _migration_v6_add_install_id(self._db)
         await _migration_v7_add_sponsor_contact_id(self._db)
+        await _migration_v8_backfill_sponsorship(self._db)
         # Created after the status migration so the partial index's WHERE clause
         # can reference the status column on the pre-status migration path.
         # Guard the index creation too: if some path we did not anticipate still
@@ -586,7 +642,6 @@ class AgentRegistryStore(BaseStore):
         capabilities: Optional[list[str]] = None,
         allow_reserved: bool = False,
         install_id: str = "",
-        sponsor_contact_id: Optional[str] = None,
     ) -> dict:
         """Mint a canonical_id, persist the record, and return it.
 
@@ -600,9 +655,10 @@ class AgentRegistryStore(BaseStore):
         layer never populates from a request body, so external callers
         cannot reach it.
 
-        ``sponsor_contact_id`` is set for delegated agents (cross-user collab
-        D1) — the contact_id of the human who sponsored this agent.  NULL for
-        all other origins.
+        Sponsorship is NOT stamped here.  Delegated agents (cross-user collab
+        D1) are recorded via ``set_sponsorship`` on the per-(identity, project)
+        association table after registration, so a single identity can be
+        sponsored independently in several projects.
 
         Raises ``RuntimeError`` if the store is not initialised, and
         ``ValueError`` if the name resolves to a reserved prefix.
@@ -642,12 +698,12 @@ class AgentRegistryStore(BaseStore):
             INSERT INTO agent_registry
                 (canonical_id, display_name, framework, user_id, origin,
                  handle, role, title, reports_to, capabilities, created_ts, status,
-                 install_id, sponsor_contact_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 install_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (canonical_id, display_name, framework, user_id, origin,
              handle, role, title, reports_to, caps_json, created_ts, initial_status,
-             install_id, sponsor_contact_id),
+             install_id),
         )
         await self._db.commit()
 
@@ -913,57 +969,136 @@ class AgentRegistryStore(BaseStore):
     async def list_by_sponsor(
         self, sponsor_contact_id: str, *, status: Optional[str] = None
     ) -> list[dict]:
-        """Return all registry records sponsored by *sponsor_contact_id*.
+        """Return every identity *sponsor_contact_id* sponsors, via the association.
 
-        Used for cascade revocation: when a contact or their project membership
-        is revoked, all sponsored agent identities are revoked and their tokens
-        invalidated.  Optionally filtered by *status*.
+        Sponsorship is now per-(identity, project): the same identity may be
+        sponsored by several contacts across several projects, so the victim
+        set for a contact's cascade is resolved through ``agent_sponsorship``
+        rather than a single column on the identity.  Each contact therefore
+        finds exactly what they sponsored in their own project(s).
+
+        Optionally filtered by *status* (on the identity row).
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
         if status is not None:
             cursor = await self._db.execute(
-                "SELECT * FROM agent_registry "
-                "WHERE sponsor_contact_id = ? AND status = ? ORDER BY id",
+                "SELECT DISTINCT ar.* FROM agent_registry ar "
+                "JOIN agent_sponsorship sp ON sp.canonical_id = ar.canonical_id "
+                "WHERE sp.sponsor_contact_id = ? AND ar.status = ? ORDER BY ar.id",
                 (sponsor_contact_id, status),
             )
         else:
             cursor = await self._db.execute(
-                "SELECT * FROM agent_registry "
-                "WHERE sponsor_contact_id = ? ORDER BY id",
+                "SELECT DISTINCT ar.* FROM agent_registry ar "
+                "JOIN agent_sponsorship sp ON sp.canonical_id = ar.canonical_id "
+                "WHERE sp.sponsor_contact_id = ? ORDER BY ar.id",
                 (sponsor_contact_id,),
             )
         rows = await cursor.fetchall()
         return [_row_to_dict(r) for r in rows]
 
-    async def set_sponsor(
-        self, canonical_id: str, sponsor_contact_id: Optional[str]
-    ) -> Optional[dict]:
-        """Set (or, with ``None``, clear) the sponsor_contact_id on a registry row.
+    async def set_sponsorship(
+        self, canonical_id: str, project_id: str, sponsor_contact_id: str
+    ) -> bool:
+        """Record that *sponsor_contact_id* sponsors *canonical_id* in *project_id*.
 
-        Updating to a *different* sponsor is allowed (e.g. when the same agent
-        identity is reused across projects - each project's sponsoring contact
-        sets its own sponsor so cascade_sponsor_revoke can find it).  Setting the
-        same sponsor is a no-op.  Clearing (``None``) is always allowed so revoke
-        cascades can reset the field.
+        The association's PRIMARY KEY (canonical_id, project_id) makes this
+        atomic and deterministic: the FIRST writer for a given
+        (identity, project) wins, and any later write is a no-op (the INSERT
+        is ignored on the unique-key conflict).  This is the atomic
+        first-writer-wins discipline the old ``sponsor_contact_id`` column
+        guard defended — moved to the table it actually belongs on.
 
-        Returns the updated record, or None if *canonical_id* does not exist.
+        Returns True if a new sponsorship row was written, False if
+        (canonical_id, project_id) was already sponsored (ignored).
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        record = await self.get(canonical_id)
-        if record is None:
-            return None
-        existing_sponsor = record.get("sponsor_contact_id")
-        # No-op when setting the same sponsor that is already set.
-        if sponsor_contact_id is not None and existing_sponsor == sponsor_contact_id:
-            return record
-        await self._db.execute(
-            "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
-            (sponsor_contact_id, canonical_id),
+        cur = await self._db.execute(
+            "INSERT OR IGNORE INTO agent_sponsorship "
+            "(canonical_id, project_id, sponsor_contact_id, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (canonical_id, project_id, sponsor_contact_id, time.time()),
         )
         await self._db.commit()
-        return await self.get(canonical_id)
+        return cur.rowcount == 1
+
+    async def remove_sponsorship(self, canonical_id: str, project_id: str) -> None:
+        """Delete the sponsorship association for (canonical_id, project_id).
+
+        Used by cascade revocation: revoking the association removes the
+        contact's claim over the identity in that project WITHOUT necessarily
+        revoking the identity itself (which only dies when no associations
+        remain).
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        await self._db.execute(
+            "DELETE FROM agent_sponsorship WHERE canonical_id = ? AND project_id = ?",
+            (canonical_id, project_id),
+        )
+        await self._db.commit()
+
+    async def list_sponsorships_for_identity(
+        self, canonical_id: str
+    ) -> list[dict]:
+        """Return every sponsorship association row for *canonical_id*.
+
+        A sponsored identity survives a contact's cascade while ANY row
+        remains; it is revoked only once the last row is removed.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT canonical_id, project_id, sponsor_contact_id, created_at "
+            "FROM agent_sponsorship WHERE canonical_id = ? ORDER BY created_at",
+            (canonical_id,),
+        )
+        return [
+            {
+                "canonical_id": r["canonical_id"],
+                "project_id": r["project_id"],
+                "sponsor_contact_id": r["sponsor_contact_id"],
+                "created_at": r["created_at"],
+            }
+            for r in await cursor.fetchall()
+        ]
+
+    async def list_sponsorships_by_contact(
+        self, sponsor_contact_id: str, *, project_id: Optional[str] = None
+    ) -> list[dict]:
+        """Return the sponsorship association rows for *sponsor_contact_id*.
+
+        Optionally scoped to a single *project_id* (membership-revoke).  This
+        is the association-level query the cascade iterates: each row names
+        the (identity, project) pair the contact actually sponsored.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        if project_id is not None:
+            cursor = await self._db.execute(
+                "SELECT canonical_id, project_id, sponsor_contact_id, created_at "
+                "FROM agent_sponsorship "
+                "WHERE sponsor_contact_id = ? AND project_id = ? ORDER BY created_at",
+                (sponsor_contact_id, project_id),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT canonical_id, project_id, sponsor_contact_id, created_at "
+                "FROM agent_sponsorship "
+                "WHERE sponsor_contact_id = ? ORDER BY created_at",
+                (sponsor_contact_id,),
+            )
+        return [
+            {
+                "canonical_id": r["canonical_id"],
+                "project_id": r["project_id"],
+                "sponsor_contact_id": r["sponsor_contact_id"],
+                "created_at": r["created_at"],
+            }
+            for r in await cursor.fetchall()
+        ]
     # ------------------------------------------------------------------
     # Lifecycle state machine
     # ------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -941,33 +941,27 @@ class AgentRegistryStore(BaseStore):
     ) -> Optional[dict]:
         """Set (or, with ``None``, clear) the sponsor_contact_id on a registry row.
 
-        Does NOT re-parent an identity that already has a sponsor — once
-        sponsored, the sponsor is immutable (cross-user collab D1 guard).  The
-        guard lives in the UPDATE predicate (atomic, no read→check→write race):
-        setting a non-null sponsor only matches rows whose sponsor is still NULL
-        or empty, so two concurrent set_sponsor calls cannot both win (the loser's
-        WHERE matches 0 rows).  Clearing with ``None`` always matches.
+        Updating to a *different* sponsor is allowed (e.g. when the same agent
+        identity is reused across projects - each project's sponsoring contact
+        sets its own sponsor so cascade_sponsor_revoke can find it).  Setting the
+        same sponsor is a no-op.  Clearing (``None``) is always allowed so revoke
+        cascades can reset the field.
 
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        if sponsor_contact_id is not None:
-            # Atomic re-parent guard: only a row with no current sponsor is
-            # eligible for a new sponsor.
-            await self._db.execute(
-                "UPDATE agent_registry SET sponsor_contact_id = ? "
-                "WHERE canonical_id = ? "
-                "AND (sponsor_contact_id IS NULL OR sponsor_contact_id = '')",
-                (sponsor_contact_id, canonical_id),
-            )
-        else:
-            # Clearing is always allowed so revoke cascades can reset the field.
-            await self._db.execute(
-                "UPDATE agent_registry SET sponsor_contact_id = NULL "
-                "WHERE canonical_id = ?",
-                (canonical_id,),
-            )
+        record = await self.get(canonical_id)
+        if record is None:
+            return None
+        existing_sponsor = record.get("sponsor_contact_id")
+        # No-op when setting the same sponsor that is already set.
+        if sponsor_contact_id is not None and existing_sponsor == sponsor_contact_id:
+            return record
+        await self._db.execute(
+            "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
+            (sponsor_contact_id, canonical_id),
+        )
         await self._db.commit()
         return await self.get(canonical_id)
     # ------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -36,18 +36,19 @@ logger = logging.getLogger(__name__)
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS agent_registry (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    canonical_id    TEXT    NOT NULL UNIQUE,
-    display_name    TEXT    NOT NULL DEFAULT '',
-    framework       TEXT    NOT NULL DEFAULT '',
-    user_id         TEXT    NOT NULL DEFAULT '',
-    origin          TEXT    NOT NULL DEFAULT 'taos-deployed',
-    handle          TEXT    NOT NULL DEFAULT '',
-    role            TEXT,
-    capabilities    TEXT    NOT NULL DEFAULT '[]',
-    created_ts      TEXT    NOT NULL,
-    revoked_at      TEXT,
-    status          TEXT    NOT NULL DEFAULT 'active'
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    canonical_id        TEXT    NOT NULL UNIQUE,
+    display_name        TEXT    NOT NULL DEFAULT '',
+    framework           TEXT    NOT NULL DEFAULT '',
+    user_id             TEXT    NOT NULL DEFAULT '',
+    origin              TEXT    NOT NULL DEFAULT 'taos-deployed',
+    handle              TEXT    NOT NULL DEFAULT '',
+    role                TEXT,
+    capabilities        TEXT    NOT NULL DEFAULT '[]',
+    created_ts          TEXT    NOT NULL,
+    revoked_at          TEXT,
+    status              TEXT    NOT NULL DEFAULT 'active',
+    sponsor_contact_id  TEXT
 );
 """
 
@@ -227,6 +228,8 @@ async def _migration_v5_add_token_min_iat(conn) -> None:
             "ALTER TABLE agent_registry ADD COLUMN token_min_iat INTEGER NOT NULL DEFAULT 0"
         )
         await conn.commit()
+
+
 async def _migration_v6_add_install_id(conn) -> None:
     """Add install_id column (idempotent), anchoring an identity to ONE install.
 
@@ -249,6 +252,26 @@ async def _migration_v6_add_install_id(conn) -> None:
     if "install_id" not in existing_cols:
         await conn.execute(
             "ALTER TABLE agent_registry ADD COLUMN install_id TEXT NOT NULL DEFAULT ''"
+        )
+        await conn.commit()
+
+
+async def _migration_v7_add_sponsor_contact_id(conn) -> None:
+    """Add sponsor_contact_id column (idempotent) for Cross-User Collab D1.
+
+    Delegated agents (those minted via a contact's delegation-request flow)
+    carry ``sponsor_contact_id`` linking back to the sponsoring contact.
+    Existing rows (non-delegated) get NULL.
+    """
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(agent_registry)")
+        ).fetchall()
+    }
+    if "sponsor_contact_id" not in existing_cols:
+        await conn.execute(
+            "ALTER TABLE agent_registry ADD COLUMN sponsor_contact_id TEXT"
         )
         await conn.commit()
 
@@ -530,6 +553,7 @@ class AgentRegistryStore(BaseStore):
         await _migration_v4_dedupe_active_handles(self._db)
         await _migration_v5_add_token_min_iat(self._db)
         await _migration_v6_add_install_id(self._db)
+        await _migration_v7_add_sponsor_contact_id(self._db)
         # Created after the status migration so the partial index's WHERE clause
         # can reference the status column on the pre-status migration path.
         # Guard the index creation too: if some path we did not anticipate still
@@ -562,6 +586,7 @@ class AgentRegistryStore(BaseStore):
         capabilities: Optional[list[str]] = None,
         allow_reserved: bool = False,
         install_id: str = "",
+        sponsor_contact_id: Optional[str] = None,
     ) -> dict:
         """Mint a canonical_id, persist the record, and return it.
 
@@ -574,6 +599,10 @@ class AgentRegistryStore(BaseStore):
         the reserved ``taos-`` prefix; it is deliberately a keyword the HTTP
         layer never populates from a request body, so external callers
         cannot reach it.
+
+        ``sponsor_contact_id`` is set for delegated agents (cross-user collab
+        D1) — the contact_id of the human who sponsored this agent.  NULL for
+        all other origins.
 
         Raises ``RuntimeError`` if the store is not initialised, and
         ``ValueError`` if the name resolves to a reserved prefix.
@@ -613,12 +642,12 @@ class AgentRegistryStore(BaseStore):
             INSERT INTO agent_registry
                 (canonical_id, display_name, framework, user_id, origin,
                  handle, role, title, reports_to, capabilities, created_ts, status,
-                 install_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 install_id, sponsor_contact_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (canonical_id, display_name, framework, user_id, origin,
              handle, role, title, reports_to, caps_json, created_ts, initial_status,
-             install_id),
+             install_id, sponsor_contact_id),
         )
         await self._db.commit()
 
@@ -881,6 +910,50 @@ class AgentRegistryStore(BaseStore):
             rows.extend(await cursor.fetchall())
         return [_row_to_dict(r) for r in rows]
 
+    async def list_by_sponsor(
+        self, sponsor_contact_id: str, *, status: Optional[str] = None
+    ) -> list[dict]:
+        """Return all registry records sponsored by *sponsor_contact_id*.
+
+        Used for cascade revocation: when a contact or their project membership
+        is revoked, all sponsored agent identities are revoked and their tokens
+        invalidated.  Optionally filtered by *status*.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        if status is not None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry "
+                "WHERE sponsor_contact_id = ? AND status = ? ORDER BY id",
+                (sponsor_contact_id, status),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry "
+                "WHERE sponsor_contact_id = ? ORDER BY id",
+                (sponsor_contact_id,),
+            )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def set_sponsor(
+        self, canonical_id: str, sponsor_contact_id: Optional[str]
+    ) -> Optional[dict]:
+        """Set (or, with ``None``, clear) the sponsor_contact_id on a registry row.
+
+        Returns the updated record, or None if *canonical_id* does not exist.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            return None
+        await self._db.execute(
+            "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
+            (sponsor_contact_id, canonical_id),
+        )
+        await self._db.commit()
+        return await self.get(canonical_id)
     # ------------------------------------------------------------------
     # Lifecycle state machine
     # ------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -942,23 +942,32 @@ class AgentRegistryStore(BaseStore):
         """Set (or, with ``None``, clear) the sponsor_contact_id on a registry row.
 
         Does NOT re-parent an identity that already has a sponsor — once
-        sponsored, the sponsor is immutable (cross-user collab D1 guard).
+        sponsored, the sponsor is immutable (cross-user collab D1 guard).  The
+        guard lives in the UPDATE predicate (atomic, no read→check→write race):
+        setting a non-null sponsor only matches rows whose sponsor is still NULL
+        or empty, so two concurrent set_sponsor calls cannot both win (the loser's
+        WHERE matches 0 rows).  Clearing with ``None`` always matches.
 
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        record = await self.get(canonical_id)
-        if record is None:
-            return None
-        # Guard: never overwrite an existing sponsor (clearing with None is
-        # always allowed so revoke cascades can reset the field).
-        if sponsor_contact_id is not None and record.get("sponsor_contact_id"):
-            return record
-        await self._db.execute(
-            "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
-            (sponsor_contact_id, canonical_id),
-        )
+        if sponsor_contact_id is not None:
+            # Atomic re-parent guard: only a row with no current sponsor is
+            # eligible for a new sponsor.
+            await self._db.execute(
+                "UPDATE agent_registry SET sponsor_contact_id = ? "
+                "WHERE canonical_id = ? "
+                "AND (sponsor_contact_id IS NULL OR sponsor_contact_id = '')",
+                (sponsor_contact_id, canonical_id),
+            )
+        else:
+            # Clearing is always allowed so revoke cascades can reset the field.
+            await self._db.execute(
+                "UPDATE agent_registry SET sponsor_contact_id = NULL "
+                "WHERE canonical_id = ?",
+                (canonical_id,),
+            )
         await self._db.commit()
         return await self.get(canonical_id)
     # ------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -941,6 +941,9 @@ class AgentRegistryStore(BaseStore):
     ) -> Optional[dict]:
         """Set (or, with ``None``, clear) the sponsor_contact_id on a registry row.
 
+        Does NOT re-parent an identity that already has a sponsor — once
+        sponsored, the sponsor is immutable (cross-user collab D1 guard).
+
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
@@ -948,6 +951,10 @@ class AgentRegistryStore(BaseStore):
         record = await self.get(canonical_id)
         if record is None:
             return None
+        # Guard: never overwrite an existing sponsor (clearing with None is
+        # always allowed so revoke cascades can reset the field).
+        if sponsor_contact_id is not None and record.get("sponsor_contact_id"):
+            return record
         await self._db.execute(
             "UPDATE agent_registry SET sponsor_contact_id = ? WHERE canonical_id = ?",
             (sponsor_contact_id, canonical_id),

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -211,6 +211,23 @@ class DecisionStore(BaseStore):
                 return None
             return _row_to_decision(row, cur.description)
 
+    async def find_by_metadata(self, key: str, value: str) -> list[dict]:
+        """Return decisions whose ``metadata`` JSON has ``metadata[key] == value``.
+
+        Uses SQLite ``json_extract`` (JSON1, bundled in the stdlib SQLite) so
+        the match is an exact JSON-key equality, not a lossy substring scan.
+        Used by the peer inbox to make ``delegation_status`` handling idempotent
+        on ``invite_id``: a retried envelope must not mint a duplicate decision.
+        """
+        async with self._db.execute(
+            "SELECT * FROM decisions "
+            "WHERE json_extract(metadata, ?) = ? ORDER BY created_at DESC",
+            (f"$.{key}", value),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_decision(r, desc) for r in rows]
+
     async def list(
         self,
         *,

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -277,12 +277,7 @@ async def _auto_approve_delegation(
             check_interval_secs=1800,
             created_by=contact_id,
             pin_required=False,
-            metadata={
-                "kind": "delegation_sponsored",
-                "sponsor_contact_id": contact_id,
-                "agent_slug": agent_slug,
-                "display_name": display_name,
-            },
+            display_name=display_name,
         )
     except Exception:
         logger.warning(
@@ -361,12 +356,7 @@ async def complete_delegation_approval(
             check_interval_secs=1800,
             created_by=contact_id,
             pin_required=False,
-            metadata={
-                "kind": "delegation_sponsored",
-                "sponsor_contact_id": contact_id,
-                "agent_slug": agent_slug,
-                "display_name": display_name,
-            },
+            display_name=display_name,
         )
     except Exception:
         logger.warning(

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -401,11 +401,14 @@ async def cascade_sponsor_revoke(
     project_id: str | None = None,
     reason: str = "sponsor revoked",
 ) -> dict:
-    """Revoke all sponsored agent identities for a contact.
+    """Revoke a contact's sponsorships, revoking identities when the last one goes.
 
-    When *project_id* is provided, only revoke agents that are members of
-    that project (membership-revoke).  When None, revoke ALL sponsored
-    identities (contact-revoke).
+    Sponsorship is a per-(identity, project) association (D1 rework).  The
+    cascade removes the contact's association rows — scoped to *project_id*
+    when provided (membership-revoke) or all of them when None
+    (contact-revoke) — and revokes the underlying identity itself only when NO
+    sponsorship rows remain.  An identity sponsored by two contacts in two
+    projects therefore survives one contact's revoke and dies on the second.
 
     Also unassigns in-flight board tasks and posts an A2A system line.
     Returns a summary dict of what was revoked.
@@ -414,24 +417,33 @@ async def cascade_sponsor_revoke(
     if registry is None:
         return {"status": "error", "error": "registry not available"}
 
-    project_store = getattr(request.app.state, "project_store", None)
-
-    # Find all active agents sponsored by this contact.
-    sponsored = await registry.list_by_sponsor(contact_id, status="active")
+    # Find the sponsorship associations for this contact, optionally scoped to
+    # a single project.  Each row names the (identity, project) pair the
+    # contact actually sponsored, so this cascade finds exactly what the
+    # contact sponsored in their own project(s) — never another contact's.
+    sponsorships = await registry.list_sponsorships_by_contact(
+        contact_id, project_id=project_id
+    )
     revoked_ids: list[str] = []
 
-    for agent in sponsored:
-        canonical_id = agent["canonical_id"]
+    for sp in sponsorships:
+        canonical_id = sp["canonical_id"]
+        sp_project_id = sp["project_id"]
 
-        # When scoped to a project, only revoke agents that are members of
-        # that project.  Contact-wide revoke (project_id=None) hits all.
-        if project_id is not None:
-            if project_store is None:
-                return {"status": "error", "error": "project store not available"}
-            if not await project_store.is_project_member(
-                project_id, canonical_id
-            ):
-                continue
+        # Revoke the association first: the contact no longer sponsors this
+        # identity in that project, regardless of the identity's fate.
+        await registry.remove_sponsorship(canonical_id, sp_project_id)
+
+        # Only ACTIVE identities are subject to revocation (a non-active
+        # identity has no live bearer).  An identity that is still sponsored
+        # elsewhere survives — it is revoked only once the last association
+        # row is gone.
+        record = await registry.get(canonical_id)
+        if record is None or record.get("status") != "active":
+            continue
+        remaining = await registry.list_sponsorships_for_identity(canonical_id)
+        if remaining:
+            continue
 
         try:
             await registry.set_status(canonical_id, "revoked", actor=contact_id)

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -321,6 +321,22 @@ async def complete_delegation_approval(
     if not all([contact_id, agent_slug, display_name, project_id]):
         return {"status": "error", "error": "incomplete decision metadata"}
 
+    # Re-validate project membership at approval time: the contact may have
+    # been removed from the project between decision creation and approval.
+    # This is the fail-closed runtime check required by section 5 of the
+    # cross-user-collab design spec.
+    project_store = getattr(request.app.state, "project_store", None)
+    if project_store is not None and not await project_store.is_project_member(
+        project_id, contact_id, member_kind="human"
+    ):
+        return {
+            "status": "error",
+            "error": (
+                f"contact {contact_id} is no longer a human collaborator "
+                f"on project {project_id}"
+            ),
+        }
+
     invite_store = getattr(request.app.state, "project_invite_store", None)
     if invite_store is None:
         return {"status": "error", "error": "invite store not available"}
@@ -429,20 +445,14 @@ async def cascade_sponsor_revoke(
                     canonical_id, exc_info=True,
                 )
 
-    # Post A2A system line.  When project_id is set, post to that project's
-    # A2A channel.  When None (contact-wide revoke), post to all projects the
-    # contact is a member of so every affected project sees the audit event.
-    try:
-        from tinyagentos.projects.a2a import ensure_a2a_channel
+    # Post A2A system line to the affected project (when scoped).
+    # Contact-wide revoke does not emit A2A — each project's membership-revoke
+    # path handles its own audit event when the cascade fires per-project.
+    if project_id:
+        try:
+            from tinyagentos.projects.a2a import ensure_a2a_channel
 
-        msg_store = request.app.state.chat_messages
-        msg = (
-            f"Collaboration with {contact_id} has been revoked. "
-            f"{len(revoked_ids)} delegated agent(s) revoked, "
-            f"{unassigned_count} task(s) unassigned."
-        )
-
-        if project_id:
+            msg_store = request.app.state.chat_messages
             channel = await ensure_a2a_channel(
                 request.app.state.chat_channels,
                 request.app.state.project_store,
@@ -453,38 +463,17 @@ async def cascade_sponsor_revoke(
                 channel_id=channel["id"],
                 author_id="system",
                 author_type="user",
-                content=msg,
+                content=(
+                    f"Collaboration with {contact_id} has been revoked. "
+                    f"{len(revoked_ids)} delegated agent(s) revoked, "
+                    f"{unassigned_count} task(s) unassigned."
+                ),
             )
-        elif project_store is not None:
-            # Contact-wide: find all projects the contact is a member of.
-            try:
-                memberships = await project_store.list_projects_for_member(contact_id)
-            except AttributeError:
-                memberships = []
-            for proj in (memberships or []):
-                pid = proj.get("id") or proj.get("project_id")
-                if not pid:
-                    continue
-                try:
-                    channel = await ensure_a2a_channel(
-                        request.app.state.chat_channels,
-                        request.app.state.project_store,
-                        pid,
-                        config=getattr(request.app.state, "config", None),
-                    )
-                    await msg_store.send_message(
-                        channel_id=channel["id"],
-                        author_id="system",
-                        author_type="user",
-                        content=msg,
-                    )
-                except Exception:
-                    pass
-    except Exception:
-        logger.warning(
-            "cascade_revoke: A2A system line failed for %s",
-            contact_id, exc_info=True,
-        )
+        except Exception:
+            logger.warning(
+                "cascade_revoke: A2A system line failed for %s",
+                contact_id, exc_info=True,
+            )
 
     return {
         "status": "revoked",

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -14,6 +14,8 @@ import logging
 import time
 from typing import Optional
 
+from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -84,15 +86,15 @@ def _validate_delegation_envelope_body(body: dict) -> tuple[bool, str, Optional[
             return False, f"{field} must be a non-empty string", None
 
     requested_scopes = body["requested_scopes"]
-    unknown = sorted(set(requested_scopes) - SPONSORED_DEFAULT_SCOPES - SPONSORED_DENY_SCOPES)
-    # Unknown scopes are not immediately denied — they require explicit
-    # per-scope Decisions approval.  We just log them here; the decision
-    # created later will surface them to the human.
+    # Reject any scope not in the closed vocabulary — the per-scope
+    # docstring requires explicit per-scope Decisions approval, but all
+    # delegated scopes are bundled into a single approve_deny card, so an
+    # unknown scope would ride through to the mint with no human awareness.
+    # Tightening to the closed vocabulary ensures only scopes the system
+    # actually enforces can be requested.
+    unknown = sorted(set(requested_scopes) - VALID_SCOPES)
     if unknown:
-        logger.info(
-            "delegation: elevated scopes in request: %r (require explicit approval)",
-            unknown,
-        )
+        return False, f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}", None
 
     parsed = {
         "agent_slug": body["agent_slug"].strip(),

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -261,7 +261,7 @@ async def _auto_approve_delegation(
     Mints a project invite (kind="agent", pin_required=false) and returns
     the invite_id + connection_bundle.
     """
-    invite_store = getattr(request.app.state, "project_invite_store", None)
+    invite_store = getattr(request.app.state, "project_invites", None)
     if invite_store is None:
         return {"status": "error", "error": "invite store not available"}
 
@@ -337,7 +337,7 @@ async def complete_delegation_approval(
             ),
         }
 
-    invite_store = getattr(request.app.state, "project_invite_store", None)
+    invite_store = getattr(request.app.state, "project_invites", None)
     if invite_store is None:
         return {"status": "error", "error": "invite store not available"}
 

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -325,10 +325,22 @@ async def complete_delegation_approval(
     if invite_store is None:
         return {"status": "error", "error": "invite store not available"}
 
+    # Re-apply scope denylist to ensure hard-denied scopes are stripped even
+    # if the stored metadata was tampered with between decision creation and
+    # approval.  The denylist is the authoritative gate; the stored scopes are
+    # the human-approved set, but the code must never mint tokens for
+    # hard-denied scopes regardless.
+    safe_scopes, re_denied = validate_delegation_scopes(granted_scopes)
+    if re_denied:
+        logger.warning(
+            "complete_delegation_approval: re-stripped hard-denied scopes %r from stored grant",
+            re_denied,
+        )
+
     try:
         invite = await invite_store.mint(
             project_id=project_id,
-            scopes=granted_scopes,
+            scopes=safe_scopes,
             approval_mode="auto",
             check_interval_secs=1800,
             created_by=contact_id,
@@ -363,9 +375,9 @@ async def cascade_sponsor_revoke(
 ) -> dict:
     """Revoke all sponsored agent identities for a contact.
 
-    When *project_id* is provided, only revoke tokens bound to that project
-    (membership-revoke).  When None, revoke ALL sponsored identities
-    (contact-revoke).
+    When *project_id* is provided, only revoke agents that are members of
+    that project (membership-revoke).  When None, revoke ALL sponsored
+    identities (contact-revoke).
 
     Also unassigns in-flight board tasks and posts an A2A system line.
     Returns a summary dict of what was revoked.
@@ -374,12 +386,23 @@ async def cascade_sponsor_revoke(
     if registry is None:
         return {"status": "error", "error": "registry not available"}
 
+    project_store = getattr(request.app.state, "project_store", None)
+
     # Find all active agents sponsored by this contact.
     sponsored = await registry.list_by_sponsor(contact_id, status="active")
     revoked_ids: list[str] = []
 
     for agent in sponsored:
         canonical_id = agent["canonical_id"]
+
+        # When scoped to a project, only revoke agents that are members of
+        # that project.  Contact-wide revoke (project_id=None) hits all.
+        if project_id is not None and project_store is not None:
+            if not await project_store.is_project_member(
+                project_id, canonical_id
+            ):
+                continue
+
         try:
             await registry.set_status(canonical_id, "revoked", actor=contact_id)
             revoked_ids.append(canonical_id)
@@ -406,9 +429,18 @@ async def cascade_sponsor_revoke(
                     canonical_id, exc_info=True,
                 )
 
-    # Post A2A system line.
+    # Post A2A system line.  When project_id is set, post to that project's
+    # A2A channel.  When None (contact-wide revoke), post to all projects the
+    # contact is a member of so every affected project sees the audit event.
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
+
+        msg_store = request.app.state.chat_messages
+        msg = (
+            f"Collaboration with {contact_id} has been revoked. "
+            f"{len(revoked_ids)} delegated agent(s) revoked, "
+            f"{unassigned_count} task(s) unassigned."
+        )
 
         if project_id:
             channel = await ensure_a2a_channel(
@@ -417,17 +449,37 @@ async def cascade_sponsor_revoke(
                 project_id,
                 config=getattr(request.app.state, "config", None),
             )
-            msg_store = request.app.state.chat_messages
             await msg_store.send_message(
                 channel_id=channel["id"],
                 author_id="system",
                 author_type="user",
-                content=(
-                    f"Collaboration with {contact_id} has been revoked. "
-                    f"{len(revoked_ids)} delegated agent(s) revoked, "
-                    f"{unassigned_count} task(s) unassigned."
-                ),
+                content=msg,
             )
+        elif project_store is not None:
+            # Contact-wide: find all projects the contact is a member of.
+            try:
+                memberships = await project_store.list_projects_for_member(contact_id)
+            except AttributeError:
+                memberships = []
+            for proj in (memberships or []):
+                pid = proj.get("id") or proj.get("project_id")
+                if not pid:
+                    continue
+                try:
+                    channel = await ensure_a2a_channel(
+                        request.app.state.chat_channels,
+                        request.app.state.project_store,
+                        pid,
+                        config=getattr(request.app.state, "config", None),
+                    )
+                    await msg_store.send_message(
+                        channel_id=channel["id"],
+                        author_id="system",
+                        author_type="user",
+                        content=msg,
+                    )
+                except Exception:
+                    pass
     except Exception:
         logger.warning(
             "cascade_revoke: A2A system line failed for %s",
@@ -524,12 +576,23 @@ async def kill_switch_per_instance(request) -> dict:
 
     Sets a flag on app.state that the peer routes check on every request.
     Does NOT revoke tokens — just blocks all new peer traffic.
-    Reversible by clearing the flag.
+    Use ``kill_switch_reenable()`` to restore peer routes.
     """
-    # Set a flag that the peer routes check.
     request.app.state._peer_disabled = True
     logger.warning("kill_switch: per-instance panic — peer routes DISABLED")
     return {"status": "panic", "peer_routes": "disabled"}
+
+
+async def kill_switch_reenable(request) -> dict:
+    """Re-enable peer routes after a per-instance panic.
+
+    Clears the panic flag set by ``kill_switch_per_instance``.
+    Does NOT re-establish revoked peer links or re-mint tokens —
+    those must be restored manually via the contacts/peer-link flow.
+    """
+    request.app.state._peer_disabled = False
+    logger.info("kill_switch: per-instance panic cleared — peer routes RE-ENABLED")
+    return {"status": "recovered", "peer_routes": "enabled"}
 
 
 def is_peer_disabled(request) -> bool:

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -276,12 +276,12 @@ async def _auto_approve_delegation(
             approval_mode="auto",
             check_interval_secs=1800,
             created_by=contact_id,
+            pin_required=False,
             metadata={
                 "kind": "delegation_sponsored",
                 "sponsor_contact_id": contact_id,
                 "agent_slug": agent_slug,
                 "display_name": display_name,
-                "pin_required": False,
             },
         )
     except Exception:
@@ -293,7 +293,7 @@ async def _auto_approve_delegation(
 
     return {
         "status": "approved",
-        "invite_id": invite["id"],
+        "invite_id": invite["record"]["invite_id"],
         "agent_slug": agent_slug,
     }
 
@@ -360,12 +360,12 @@ async def complete_delegation_approval(
             approval_mode="auto",
             check_interval_secs=1800,
             created_by=contact_id,
+            pin_required=False,
             metadata={
                 "kind": "delegation_sponsored",
                 "sponsor_contact_id": contact_id,
                 "agent_slug": agent_slug,
                 "display_name": display_name,
-                "pin_required": False,
             },
         )
     except Exception:
@@ -377,7 +377,7 @@ async def complete_delegation_approval(
 
     return {
         "status": "approved",
-        "invite_id": invite["id"],
+        "invite_id": invite["record"]["invite_id"],
         "agent_slug": agent_slug,
     }
 
@@ -413,7 +413,9 @@ async def cascade_sponsor_revoke(
 
         # When scoped to a project, only revoke agents that are members of
         # that project.  Contact-wide revoke (project_id=None) hits all.
-        if project_id is not None and project_store is not None:
+        if project_id is not None:
+            if project_store is None:
+                return {"status": "error", "error": "project store not available"}
             if not await project_store.is_project_member(
                 project_id, canonical_id
             ):

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -41,27 +41,26 @@ _PROJECT_SCOPES: frozenset[str] = frozenset({"project_tasks", "canvas_read", "ca
 
 def validate_delegation_scopes(
     requested_scopes: list[str],
-) -> tuple[list[str], list[str]]:
-    """Validate and filter scopes for a delegation request.
+) -> tuple[list[str], list[str], list[str]]:
+    """Split *requested_scopes* into ``(tier, elevated, denied)``.
 
-    Returns ``(granted_scopes, denied_scopes)``.  Scopes in
-    ``SPONSORED_DENY_SCOPES`` are stripped with a warning; scopes outside
-    ``SPONSORED_DEFAULT_SCOPES`` require explicit per-scope Decisions approval
-    but are NOT auto-denied — they surface to the human for approval.
-
-    The returned ``granted_scopes`` are safe-to-mint; any scope in
-    ``denied_scopes`` was hard-denied and will never be included in the minted
-    invite.
+    * ``tier`` — scopes in the #2019 default allowlist
+      (``SPONSORED_DEFAULT_SCOPES``); safe to auto-grant.
+    * ``elevated`` — scopes outside BOTH the allowlist and the deny list;
+      require explicit per-scope human approval and are NEVER auto-granted.
+    * ``denied`` — scopes in ``SPONSORED_DENY_SCOPES``; hard-denied and never
+      minted.
     """
     requested_set = set(requested_scopes)
     denied = sorted(requested_set & SPONSORED_DENY_SCOPES)
-    allowed = sorted(requested_set - SPONSORED_DENY_SCOPES)
+    tier = sorted(requested_set & SPONSORED_DEFAULT_SCOPES)
+    elevated = sorted(requested_set - SPONSORED_DEFAULT_SCOPES - SPONSORED_DENY_SCOPES)
     if denied:
         logger.warning(
             "delegation: hard-denied scopes %r from request %r",
             denied, sorted(requested_set),
         )
-    return allowed, denied
+    return tier, elevated, denied
 
 
 def _validate_delegation_envelope_body(body: dict) -> tuple[bool, str, Optional[dict]]:
@@ -150,22 +149,27 @@ async def process_delegation_request(
             ),
         }
 
-    # Apply scope denylist.
-    granted_scopes, denied_scopes = validate_delegation_scopes(requested_scopes)
+    # Split the request into the default (allowlist) tier, elevated scopes, and
+    # hard-denied scopes.  Only the tier is ever auto-grantable; elevated scopes
+    # require explicit human approval and hard-denied scopes are never minted.
+    tier_scopes, elevated_scopes, denied_scopes = validate_delegation_scopes(requested_scopes)
 
     # Check project policy: auto_approve_delegation knob.
     auto_approve = await project_store.get_project_setting(
         project_id, "auto_approve_delegation", default=False
     )
 
-    if auto_approve:
-        # Future dev-swarm path: immediate approval.
+    # Auto-approve is only ever allowed when there are NO elevated scopes — a
+    # remote contact must never be auto-granted a scope outside the default
+    # tier.  Any elevated scope forces the manual path.
+    if auto_approve and not elevated_scopes:
+        # Future dev-swarm path: immediate approval (tier scopes only).
         return await _auto_approve_delegation(
             request,
             contact_id=contact_id,
             agent_slug=agent_slug,
             display_name=display_name,
-            granted_scopes=granted_scopes,
+            granted_scopes=tier_scopes,
             denied_scopes=denied_scopes,
             project_id=project_id,
         )
@@ -176,7 +180,8 @@ async def process_delegation_request(
         contact_id=contact_id,
         agent_slug=agent_slug,
         display_name=display_name,
-        granted_scopes=granted_scopes,
+        granted_scopes=tier_scopes,
+        elevated_scopes=elevated_scopes,
         denied_scopes=denied_scopes,
         project_id=project_id,
     )
@@ -189,15 +194,16 @@ async def _create_delegation_decision(
     agent_slug: str,
     display_name: str,
     granted_scopes: list[str],
+    elevated_scopes: list[str],
     denied_scopes: list[str],
     project_id: str,
 ) -> dict:
     """Create a blocking Decisions card for manual delegation approval.
 
-    The human sees: "contact {contact_id} wants to delegate agent
-    '{display_name}' ({agent_slug}) to project {project_id} with scopes
-    {granted_scopes}."  Any hard-denied scopes are noted in the question
-    text so the human knows they were stripped.
+    The human sees the routine (tier) scopes and — separately and per-scope —
+    any elevated scopes that require explicit approval, so elevated scopes are
+    never bundled silently into the routine grant.  Hard-denied scopes are
+    noted in the question text so the human knows they were stripped.
     """
     decision_store = getattr(request.app.state, "decision_store", None)
     if decision_store is None:
@@ -206,8 +212,13 @@ async def _create_delegation_decision(
     question_parts = [
         f"{contact_id} wants to delegate agent "
         f"'{display_name}' ({agent_slug}) to this project",
-        f"Requested scopes: {', '.join(granted_scopes)}",
+        f"Routine scopes: {', '.join(granted_scopes) or '(none)'}",
     ]
+    if elevated_scopes:
+        question_parts.append(
+            f"Elevated scopes — require explicit approval: "
+            f"{', '.join(elevated_scopes)}"
+        )
     if denied_scopes:
         question_parts.append(
             f"(Hard-denied: {', '.join(denied_scopes)} — "
@@ -229,6 +240,7 @@ async def _create_delegation_decision(
                 "agent_slug": agent_slug,
                 "display_name": display_name,
                 "granted_scopes": granted_scopes,
+                "elevated_scopes": elevated_scopes,
                 "denied_scopes": denied_scopes,
                 "project_id": project_id,
             },
@@ -278,6 +290,7 @@ async def _auto_approve_delegation(
             created_by=contact_id,
             pin_required=False,
             display_name=display_name,
+            metadata={"sponsor_contact_id": contact_id},
         )
     except Exception:
         logger.warning(
@@ -311,6 +324,7 @@ async def complete_delegation_approval(
     agent_slug = decision_metadata.get("agent_slug", "")
     display_name = decision_metadata.get("display_name", "")
     granted_scopes = decision_metadata.get("granted_scopes", [])
+    elevated_scopes = decision_metadata.get("elevated_scopes", [])
     project_id = decision_metadata.get("project_id", "")
 
     if not all([contact_id, agent_slug, display_name, project_id]):
@@ -319,9 +333,12 @@ async def complete_delegation_approval(
     # Re-validate project membership at approval time: the contact may have
     # been removed from the project between decision creation and approval.
     # This is the fail-closed runtime check required by section 5 of the
-    # cross-user-collab design spec.
+    # cross-user-collab design spec.  A missing project_store is an error, not
+    # a pass (the old code failed OPEN and minted anyway).
     project_store = getattr(request.app.state, "project_store", None)
-    if project_store is not None and not await project_store.is_project_member(
+    if project_store is None:
+        return {"status": "error", "error": "project store not available"}
+    if not await project_store.is_project_member(
         project_id, contact_id, member_kind="human"
     ):
         return {
@@ -341,7 +358,9 @@ async def complete_delegation_approval(
     # approval.  The denylist is the authoritative gate; the stored scopes are
     # the human-approved set, but the code must never mint tokens for
     # hard-denied scopes regardless.
-    safe_scopes, re_denied = validate_delegation_scopes(granted_scopes)
+    combined = list(dict.fromkeys(granted_scopes + elevated_scopes))
+    safe_tier, safe_elevated, re_denied = validate_delegation_scopes(combined)
+    safe_scopes = safe_tier + safe_elevated
     if re_denied:
         logger.warning(
             "complete_delegation_approval: re-stripped hard-denied scopes %r from stored grant",
@@ -357,6 +376,7 @@ async def complete_delegation_approval(
             created_by=contact_id,
             pin_required=False,
             display_name=display_name,
+            metadata={"sponsor_contact_id": contact_id},
         )
     except Exception:
         logger.warning(
@@ -482,36 +502,42 @@ async def _unassign_agent_tasks(
     canonical_id: str,
     project_id: str | None = None,
 ) -> int:
-    """Unassign all in-flight tasks for *canonical_id*, moving them back to 'ready'.
+    """Release every in-flight (claimed) task held by *canonical_id*.
 
-    Returns the count of tasks unassigned.
+    The task store's vocabulary is ``open``/``claimed`` with ``claimed_by`` —
+    NOT ``status="in_progress"`` + ``assignee_id``.  It enforces one active
+    claim per agent, so there is at most one 'claimed' task to release.  Uses
+    the store's real release path (``release_task`` — the ``claimed -> open``
+    transition that clears ``claimed_by``/``claimed_at``).
+
+    Returns the count of tasks released.
     """
-    # The task store interface varies by implementation; use the available
-    # method to find and unassign.  We query for tasks with assignee matching
-    # the agent's canonical_id and reset them.
-    try:
-        tasks = await task_store.list_for_assignee(canonical_id)
-    except AttributeError:
-        # Fall back: try list_tasks with filter.
-        try:
-            all_tasks = await task_store.list_tasks(
-                project_id=project_id,
-                status="in_progress",
-            )
-            tasks = [t for t in all_tasks if t.get("assignee_id") == canonical_id]
-        except Exception:
-            return 0
-
     count = 0
-    for task in tasks:
-        task_id = task.get("id") or task.get("task_id")
-        if not task_id:
-            continue
+    while True:
         try:
-            await task_store.update_task(task_id, assignee_id=None, status="ready")
-            count += 1
+            task_id = await task_store.held_task(canonical_id)
+        except AttributeError:
+            logger.warning(
+                "unassign_agent_tasks: task store has no held_task(); "
+                "skipping task release for %s",
+                canonical_id,
+            )
+            return count
+        if task_id is None:
+            break
+        try:
+            released = await task_store.release_task(task_id, canonical_id)
         except Exception:
-            pass
+            logger.warning(
+                "unassign_agent_tasks: release_task(%s) failed for %s",
+                task_id, canonical_id, exc_info=True,
+            )
+            break
+        if not released:
+            # The claim changed under us (e.g. already released); stop rather
+            # than spin.
+            break
+        count += 1
 
     return count
 

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -1,0 +1,537 @@
+"""Agent delegation handler — cross-user collab D1.
+
+Processes delegation-request envelopes from remote contacts, applies
+scope denylist and policy gates, creates Decisions cards for manual
+approval, and on approval mints project invites for the sponsored agent.
+
+Also provides cascade revocation and kill-switch machinery.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Scope denylist — hard-coded scopes that can NEVER be granted to sponsored
+# agents in v1, regardless of owner decisions (design section 5).
+# ---------------------------------------------------------------------------
+
+SPONSORED_DENY_SCOPES: frozenset[str] = frozenset({
+    "files_write",
+    "decisions_write",
+})
+
+# Default scope tier for delegated agents per design section 5.
+SPONSORED_DEFAULT_SCOPES: frozenset[str] = frozenset({
+    "a2a_send",
+    "a2a_receive",
+    "project_tasks",
+    "canvas_read",
+    "registry_feeds_read",
+})
+
+# Scopes that bind the JWT to a specific project (same set as agent_auth_requests).
+_PROJECT_SCOPES: frozenset[str] = frozenset({"project_tasks", "canvas_read", "canvas_write"})
+
+
+def validate_delegation_scopes(
+    requested_scopes: list[str],
+) -> tuple[list[str], list[str]]:
+    """Validate and filter scopes for a delegation request.
+
+    Returns ``(granted_scopes, denied_scopes)``.  Scopes in
+    ``SPONSORED_DENY_SCOPES`` are stripped with a warning; scopes outside
+    ``SPONSORED_DEFAULT_SCOPES`` require explicit per-scope Decisions approval
+    but are NOT auto-denied — they surface to the human for approval.
+
+    The returned ``granted_scopes`` are safe-to-mint; any scope in
+    ``denied_scopes`` was hard-denied and will never be included in the minted
+    invite.
+    """
+    requested_set = set(requested_scopes)
+    denied = sorted(requested_set & SPONSORED_DENY_SCOPES)
+    allowed = sorted(requested_set - SPONSORED_DENY_SCOPES)
+    if denied:
+        logger.warning(
+            "delegation: hard-denied scopes %r from request %r",
+            denied, sorted(requested_set),
+        )
+    return allowed, denied
+
+
+def _validate_delegation_envelope_body(body: dict) -> tuple[bool, str, Optional[dict]]:
+    """Validate the body of a delegation-request envelope.
+
+    Returns ``(ok, error, parsed)``.  ``parsed`` is a dict with keys
+    ``agent_slug``, ``display_name``, ``requested_scopes``, and ``project_id``
+    when valid.
+    """
+    required = ("agent_slug", "display_name", "requested_scopes", "project_id")
+    for field in required:
+        if field not in body:
+            return False, f"missing required field: {field}", None
+        value = body[field]
+        if field == "requested_scopes":
+            if not isinstance(value, list):
+                return False, f"{field} must be a list", None
+            if not value:
+                return False, f"{field} must not be empty", None
+        elif not isinstance(value, str) or not value.strip():
+            return False, f"{field} must be a non-empty string", None
+
+    requested_scopes = body["requested_scopes"]
+    unknown = sorted(set(requested_scopes) - SPONSORED_DEFAULT_SCOPES - SPONSORED_DENY_SCOPES)
+    # Unknown scopes are not immediately denied — they require explicit
+    # per-scope Decisions approval.  We just log them here; the decision
+    # created later will surface them to the human.
+    if unknown:
+        logger.info(
+            "delegation: elevated scopes in request: %r (require explicit approval)",
+            unknown,
+        )
+
+    parsed = {
+        "agent_slug": body["agent_slug"].strip(),
+        "display_name": body["display_name"].strip(),
+        "requested_scopes": body["requested_scopes"],
+        "project_id": body["project_id"].strip(),
+    }
+    return True, "", parsed
+
+
+async def process_delegation_request(
+    request,
+    *,
+    contact_id: str,
+    envelope_body: dict,
+) -> dict:
+    """Process a delegation-request envelope from a remote contact.
+
+    Called from the peer inbox when envelope.kind == "delegation_request".
+
+    1. Validate envelope body structure.
+    2. Verify the contact has ``member_kind="human"`` in the target project.
+    3. Apply scope denylist (strip ``files_write``, ``decisions_write``).
+    4. Check ``auto_approve_delegation`` project setting.
+       - If ON (dev-swarm future): auto-mint invite, return result.
+       - If OFF (v1 default): create a blocking Decisions card.
+
+    Returns a dict suitable for the peer inbox response envelope.
+    On pending-approval: ``{"status": "pending_approval", "decision_id": ...}``
+    On auto-approved: ``{"status": "approved", "invite_id": ..., ...}``
+    """
+    ok, err, parsed = _validate_delegation_envelope_body(envelope_body)
+    if not ok or parsed is None:
+        return {"status": "error", "error": err}
+
+    agent_slug = parsed["agent_slug"]
+    display_name = parsed["display_name"]
+    requested_scopes = parsed["requested_scopes"]
+    project_id = parsed["project_id"]
+
+    # Verify sender is an active human collaborator on the target project.
+    project_store = getattr(request.app.state, "project_store", None)
+    if project_store is None:
+        return {"status": "error", "error": "project store not available"}
+
+    if not await project_store.is_project_member(
+        project_id, contact_id, member_kind="human"
+    ):
+        return {
+            "status": "error",
+            "error": (
+                f"contact {contact_id} is not a human collaborator on project "
+                f"{project_id}"
+            ),
+        }
+
+    # Apply scope denylist.
+    granted_scopes, denied_scopes = validate_delegation_scopes(requested_scopes)
+
+    # Check project policy: auto_approve_delegation knob.
+    auto_approve = await project_store.get_project_setting(
+        project_id, "auto_approve_delegation", default=False
+    )
+
+    if auto_approve:
+        # Future dev-swarm path: immediate approval.
+        return await _auto_approve_delegation(
+            request,
+            contact_id=contact_id,
+            agent_slug=agent_slug,
+            display_name=display_name,
+            granted_scopes=granted_scopes,
+            denied_scopes=denied_scopes,
+            project_id=project_id,
+        )
+
+    # v1 manual path: create a blocking Decisions card.
+    return await _create_delegation_decision(
+        request,
+        contact_id=contact_id,
+        agent_slug=agent_slug,
+        display_name=display_name,
+        granted_scopes=granted_scopes,
+        denied_scopes=denied_scopes,
+        project_id=project_id,
+    )
+
+
+async def _create_delegation_decision(
+    request,
+    *,
+    contact_id: str,
+    agent_slug: str,
+    display_name: str,
+    granted_scopes: list[str],
+    denied_scopes: list[str],
+    project_id: str,
+) -> dict:
+    """Create a blocking Decisions card for manual delegation approval.
+
+    The human sees: "contact {contact_id} wants to delegate agent
+    '{display_name}' ({agent_slug}) to project {project_id} with scopes
+    {granted_scopes}."  Any hard-denied scopes are noted in the question
+    text so the human knows they were stripped.
+    """
+    decision_store = getattr(request.app.state, "decision_store", None)
+    if decision_store is None:
+        return {"status": "error", "error": "decision store not available"}
+
+    question_parts = [
+        f"{contact_id} wants to delegate agent "
+        f"'{display_name}' ({agent_slug}) to this project",
+        f"Requested scopes: {', '.join(granted_scopes)}",
+    ]
+    if denied_scopes:
+        question_parts.append(
+            f"(Hard-denied: {', '.join(denied_scopes)} — "
+            f"these scopes cannot be granted to delegated agents in v1)"
+        )
+
+    question = ". ".join(question_parts) + "."
+
+    try:
+        decision = await decision_store.create(
+            from_agent=contact_id,
+            question=question,
+            type="approve_deny",
+            priority="blocking",
+            project_id=project_id,
+            metadata={
+                "kind": "collab_delegation_gate",
+                "contact_id": contact_id,
+                "agent_slug": agent_slug,
+                "display_name": display_name,
+                "granted_scopes": granted_scopes,
+                "denied_scopes": denied_scopes,
+                "project_id": project_id,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "delegation: failed to create decision for %s / %s",
+            contact_id, agent_slug, exc_info=True,
+        )
+        return {"status": "error", "error": "failed to create approval decision"}
+
+    return {
+        "status": "pending_approval",
+        "decision_id": decision["id"],
+    }
+
+
+async def _auto_approve_delegation(
+    request,
+    *,
+    contact_id: str,
+    agent_slug: str,
+    display_name: str,
+    granted_scopes: list[str],
+    denied_scopes: list[str],
+    project_id: str,
+) -> dict:
+    """Auto-approve a delegation request (dev-swarm future path).
+
+    Mints a project invite (kind="agent", pin_required=false) and returns
+    the invite_id + connection_bundle.
+    """
+    invite_store = getattr(request.app.state, "project_invite_store", None)
+    if invite_store is None:
+        return {"status": "error", "error": "invite store not available"}
+
+    # The project-scoped scopes require a non-null project_id for the JWT.
+    project_scopes = sorted(set(granted_scopes) & _PROJECT_SCOPES)
+    non_project_scopes = sorted(set(granted_scopes) - _PROJECT_SCOPES)
+
+    try:
+        invite = await invite_store.mint(
+            project_id=project_id,
+            scopes=non_project_scopes + project_scopes,
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by=contact_id,
+            metadata={
+                "kind": "delegation_sponsored",
+                "sponsor_contact_id": contact_id,
+                "agent_slug": agent_slug,
+                "display_name": display_name,
+                "pin_required": False,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "delegation: failed to create invite for %s / %s",
+            contact_id, agent_slug, exc_info=True,
+        )
+        return {"status": "error", "error": "failed to create project invite"}
+
+    return {
+        "status": "approved",
+        "invite_id": invite["id"],
+        "agent_slug": agent_slug,
+    }
+
+
+async def complete_delegation_approval(
+    request,
+    *,
+    decision_metadata: dict,
+) -> dict:
+    """Complete a delegation approval after the human answers the Decisions card.
+
+    Called from the decisions route when a delegation_gate decision is approved.
+    ``decision_metadata`` is the metadata dict stored on the decision at creation
+    time (contains contact_id, agent_slug, display_name, granted_scopes, etc.).
+
+    Mints a project invite and returns the result for delivery over the peer
+    channel.
+    """
+    contact_id = decision_metadata.get("contact_id", "")
+    agent_slug = decision_metadata.get("agent_slug", "")
+    display_name = decision_metadata.get("display_name", "")
+    granted_scopes = decision_metadata.get("granted_scopes", [])
+    project_id = decision_metadata.get("project_id", "")
+
+    if not all([contact_id, agent_slug, display_name, project_id]):
+        return {"status": "error", "error": "incomplete decision metadata"}
+
+    invite_store = getattr(request.app.state, "project_invite_store", None)
+    if invite_store is None:
+        return {"status": "error", "error": "invite store not available"}
+
+    try:
+        invite = await invite_store.mint(
+            project_id=project_id,
+            scopes=granted_scopes,
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by=contact_id,
+            metadata={
+                "kind": "delegation_sponsored",
+                "sponsor_contact_id": contact_id,
+                "agent_slug": agent_slug,
+                "display_name": display_name,
+                "pin_required": False,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "delegation: complete_approval: failed to create invite for %s / %s",
+            contact_id, agent_slug, exc_info=True,
+        )
+        return {"status": "error", "error": "failed to create project invite"}
+
+    return {
+        "status": "approved",
+        "invite_id": invite["id"],
+        "agent_slug": agent_slug,
+    }
+
+
+async def cascade_sponsor_revoke(
+    request,
+    *,
+    contact_id: str,
+    project_id: str | None = None,
+    reason: str = "sponsor revoked",
+) -> dict:
+    """Revoke all sponsored agent identities for a contact.
+
+    When *project_id* is provided, only revoke tokens bound to that project
+    (membership-revoke).  When None, revoke ALL sponsored identities
+    (contact-revoke).
+
+    Also unassigns in-flight board tasks and posts an A2A system line.
+    Returns a summary dict of what was revoked.
+    """
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        return {"status": "error", "error": "registry not available"}
+
+    # Find all active agents sponsored by this contact.
+    sponsored = await registry.list_by_sponsor(contact_id, status="active")
+    revoked_ids: list[str] = []
+
+    for agent in sponsored:
+        canonical_id = agent["canonical_id"]
+        try:
+            await registry.set_status(canonical_id, "revoked", actor=contact_id)
+            revoked_ids.append(canonical_id)
+        except Exception:
+            logger.warning(
+                "cascade_revoke: failed to revoke %s (sponsor %s)",
+                canonical_id, contact_id, exc_info=True,
+            )
+
+    # Unassign in-flight board tasks for all revoked agent identities.
+    task_store = getattr(request.app.state, "project_task_store", None)
+    unassigned_count = 0
+    if task_store is not None and revoked_ids:
+        for canonical_id in revoked_ids:
+            try:
+                # Find tasks assigned to this agent and move them back to ready.
+                unassigned = await _unassign_agent_tasks(
+                    task_store, canonical_id, project_id
+                )
+                unassigned_count += unassigned
+            except Exception:
+                logger.warning(
+                    "cascade_revoke: task unassign failed for %s",
+                    canonical_id, exc_info=True,
+                )
+
+    # Post A2A system line.
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+
+        if project_id:
+            channel = await ensure_a2a_channel(
+                request.app.state.chat_channels,
+                request.app.state.project_store,
+                project_id,
+                config=getattr(request.app.state, "config", None),
+            )
+            msg_store = request.app.state.chat_messages
+            await msg_store.send_message(
+                channel_id=channel["id"],
+                author_id="system",
+                author_type="user",
+                content=(
+                    f"Collaboration with {contact_id} has been revoked. "
+                    f"{len(revoked_ids)} delegated agent(s) revoked, "
+                    f"{unassigned_count} task(s) unassigned."
+                ),
+            )
+    except Exception:
+        logger.warning(
+            "cascade_revoke: A2A system line failed for %s",
+            contact_id, exc_info=True,
+        )
+
+    return {
+        "status": "revoked",
+        "contact_id": contact_id,
+        "revoked_agents": len(revoked_ids),
+        "unassigned_tasks": unassigned_count,
+        "revoked_ids": revoked_ids,
+        "reason": reason,
+    }
+
+
+async def _unassign_agent_tasks(
+    task_store,
+    canonical_id: str,
+    project_id: str | None = None,
+) -> int:
+    """Unassign all in-flight tasks for *canonical_id*, moving them back to 'ready'.
+
+    Returns the count of tasks unassigned.
+    """
+    # The task store interface varies by implementation; use the available
+    # method to find and unassign.  We query for tasks with assignee matching
+    # the agent's canonical_id and reset them.
+    try:
+        tasks = await task_store.list_for_assignee(canonical_id)
+    except AttributeError:
+        # Fall back: try list_tasks with filter.
+        try:
+            all_tasks = await task_store.list_tasks(
+                project_id=project_id,
+                status="in_progress",
+            )
+            tasks = [t for t in all_tasks if t.get("assignee_id") == canonical_id]
+        except Exception:
+            return 0
+
+    count = 0
+    for task in tasks:
+        task_id = task.get("id") or task.get("task_id")
+        if not task_id:
+            continue
+        try:
+            await task_store.update_task(task_id, assignee_id=None, status="ready")
+            count += 1
+        except Exception:
+            pass
+
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch: 3 levels per design section 5
+# ---------------------------------------------------------------------------
+
+async def kill_switch_per_contact(request, *, contact_id: str) -> dict:
+    """Level 2 kill-switch: pause collaboration with a specific contact.
+
+    Suspends the peer link and revokes all sponsored tokens.  Reversible
+    (the peer link can be re-established).
+    """
+    contacts_store = getattr(request.app.state, "contacts_store", None)
+    if contacts_store is None:
+        return {"status": "error", "error": "contacts store not available"}
+
+    # Suspend the peer link (revoke the inbound token, set status to suspended).
+    try:
+        await contacts_store.revoke_peer_link(contact_id)
+    except Exception:
+        logger.warning(
+            "kill_switch_per_contact: peer link revoke failed for %s",
+            contact_id, exc_info=True,
+        )
+
+    # Cascade to all sponsored agents.
+    cascade_result = await cascade_sponsor_revoke(
+        request, contact_id=contact_id, reason="kill-switch (per-contact pause)",
+    )
+
+    return {
+        "status": "paused",
+        "contact_id": contact_id,
+        "revoked_agents": cascade_result.get("revoked_agents", 0),
+        "unassigned_tasks": cascade_result.get("unassigned_tasks", 0),
+    }
+
+
+async def kill_switch_per_instance(request) -> dict:
+    """Level 3 kill-switch: disable the entire peer route family.
+
+    Sets a flag on app.state that the peer routes check on every request.
+    Does NOT revoke tokens — just blocks all new peer traffic.
+    Reversible by clearing the flag.
+    """
+    # Set a flag that the peer routes check.
+    request.app.state._peer_disabled = True
+    logger.warning("kill_switch: per-instance panic — peer routes DISABLED")
+    return {"status": "panic", "peer_routes": "disabled"}
+
+
+def is_peer_disabled(request) -> bool:
+    """Check whether the per-instance peer panic switch is active."""
+    return getattr(request.app.state, "_peer_disabled", False)

--- a/tinyagentos/delegation_handler.py
+++ b/tinyagentos/delegation_handler.py
@@ -15,6 +15,7 @@ import time
 from typing import Optional
 
 from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+from tinyagentos.routes.decisions import SERVER_RAISED_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,9 @@ async def process_delegation_request(
 
     1. Validate envelope body structure.
     2. Verify the contact has ``member_kind="human"`` in the target project.
-    3. Apply scope denylist (strip ``files_write``, ``decisions_write``).
+    3. Apply scope denylist: ``files_write`` and ``decisions_write`` are moved
+       into a hard-denied set and never granted (not silently stripped from the
+       request).
     4. Check ``auto_approve_delegation`` project setting.
        - If ON (dev-swarm future): auto-mint invite, return result.
        - If OFF (v1 default): create a blocking Decisions card.
@@ -237,6 +240,7 @@ async def _create_delegation_decision(
             priority="blocking",
             project_id=project_id,
             metadata={
+                SERVER_RAISED_KEY: True,
                 "kind": "collab_delegation_gate",
                 "contact_id": contact_id,
                 "agent_slug": agent_slug,

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -320,9 +320,13 @@ async def send_envelope(
     This is the reusable outbound half of the peer channel — the inbound half
     is ``POST /api/peer/inbox`` in ``routes/peer.py``.
     """
+    # ``to_contact_id`` is the full ``hub:<username>`` contact id (the key the
+    # contacts store uses).  ``build_envelope`` prefixes ``hub:`` itself, so
+    # strip it here — otherwise the envelope is addressed ``hub:hub:<user>``
+    # and the receiver 403s it.
     envelope = build_envelope(
         from_username=from_username,
-        to_username=to_contact_id,
+        to_username=to_contact_id.removeprefix("hub:"),
         kind=kind,
         body=body,
     )

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -338,11 +338,10 @@ async def send_envelope(
     import httpx
 
     outbound_token = peer_link.get("outbound_token", "")
-    for ep in sorted(
-        peer_link["endpoints"],
-        key=lambda e: e.get("priority", 99),
-    ):
-        inbox_url = f"{ep['url'].rstrip('/')}/api/peer/inbox"
+    # Endpoints are plain URL strings (the canonical shape written by
+    # ``establish_peer_link``), not ``{"url": ..., "priority": ...}`` dicts.
+    for ep in peer_link["endpoints"]:
+        inbox_url = f"{str(ep).rstrip('/')}/api/peer/inbox"
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 resp = await client.post(

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -320,13 +320,21 @@ async def send_envelope(
     This is the reusable outbound half of the peer channel — the inbound half
     is ``POST /api/peer/inbox`` in ``routes/peer.py``.
     """
-    # ``to_contact_id`` is the full ``hub:<username>`` contact id (the key the
-    # contacts store uses).  ``build_envelope`` prefixes ``hub:`` itself, so
-    # strip it here — otherwise the envelope is addressed ``hub:hub:<user>``
-    # and the receiver 403s it.
+    # ``to_contact_id`` must be the full ``hub:<username>`` contact id (the key
+    # the contacts store uses).  ``build_envelope`` prefixes ``hub:`` itself, so
+    # strip it here — otherwise the envelope is addressed ``hub:hub:<user>`` and
+    # the receiver 403s it.  Fail loudly on a wrong shape rather than silently
+    # producing a ``hub:peer:abc`` address that never matches the remote id.
+    if not to_contact_id.startswith("hub:"):
+        raise ValueError(
+            f"to_contact_id must be a 'hub:<username>' id, got {to_contact_id!r}"
+        )
+    to_username = to_contact_id[len("hub:"):]
+    if not to_username:
+        raise ValueError("to_contact_id has an empty hub username")
     envelope = build_envelope(
         from_username=from_username,
-        to_username=to_contact_id.removeprefix("hub:"),
+        to_username=to_username,
         kind=kind,
         body=body,
     )
@@ -338,10 +346,22 @@ async def send_envelope(
     import httpx
 
     outbound_token = peer_link.get("outbound_token", "")
-    # Endpoints are plain URL strings (the canonical shape written by
-    # ``establish_peer_link``), not ``{"url": ..., "priority": ...}`` dicts.
-    for ep in peer_link["endpoints"]:
-        inbox_url = f"{str(ep).rstrip('/')}/api/peer/inbox"
+    # Endpoints are plain URL strings in declaration order (``establish_peer_link``
+    # stores ``list[str]``; JSON preserves insertion order, so the primary
+    # endpoint is first).  For forward/backward compatibility we also accept
+    # ``{"url": ..., "priority": ...}`` dicts and sort those by priority (lowest
+    # first) so a declared-primary endpoint is tried before a fallback.  The
+    # sort is stable, so string endpoints keep their insertion order.
+    endpoints = peer_link["endpoints"]
+
+    def _endpoint_sort_key(ep) -> tuple:
+        if isinstance(ep, dict):
+            return (0, ep.get("priority", 99))
+        return (0, 99)
+
+    for ep in sorted(endpoints, key=_endpoint_sort_key):
+        ep_url = ep.get("url", "") if isinstance(ep, dict) else str(ep)
+        inbox_url = f"{ep_url.rstrip('/')}/api/peer/inbox"
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 resp = await client.post(

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -43,7 +43,7 @@ def build_envelope(
     """Build a signed envelope from this node to a remote contact.
 
     ``kind`` is one of: ``handshake``, ``collab_invite``, ``delegation_request``,
-    ``chat``, ``ack``.  ``body`` is the payload dict.
+    ``delegation_status``, ``chat``, ``ack``.  ``body`` is the payload dict.
 
     The envelope is signed with this node's Ed25519 signing key (from
     ``hub.identity``), so the receiver can verify it against the pinned pubkey
@@ -296,6 +296,66 @@ async def deliver_handshake(
 
 # ---------------------------------------------------------------------------
 # helpers
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Outbound delivery
+# ---------------------------------------------------------------------------
+
+async def send_envelope(
+    contacts_store,
+    *,
+    from_username: str,
+    to_contact_id: str,
+    kind: str,
+    body: dict | None = None,
+) -> tuple[bool, str]:
+    """Build a signed envelope and deliver it to a remote contact's peer inbox.
+
+    Returns ``(delivered, error)``.  ``delivered`` is True when the envelope
+    was accepted (2xx) by at least one remote endpoint.  ``error`` is an empty
+    string on success, otherwise a human-readable reason.
+
+    This is the reusable outbound half of the peer channel — the inbound half
+    is ``POST /api/peer/inbox`` in ``routes/peer.py``.
+    """
+    envelope = build_envelope(
+        from_username=from_username,
+        to_username=to_contact_id,
+        kind=kind,
+        body=body,
+    )
+
+    peer_link = await contacts_store.get_peer_link(to_contact_id)
+    if peer_link is None or not peer_link.get("endpoints"):
+        return False, "no peer endpoints for contact"
+
+    import httpx
+
+    outbound_token = peer_link.get("outbound_token", "")
+    for ep in sorted(
+        peer_link["endpoints"],
+        key=lambda e: e.get("priority", 99),
+    ):
+        inbox_url = f"{ep['url'].rstrip('/')}/api/peer/inbox"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    inbox_url,
+                    json={"envelope": envelope},
+                    headers={
+                        "Authorization": f"Bearer {outbound_token}",
+                        "Content-Type": "application/json",
+                    },
+                )
+                if 200 <= resp.status_code < 300:
+                    return True, ""
+        except Exception:
+            continue
+    return False, "failed to deliver envelope to any peer endpoint"
+
+
 # ---------------------------------------------------------------------------
 
 

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -366,21 +366,24 @@ class ProjectInviteStore(BaseStore):
         if attempts >= _MAX_ATTEMPTS:
             raise InvitePinError("invalid invite id or pin")
 
-        pin_hash = hashlib.sha256(pin.encode()).hexdigest()
-        if not hmac.compare_digest(pin_hash, row["pin_hash"] or ""):
-            await self._db.execute(
-                "UPDATE project_invites SET redeem_attempts = redeem_attempts + 1 WHERE invite_id = ?",
-                (invite_id,),
-            )
-            await self._db.commit()
-            new_attempts = attempts + 1
-            if new_attempts >= _MAX_ATTEMPTS:
+        # When pin_required is False the invite carries no PIN gate; any
+        # pin value (including empty string) is accepted (A2 fix #2048).
+        if row["pin_required"]:
+            pin_hash = hashlib.sha256(pin.encode()).hexdigest()
+            if not hmac.compare_digest(pin_hash, row["pin_hash"] or ""):
                 await self._db.execute(
-                    "UPDATE project_invites SET status = 'expired' WHERE invite_id = ?",
+                    "UPDATE project_invites SET redeem_attempts = redeem_attempts + 1 WHERE invite_id = ?",
                     (invite_id,),
                 )
                 await self._db.commit()
-            raise InvitePinError("invalid invite id or pin")
+                new_attempts = attempts + 1
+                if new_attempts >= _MAX_ATTEMPTS:
+                    await self._db.execute(
+                        "UPDATE project_invites SET status = 'expired' WHERE invite_id = ?",
+                        (invite_id,),
+                    )
+                    await self._db.commit()
+                raise InvitePinError("invalid invite id or pin")
 
         # Atomically claim the invite (pending→claimed) rather than immediately
         # marking it redeemed.  The caller must flip claimed→redeemed on success

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -126,7 +126,14 @@ class ProjectInviteStore(BaseStore):
         )
         await self._db.commit()
 
-    def _generate_invite_id(self) -> str:
+    def _generate_invite_id(self, *, pin_required: bool = True) -> str:
+        # PIN-free invites carry no PIN gate, so a 6-digit numeric id would be a
+        # guessable credential (the per-IP rate limit does not hold across
+        # source IPs).  Use a high-entropy token_urlsafe id for those kinds.
+        # PIN-required invites keep the short 6-digit id — the PIN supplies the
+        # entropy.
+        if not pin_required:
+            return secrets.token_urlsafe(32)
         return f"{secrets.randbelow(1_000_000):06d}"
 
     def _generate_pin(self) -> str:
@@ -197,7 +204,7 @@ class ProjectInviteStore(BaseStore):
         # collision surfaces as a slight latency bump rather than a 500.
         max_retries = 5
         for attempt in range(max_retries):
-            invite_id = self._generate_invite_id()
+            invite_id = self._generate_invite_id(pin_required=pin_required)
             try:
                 await self._db.execute(
                     """

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -32,7 +32,8 @@ CREATE TABLE IF NOT EXISTS project_invites (
     display_name         TEXT,
     kind                 TEXT NOT NULL DEFAULT 'agent',
     pin_required         INTEGER NOT NULL DEFAULT 1,
-    contact_id           TEXT
+    contact_id           TEXT,
+    metadata             TEXT NOT NULL DEFAULT '{}'
 );
 """
 
@@ -110,6 +111,11 @@ class ProjectInviteStore(BaseStore):
                 "ALTER TABLE project_invites ADD COLUMN contact_id TEXT"
             )
             await self._db.commit()
+        if "metadata" not in existing_cols:
+            await self._db.execute(
+                "ALTER TABLE project_invites ADD COLUMN metadata TEXT NOT NULL DEFAULT '{}'"
+            )
+            await self._db.commit()
         await self._db.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_invites_project "
             "ON project_invites(project_id)"
@@ -132,7 +138,8 @@ class ProjectInviteStore(BaseStore):
                    kind: str = "agent",
                    pin_required: bool = True,
                    contact_id: str | None = None,
-                   ttl_secs: int | None = None) -> dict:
+                   ttl_secs: int | None = None,
+                   metadata: dict | None = None) -> dict:
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")
 
@@ -197,8 +204,8 @@ class ProjectInviteStore(BaseStore):
                     INSERT INTO project_invites
                         (invite_id, project_id, pin_hash, scopes, approval_mode,
                          check_interval_secs, created_by, created_ts, expires_ts, status,
-                         display_name, kind, pin_required, contact_id)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
+                         display_name, kind, pin_required, contact_id, metadata)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
                     """,
                     (
                         invite_id,
@@ -214,6 +221,7 @@ class ProjectInviteStore(BaseStore):
                         kind,
                         int(pin_required),
                         contact_id,
+                        json.dumps(metadata or {}),
                     ),
                 )
                 await self._db.commit()
@@ -249,6 +257,7 @@ class ProjectInviteStore(BaseStore):
                 "kind": kind,
                 "pin_required": int(pin_required),
                 "contact_id": contact_id,
+                "metadata": metadata or {},
             },
             "pin": pin,
         }
@@ -458,4 +467,12 @@ class ProjectInviteStore(BaseStore):
     def _row_to_dict(self, row: aiosqlite.Row) -> dict:
         if row is None:
             return {}
-        return dict(row)
+        d = dict(row)
+        # Deserialise JSON columns.
+        for field in ("scopes", "metadata"):
+            if field in d and isinstance(d[field], str):
+                try:
+                    d[field] = json.loads(d[field])
+                except (ValueError, TypeError):
+                    pass
+        return d

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -458,6 +458,64 @@ class ProjectStore(ProjectsDBStore):
             keys = [d[0] for d in cur.description]
         return dict(zip(keys, row))
 
+    async def is_project_member(
+        self, project_id: str, member_id: str, *, member_kind: str | None = None
+    ) -> bool:
+        """Return True if *member_id* is a member of *project_id*.
+
+        When *member_kind* is provided, only match members of that kind
+        (e.g. ``"human"`` for cross-user collab delegation checks).
+        """
+        if member_kind is not None:
+            async with self._db.execute(
+                "SELECT 1 FROM project_members "
+                "WHERE project_id = ? AND member_id = ? AND member_kind = ?",
+                (project_id, member_id, member_kind),
+            ) as cur:
+                return (await cur.fetchone()) is not None
+        else:
+            async with self._db.execute(
+                "SELECT 1 FROM project_members "
+                "WHERE project_id = ? AND member_id = ?",
+                (project_id, member_id),
+            ) as cur:
+                return (await cur.fetchone()) is not None
+
+    async def get_project_setting(
+        self, project_id: str, key: str, default=None
+    ):
+        """Read a single key from the project's JSON settings dict.
+
+        Returns *default* if the project does not exist, has no settings, or
+        the key is absent.
+        """
+        project = await self.get_project(project_id)
+        if project is None:
+            return default
+        settings = project.get("settings") or {}
+        return settings.get(key, default)
+
+    async def set_project_setting(
+        self, project_id: str, key: str, value
+    ) -> bool:
+        """Set a single key in the project's JSON settings dict.
+
+        Returns True if the project was found and updated, False otherwise.
+        """
+        project = await self.get_project(project_id)
+        if project is None:
+            return False
+        settings = project.get("settings") or {}
+        if not isinstance(settings, dict):
+            settings = {}
+        settings[key] = value
+        await self._db.execute(
+            "UPDATE projects SET settings = ?, updated_at = ? WHERE id = ?",
+            (json.dumps(settings), time.time(), project_id),
+        )
+        await self._db.commit()
+        return True
+
     async def log_activity(
         self,
         project_id: str,

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -487,12 +487,15 @@ class ProjectStore(ProjectsDBStore):
         """Read a single key from the project's JSON settings dict.
 
         Returns *default* if the project does not exist, has no settings, or
-        the key is absent.
+        the key is absent.  Also returns *default* when the settings value is
+        not a dict (malformed DB row guard).
         """
         project = await self.get_project(project_id)
         if project is None:
             return default
         settings = project.get("settings") or {}
+        if not isinstance(settings, dict):
+            return default
         return settings.get(key, default)
 
     async def set_project_setting(

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -584,15 +584,14 @@ async def approve_request_record(
                 framework=record["framework"],
                 project_id=project_id,
             )
-            # For sponsored agents (cross-user collab D1), set the sponsor
-            # on the existing identity when reusing it for a new project.
+            # For sponsored agents (cross-user collab D1), record the
+            # sponsorship as a per-(identity, project) association, not a
+            # stamp on the reused identity — so each project's contact finds
+            # exactly what they sponsored.
             if sponsor_contact_id:
-                updated = await registry.set_sponsor(existing_cid, sponsor_contact_id)
-                if updated is None:
-                    logger.warning(
-                        "auth-approve: set_sponsor returned None for %s (identity gone?)",
-                        existing_cid,
-                    )
+                await registry.set_sponsorship(
+                    existing_cid, project_id, sponsor_contact_id
+                )
             await add_agent_to_project(
                 request,
                 canonical_id=existing_cid,
@@ -643,7 +642,6 @@ async def approve_request_record(
             # auth-request record / invite, not the registry origin column.
             origin="external-selfjoin",
             handle=handle,
-            sponsor_contact_id=sponsor_contact_id,
         )
         canonical_id = reg_record["canonical_id"]
 
@@ -652,6 +650,15 @@ async def approve_request_record(
         # them to 'active' so they are NOT in the bus inactive/revocation feed and
         # @taOSmd's identity-AND-grant gate accepts them.
         await registry.set_status(canonical_id, "active", actor=decided_by)
+
+        # Record sponsorship as a per-(identity, project) association (D1
+        # rework): the delegation was for THIS project, so the association is
+        # keyed to it rather than stamped on the identity.  project_id is always
+        # set for a delegated agent (the delegation flow requires it).
+        if sponsor_contact_id and project_id:
+            await registry.set_sponsorship(
+                canonical_id, project_id, sponsor_contact_id
+            )
     except IntegrityError:
         # A concurrent approve already took this active handle (the partial
         # unique index fired). Roll back the failed write and remove the

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -587,7 +587,12 @@ async def approve_request_record(
             # For sponsored agents (cross-user collab D1), set the sponsor
             # on the existing identity when reusing it for a new project.
             if sponsor_contact_id:
-                await registry.set_sponsor(existing_cid, sponsor_contact_id)
+                updated = await registry.set_sponsor(existing_cid, sponsor_contact_id)
+                if updated is None:
+                    logger.warning(
+                        "auth-approve: set_sponsor returned None for %s (identity gone?)",
+                        existing_cid,
+                    )
             await add_agent_to_project(
                 request,
                 canonical_id=existing_cid,

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -415,6 +415,7 @@ async def approve_request_record(
     project_id: str | None = None,
     display_name: str | None = None,
     defer_binding: bool = False,
+    sponsor_contact_id: str | None = None,
 ) -> dict:
     """Register an agent, mint its token, write grants + relationships +
     membership + a2a sync, and record the decision.
@@ -433,6 +434,10 @@ async def approve_request_record(
     until the agent is later bound to a project via
     ``POST /api/projects/{id}/members/assign-agent``. This complements the
     create-new path (which binds to the picked project at mint time).
+
+    ``sponsor_contact_id`` is set for delegated agents (cross-user collab D1)
+    — the contact_id of the human who sponsored this agent.  Omitted (None) for
+    normal consent and invite flows.
 
     Returns ``{"status": "accepted", "canonical_id": ...}``.
 
@@ -579,6 +584,10 @@ async def approve_request_record(
                 framework=record["framework"],
                 project_id=project_id,
             )
+            # For sponsored agents (cross-user collab D1), set the sponsor
+            # on the existing identity when reusing it for a new project.
+            if sponsor_contact_id:
+                await registry.set_sponsor(existing_cid, sponsor_contact_id)
             await add_agent_to_project(
                 request,
                 canonical_id=existing_cid,
@@ -629,6 +638,7 @@ async def approve_request_record(
             # auth-request record / invite, not the registry origin column.
             origin="external-selfjoin",
             handle=handle,
+            sponsor_contact_id=sponsor_contact_id,
         )
         canonical_id = reg_record["canonical_id"]
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -37,12 +37,13 @@ _ANSWER_THREAD = "decisions"
 # surface, not an approval channel), and the agent mirror path must refuse them
 # so an agent cannot self-approve a gate it created.  Keeping the list in one
 # place prevents drift between the two call sites and the applier functions.
-GATE_DECISION_KINDS = ("execution_gate", "delegation_gate", "app_grant")
+GATE_DECISION_KINDS = ("execution_gate", "delegation_gate", "app_grant", "collab_delegation_gate")
 
 # Server-stamped provenance marker for gate decisions (tsk-mul5pa).  The
 # public create path strips this key so an API caller can never self-stamp a
 # privileged gate; only the internal raisers (peer-inbox delegation dispatch,
-# execution-gate raiser, device-pairing raiser, app-grant flow) set it.  Every
+# execution-gate raiser, device-pairing raiser, app-grant flow, collab
+# delegation-gate raiser) set it.  Every
 # _apply_*_grant handler refuses to act when it is absent, so a caller-supplied
 # metadata.kind can never mint a grant on approval.
 SERVER_RAISED_KEY = "_server_raised"
@@ -872,6 +873,12 @@ async def _apply_collab_delegation_grant(request: Request, decision: dict, value
     Mirrors ``_apply_delegation_grant``: the answer is already persisted, so a
     mint hiccup must not fail the answer."""
     meta = decision.get("metadata") or {}
+    if meta.get(SERVER_RAISED_KEY) is not True:
+        logger.warning(
+            "gate decision %s refused: missing server provenance (kind=%r)",
+            decision.get("id"), meta.get("kind"),
+        )
+        return False
     if meta.get("kind") != "collab_delegation_gate":
         return False
     approved = value == "approve"

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -606,7 +606,8 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
     routed_exec = await _apply_execution_grant(request, updated, stored_value)
     routed_deleg = await _apply_delegation_grant(request, updated, stored_value)
     routed_pair = await _apply_device_pairing_grant(request, updated, stored_value)
-    if not (routed_app or routed_exec or routed_deleg or routed_pair):
+    routed_collab = await _apply_collab_delegation_grant(request, updated, stored_value)
+    if not (routed_app or routed_exec or routed_deleg or routed_pair or routed_collab):
         await _route_answer_to_agent(updated, stored_value, note=body.note)
     return updated
 
@@ -798,6 +799,48 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
         reply = "delegation approved - the task has been assigned"
     else:
         reply = "delegation approved, but assigning the task failed - please retry"
+    await _route_answer_to_agent(decision, reply)
+    return True
+
+
+async def _apply_collab_delegation_grant(request: Request, decision: dict, value) -> bool:
+    """Side effect for a cross-user collab delegation-gate Decision (D1): the
+    decision's metadata carries {kind: "collab_delegation_gate", contact_id,
+    agent_slug, display_name, granted_scopes, denied_scopes, project_id}.
+    Approving it mints the sponsored project invite via
+    ``complete_delegation_approval`` — this is the manual approval path that
+    previously had NO caller, so a delegation request reached a Decisions card
+    but nothing ever happened on approval.  Denying just routes the answer.
+    Mirrors ``_apply_delegation_grant``: the answer is already persisted, so a
+    mint hiccup must not fail the answer."""
+    meta = decision.get("metadata") or {}
+    if meta.get("kind") != "collab_delegation_gate":
+        return False
+    approved = value == "approve"
+    completed = False
+    if approved:
+        try:
+            from tinyagentos.delegation_handler import complete_delegation_approval
+
+            result = await complete_delegation_approval(
+                request, decision_metadata=meta
+            )
+            completed = result.get("status") == "approved"
+        except Exception:
+            logger.warning(
+                "collab delegation approval failed for decision %s",
+                decision.get("id"), exc_info=True,
+            )
+    # The collab delegation decision's from_agent is a hub contact id (e.g.
+    # "hub:sponsor"), not an "@agent" handle, so _route_answer_to_agent is a
+    # no-op here; the mint result is delivered over the peer channel.  Keep the
+    # reply routing call for symmetry/consistency with the other gate handlers.
+    if not approved:
+        reply = "delegation denied"
+    elif completed:
+        reply = "delegation approved - the agent invite has been minted"
+    else:
+        reply = "delegation approved, but minting the invite failed - please retry"
     await _route_answer_to_agent(decision, reply)
     return True
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -837,7 +837,6 @@ async def _deliver_delegation_invite(
             return
 
         from_username = local_id.removeprefix("hub:")
-        to_username = contact_id.removeprefix("hub:")
 
         body: dict = {
             "invite_id": invite_id,

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -803,6 +803,65 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
     return True
 
 
+async def _deliver_delegation_invite(
+    request: Request,
+    meta: dict,
+    invite_id: str,
+) -> None:
+    """Best-effort: deliver a minted delegation invite_id to the requester
+    over the peer channel so their agent runner can redeem it.
+
+    Never raises — the invite is already minted and persisted on this side,
+    so a delivery failure must not roll it back.
+    """
+    contact_id = meta.get("contact_id", "")
+    agent_slug = meta.get("agent_slug", "")
+    project_id = meta.get("project_id", "")
+
+    if not contact_id or not invite_id:
+        return
+
+    contacts_store = getattr(request.app.state, "contacts_store", None)
+    if contacts_store is None:
+        return
+
+    try:
+        import asyncio
+        from tinyagentos.peer import resolve_local_identity_id, send_envelope
+
+        data_dir = getattr(request.app.state, "data_dir", None)
+        local_id = await asyncio.to_thread(
+            resolve_local_identity_id, data_dir
+        )
+        if local_id is None:
+            return
+
+        from_username = local_id.removeprefix("hub:")
+        to_username = contact_id.removeprefix("hub:")
+
+        body: dict = {
+            "invite_id": invite_id,
+            "agent_slug": agent_slug,
+            "project_id": project_id,
+        }
+        delivered, err = await send_envelope(
+            contacts_store,
+            from_username=from_username,
+            to_contact_id=contact_id,
+            kind="delegation_status",
+            body=body,
+        )
+        if not delivered:
+            logger.warning(
+                "delegation_status delivery failed for decision invite %s: %s",
+                invite_id, err,
+            )
+    except Exception:
+        logger.warning(
+            "delegation_status delivery error for invite %s", invite_id, exc_info=True,
+        )
+
+
 async def _apply_collab_delegation_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for a cross-user collab delegation-gate Decision (D1): the
     decision's metadata carries {kind: "collab_delegation_gate", contact_id,
@@ -818,6 +877,7 @@ async def _apply_collab_delegation_grant(request: Request, decision: dict, value
         return False
     approved = value == "approve"
     completed = False
+    invite_id = None
     if approved:
         try:
             from tinyagentos.delegation_handler import complete_delegation_approval
@@ -826,6 +886,8 @@ async def _apply_collab_delegation_grant(request: Request, decision: dict, value
                 request, decision_metadata=meta
             )
             completed = result.get("status") == "approved"
+            if completed:
+                invite_id = result.get("invite_id")
         except Exception:
             logger.warning(
                 "collab delegation approval failed for decision %s",
@@ -842,6 +904,11 @@ async def _apply_collab_delegation_grant(request: Request, decision: dict, value
     else:
         reply = "delegation approved, but minting the invite failed - please retry"
     await _route_answer_to_agent(decision, reply)
+    # Deliver the invite_id to the requester over the peer channel so their
+    # agent runner can redeem it.  Best-effort: the invite is already minted
+    # and persisted; a delivery failure does not roll back the mint.
+    if completed and invite_id:
+        await _deliver_delegation_invite(request, meta, invite_id)
     return True
 
 

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -440,12 +440,56 @@ async def _handle_delegation_status(
         "contact_id": contact_id,
     }
 
+    # Idempotency on invite_id: nonces stop exact replays but not a sponsor
+    # retrying the same delegation_status after a 5xx (distinct nonce, same
+    # invite_id).  Look up any decision already recording this invite_id and
+    # return it instead of minting a duplicate that would pollute the feed.
+    try:
+        existing = await decision_store.find_by_metadata("invite_id", invite_id)
+    except Exception as exc:
+        logger.warning(
+            "peer_inbox: metadata lookup failed for invite_id=%s: %s",
+            invite_id, exc,
+        )
+        existing = []
+    if existing:
+        decision_id = existing[0]["id"]
+        logger.info(
+            "peer_inbox: delegation_status for invite_id=%s already recorded "
+            "as decision %s (duplicate delivery)",
+            invite_id, decision_id,
+        )
+        return {
+            "status": "received",
+            "kind": "delegation_status",
+            "decision_id": decision_id,
+            "invite_id": invite_id,
+            "dispatched": True,
+            "duplicate": True,
+        }
+
+    # Resolve the owner (the local project owner) so the decision is not
+    # ownerless and project-scoped queries surface it.  Best-effort: an absent
+    # project store or unknown project leaves user_id empty (still scoped via
+    # project_id).
+    user_id = ""
+    project_store = getattr(request.app.state, "project_store", None)
+    if project_store is not None and project_id:
+        try:
+            project = await project_store.get_project(project_id)
+            if project:
+                user_id = project.get("user_id") or ""
+        except Exception:
+            user_id = ""
+
     try:
         decision = await decision_store.create(
-            from_agent=f"peer:{contact_id}",
+            from_agent="system:delegation",
             question=question,
             type="free_text",
             priority="normal",
+            project_id=project_id or None,
+            user_id=user_id,
             metadata=metadata,
         )
         logger.info(

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -242,12 +242,31 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
             "agent_slug": result.get("agent_slug"),
         }
 
+    # Dispatch delegation_status — the remote instance is notifying us that a
+    # delegation request was approved and an invite was minted.  Log and return
+    # the invite_id so it is visible in the node's logs.
+    if kind == "delegation_status":
+        body_data = envelope.get("body", {})
+        invite_id = body_data.get("invite_id", "unknown")
+        agent_slug = body_data.get("agent_slug", "unknown")
+        project_id = body_data.get("project_id", "unknown")
+        logger.info(
+            "peer_inbox: delegation_status contact=%s invite=%s agent=%s project=%s",
+            contact_id, invite_id, agent_slug, project_id,
+        )
+        return {
+            "status": "received",
+            "kind": kind,
+            "invite_id": invite_id,
+            "agent_slug": agent_slug,
+            "project_id": project_id,
+        }
+
     # Log unrecognised kinds for debugging; they are accepted but not dispatched.
     logger.info(
         "peer_inbox: contact=%s kind=%s nonce=%s (unrecognised kind — accepted, no dispatch)",
         contact_id, kind, envelope.get("nonce", "?"),
     )
-
     return {"status": "received", "kind": kind, "nonce": envelope.get("nonce")}
 
 

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -86,6 +86,11 @@ async def _authenticate_peer(request: Request) -> str:
     if store is None:
         raise HTTPException(status_code=503, detail="peer channel not available")
 
+    # Per-instance panic kill-switch (D1 level 3): blocks all peer traffic.
+    from tinyagentos.delegation_handler import is_peer_disabled
+    if is_peer_disabled(request):
+        raise HTTPException(status_code=503, detail="peer routes disabled (per-instance panic)")
+
     auth = request.headers.get("authorization", "")
     if not auth.lower().startswith("bearer "):
         raise HTTPException(status_code=401, detail="bearer token required")
@@ -209,7 +214,7 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
     # Mark peer as seen
     await store.mark_peer_seen(contact_id)
 
-    # Dispatch the envelope by kind.
+    # Log the envelope kind for debugging; dispatch known kinds to their handlers.
     kind = envelope.get("kind", "unknown")
     body_data = envelope.get("body", {})
 
@@ -224,6 +229,16 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
         "peer_inbox: contact=%s kind=%s nonce=%s (unrecognised kind — accepted, no dispatch)",
         contact_id, kind, envelope.get("nonce", "?"),
     )
+
+    # Dispatch delegation requests to the cross-user collab handler (D1).
+    if kind == "delegation_request":
+        from tinyagentos.delegation_handler import process_delegation_request
+
+        body_data = envelope.get("body", {})
+        result = await process_delegation_request(
+            request, contact_id=contact_id, envelope_body=body_data,
+        )
+        return {"status": result.get("status", "unknown"), "detail": result}
 
     return {"status": "received", "kind": kind, "nonce": envelope.get("nonce")}
 

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -243,24 +243,11 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
         }
 
     # Dispatch delegation_status — the remote instance is notifying us that a
-    # delegation request was approved and an invite was minted.  Log and return
-    # the invite_id so it is visible in the node's logs.
+    # delegation request was approved and an invite was minted.  Persist it
+    # durably (invite_id in decision metadata) so the local agent runner can
+    # poll for and redeem the invite, rather than only logging it.
     if kind == "delegation_status":
-        body_data = envelope.get("body", {})
-        invite_id = body_data.get("invite_id", "unknown")
-        agent_slug = body_data.get("agent_slug", "unknown")
-        project_id = body_data.get("project_id", "unknown")
-        logger.info(
-            "peer_inbox: delegation_status contact=%s invite=%s agent=%s project=%s",
-            contact_id, invite_id, agent_slug, project_id,
-        )
-        return {
-            "status": "received",
-            "kind": kind,
-            "invite_id": invite_id,
-            "agent_slug": agent_slug,
-            "project_id": project_id,
-        }
+        return await _handle_delegation_status(request, contact_id, envelope, body_data)
 
     # Log unrecognised kinds for debugging; they are accepted but not dispatched.
     logger.info(
@@ -397,6 +384,92 @@ async def peer_ack(body: PeerAck, request: Request):
     )
 
     return {"status": "acked", "envelope_id": body.envelope_id}
+
+
+# ---------------------------------------------------------------------------
+# Delegation status handler
+# ---------------------------------------------------------------------------
+
+
+async def _handle_delegation_status(
+    request: Request,
+    contact_id: str,
+    envelope: dict,
+    body_data: dict,
+) -> dict:
+    """Handle an incoming delegation_status envelope — the sponsor notifying
+    us that a delegation request was approved and a sponsored invite minted.
+
+    Persists a durable decision record with ``invite_id`` in metadata so the
+    local agent runner can poll for and redeem the invite — the equivalent of
+    how ``collab_invite`` persists into ``decision_store``.  Without a durable
+    landing place the approval result would be dropped on the floor (logged,
+    then gone) and the delegation could never complete cross-instance.
+
+    The envelope body is expected to contain:
+      invite_id, agent_slug, project_id
+    """
+    decision_store = getattr(request.app.state, "decision_store", None)
+    if decision_store is None:
+        logger.warning(
+            "peer_inbox: delegation_status received but decision_store not available"
+        )
+        return {"status": "received", "kind": "delegation_status", "dispatched": False}
+
+    invite_id = body_data.get("invite_id", "")
+    agent_slug = body_data.get("agent_slug", "unknown")
+    project_id = body_data.get("project_id", "")
+
+    if not invite_id:
+        logger.warning(
+            "peer_inbox: delegation_status missing invite_id from contact=%s",
+            contact_id,
+        )
+        return {"status": "received", "kind": "delegation_status", "dispatched": False}
+
+    question = (
+        f"Delegation request approved: agent '{agent_slug}' was granted a "
+        f"sponsored invite for project {project_id}. Invite id: {invite_id}"
+    )
+
+    metadata: dict = {
+        "envelope_kind": "delegation_status",
+        "invite_id": invite_id,
+        "agent_slug": agent_slug,
+        "project_id": project_id,
+        "contact_id": contact_id,
+    }
+
+    try:
+        decision = await decision_store.create(
+            from_agent=f"peer:{contact_id}",
+            question=question,
+            type="free_text",
+            priority="normal",
+            metadata=metadata,
+        )
+        logger.info(
+            "peer_inbox: delegation_status → decision %s created for contact=%s",
+            decision["id"], contact_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "peer_inbox: failed to persist delegation_status decision: %s", exc
+        )
+        return {
+            "status": "received",
+            "kind": "delegation_status",
+            "dispatched": False,
+            "error": str(exc),
+        }
+
+    return {
+        "status": "received",
+        "kind": "delegation_status",
+        "decision_id": decision["id"],
+        "invite_id": invite_id,
+        "dispatched": True,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -224,21 +224,29 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
     if kind in ("collab_invite_accept", "collab_invite_decline"):
         return await _handle_collab_response(request, contact_id, envelope, body_data, kind)
 
+    # Dispatch delegation requests to the cross-user collab handler (D1).
+    # This MUST sit above the unrecognised-kind log so a delegation request
+    # does not log "no dispatch" and then dispatch.
+    if kind == "delegation_request":
+        from tinyagentos.delegation_handler import process_delegation_request
+
+        result = await process_delegation_request(
+            request, contact_id=contact_id, envelope_body=body_data,
+        )
+        # Return a summary to the peer; do NOT leak handler internals (the full
+        # result dict) verbatim.
+        return {
+            "status": result.get("status", "unknown"),
+            "decision_id": result.get("decision_id"),
+            "invite_id": result.get("invite_id"),
+            "agent_slug": result.get("agent_slug"),
+        }
+
     # Log unrecognised kinds for debugging; they are accepted but not dispatched.
     logger.info(
         "peer_inbox: contact=%s kind=%s nonce=%s (unrecognised kind — accepted, no dispatch)",
         contact_id, kind, envelope.get("nonce", "?"),
     )
-
-    # Dispatch delegation requests to the cross-user collab handler (D1).
-    if kind == "delegation_request":
-        from tinyagentos.delegation_handler import process_delegation_request
-
-        body_data = envelope.get("body", {})
-        result = await process_delegation_request(
-            request, contact_id=contact_id, envelope_body=body_data,
-        )
-        return {"status": result.get("status", "unknown"), "detail": result}
 
     return {"status": "received", "kind": kind, "nonce": envelope.get("nonce")}
 

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -1149,6 +1149,15 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
     if "project_tasks" not in scopes:
         scopes = ["project_tasks"] + scopes
 
+    # Extract sponsor_contact_id from delegation-sponsored invites (D1).
+    invite_metadata = invite.get("metadata") or {}
+    if isinstance(invite_metadata, str):
+        try:
+            invite_metadata = json.loads(invite_metadata)
+        except (ValueError, TypeError):
+            invite_metadata = {}
+    sponsor_contact_id = invite_metadata.get("sponsor_contact_id") if isinstance(invite_metadata, dict) else None
+
     handle = _derive_handle(project.get("slug") or invite["project_id"], body.harness, body.label)
     handle = await _dedupe_handle(request, handle)
 
@@ -1183,6 +1192,7 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
                 effective_project=invite["project_id"],
                 decided_by=invite["created_by"],
                 project_id=invite["project_id"],
+                sponsor_contact_id=sponsor_contact_id,
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
             await store.rollback_to_pending(body.invite_id)
@@ -1239,6 +1249,15 @@ async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict,
             raw_scopes = []
     scopes = list(raw_scopes)
 
+    # Extract sponsor_contact_id from delegation-sponsored invites (D1).
+    invite_metadata = invite.get("metadata") or {}
+    if isinstance(invite_metadata, str):
+        try:
+            invite_metadata = json.loads(invite_metadata)
+        except (ValueError, TypeError):
+            invite_metadata = {}
+    sponsor_contact_id = invite_metadata.get("sponsor_contact_id") if isinstance(invite_metadata, dict) else None
+
     display_name = invite.get("display_name")
     handle = _derive_os_handle(display_name, body.harness, body.label)
     handle = await _dedupe_handle(request, handle)
@@ -1266,6 +1285,7 @@ async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict,
                 decided_by=invite["created_by"],
                 project_id=None,
                 display_name=display_name,
+                sponsor_contact_id=sponsor_contact_id,
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
             await store.rollback_to_pending(body.invite_id)

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -99,6 +99,10 @@ class UpdateProjectIn(BaseModel):
     settings: dict | None = None
 
 
+class ProjectSettingIn(BaseModel):
+    value: object
+
+
 def _mirror(request: Request, project: dict) -> None:
     # Folder mirror is best-effort: if the disk write fails (permissions, full
     # filesystem, transient I/O), the DB row is still authoritative and the
@@ -233,6 +237,45 @@ async def update_project(
     await pstore.log_activity(project_id, user.user_id, "project.updated", payload.model_dump(exclude_none=True))
     _mirror(request, p)
     return p
+
+
+@router.get("/api/projects/{project_id}/settings/{key}")
+async def get_project_setting_route(
+    project_id: str,
+    key: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    value = await store.get_project_setting(project_id, key)
+    return {"key": key, "value": value}
+
+
+@router.put("/api/projects/{project_id}/settings/{key}")
+async def set_project_setting_route(
+    project_id: str,
+    key: str,
+    payload: ProjectSettingIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.project_store
+    p = await store.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, p["user_id"])
+    ok = await store.set_project_setting(project_id, key, payload.value)
+    if not ok:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.log_activity(
+        project_id, user.user_id, "project.settings.updated", {"key": key}
+    )
+    return {"key": key, "value": payload.value}
 
 
 @router.post("/api/projects/{project_id}/archive")


### PR DESCRIPTION
Task: t_b72392f4. Fixes #2019.

## Summary
Implement cross-user agent delegation (milestone D1 of EPIC #2012).

## Changes
- **sponsor_contact_id**: New column on agent_registry (schema + migration + store API: list_by_sponsor, set_sponsor)
- **Delegation request envelope**: Peer inbox dispatches delegation_request envelopes to delegation_handler
- **Policy gate**: Per-project auto_approve_delegation knob (default OFF); manual Decisions card on delegation
- **Sponsored scope tier**: Default {a2a_send, a2a_receive, project_tasks, canvas_read, registry_feeds_read}
- **Hard-deny**: files_write and decisions_write rejected at scope validation for sponsored agents
- **Decisions integration**: collab_delegation_gate kind triggers invite mint on approve; deny routes answer back
- **Revoke cascade**: contact/membership revocation → revoke all sponsored identities → unassign board tasks
- **3-level kill-switch**: per-agent (existing), per-contact pause (peer link + tokens), per-instance panic (disable peer routes)
- **Invite metadata**: JSON column on project_invites; sponsor_contact_id flows through redeem into agent_registry
- **Project store helpers**: is_project_member(), get/set_project_setting()

## Files changed
- tinyagentos/agent_registry_store.py — v5 migration + register param + list_by_sponsor + set_sponsor
- tinyagentos/delegation_handler.py — NEW: scope validation, envelope dispatch, decisions, cascade, kill-switch
- tinyagentos/routes/peer.py — delegation_request dispatch in inbox, peer panic check
- tinyagentos/routes/decisions.py — collab_delegation_gate decision handler
- tinyagentos/routes/agent_auth_requests.py — sponsor_contact_id param in approve_request_record
- tinyagentos/routes/project_invites.py — metadata extraction + sponsor_contact_id on redeem
- tinyagentos/projects/invite_store.py — metadata column + mint() param
- tinyagentos/projects/project_store.py — is_project_member() + get/set_project_setting()
- tests/test_collab_d1_delegation.py — NEW: 15 tests (scope validation, envelope parsing, registry methods)

## Tests
311 tests pass across: test_collab_d1_delegation, test_agent_registry, test_project_store, test_invite_store, test_contacts_peer, test_auth_middleware, test_auth_requests_store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-user delegation with sponsor-aware agent assignment and project-scoped access.
  * Added automatic or approval-based delegation workflows with scope validation.
  * Added project settings and membership controls.
  * Added invite metadata, sponsor propagation, and PIN-optional redemption with secure invite IDs.
  * Added controls to pause delegation by contact, disable peer activity instance-wide, and restore activity.
* **Bug Fixes**
  * Prevented unauthorized scopes and unsafe sponsor reassignment.
  * Added fail-closed revocation and approval handling.
* **Tests**
  * Expanded coverage across delegation, invitations, sponsorship, settings, and approval workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->