### PR TITLE
check_doc_gate invariants: file:line citations and cross-repo paths fail as nonexistent

### DIFF
--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -65,6 +65,12 @@ _GLOB_OR_PLACEHOLDER_CHARS = set("*?[]{}<>$~")
 # Trailing punctuation that is prose/markdown decoration, not part of the path.
 _TRAILING_PUNCT = ".,;:!?)]}'\"`"
 
+# A line-citation suffix: `:123`, `:12-20`, `:1,5-9`, and repeated groups so
+# file:line:col (ripgrep, compiler output) collapses in one pass. Applied
+# AFTER the trailing-punct strip — the anchor is defeated by a trailing full
+# stop or comma otherwise, and citations ending a sentence are the common case.
+_LINE_SUFFIX_RE = re.compile(r"(?::[0-9]+(?:-[0-9]+)?(?:,[0-9]+(?:-[0-9]+)?)*)+$")
+
 
 def _clean_token(raw: str) -> str | None:
     """Normalize a raw regex match into a bare repo-relative path, or None
@@ -74,9 +80,9 @@ def _clean_token(raw: str) -> str | None:
     for sep in ("#", "?", "::"):
         if sep in token:
             token = token.split(sep, 1)[0]
-    token = re.sub(r":[0-9]+(?:-[0-9]+)?(?:,[0-9]+(?:-[0-9]+)?)*$", "", token)
     while token and token[-1] in _TRAILING_PUNCT:
         token = token[:-1]
+    token = _LINE_SUFFIX_RE.sub("", token)
     if not token:
         return None
     if any(c in _GLOB_OR_PLACEHOLDER_CHARS for c in token):

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -54,8 +54,9 @@ EXIT_CONFIG_ERROR = 3
 # exist in the repo itself. `-` is in the lookbehind for the same reason:
 # home-dir slugs like "-*-tinyagentos/memory/MEMORY.md" embed a repo prefix
 # after a hyphen, and the glob `*` sits BEFORE the match so the glob filter
-# never sees it.
-_TOKEN_RE = re.compile(r"(?<![\w/-])(?:scripts|tinyagentos|docs|desktop)/[^\s`\"'|]+")
+# never sees it. `)` and `]` are excluded from the token body so a markdown
+# link's closing bracket ends the token instead of gluing the URL on.
+_TOKEN_RE = re.compile(r"(?<![\w/-])(?:scripts|tinyagentos|docs|desktop)/[^\s`\"'|)\]]+")
 
 # Chars that mark a token as a glob pattern or a <placeholder> rather than a
 # concrete repo path -- these are never asserted to exist.
@@ -73,6 +74,7 @@ def _clean_token(raw: str) -> str | None:
     for sep in ("#", "?", "::"):
         if sep in token:
             token = token.split(sep, 1)[0]
+    token = re.sub(r":[0-9]+(?:-[0-9]+)?(?:,[0-9]+(?:-[0-9]+)?)*$", "", token)
     while token and token[-1] in _TRAILING_PUNCT:
         token = token[:-1]
     if not token:

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -175,6 +175,30 @@ class TestCheckReferencedPaths:
         failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
         assert failures == []
 
+    def test_file_line_citation_is_ignored(self, tmp_path: Path):
+        """A file:line citation like `scripts/foo.sh:123` must not be treated as
+        a nonexistent path; the line-number suffix is stripped before the
+        existence check."""
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "foo.sh").write_text("#!/bin/sh\n")
+        readme = tmp_path / "README.md"
+        readme.write_text("See `scripts/foo.sh:123` for details.\n")
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
+    def test_markdown_link_url_not_consumed_as_path(self, tmp_path: Path):
+        """A markdown link whose URL points to another repo must not have the
+        URL consumed as part of the path token."""
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "agent-manual.md").write_text("# Agent Manual\n")
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "See [docs/agent-manual.md]"
+            "(https://github.com/other/repo/blob/main/docs/agent-manual.md).\n"
+        )
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -186,6 +186,36 @@ class TestCheckReferencedPaths:
         failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
         assert failures == []
 
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "See scripts/foo.sh:123. That is the place.",   # sentence-ending stop
+            "In scripts/foo.sh:123, the loop starts.",       # list/apposition comma
+            "grep hit at scripts/foo.sh:12:34 today",        # file:line:col
+            "the range (scripts/foo.sh:12-20) covers it",    # paren-closed range
+            "multi scripts/foo.sh:1,5-9 selection",          # comma range list
+        ],
+    )
+    def test_citation_shapes_with_punctuation_are_ignored(self, tmp_path: Path, prose):
+        """The four shapes that false-positived when the suffix strip ran
+        BEFORE the trailing-punct loop (lead block on #2307): the punct
+        defeats an end-anchored regex. Each proved red on the pre-reorder
+        commit."""
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "foo.sh").write_text("#!/bin/sh\n")
+        (tmp_path / "README.md").write_text(prose + "\n")
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
+    def test_colon_in_real_filename_is_preserved(self, tmp_path: Path):
+        """A path legitimately containing a colon is NOT truncated - only
+        numeric line-citation suffixes are stripped."""
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "weird:name.md").write_text("x\n")
+        (tmp_path / "README.md").write_text("See docs/weird:name.md here.\n")
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
     def test_markdown_link_url_not_consumed_as_path(self, tmp_path: Path):
         """A markdown link whose URL points to another repo must not have the
         URL consumed as part of the path token."""


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_doc_gate invariants: file:line citations and cross-repo paths fail as nonexistent

Autonomous build of board card tsk-zcnklp.



Files:
 scripts/check_doc_gate.py |  3 ++-
 tests/test_doc_gate.py    | 24 ++++++++++++++++++++++++
 2 files changed, 26 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file references with source-line citations, punctuation, and line ranges.
  * Preserved valid filenames containing colons.
  * Prevented path-like text in external Markdown URLs from being incorrectly flagged.

* **Tests**
  * Added coverage for file-and-line citations, punctuation variants, colon-containing filenames, and external URLs with path-like content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->