### PR TITLE
feat(app-catalog): add taOSr1 service (R1 -> taOS PA bridge, LXC)

### DIFF
--- a/app-catalog/catalog.yaml
+++ b/app-catalog/catalog.yaml
@@ -579,6 +579,12 @@ apps:
     version: 1.22.0
     name: Gitea (LXC)
     description: "Self-hosted Git server in an isolated LXC container"
+  - id: taosr1
+    type: service
+    category: agent-bridge
+    version: 0.1.0
+    name: taOSr1
+    description: "Rabbit R1 push-to-talk bridge to the taOS Personal Agent (PA) via the agent-as-a-model surface. Three agent slots."
   - id: code-server
     type: dev-tool
     version: 4.96.0

--- a/app-catalog/services/taosr1/manifest.yaml
+++ b/app-catalog/services/taosr1/manifest.yaml
@@ -1,0 +1,58 @@
+id: taosr1
+name: taOSr1
+type: service
+category: agent-bridge
+version: 0.1.0
+backend: lxc
+description: "Rabbit R1 push-to-talk bridge to the taOS Personal Agent (PA). Provisions an LXC running the taOSr1 shim, which relays R1 utterances to the taOS agent-as-a-model surface (/v1/chat/completions) and streams replies back. Three agent slots let you assign which taOS agents answer on the R1."
+homepage: https://github.com/jaylfc/taOSr1
+license: MIT
+
+requires:
+  ram_mb: 256
+  disk_mb: 200
+  ports: [7901]
+  inputs:
+    - name: taos_base_url
+      label: "taOS controller URL"
+      type: url
+      required: true
+      default: "http://192.168.6.123:6969"
+      description: "The taOS controller the shim relays to (agent-as-a-model surface)."
+    - name: consent_key
+      label: "Agent-model consent key"
+      type: secret
+      required: true
+      description: "Consent key minted by the owner (taOS /api/agent-model-keys)."
+
+install:
+  method: lxc
+  image: images:debian/bookworm
+  memory_limit: "256MiB"
+  cpu_limit: 1
+  ports:
+    http: 7901
+  # The shim + a tiny slot-assignment UI run inside the container.
+  repo: https://github.com/jaylfc/taOSr1
+  service_name: taosr1
+  state_paths:
+    - /etc/taosr1/
+    - /home/taosr1/.hermes/
+  ui_port: 7901
+  ui_path: "/"
+
+lifecycle:
+  health_check: "curl -sf http://localhost:7901/healthz"
+
+slots: 3
+slot_assignments:
+  # Populated by the user in the app UI; each slot maps to a taOS agent id.
+  # The shim reads these and routes R1 push-to-talk per active slot.
+  method: taos_agent_picker
+
+hardware_tiers:
+  arm-npu-16gb: full
+  arm-cpu-8gb: full
+  x86-cuda-12gb: full
+  cpu-only: full
+  apple-silicon: full


### PR DESCRIPTION
Registers the taOSr1 app in the catalog as a `service` with `backend: lxc`, provisioning an LXC that runs the taOSr1 shim (github.com/jaylfc/taOSr1). The shim relays Rabbit R1 push-to-talk to the taOS agent-as-a-model surface (/v1/chat/completions, consent key) and streams replies back. Exposes a 3-slot UI for assigning taOS agents.

Pattern copied from gitea-lxc (backend: lxc, ui_port, state_paths, lifecycle.health_check).

Depends on:
- taOS PR #2176 (agent turn execution slice) — CI green, awaiting merge
- the shim repo github.com/jaylfc/taOSr1 (built + tested)

Open questions for @taOS-dev (msg 1659): slot-assignment UI design + whether the platform renders slots from a manifest field or I bundle a SPA. Holding the SPA until that's settled.