### PR TITLE
Fix-forward PR 2220 (os-events SSE): doc-gate + hook fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
   `POST /api/desktop/screenshot` prominently featured. The agent-manual index now
   points at both the OS skill and the existing `taos-development-skill`. Draft for
   @taOS-dev review.
+- **OS-level typed change-event stream + `useOsEvents` hook.** A new authenticated
+  SSE endpoint (`GET /api/os/events`) streams typed change events carrying only the
+  event kind and id, never the payload, so apps can opt into live updates with a
+  single hook call. The shared `useOsEvents(kinds, onEvent)` hook manages a single
+  per-client connection, exposes `connected` and `stale` flags, and handles
+  reconnect with exponential backoff.
 - Projects gain a Notes area: title + markdown notes per project, readable and
   writable by the project owner or by an agent holding a project-bound
   `project_notes` grant (new requestable scope) (#2285).

--- a/desktop/src/hooks/use-os-events.test.ts
+++ b/desktop/src/hooks/use-os-events.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOsEvents, OsEvent } from "./use-os-events";
+
+// ---------------------------------------------------------------------------
+// Mock EventSource -- must use a regular function (not arrow) so `new` works
+// ---------------------------------------------------------------------------
+
+type MessageListener = (e: MessageEvent) => void;
+
+interface MockEventSource {
+  url: string;
+  onopen: (() => void) | null;
+  onmessage: MessageListener | null;
+  onerror: ((e: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+  _fire: (data: unknown) => void;
+  _fireError: () => void;
+}
+
+let lastEs: MockEventSource | null = null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockEventSourceCtor = vi.fn().mockImplementation(function (this: any, url: string) {
+  this.url = url;
+  this.onopen = null;
+  this.onmessage = null;
+  this.onerror = null;
+  this.close = vi.fn();
+  this.readyState = 0; // CONNECTING
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  this._fire = (data: unknown) => {
+    (this as MockEventSource).onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  };
+  this._fireError = () => {
+    (this as MockEventSource).onerror?.(new Event("error"));
+  };
+  lastEs = this as MockEventSource;
+});
+
+beforeEach(() => {
+  vi.stubGlobal("EventSource", MockEventSourceCtor);
+  MockEventSourceCtor.mockClear();
+  lastEs = null;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useOsEvents", () => {
+  it("opens an EventSource to /api/os/events with kinds on mount", () => {
+    renderHook(() => useOsEvents(["projects.task.changed"], () => {}));
+    expect(MockEventSourceCtor).toHaveBeenCalledWith(
+      "/api/os/events?kinds=projects.task.changed",
+    );
+  });
+
+  it("opens an EventSource without kinds when kinds is empty", () => {
+    renderHook(() => useOsEvents([], () => {}));
+    expect(MockEventSourceCtor).toHaveBeenCalledWith("/api/os/events");
+  });
+
+  it("calls onEvent for matching kind", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useOsEvents(["projects.task.changed"], onEvent));
+
+    act(() => {
+      lastEs?._fire({
+        kind: "projects.task.changed",
+        id: "evt-1",
+        ts: 1234567890.0,
+      });
+    });
+
+    expect(onEvent).toHaveBeenCalledWith({
+      kind: "projects.task.changed",
+      id: "evt-1",
+      ts: 1234567890.0,
+    });
+  });
+
+  it("ignores non-matching kind", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useOsEvents(["projects.task.changed"], onEvent));
+
+    act(() => {
+      lastEs?._fire({
+        kind: "agents.status.changed",
+        id: "evt-2",
+        ts: 1234567890.0,
+      });
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("sets connected=true and stale=false on open", async () => {
+    const { result } = renderHook(() =>
+      useOsEvents(["projects.task.changed"], () => {}),
+    );
+
+    act(() => {
+      lastEs?.onopen?.();
+    });
+
+    expect(result.current.connected).toBe(true);
+    expect(result.current.stale).toBe(false);
+  });
+
+  it("sets connected=false and stale=true on hard disconnect", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useOsEvents(["projects.task.changed"], () => {}),
+    );
+
+    act(() => {
+      lastEs?.onopen?.();
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.stale).toBe(false);
+
+    act(() => {
+      if (lastEs) {
+        lastEs.readyState = EventSource.CLOSED;
+        lastEs._fireError();
+      }
+    });
+
+    expect(result.current.connected).toBe(false);
+    expect(result.current.stale).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useOsEvents(["projects.task.changed"], () => {}),
+    );
+    unmount();
+    expect(lastEs?.close).toHaveBeenCalled();
+  });
+
+  it("deduplicates events by id", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useOsEvents(["projects.task.changed"], onEvent));
+
+    act(() => {
+      lastEs?._fire({
+        kind: "projects.task.changed",
+        id: "evt-dup",
+        ts: 1234567890.0,
+      });
+      lastEs?._fire({
+        kind: "projects.task.changed",
+        id: "evt-dup",
+        ts: 1234567890.0,
+      });
+    });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconnects after drop and receives new events", async () => {
+    vi.useFakeTimers();
+    const onEvent = vi.fn();
+    const { result } = renderHook(() =>
+      useOsEvents(["projects.task.changed"], onEvent),
+    );
+
+    act(() => {
+      lastEs?.onopen?.();
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.stale).toBe(false);
+
+    act(() => {
+      if (lastEs) {
+        lastEs.readyState = EventSource.CLOSED;
+        lastEs._fireError();
+      }
+    });
+    expect(result.current.connected).toBe(false);
+    expect(result.current.stale).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(MockEventSourceCtor).toHaveBeenCalledTimes(2);
+    expect(lastEs).not.toBeNull();
+    act(() => {
+      lastEs?.onopen?.();
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.stale).toBe(false);
+
+    act(() => {
+      lastEs?._fire({
+        kind: "projects.task.changed",
+        id: "evt-reconnect",
+        ts: 1234567890.0,
+      });
+    });
+    expect(onEvent).toHaveBeenCalledWith({
+      kind: "projects.task.changed",
+      id: "evt-reconnect",
+      ts: 1234567890.0,
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("ignores events with no kind", () => {
+    const onEvent = vi.fn();
+    renderHook(() => useOsEvents(["projects.task.changed"], onEvent));
+
+    act(() => {
+      lastEs?._fire({
+        id: "evt-nokind",
+        ts: 1234567890.0,
+      });
+    });
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/hooks/use-os-events.ts
+++ b/desktop/src/hooks/use-os-events.ts
@@ -1,0 +1,113 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+
+export type OsEvent = {
+  kind: string;
+  id: string;
+  ts: number;
+};
+
+type OsEventHandler = (event: OsEvent) => void;
+
+const RECONNECT_DELAY_MS = 5000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+const MAX_SEEN_IDS = 128;
+
+export function useOsEvents(kinds: string[], onEvent: OsEventHandler): {
+  connected: boolean;
+  stale: boolean;
+} {
+  const [connected, setConnected] = useState(false);
+  const [stale, setStale] = useState(true);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const stoppedRef = useRef(false);
+  const esRef = useRef<EventSource | null>(null);
+  const seenIdsRef = useRef<string[]>([]);
+  const seenRef = useRef(new Set<string>());
+  const onEventRef = useRef(onEvent);
+  const kindsRef = useRef(kinds);
+
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    kindsRef.current = kinds;
+  }, [kinds]);
+
+  const connect = useCallback(() => {
+    if (stoppedRef.current) return;
+
+    const kindsParam = kindsRef.current.join(",");
+    const url = kindsParam
+      ? `/api/os/events?kinds=${encodeURIComponent(kindsParam)}`
+      : "/api/os/events";
+
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    const alreadySeen = (id: string | undefined): boolean => {
+      if (!id) return false;
+      if (seenRef.current.has(id)) return true;
+      seenRef.current.add(id);
+      seenIdsRef.current.push(id);
+      if (seenIdsRef.current.length > MAX_SEEN_IDS) {
+        const oldest = seenIdsRef.current.shift();
+        if (oldest) seenRef.current.delete(oldest);
+      }
+      return false;
+    };
+
+    es.onopen = () => {
+      reconnectAttemptsRef.current = 0;
+      setConnected(true);
+      setStale(false);
+    };
+
+    es.onmessage = (msg) => {
+      let event: OsEvent | null;
+      try {
+        event = JSON.parse(msg.data as string) as OsEvent;
+      } catch {
+        return;
+      }
+      if (!event || typeof event !== "object") return;
+      if (!event.kind) return;
+      if (kindsRef.current.length > 0 && !kindsRef.current.includes(event.kind)) {
+        return;
+      }
+      if (alreadySeen(event.id)) return;
+      onEventRef.current(event);
+    };
+
+    es.onerror = () => {
+      if (!stoppedRef.current && es.readyState === EventSource.CLOSED) {
+        const delay = Math.min(
+          RECONNECT_DELAY_MS * 2 ** reconnectAttemptsRef.current,
+          MAX_RECONNECT_DELAY_MS,
+        );
+        reconnectAttemptsRef.current += 1;
+        setConnected(false);
+        setStale(true);
+        reconnectTimerRef.current = setTimeout(() => {
+          if (!stoppedRef.current) connect();
+        }, delay);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    stoppedRef.current = false;
+    connect();
+
+    return () => {
+      stoppedRef.current = true;
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      esRef.current?.close();
+      setConnected(false);
+      setStale(true);
+    };
+  }, [connect]);
+
+  return { connected, stale };
+}

--- a/tests/test_os_events.py
+++ b/tests/test_os_events.py
@@ -1,0 +1,282 @@
+"""Tests for GET /api/os/events."""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.datastructures import State
+
+from tinyagentos.events.bus import EventBus, SystemEvent
+from tinyagentos.routes.os_events import router as os_events_router
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.state.event_bus = EventBus()
+
+    @app.middleware("http")
+    async def _auth_middleware(request, call_next):
+        request.state.user_id = "test-user"
+        request.state.is_admin = False
+        return await call_next(request)
+
+    app.include_router(os_events_router)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_requires_auth():
+    """Unauthenticated requests are rejected with 401."""
+    app = FastAPI()
+    app.state.event_bus = EventBus()
+    app.include_router(os_events_router)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as no_auth:
+        resp = await no_auth.get("/api/os/events")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_requires_auth_explicit_setup():
+    """Belt-and-braces: request.state.user_id=None gives 401."""
+    from tinyagentos.routes.os_events import os_events
+    from unittest.mock import MagicMock
+
+    req = MagicMock()
+    req.state.user_id = None
+    resp = await os_events(req)
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Streaming behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_delivers_subscribed_kinds():
+    """An event whose kind matches the filter is delivered."""
+    app = _make_app()
+    bus: EventBus = app.state.event_bus
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "headers": [(b"accept", b"text/event-stream")],
+        "scheme": "http",
+        "path": "/api/os/events",
+        "raw_path": b"/api/os/events?kinds=projects.task.changed",
+        "query_string": b"kinds=projects.task.changed",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+        "state": State(),
+    }
+    scope["state"].user_id = "user-1"
+    scope["state"].is_admin = False
+
+    lines: list[str] = []
+    done = asyncio.Event()
+
+    async def receive():
+        await done.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.body":
+            body = message.get("body", b"")
+            for line in body.decode().split("\n"):
+                s = line.rstrip("\r")
+                if s.startswith("data:"):
+                    lines.append(s)
+                    done.set()
+
+    task = asyncio.create_task(app(scope, receive, send))
+    await asyncio.sleep(0.2)
+
+    await bus.broadcast(
+        SystemEvent(
+            kind="projects.task.changed",
+            source="system",
+            targets=["broadcast"],
+            payload={"task_id": "tsk-123"},
+        )
+    )
+
+    try:
+        await asyncio.wait_for(done.wait(), timeout=3.0)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    assert lines, "no data: line received"
+    evt = json.loads(lines[0][5:].strip())
+    assert evt["kind"] == "projects.task.changed"
+    assert "payload" not in evt
+    assert evt["id"] is not None
+    assert evt["ts"] is not None
+
+
+@pytest.mark.asyncio
+async def test_stream_filters_kinds():
+    """An event whose kind does NOT match the filter is dropped."""
+    app = _make_app()
+    bus: EventBus = app.state.event_bus
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "headers": [(b"accept", b"text/event-stream")],
+        "scheme": "http",
+        "path": "/api/os/events",
+        "raw_path": b"/api/os/events?kinds=projects.task.changed",
+        "query_string": b"kinds=projects.task.changed",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+        "state": State(),
+    }
+    scope["state"].user_id = "user-1"
+    scope["state"].is_admin = False
+
+    lines: list[str] = []
+    got_wrong_kind = asyncio.Event()
+
+    async def receive():
+        await got_wrong_kind.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        if message["type"] == "http.response.body":
+            body = message.get("body", b"")
+            for line in body.decode().split("\n"):
+                s = line.rstrip("\r")
+                if s.startswith("data:"):
+                    lines.append(s)
+                    got_wrong_kind.set()
+
+    task = asyncio.create_task(app(scope, receive, send))
+    await asyncio.sleep(0.2)
+
+    await bus.broadcast(
+        SystemEvent(
+            kind="agents.status.changed",
+            source="system",
+            targets=["broadcast"],
+            payload={"agent_id": "agent-1"},
+        )
+    )
+
+    try:
+        await asyncio.wait_for(got_wrong_kind.wait(), timeout=1.0)
+    except asyncio.TimeoutError:
+        pass  # expected: wrong kind must not arrive
+
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+    assert not lines, f"expected no events for wrong kind, got: {lines}"
+
+
+@pytest.mark.asyncio
+async def test_stream_two_subscribers_both_receive():
+    """Two authenticated clients subscribed to the same kind both get the event."""
+    app = _make_app()
+    bus: EventBus = app.state.event_bus
+
+    results: list[list[str]] = [[], []]
+    dones = [asyncio.Event(), asyncio.Event()]
+    tasks: list[asyncio.Task] = []
+
+    for i in range(2):
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "headers": [(b"accept", b"text/event-stream")],
+            "scheme": "http",
+            "path": "/api/os/events",
+            "raw_path": b"/api/os/events",
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 1234 + i),
+            "root_path": "",
+            "state": State(),
+        }
+        scope["state"].user_id = f"user-{i}"
+        scope["state"].is_admin = False
+
+        async def receive(idx=i):
+            await dones[idx].wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message, idx=i):
+            if message["type"] == "http.response.body":
+                body = message.get("body", b"")
+                for line in body.decode().split("\n"):
+                    s = line.rstrip("\r")
+                    if s.startswith("data:"):
+                        results[idx].append(s)
+                        dones[idx].set()
+
+        tasks.append(asyncio.create_task(app(scope, receive, send)))
+
+    await asyncio.sleep(0.2)
+
+    await bus.broadcast(
+        SystemEvent(
+            kind="projects.task.changed",
+            source="system",
+            targets=["broadcast"],
+            payload={"task_id": "tsk-123"},
+        )
+    )
+
+    try:
+        await asyncio.wait_for(dones[0].wait(), timeout=3.0)
+        await asyncio.wait_for(dones[1].wait(), timeout=3.0)
+    finally:
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    assert len(results[0]) == 1
+    assert len(results[1]) == 1
+    evt0 = json.loads(results[0][0][5:].strip())
+    evt1 = json.loads(results[1][0][5:].strip())
+    assert evt0["kind"] == "projects.task.changed"
+    assert evt1["kind"] == "projects.task.changed"
+    assert "payload" not in evt0
+    assert "payload" not in evt1
+    assert evt0["id"] is not None
+    assert evt1["id"] is not None

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -347,6 +347,9 @@ def register_all_routers(app):
     from tinyagentos.routes.event_stream import router as event_stream_router
     app.include_router(event_stream_router, dependencies=_csrf)
 
+    from tinyagentos.routes.os_events import router as os_events_router
+    app.include_router(os_events_router, dependencies=_csrf)
+
     # OTLP/HTTP+JSON receiver -- Phase 2 observability.
     # POST /v1/traces accepts ExportTraceServiceRequest JSON and writes spans
     # to the per-agent SpanStore (app.state.span_store_registry).

--- a/tinyagentos/routes/os_events.py
+++ b/tinyagentos/routes/os_events.py
@@ -1,0 +1,121 @@
+"""SSE endpoint: GET /api/os/events
+
+Streams typed OS-level change events from the EventBus.  Each frame carries
+only the event kind and id -- NEVER the payload -- so the client can react
+to changes without learning the contents.
+
+Auth: session cookie via AuthMiddleware (this path is NOT in EXEMPT_PATHS, so
+unauthenticated requests are rejected with 401 before they reach the handler).
+The handler also checks user_id explicitly to produce a clear error if the
+middleware somehow skips it (belt-and-braces).
+
+Query params:
+  kinds: comma-separated list of event kinds to subscribe to (e.g.
+         "projects.task.changed,agents.status.changed,notifications.new").
+         An empty or missing kinds parameter means "subscribe to all".
+
+Reconnect / resume: the EventBus replay buffer (last 32 events per channel)
+is delivered to new subscribers automatically on subscribe(), so recent
+events are re-streamed on every (re)connect.  This is best-effort, not
+precise replay via Last-Event-ID.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter
+from fastapi.requests import Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/os/events")
+async def os_events(request: Request):
+    """SSE stream of typed OS change events for the calling user.
+
+    Subscribes to both the per-user channel (``user:<id>``) and the broadcast
+    channel on the EventBus and merges them.  Keepalives are sent every 10 s
+    so proxies don't close the connection.  Both channel subscriptions are
+    cleaned up on disconnect or generator cancellation.
+
+    The ``kinds`` query parameter limits events to a comma-separated list of
+    kinds; an empty or omitted parameter means "all kinds".  Events are
+    emitted with only ``kind`` and ``id`` fields -- never the payload.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    event_bus = getattr(request.app.state, "event_bus", None)
+    if event_bus is None:
+        return JSONResponse({"detail": "Service starting"}, status_code=503)
+
+    kinds_param = request.query_params.get("kinds", "")
+    allowed_kinds = (
+        {k.strip() for k in kinds_param.split(",") if k.strip()}
+        if kinds_param
+        else None
+    )
+
+    user_ch = f"user:{user_id}"
+    user_q = await event_bus.subscribe(user_ch)
+    bcast_q = await event_bus.subscribe("broadcast")
+
+    # Merge both channels into a single queue so the generator has one await.
+    merged: asyncio.Queue = asyncio.Queue()
+
+    async def _relay(src: asyncio.Queue) -> None:
+        while True:
+            ev = await src.get()
+            await merged.put(ev)
+
+    relay_tasks = [
+        asyncio.create_task(_relay(user_q), name="os-events-relay-user"),
+        asyncio.create_task(_relay(bcast_q), name="os-events-relay-bcast"),
+    ]
+
+    async def gen():
+        seq = 0
+        try:
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    event = await asyncio.wait_for(merged.get(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    yield ":keepalive\n\n"
+                    continue
+                if allowed_kinds is not None and event.kind not in allowed_kinds:
+                    continue
+                seq += 1
+                data = json.dumps(
+                    {
+                        "kind": event.kind,
+                        "id": event.trace_id,
+                        "ts": event.ts,
+                    }
+                )
+                yield f"id: {seq}\ndata: {data}\n\n"
+        finally:
+            for t in relay_tasks:
+                t.cancel()
+            await asyncio.gather(*relay_tasks, return_exceptions=True)
+            await event_bus.unsubscribe(user_ch, user_q)
+            await event_bus.unsubscribe("broadcast", bcast_q)
+
+    # Cache-Control: no-cache + X-Accel-Buffering: no prevent nginx/proxies
+    # from buffering the stream (which would coalesce or delay events).
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward PR 2220 (os-events SSE): doc-gate + hook fixes

Autonomous build of board card tsk-jmctoa.

- New authenticated SSE endpoint at GET /api/os/events streams typed
  change events (kind + id only, never payload) filtered by kinds query param
- New shared client hook useOsEvents(kinds, onEvent) returns connected/stale
  flags, manages single per-client EventSource with exponential backoff
- Reuses existing EventBus SSE plumbing and auth middleware
- Backend tests cover auth gate, kind filtering, and multi-subscriber delivery
- Frontend tests cover hook mount, kind filtering, dedup, stale flag, and reconnect

Files:
 CHANGELOG.md                            |   6 +
 desktop/src/hooks/use-os-events.test.ts | 228 ++++++++++++++++++++++++++
 desktop/src/hooks/use-os-events.ts      | 113 +++++++++++++
 tests/test_os_events.py                 | 282 ++++++++++++++++++++++++++++++++
 tinyagentos/routes/__init__.py          |   3 +
 tinyagentos/routes/os_events.py         | 121 ++++++++++++++
 6 files changed, 753 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated, real-time operating-system event stream.
  * Events include identifiers, types, and timestamps while omitting payload details.
  * Added reliable connection monitoring with freshness status and automatic reconnection after interruptions.
  * Supports filtering for relevant event types and safely handles duplicate or invalid events.

* **Documentation**
  * Added an Unreleased changelog entry describing the new event-stream capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->