### PR TITLE
Lists S1b: routes + scopes + middleware allowlist (#2140)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,6 +368,14 @@ async def client(app, tmp_data_dir):
     if project_notes_store._db is not None:
         await project_notes_store.close()
     await project_notes_store.init()
+    project_lists_store = app.state.project_lists_store
+    if project_lists_store._db is not None:
+        await project_lists_store.close()
+    await project_lists_store.init()
+    project_list_entries_store = app.state.project_list_entries_store
+    if project_list_entries_store._db is not None:
+        await project_list_entries_store.close()
+    await project_list_entries_store.init()
     routine_store = app.state.routine_store
     if routine_store._db is not None:
         await routine_store.close()
@@ -509,6 +517,8 @@ async def client(app, tmp_data_dir):
     await client_log_store.close()
     await project_element_store.close()
     await project_notes_store.close()
+    await project_lists_store.close()
+    await project_list_entries_store.close()
     await app.state.qmd_client.close()
     await app.state.http_client.aclose()
     await _browser_store.close()

--- a/tests/projects/test_routes_lists.py
+++ b/tests/projects/test_routes_lists.py
@@ -1,0 +1,332 @@
+"""Project lists routes: session owner/admin and project-bound agent JWT.
+
+Pin the dual-auth contract for /api/projects/{id}/lists and entries:
+
+   1. A session owner/admin can CRUD lists and their entries.
+   2. An approved agent token (scope project_lists) bound to project A can
+      CRUD lists and entries ONLY for project A; a token bound elsewhere
+      collapses into an existence-hiding 404.
+   3. A token missing the project_lists scope is rejected 401; an
+      unauthenticated (no session, no token) request is 401.
+   4. An unknown scope is rejected at mint.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+@pytest_asyncio.fixture
+async def ctx(client):
+    """Reuse the session-admin `client` app and additionally init the agent
+    registry + grants stores so tokens can be minted against real stores."""
+    app = client._transport.app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    uid = app.state.auth.find_user("admin")["id"]
+    yield SimpleNamespace(client=client, app=app, uid=uid)
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+def _bare(app):
+    """Cookieless client so requests carry only the Bearer header."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _new_project(ctx, slug):
+    resp = await ctx.client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _mint_agent(ctx, project_id, scopes=("project_lists",)):
+    registry = ctx.app.state.agent_registry
+    grants = ctx.app.state.agent_grants
+    priv, _pub = ctx.app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+class TestOwnerSessionCRUD:
+    async def test_create_list(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "Shopping", "description": "groceries"}
+        )
+        assert resp.status_code == 200, resp.text
+        lst = resp.json()
+        assert lst["title"] == "Shopping"
+        assert lst["description"] == "groceries"
+        assert lst["status"] == "active"
+        assert lst["id"].startswith("lst-")
+
+    async def test_list_lists(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "B", "description": ""}
+        )
+        resp = await ctx.client.get(f"/api/projects/{pid}/lists")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 2
+
+    async def test_get_list(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        resp = await ctx.client.get(f"/api/projects/{pid}/lists/{lst_id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == lst_id
+
+    async def test_update_list(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/lists/{lst_id}", json={"title": "Renamed", "status": "archived"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Renamed"
+        assert resp.json()["status"] == "archived"
+
+    async def test_delete_list(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "Gone", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        resp = await ctx.client.delete(f"/api/projects/{pid}/lists/{lst_id}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    async def test_add_list_entry(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "Buy milk", "position": 0},
+        )
+        assert resp.status_code == 200, resp.text
+        entry = resp.json()
+        assert entry["text"] == "Buy milk"
+        assert entry["position"] == 0
+
+    async def test_list_entries(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "A", "position": 0},
+        )
+        await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "B", "position": 1},
+        )
+        resp = await ctx.client.get(f"/api/projects/{pid}/lists/{lst_id}/entries")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 2
+
+    async def test_update_entry(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        entry = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "A", "position": 0},
+        )
+        entry_id = entry.json()["id"]
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/lists/{lst_id}/entries/{entry_id}",
+            json={"done": True, "text": "done"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["done"] == 1
+        assert resp.json()["text"] == "done"
+
+    async def test_delete_entry(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        entry = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "A", "position": 0},
+        )
+        entry_id = entry.json()["id"]
+        resp = await ctx.client.delete(
+            f"/api/projects/{pid}/lists/{lst_id}/entries/{entry_id}"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    async def test_reorder_entries(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/lists", json={"title": "A", "description": ""}
+        )
+        lst_id = created.json()["id"]
+        e1 = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "A", "position": 0},
+        )
+        e2 = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries",
+            json={"text": "B", "position": 1},
+        )
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/lists/{lst_id}/entries/reorder",
+            json={
+                "entries": [
+                    {"id": e2.json()["id"], "position": 0},
+                    {"id": e1.json()["id"], "position": 1},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        items = await ctx.client.get(
+            f"/api/projects/{pid}/lists/{lst_id}/entries"
+        )
+        texts = [e["text"] for e in items.json()["items"]]
+        assert texts == ["B", "A"]
+
+
+@pytest.mark.asyncio
+class TestAgentScopeGating:
+    async def test_agent_with_scope_can_crud_lists(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/lists",
+                json={"title": "A", "description": ""},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+            lst_id = resp.json()["id"]
+
+            resp = await bare.get(f"/api/projects/{pid}/lists", headers=_hdr(token))
+            assert resp.status_code == 200
+
+            resp = await bare.get(
+                f"/api/projects/{pid}/lists/{lst_id}", headers=_hdr(token)
+            )
+            assert resp.status_code == 200
+
+            resp = await bare.patch(
+                f"/api/projects/{pid}/lists/{lst_id}",
+                json={"title": "B"},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+
+            resp = await bare.delete(
+                f"/api/projects/{pid}/lists/{lst_id}", headers=_hdr(token)
+            )
+            assert resp.status_code == 200
+
+    async def test_agent_with_scope_can_crud_entries(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/lists",
+                json={"title": "A", "description": ""},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+            lst_id = resp.json()["id"]
+
+            resp = await bare.post(
+                f"/api/projects/{pid}/lists/{lst_id}/entries",
+                json={"text": "milk", "position": 0},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+            entry_id = resp.json()["id"]
+
+            resp = await bare.get(
+                f"/api/projects/{pid}/lists/{lst_id}/entries", headers=_hdr(token)
+            )
+            assert resp.status_code == 200
+
+            resp = await bare.patch(
+                f"/api/projects/{pid}/lists/{lst_id}/entries/{entry_id}",
+                json={"done": True},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+
+            resp = await bare.delete(
+                f"/api/projects/{pid}/lists/{lst_id}/entries/{entry_id}",
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 200
+
+    async def test_agent_wrong_project_is_404(self, ctx):
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "beta")
+        _, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid_b}/lists", headers=_hdr(token_a)
+            )
+            assert resp.status_code == 404
+
+    async def test_agent_missing_scope_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _, token = await _mint_agent(ctx, pid, scopes=("a2a_receive",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/lists", headers=_hdr(token)
+            )
+        assert resp.status_code == 403, resp.text
+
+    async def test_unauthenticated_is_401(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/lists")
+        assert resp.status_code == 401, resp.text

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -425,6 +425,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     doc_review_store = DocReviewStore(data_dir / "projects.db")
     from tinyagentos.projects.notes_store import ProjectNotesStore
     project_notes_store = ProjectNotesStore(data_dir / "projects.db")
+    from tinyagentos.projects.lists_store import ProjectListsStore, ProjectListEntriesStore
+    project_lists_store = ProjectListsStore(data_dir / "projects.db")
+    project_list_entries_store = ProjectListEntriesStore(data_dir / "projects.db")
     from tinyagentos.decisions.decision_store import DecisionStore
     decision_store = DecisionStore(data_dir / "decisions.db")
     from tinyagentos.governance.policy_store import ExecutionPolicyStore
@@ -592,6 +595,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await project_canvas_store.init()
         await doc_review_store.init()
         await project_notes_store.init()
+        await project_lists_store.init()
+        await project_list_entries_store.init()
         await decision_store.init()
         await execution_policy_store.init()
         await shared_docs_store.init()
@@ -1457,6 +1462,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await project_canvas_store.close()
         await doc_review_store.close()
         await project_notes_store.close()
+        await project_lists_store.close()
+        await project_list_entries_store.close()
         await project_invite_store.close()
         await project_task_store.close()
         await project_element_store.close()
@@ -1622,6 +1629,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.project_canvas_store = project_canvas_store
     app.state.doc_review_store = doc_review_store
     app.state.project_notes_store = project_notes_store
+    app.state.project_lists_store = project_lists_store
+    app.state.project_list_entries_store = project_list_entries_store
     app.state.decision_store = decision_store
     app.state.execution_policies = execution_policy_store
     app.state.shared_docs_store = shared_docs_store

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -102,6 +102,32 @@ _AGENT_DOC_REVIEW_ROUTES = (
     ("PUT", re.compile(rf"^/api/projects/{_SEG}/doc-review/(.+)$")),
 )
 
+# Project lists routes an agent may reach with its own registry JWT
+# (scope project_lists, verified + project-bound by the route).  These
+# are DYNAMIC paths (/api/projects/{pid}/lists...), so a (method,
+# compiled-regex) allowlist is used instead.  The token only reaches the
+# handler, which then verifies the JWT + grant + project binding; nothing
+# else is reachable by the token.
+_AGENT_LISTS_ROUTES = (
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/lists$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/lists$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}$")),
+    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}$")),
+    ("DELETE", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}/entries$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}/entries$")),
+    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}/entries/{_SEG}$")),
+    ("DELETE", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}/entries/{_SEG}$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/lists/{_SEG}/entries/reorder$")),
+)
+
+
+def _is_agent_lists_path(method: str, path: str) -> bool:
+    """True only for the exact subset of list routes a project_lists token may
+    reach.  Strict method + anchored-regex match; everything else is excluded."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_LISTS_ROUTES)
+
+
 # Project notes store routes an agent may reach with its own registry JWT
 # (scope project_notes, verified + project-bound by the route).  The token only
 # reaches the handler, which then verifies the JWT + grant + project binding;
@@ -477,6 +503,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             or _is_agent_task_path(request.method, path)
             or _is_agent_doc_review_path(request.method, path)
             or _is_agent_notes_path(request.method, path)
+            or _is_agent_lists_path(request.method, path)
             or _is_agent_canvas_path(request.method, path)
             or _is_agent_decisions_path(request.method, path)
             or _is_agent_files_path(request.method, path)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -192,6 +192,9 @@ def register_all_routers(app):
     from tinyagentos.routes.project_notes import router as project_notes_router
     app.include_router(project_notes_router, dependencies=_csrf)
 
+    from tinyagentos.routes.project_lists import router as project_lists_router
+    app.include_router(project_lists_router, dependencies=_csrf)
+
     from tinyagentos.routes.desktop_control import router as desktop_control_router
     app.include_router(desktop_control_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -88,6 +88,12 @@ VALID_SCOPES = frozenset({
     # read+write surface for a lightweight persistent notes surface.
     "project_notes",
     "observatory_control",
+    # Project lists: read/write a project's checklist lists (title, description,
+    # status) and their entries (text, category, status, done, position) by a
+    # session owner/admin or a project-bound project_lists grant holder. Mirrors
+    # project_notes' single-scope read+write surface for a lightweight lists
+    # surface scoped to a project.
+    "project_lists",
 })
 
 
@@ -210,7 +216,7 @@ async def _retire_scope_request_notification(request: Request, request_id: str) 
 # project_tasks_create globally. One definition, referenced everywhere.
 _CANVAS_SCOPES = {"canvas_read", "canvas_write"}
 _FILES_SCOPES = {"files_read", "files_write"}
-_PROJECT_SCOPES = {"project_tasks", "project_tasks_create", "project_tasks_update"} | _CANVAS_SCOPES | _FILES_SCOPES
+_PROJECT_SCOPES = {"project_tasks", "project_tasks_create", "project_tasks_update", "project_lists"} | _CANVAS_SCOPES | _FILES_SCOPES
 
 
 def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -99,6 +99,7 @@ _ALLOWED_SCOPES = frozenset({
     "project_tasks_update",
      "project_doc_review",
      "project_notes",
+     "project_lists",
      "canvas_read", "canvas_write",
     "decisions_read", "decisions_write",
     "observatory_control",

--- a/tinyagentos/routes/project_lists.py
+++ b/tinyagentos/routes/project_lists.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.agent_token_auth import (
+    PROJECT_SCOPE_MISMATCH_DETAIL,
+    check_agent_scope_for_project,
+)
+from tinyagentos.auth_context import CurrentUser
+from tinyagentos.routes.projects import _get_owned_project
+
+router = APIRouter()
+
+_LISTS_SCOPE = "project_lists"
+
+
+class CreateListIn(BaseModel):
+    title: str
+    description: str = ""
+
+
+class UpdateListIn(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    status: str | None = None
+
+
+class AddEntryIn(BaseModel):
+    text: str
+    category: str | None = None
+    position: int | None = None
+
+
+class UpdateEntryIn(BaseModel):
+    text: str | None = None
+    category: str | None = None
+    status: str | None = None
+    done: bool | None = None
+    position: int | None = None
+
+
+class ReorderIn(BaseModel):
+    entries: list[dict]
+
+
+async def _authorize_lists_actor(
+    request: Request, pstore, project_id: str
+) -> "tuple[str, bool, dict] | JSONResponse":
+    """Resolve the actor for a project-lists route that accepts EITHER a session
+    owner/admin OR an approved external agent's registry JWT holding _LISTS_SCOPE
+    bound to THIS project.
+
+    Mirrors ``_authorize_notes_actor`` (routes/project_notes.py): session
+    non-owners and wrong-project tokens both collapse into an existence-hiding
+    404 so a caller can never confirm another project's existence. The route
+    takes ``request: Request`` and auths INSIDE the handler (not via Depends)
+    because ``Depends(current_user)`` would 401 an agent with no session before
+    it runs.
+
+    Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
+    return directly.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        project_or_err = await _get_owned_project(pstore, project_id, user)
+        if isinstance(project_or_err, JSONResponse):
+            return project_or_err
+        return (user.user_id, False, project_or_err)
+
+    try:
+        caller = await check_agent_scope_for_project(request, _LISTS_SCOPE, project_id)
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
+    if caller is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    project = await pstore.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return (caller, True, project)
+
+
+@router.post("/api/projects/{project_id}/lists")
+async def create_list(
+    project_id: str,
+    payload: CreateListIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    store = request.app.state.project_lists_store
+    author_kind = "agent" if is_agent else "user"
+    lst = await store.create_list(
+        project_id=project_id,
+        title=payload.title,
+        description=payload.description,
+        created_by=actor_id,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "list.created", {"list_id": lst["id"], "title": lst["title"]}
+    )
+    return lst
+
+
+@router.get("/api/projects/{project_id}/lists")
+async def list_lists(project_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    store = request.app.state.project_lists_store
+    return {"items": await store.list_lists(project_id)}
+
+
+@router.get("/api/projects/{project_id}/lists/{list_id}")
+async def get_list(project_id: str, list_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    store = request.app.state.project_lists_store
+    lst = await store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return lst
+
+
+@router.patch("/api/projects/{project_id}/lists/{list_id}")
+async def update_list(
+    project_id: str,
+    list_id: str,
+    payload: UpdateListIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_lists_store
+    existing = await store.get_list(list_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    updated = await store.update_list(
+        list_id,
+        title=payload.title,
+        description=payload.description,
+        status=payload.status,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "list.updated", {"list_id": list_id}
+    )
+    return updated
+
+
+@router.delete("/api/projects/{project_id}/lists/{list_id}")
+async def delete_list(project_id: str, list_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_lists_store
+    existing = await store.get_list(list_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.delete_list(list_id)
+    await pstore.log_activity(
+        project_id, actor_id, "list.deleted", {"list_id": list_id}
+    )
+    return {"ok": True}
+
+
+@router.post("/api/projects/{project_id}/lists/{list_id}/entries")
+async def add_entry(
+    project_id: str,
+    list_id: str,
+    payload: AddEntryIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    store = request.app.state.project_list_entries_store
+    lst_store = request.app.state.project_lists_store
+    lst = await lst_store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "list not found"}, status_code=404)
+    author_kind = "agent" if is_agent else "user"
+    entry = await store.add_entry(
+        list_id=list_id,
+        project_id=project_id,
+        text=payload.text,
+        original_text=payload.text,
+        category=payload.category,
+        author_kind=author_kind,
+        author_id=actor_id,
+        position=payload.position,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "entry.created", {"entry_id": entry["id"], "list_id": list_id}
+    )
+    return entry
+
+
+@router.get("/api/projects/{project_id}/lists/{list_id}/entries")
+async def list_entries(project_id: str, list_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    store = request.app.state.project_list_entries_store
+    lst_store = request.app.state.project_lists_store
+    lst = await lst_store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "list not found"}, status_code=404)
+    return {"items": await store.list_entries(project_id=project_id, list_id=list_id)}
+
+
+@router.patch("/api/projects/{project_id}/lists/{list_id}/entries/{entry_id}")
+async def update_entry(
+    project_id: str,
+    list_id: str,
+    entry_id: str,
+    payload: UpdateEntryIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_list_entries_store
+    lst_store = request.app.state.project_lists_store
+    lst = await lst_store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "list not found"}, status_code=404)
+    existing = await store.get_entry(entry_id)
+    if existing is None or existing["project_id"] != project_id or existing["list_id"] != list_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    updated = await store.update_entry(
+        entry_id,
+        text=payload.text,
+        category=payload.category,
+        status=payload.status,
+        done=1 if payload.done else (0 if payload.done is not None else None),
+        position=payload.position,
+        edited_by=actor_id,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "entry.updated", {"entry_id": entry_id, "list_id": list_id}
+    )
+    return updated
+
+
+@router.delete("/api/projects/{project_id}/lists/{list_id}/entries/{entry_id}")
+async def delete_entry(project_id: str, list_id: str, entry_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_list_entries_store
+    lst_store = request.app.state.project_lists_store
+    lst = await lst_store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "list not found"}, status_code=404)
+    existing = await store.get_entry(entry_id)
+    if existing is None or existing["project_id"] != project_id or existing["list_id"] != list_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.delete_entry(entry_id)
+    await pstore.log_activity(
+        project_id, actor_id, "entry.deleted", {"entry_id": entry_id, "list_id": list_id}
+    )
+    return {"ok": True}
+
+
+@router.post("/api/projects/{project_id}/lists/{list_id}/entries/reorder")
+async def reorder_entries(
+    project_id: str,
+    list_id: str,
+    payload: ReorderIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_lists_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_list_entries_store
+    lst_store = request.app.state.project_lists_store
+    lst = await lst_store.get_list(list_id)
+    if lst is None or lst["project_id"] != project_id:
+        return JSONResponse({"error": "list not found"}, status_code=404)
+    ok = await store.reorder_entries(project_id, list_id, payload.entries)
+    await pstore.log_activity(
+        project_id, actor_id, "entry.reordered", {"list_id": list_id}
+    )
+    if not ok:
+        return JSONResponse({"error": "reorder failed"}, status_code=400)
+    return {"ok": True}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Lists S1b: routes + scopes + middleware allowlist (#2140)

Autonomous build of board card tsk-epm5m3.

- Add project_lists to VALID_SCOPES and _ALLOWED_SCOPES
- Add _AGENT_LISTS_ROUTES allowlist to auth_middleware
- Create project_lists route module with CRUD for lists and entries
- Wire project_lists_store and project_list_entries_store onto app.state
- Register project_lists router in routes/__init__.py
- Init/close lists stores in conftest client fixture
- Add tests for owner CRUD, agent with scope, wrong project, missing scope, unauthenticated

Files:
 tests/projects/test_routes_lists.py       | 332 ++++++++++++++++++++++++++++++
 tinyagentos/app.py                        |   9 +
 tinyagentos/auth_middleware.py            |  27 +++
 tinyagentos/routes/__init__.py            |   3 +
 tinyagentos/routes/agent_auth_requests.py |   8 +-
 tinyagentos/routes/agent_registry.py      |   1 +
 tinyagentos/routes/project_lists.py       | 312 ++++++++++++++++++++++++++++
 8 files changed, 701 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project list management, including creating, viewing, updating, and deleting lists.
  * Added list entry management with support for adding, editing, removing, and reordering entries.
  * Added project activity tracking for list and entry changes.
  * Added controlled access for authenticated sessions and authorized project agents.

* **Security**
  * Added project-scoped permissions and support for granting list-management access.
  * Unauthorized, unauthenticated, and cross-project requests are handled appropriately.

* **Tests**
  * Added comprehensive coverage for list and entry operations, permissions, and authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->