### PR TITLE
Wallpaper fit options (fill/fit/stretch/center/tile), persisted PER DEVICE

### DIFF
--- a/changelog.d/2357-wallpaper-fit-options.md
+++ b/changelog.d/2357-wallpaper-fit-options.md
@@ -1,0 +1,6 @@
+### Added
+
+- Wallpaper fit options in Settings → Desktop & Dock: fill, fit, stretch,
+  center, and tile. The choice is persisted per device (localStorage, keyed
+  by a locally minted device id that is never sent to the server), so each
+  screen keeps the fit that suits its aspect ratio (#2357).

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -259,16 +259,6 @@ export function App() {
   // box (#58). An explicit user choice is always honored and never overridden.
   usePerfAutoDetect();
 
-  // Persist a stable per-browser-profile device id (never sent to the server)
-  // so the per-device wallpaper-fit preference is isolated from other devices.
-  useEffect(() => {
-    const KEY = "taos-wallpaper-device-id";
-    if (typeof window === "undefined") return;
-    if (!localStorage.getItem(KEY)) {
-      localStorage.setItem(KEY, crypto.randomUUID());
-    }
-  }, []);
-
   // Sync the persistent backend notification feed into the bell (desktop and
   // mobile both render NotificationCentre under this component).
   useServerNotifications();
@@ -395,7 +385,7 @@ export function App() {
             <div className="h-screen w-screen flex flex-col overflow-hidden bg-shell-bg text-shell-text">
               <EffectsLayer />
               <TopBar onSearchOpen={toggleSearch} onAssistantOpen={toggleAssistant} />
-              <Desktop wallpaperFit={wallpaperFit} letterboxBg={wallpaperFit === "fit" || wallpaperFit === "center" ? (useLightWallpaper ? wallpaperLightFallback : wallpaperFallback) : undefined} />
+              <Desktop />
               <Dock onLaunchpadOpen={toggleLaunchpad} />
               <Launchpad open={launchpadOpen} onClose={() => setLaunchpadOpen(false)} onOpenApp={(wid) => setActiveWindowId(wid)} />
               <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} onOpenApp={(wid) => setActiveWindowId(wid)} />

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -197,6 +197,7 @@ export function App() {
   const wallpaperOverlayText = useThemeStore((s) => s.wallpaperOverlayText);
   const showOverlayText = useThemeStore((s) => s.showOverlayText);
   const reduceEffects = useThemeStore((s) => s.reduceEffects);
+  const wallpaperFit = useThemeStore((s) => s.wallpaperFit);
   const isAnimatedWallpaper = wallpaperKind === "animated";
   const useLightWallpaper = scheme === "light" && !!wallpaperLightImage;
   const effWallpaperImage = useLightWallpaper ? wallpaperLightImage : wallpaperImage;
@@ -257,6 +258,16 @@ export function App() {
   // effects on a struggling device, so low-end hardware is smooth out of the
   // box (#58). An explicit user choice is always honored and never overridden.
   usePerfAutoDetect();
+
+  // Persist a stable per-browser-profile device id (never sent to the server)
+  // so the per-device wallpaper-fit preference is isolated from other devices.
+  useEffect(() => {
+    const KEY = "taos-wallpaper-device-id";
+    if (typeof window === "undefined") return;
+    if (!localStorage.getItem(KEY)) {
+      localStorage.setItem(KEY, crypto.randomUUID());
+    }
+  }, []);
 
   // Sync the persistent backend notification feed into the bell (desktop and
   // mobile both render NotificationCentre under this component).
@@ -384,7 +395,7 @@ export function App() {
             <div className="h-screen w-screen flex flex-col overflow-hidden bg-shell-bg text-shell-text">
               <EffectsLayer />
               <TopBar onSearchOpen={toggleSearch} onAssistantOpen={toggleAssistant} />
-              <Desktop />
+              <Desktop wallpaperFit={wallpaperFit} letterboxBg={wallpaperFit === "fit" || wallpaperFit === "center" ? (useLightWallpaper ? wallpaperLightFallback : wallpaperFallback) : undefined} />
               <Dock onLaunchpadOpen={toggleLaunchpad} />
               <Launchpad open={launchpadOpen} onClose={() => setLaunchpadOpen(false)} onOpenApp={(wid) => setActiveWindowId(wid)} />
               <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} onOpenApp={(wid) => setActiveWindowId(wid)} />
@@ -407,7 +418,7 @@ export function App() {
     <ShortcutProvider>
       <SystemShortcuts toggleSearch={toggleSearch} toggleLaunchpad={toggleLaunchpad} toggleAssistant={toggleAssistant} />
       <LoginGate>
-    <div className={`taos-wallpaper taos-mobile-root relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} style={{ backgroundColor: effWallpaperFallback, ["--wallpaper-desktop" as never]: isAnimatedWallpaper ? "none" : effWallpaperImage, ["--wallpaper-mobile" as never]: isAnimatedWallpaper ? "none" : effWallpaperMobile }}>
+    <div className={`taos-wallpaper taos-mobile-root relative h-screen w-screen flex flex-col text-shell-text${isBrowserMobile ? " taos-browser" : ""}`} data-wallpaper-fit={wallpaperFit || undefined} style={{ backgroundColor: effWallpaperFallback, ["--wallpaper-desktop" as never]: isAnimatedWallpaper ? "none" : effWallpaperImage, ["--wallpaper-mobile" as never]: isAnimatedWallpaper ? "none" : effWallpaperMobile }}>
       {isAnimatedWallpaper && !reduceEffects && wallpaperComponent === "particles" && <ParticlesWallpaper />}
       {showOverlayText && wallpaperOverlayText && <WallpaperTextOverlay text={wallpaperOverlayText} />}
       <EffectsLayer />

--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -27,6 +27,7 @@ import {
 import { useShortcuts } from "@/hooks/use-shortcut-registry";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useThemeStore } from "@/stores/theme-store";
+import { WALLPAPER_FIT_OPTIONS } from "@/stores/theme-store";
 import { useDockStore } from "@/stores/dock-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
 import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp/_shared";
@@ -762,6 +763,8 @@ export function DesktopDockSection() {
   const wallpaperLightImage = useThemeStore((s) => s.wallpaperLightImage);
   const wallpaperLightFallback = useThemeStore((s) => s.wallpaperLightFallback);
   const scheme = useThemeStore((s) => s.scheme);
+  const wallpaperFit = useThemeStore((s) => s.wallpaperFit);
+  const setWallpaperFit = useThemeStore((s) => s.setWallpaperFit);
   const getWallpapers = useThemeStore((s) => s.getWallpapers);
   const [showPicker, setShowPicker] = useState(false);
 
@@ -806,6 +809,26 @@ export function DesktopDockSection() {
             >
               Change…
             </Button>
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <p className="text-sm font-medium mb-3">Wallpaper fit</p>
+          <p className="text-xs text-shell-text-tertiary mb-3">
+            How the wallpaper fills the screen. Fit and center use the wallpaper fallback colour for the letterbox bars.
+          </p>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Wallpaper fit">
+            {WALLPAPER_FIT_OPTIONS.map((fit) => (
+              <Button
+                key={fit}
+                variant={wallpaperFit === fit ? "secondary" : "outline"}
+                size="sm"
+                onClick={() => setWallpaperFit(fit)}
+                aria-pressed={wallpaperFit === fit}
+              >
+                {fit.charAt(0).toUpperCase() + fit.slice(1)}
+              </Button>
+            ))}
           </div>
         </Card>
 

--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -23,7 +23,7 @@ type ContextMenuState = {
   y: number;
 } | null;
 
-export function Desktop() {
+export function Desktop({ wallpaperFit, letterboxBg }: { wallpaperFit?: string; letterboxBg?: string }) {
   const windows = useProcessStore((s) => s.windows);
   const { openWindow, reclampAllWindows } = useProcessStore();
   const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
@@ -44,6 +44,7 @@ export function Desktop() {
   const effImage = useLight ? wallpaperLightImage : wallpaperImage;
   const effMobile = useLight ? wallpaperLightMobileImage : wallpaperMobileImage;
   const effFallback = useLight ? wallpaperLightFallback : wallpaperFallback;
+  const bgColor = letterboxBg ?? effFallback;
   const { showWidgets, toggleWidgets } = useWidgetStore();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [wallpaperPickerOpen, setWallpaperPickerOpen] = useState(false);
@@ -158,7 +159,8 @@ export function Desktop() {
   return (
     <div
       className="taos-wallpaper relative flex-1 overflow-hidden"
-      style={{ backgroundColor: effFallback, ["--wallpaper-desktop" as never]: isAnimated ? "none" : effImage, ["--wallpaper-mobile" as never]: isAnimated ? "none" : effMobile }}
+      style={{ backgroundColor: bgColor, ["--wallpaper-desktop" as never]: isAnimated ? "none" : effImage, ["--wallpaper-mobile" as never]: isAnimated ? "none" : effMobile }}
+      data-wallpaper-fit={wallpaperFit || undefined}
       onContextMenu={handleContextMenu}
       data-desktop-surface
     >

--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -23,7 +23,7 @@ type ContextMenuState = {
   y: number;
 } | null;
 
-export function Desktop({ wallpaperFit, letterboxBg }: { wallpaperFit?: string; letterboxBg?: string }) {
+export function Desktop() {
   const windows = useProcessStore((s) => s.windows);
   const { openWindow, reclampAllWindows } = useProcessStore();
   const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
@@ -38,13 +38,13 @@ export function Desktop({ wallpaperFit, letterboxBg }: { wallpaperFit?: string; 
   const wallpaperOverlayText = useThemeStore((s) => s.wallpaperOverlayText);
   const showOverlayText = useThemeStore((s) => s.showOverlayText);
   const reduceEffects = useThemeStore((s) => s.reduceEffects);
+  const wallpaperFit = useThemeStore((s) => s.wallpaperFit);
   const isAnimated = wallpaperKind === "animated";
   // Invert the wallpaper with the theme: use the light variant when present.
   const useLight = scheme === "light" && !!wallpaperLightImage;
   const effImage = useLight ? wallpaperLightImage : wallpaperImage;
   const effMobile = useLight ? wallpaperLightMobileImage : wallpaperMobileImage;
   const effFallback = useLight ? wallpaperLightFallback : wallpaperFallback;
-  const bgColor = letterboxBg ?? effFallback;
   const { showWidgets, toggleWidgets } = useWidgetStore();
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
   const [wallpaperPickerOpen, setWallpaperPickerOpen] = useState(false);
@@ -159,7 +159,7 @@ export function Desktop({ wallpaperFit, letterboxBg }: { wallpaperFit?: string; 
   return (
     <div
       className="taos-wallpaper relative flex-1 overflow-hidden"
-      style={{ backgroundColor: bgColor, ["--wallpaper-desktop" as never]: isAnimated ? "none" : effImage, ["--wallpaper-mobile" as never]: isAnimated ? "none" : effMobile }}
+      style={{ backgroundColor: effFallback, ["--wallpaper-desktop" as never]: isAnimated ? "none" : effImage, ["--wallpaper-mobile" as never]: isAnimated ? "none" : effMobile }}
       data-wallpaper-fit={wallpaperFit || undefined}
       onContextMenu={handleContextMenu}
       data-desktop-surface

--- a/desktop/src/stores/__tests__/wallpaper-fit.test.ts
+++ b/desktop/src/stores/__tests__/wallpaper-fit.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useThemeStore, loadWallpaperFit } from "../theme-store";
+import {
+  WALLPAPER_FIT_OPTIONS,
+  wallpaperFitToClass,
+  type WallpaperFit,
+} from "../theme-store";
+
+const reset = () => {
+  useThemeStore.setState({
+    wallpaperId: "graphite",
+    wallpaperImage: "url('/static/wallpaper-graphite.png')",
+    wallpaperMobileImage: "url('/static/wallpaper-graphite-mobile.png')",
+    wallpaperFallback: "#141415",
+    wallpaperLightImage: "url('/static/wallpaper-graphite-light.png')",
+    wallpaperLightMobileImage: "url('/static/wallpaper-graphite-light-mobile.png')",
+    wallpaperLightFallback: "#eef0f3",
+    wallpaperKind: "image",
+    wallpaperComponent: null,
+    wallpaperOverlayText: null,
+    showOverlayText: true,
+    wallpaperParams: { density: 200, speed: 0.5, glow: 6 },
+    showDesktopIcons: true,
+    reduceEffects: false,
+    wallpaperFit: "fill",
+    structure: {},
+    effects: [],
+    activeThemeId: "default",
+    wallpaperByTheme: {},
+    themeDefaultWallpaper: {},
+    themeDefaultWallpaperId: {},
+    wallpaperIdByTheme: {},
+  });
+};
+
+describe("wallpaper-fit (per-device, CSS-driven)", () => {
+  beforeEach(() => {
+    reset();
+    localStorage.clear();
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  wallpaperFitToClass — the fit-to-CSS mapping                       */
+  /* ------------------------------------------------------------------ */
+
+  describe("wallpaperFitToClass", () => {
+    const expected: Record<WallpaperFit, string> = {
+      fill: 'data-wallpaper-fit="fill"',
+      fit: 'data-wallpaper-fit="fit"',
+      stretch: 'data-wallpaper-fit="stretch"',
+      center: 'data-wallpaper-fit="center"',
+      tile: 'data-wallpaper-fit="tile"',
+    };
+
+    it.each(WALLPAPER_FIT_OPTIONS)(
+      "maps %s to its CSS data attribute",
+      (fit) => {
+        expect(wallpaperFitToClass(fit)).toBe(expected[fit]);
+      }
+    );
+
+    it("returns a distinct value for every option", () => {
+      const classes = WALLPAPER_FIT_OPTIONS.map(wallpaperFitToClass);
+      expect(new Set(classes).size).toBe(WALLPAPER_FIT_OPTIONS.length);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Per-device persistence                                              */
+  /* ------------------------------------------------------------------ */
+
+  it("setWallpaperFit stores the value under the current device id", () => {
+    useThemeStore.getState().setWallpaperFit("fit");
+    const deviceId = localStorage.getItem("taos-wallpaper-device-id")!;
+    expect(localStorage.getItem("taos-wallpaper-fit:" + deviceId)).toBe("fit");
+  });
+
+  it("the stored value is isolated from another device id", () => {
+    localStorage.setItem("taos-wallpaper-device-id", "device-A");
+    localStorage.setItem("taos-wallpaper-fit:device-A", "stretch");
+    localStorage.setItem("taos-wallpaper-device-id", "device-B");
+
+    // Re-initialise fit state for the new device id
+    useThemeStore.setState({ wallpaperFit: "fill" });
+
+    useThemeStore.getState().setWallpaperFit("center");
+    const deviceB = localStorage.getItem("taos-wallpaper-device-id")!;
+    expect(localStorage.getItem("taos-wallpaper-fit:" + deviceB)).toBe("center");
+    // device-A's choice must be untouched
+    expect(localStorage.getItem("taos-wallpaper-fit:device-A")).toBe("stretch");
+  });
+
+  it("loads the persisted value as the initial store state", () => {
+    localStorage.clear();
+    // Set a known device id and stored fit before calling loadWallpaperFit,
+    // simulating a fresh page load where localStorage already has the pref.
+    localStorage.setItem("taos-wallpaper-device-id", "reload-device");
+    localStorage.setItem("taos-wallpaper-fit:reload-device", "tile");
+    expect(loadWallpaperFit()).toBe("tile");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Default when nothing is stored                                      */
+  /* ------------------------------------------------------------------ */
+
+  it("defaults to fill when no preference is stored", () => {
+    localStorage.clear();
+    useThemeStore.setState({ wallpaperFit: "fill" });
+    expect(useThemeStore.getState().wallpaperFit).toBe("fill");
+  });
+
+  it("ignores an invalid stored value and falls back to fill", () => {
+    localStorage.setItem("taos-wallpaper-device-id", "bad-device");
+    localStorage.setItem("taos-wallpaper-fit:bad-device", "not-a-real-fit");
+    useThemeStore.setState({ wallpaperFit: "fill" });
+    expect(useThemeStore.getState().wallpaperFit).toBe("fill");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Store state updates                                                 */
+  /* ------------------------------------------------------------------ */
+
+  it("updates wallpaperFit in store state when setWallpaperFit is called", () => {
+    const before = useThemeStore.getState().wallpaperFit;
+    useThemeStore.getState().setWallpaperFit("stretch");
+    expect(useThemeStore.getState().wallpaperFit).toBe("stretch");
+    useThemeStore.getState().setWallpaperFit(before);
+  });
+
+  it("setWallpaperFit flips between two values round-tripping through the store", () => {
+    useThemeStore.getState().setWallpaperFit("center");
+    expect(useThemeStore.getState().wallpaperFit).toBe("center");
+    useThemeStore.getState().setWallpaperFit("fill");
+    expect(useThemeStore.getState().wallpaperFit).toBe("fill");
+  });
+
+  /* ------------------------------------------------------------------ */
+  /*  Key derivation — per-device isolation at the key level              */
+  /* ------------------------------------------------------------------ */
+
+  it("derives a different localStorage key for each device id", () => {
+    const ids = ["alpha", "bravo", "charlie"];
+    const keys = ids.map((id) => "taos-wallpaper-fit:" + id);
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("does not include the server-synced user id in the localStorage key", () => {
+    const key = "taos-wallpaper-fit:" + localStorage.getItem("taos-wallpaper-device-id")!;
+    expect(key).not.toContain("taos.user.id");
+  });
+});

--- a/desktop/src/stores/__tests__/wallpaper-fit.test.ts
+++ b/desktop/src/stores/__tests__/wallpaper-fit.test.ts
@@ -1,10 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useThemeStore, loadWallpaperFit } from "../theme-store";
-import {
-  WALLPAPER_FIT_OPTIONS,
-  wallpaperFitToClass,
-  type WallpaperFit,
-} from "../theme-store";
 
 const reset = () => {
   useThemeStore.setState({
@@ -37,32 +32,6 @@ describe("wallpaper-fit (per-device, CSS-driven)", () => {
   beforeEach(() => {
     reset();
     localStorage.clear();
-  });
-
-  /* ------------------------------------------------------------------ */
-  /*  wallpaperFitToClass — the fit-to-CSS mapping                       */
-  /* ------------------------------------------------------------------ */
-
-  describe("wallpaperFitToClass", () => {
-    const expected: Record<WallpaperFit, string> = {
-      fill: 'data-wallpaper-fit="fill"',
-      fit: 'data-wallpaper-fit="fit"',
-      stretch: 'data-wallpaper-fit="stretch"',
-      center: 'data-wallpaper-fit="center"',
-      tile: 'data-wallpaper-fit="tile"',
-    };
-
-    it.each(WALLPAPER_FIT_OPTIONS)(
-      "maps %s to its CSS data attribute",
-      (fit) => {
-        expect(wallpaperFitToClass(fit)).toBe(expected[fit]);
-      }
-    );
-
-    it("returns a distinct value for every option", () => {
-      const classes = WALLPAPER_FIT_OPTIONS.map(wallpaperFitToClass);
-      expect(new Set(classes).size).toBe(WALLPAPER_FIT_OPTIONS.length);
-    });
   });
 
   /* ------------------------------------------------------------------ */
@@ -105,15 +74,13 @@ describe("wallpaper-fit (per-device, CSS-driven)", () => {
 
   it("defaults to fill when no preference is stored", () => {
     localStorage.clear();
-    useThemeStore.setState({ wallpaperFit: "fill" });
-    expect(useThemeStore.getState().wallpaperFit).toBe("fill");
+    expect(loadWallpaperFit()).toBe("fill");
   });
 
   it("ignores an invalid stored value and falls back to fill", () => {
     localStorage.setItem("taos-wallpaper-device-id", "bad-device");
     localStorage.setItem("taos-wallpaper-fit:bad-device", "not-a-real-fit");
-    useThemeStore.setState({ wallpaperFit: "fill" });
-    expect(useThemeStore.getState().wallpaperFit).toBe("fill");
+    expect(loadWallpaperFit()).toBe("fill");
   });
 
   /* ------------------------------------------------------------------ */
@@ -132,20 +99,5 @@ describe("wallpaper-fit (per-device, CSS-driven)", () => {
     expect(useThemeStore.getState().wallpaperFit).toBe("center");
     useThemeStore.getState().setWallpaperFit("fill");
     expect(useThemeStore.getState().wallpaperFit).toBe("fill");
-  });
-
-  /* ------------------------------------------------------------------ */
-  /*  Key derivation — per-device isolation at the key level              */
-  /* ------------------------------------------------------------------ */
-
-  it("derives a different localStorage key for each device id", () => {
-    const ids = ["alpha", "bravo", "charlie"];
-    const keys = ids.map((id) => "taos-wallpaper-fit:" + id);
-    expect(new Set(keys).size).toBe(3);
-  });
-
-  it("does not include the server-synced user id in the localStorage key", () => {
-    const key = "taos-wallpaper-fit:" + localStorage.getItem("taos-wallpaper-device-id")!;
-    expect(key).not.toContain("taos.user.id");
   });
 });

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -187,6 +187,39 @@ function loadReduceEffects(): boolean {
   }
 }
 
+// Per-device wallpaper fit preference: the right fit depends on the physical
+// screen's aspect ratio, so it must NOT be keyed to the user account. A stable
+// device id is minted once per browser profile and stored in localStorage;
+// the fit preference is then keyed on that id so switching devices never
+// overwrites another device's choice.
+const DEVICE_ID_KEY = "taos-wallpaper-device-id";
+function getDeviceId(): string {
+  let id = localStorage.getItem(DEVICE_ID_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(DEVICE_ID_KEY, id);
+  }
+  return id;
+}
+export const WALLPAPER_FIT_OPTIONS = ["fill", "fit", "stretch", "center", "tile"] as const;
+export type WallpaperFit = (typeof WALLPAPER_FIT_OPTIONS)[number];
+const WALLPAPER_FIT_KEY = "taos-wallpaper-fit:";
+function wallpaperFitKey(): string {
+  return WALLPAPER_FIT_KEY + getDeviceId();
+}
+export function wallpaperFitToClass(fit: WallpaperFit): string {
+  return `data-wallpaper-fit="${fit}"`;
+}
+export function loadWallpaperFit(): WallpaperFit {
+  try {
+    const raw = localStorage.getItem(wallpaperFitKey());
+    if (raw && WALLPAPER_FIT_OPTIONS.includes(raw as WallpaperFit)) return raw as WallpaperFit;
+  } catch {
+    // best-effort
+  }
+  return "fill";
+}
+
 interface ThemeStore {
   wallpaperId: string;
   wallpaperImage: string;
@@ -205,6 +238,7 @@ interface ThemeStore {
   wallpaperParams: WallpaperParams;
   showDesktopIcons: boolean;
   reduceEffects: boolean;
+  wallpaperFit: WallpaperFit;
   structure: Record<string, { variant?: string } & Record<string, unknown>>;
   effects: { module: string; params?: Record<string, unknown> }[];
 
@@ -220,6 +254,7 @@ interface ThemeStore {
   setWallpaper: (id: string) => void;
   toggleOverlayText: () => void;
   setWallpaperParam: (key: keyof WallpaperParams, value: number) => void;
+  setWallpaperFit: (fit: WallpaperFit) => void;
   toggleDesktopIcons: () => void;
   setReduceEffects: (on: boolean) => void;
   getWallpapers: () => Wallpaper[];
@@ -242,6 +277,7 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
   wallpaperParams: loadWallpaperParams(),
   showDesktopIcons: true,
   reduceEffects: loadReduceEffects(),
+  wallpaperFit: loadWallpaperFit(),
   structure: {},
   effects: [],
 
@@ -298,6 +334,15 @@ export const useThemeStore = create<ThemeStore>((set, get) => ({
       // best-effort
     }
     set({ reduceEffects: on });
+  },
+
+  setWallpaperFit(fit) {
+    try {
+      localStorage.setItem(wallpaperFitKey(), fit);
+    } catch {
+      // best-effort
+    }
+    set({ wallpaperFit: fit });
   },
 
   getWallpapers: () => WALLPAPERS,

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -207,9 +207,6 @@ const WALLPAPER_FIT_KEY = "taos-wallpaper-fit:";
 function wallpaperFitKey(): string {
   return WALLPAPER_FIT_KEY + getDeviceId();
 }
-export function wallpaperFitToClass(fit: WallpaperFit): string {
-  return `data-wallpaper-fit="${fit}"`;
-}
 export function loadWallpaperFit(): WallpaperFit {
   try {
     const raw = localStorage.getItem(wallpaperFitKey());

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -188,6 +188,15 @@
   background-size: cover;
 }
 @media (max-width: 767px), (orientation: portrait) {
+  /* On phones we switch to a portrait-cropped image if the wallpaper
+     provides one.
+
+     Sizing is `cover`, NOT `100% 100%`. Stretching both axes distorted the
+     image on any display whose aspect ratio did not match the asset, and
+     `(orientation: portrait)` matches every screen where height >= width,
+     which includes SQUARE displays: a square device took the phone branch and
+     had a wide wallpaper squashed into it (reported 2026-08-02). `cover` fills
+     the screen and crops the overflow instead of deforming the picture. */
   .taos-wallpaper {
     background-image: var(--wallpaper-mobile, var(--wallpaper-desktop));
     background-size: cover;
@@ -212,15 +221,9 @@
   background-size: auto;
   background-repeat: repeat;
 }
-
-/* Letterbox bars for fit and center — use the wallpaper fallback so bars
-   blend with the image instead of showing a jarring default colour. */
-.taos-wallpaper[data-wallpaper-fit="fit"] {
-  background-color: var(--wallpaper-fallback);
-}
-.taos-wallpaper[data-wallpaper-fit="center"] {
-  background-color: var(--wallpaper-fallback);
-}
+/* Letterbox bars for fit/center need no rule here: every .taos-wallpaper
+   element sets the wallpaper fallback colour as an inline background, and
+   an inline style always wins over anything this sheet could declare. */
 
 /* React-grid-layout dark theme overrides for widget system */
 .react-grid-item.react-grid-placeholder {

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -173,10 +173,13 @@
 }
 
 /* Wallpaper sizing
-   ----------------
-   Desktop fills the viewport (cover crops edges if aspect mismatches).
-   Mobile/portrait scales the full image in (contain) so pieces like the
-   'taOS' letters near the edges of a wide wallpaper aren't clipped.
+    ----------------
+    Desktop fills the viewport (cover crops edges if aspect mismatches).
+    Mobile/portrait scales the full image in (contain) so pieces like the
+    'taOS' letters near the edges of a wide wallpaper aren't clipped.
+
+    User choice: data-wallpaper-fit attribute on .taos-wallpaper overrides
+    the default cover behaviour. Per-device, persisted in localStorage.
 */
 .taos-wallpaper {
   background-image: var(--wallpaper-desktop);
@@ -185,19 +188,38 @@
   background-size: cover;
 }
 @media (max-width: 767px), (orientation: portrait) {
-  /* On phones we switch to a portrait-cropped image if the wallpaper
-     provides one.
-
-     Sizing is `cover`, NOT `100% 100%`. Stretching both axes distorted the
-     image on any display whose aspect ratio did not match the asset, and
-     `(orientation: portrait)` matches every screen where height >= width,
-     which includes SQUARE displays: a square device took the phone branch and
-     had a wide wallpaper squashed into it (reported 2026-08-02). `cover` fills
-     the screen and crops the overflow instead of deforming the picture. */
   .taos-wallpaper {
     background-image: var(--wallpaper-mobile, var(--wallpaper-desktop));
     background-size: cover;
   }
+}
+
+/* Wallpaper fit options — attribute-driven, no inline styles */
+.taos-wallpaper[data-wallpaper-fit="fill"] {
+  background-size: cover;
+}
+.taos-wallpaper[data-wallpaper-fit="fit"] {
+  background-size: contain;
+}
+.taos-wallpaper[data-wallpaper-fit="stretch"] {
+  background-size: 100% 100%;
+}
+.taos-wallpaper[data-wallpaper-fit="center"] {
+  background-size: auto;
+  background-position: center;
+}
+.taos-wallpaper[data-wallpaper-fit="tile"] {
+  background-size: auto;
+  background-repeat: repeat;
+}
+
+/* Letterbox bars for fit and center — use the wallpaper fallback so bars
+   blend with the image instead of showing a jarring default colour. */
+.taos-wallpaper[data-wallpaper-fit="fit"] {
+  background-color: var(--wallpaper-fallback);
+}
+.taos-wallpaper[data-wallpaper-fit="center"] {
+  background-color: var(--wallpaper-fallback);
 }
 
 /* React-grid-layout dark theme overrides for widget system */


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Wallpaper fit options (fill/fit/stretch/center/tile), persisted PER DEVICE

Autonomous build of board card tsk-jar622.



Files:
 desktop/src/App.tsx                                |  15 +-
 desktop/src/apps/SettingsApp.tsx                   |  23 ++++
 desktop/src/components/Desktop.tsx                 |   6 +-
 desktop/src/stores/__tests__/wallpaper-fit.test.ts | 151 +++++++++++++++++++++
 desktop/src/stores/theme-store.ts                  |  45 ++++++
 desktop/src/theme/tokens.css                       |  48 +++++--
 6 files changed, 271 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wallpaper fit controls in Desktop & Dock settings.
  * Choose from fill, fit, stretch, center, or tile display modes.
  * Wallpaper preferences are saved separately for each device and restored automatically.
  * Added letterbox backgrounds for supported fit modes.
  * Applied wallpaper sizing consistently across desktop and mobile layouts.
  * Invalid or unavailable preferences automatically fall back to the fill mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Red-first evidence (lead-run at merge ref)

The PR's test file executed at the merge ref `origin/dev` (eda3670d), before the fix:

```
 ❯ src/stores/__tests__/wallpaper-fit.test.ts (7 tests | 7 failed) 24ms
 FAIL  src/stores/__tests__/wallpaper-fit.test.ts > wallpaper-fit (per-device, CSS-driven) > setWallpaperFit stores the value under the current device id
TypeError: useThemeStore.getState(...).setWallpaperFit is not a function
 FAIL  src/stores/__tests__/wallpaper-fit.test.ts > wallpaper-fit (per-device, CSS-driven) > the stored value is isolated from another device id
TypeError: useThemeStore.getState(...).setWallpaperFit is not a function
 Tests  7 failed (7)
```

Additionally the invalid-value fallback test was proven red against a validation-skipping mutation of `loadWallpaperFit` on the PR head (1 failed | 6 passed), then the mutation reverted.
