### PR TITLE
fix(lists): get_entry cursor scope + reorder rollback on failure (tsk-u23vjy)

### DIFF
--- a/changelog.d/2361-lists-store-cursor-rollback.md
+++ b/changelog.d/2361-lists-store-cursor-rollback.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Project list entries: `get_entry` no longer reads cursor metadata after the
+  cursor closes, and a failed reorder now rolls back its partial updates so a
+  later unrelated write cannot commit a half-applied ordering (tsk-u23vjy,
+  fix-forward of #2183).

--- a/tests/projects/test_lists_store.py
+++ b/tests/projects/test_lists_store.py
@@ -327,3 +327,71 @@ async def test_concurrent_add_entry_distinct_positions(entries_store, monkeypatc
 
     positions = {e1["position"], e2["position"]}
     assert len(positions) == 2, f"expected distinct positions, got {positions}"
+
+
+# ---------------------------------------------------------------------------
+# tsk-u23vjy (fix-forward of the closed duplicate PR #2183, re-scoped to what
+# is real on dev): of the card's four defects, position-0 collision is already
+# fixed by the atomic INSERT (#2265, concurrency test above) and NULL list_id
+# rows are impossible (schema: list_id TEXT NOT NULL). The two below remain.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_entry_reads_description_before_cursor_closes(entries_store):
+    e = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="Test entry",
+        original_text="Test entry", author_kind="agent", author_id="agent-1",
+    )
+    result = await entries_store.get_entry(e["id"])
+    assert result is not None
+    assert result["id"] == e["id"]
+    assert result["text"] == "Test entry"
+
+
+@pytest.mark.asyncio
+async def test_reorder_entries_rolls_back_on_exception(entries_store, monkeypatch):
+    """If an UPDATE raises partway, the earlier UPDATEs must be rolled back --
+    otherwise they sit pending on the shared connection and the next unrelated
+    commit() flushes a half-applied reorder."""
+    a = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="A", original_text="A",
+        author_kind="agent", author_id="agent-1",
+    )
+    b = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="B", original_text="B",
+        author_kind="agent", author_id="agent-1",
+    )
+
+    real_execute = entries_store._db.execute
+    update_calls = 0
+
+    async def failing_execute(sql, params=()):
+        nonlocal update_calls
+        if sql.startswith("UPDATE project_list_entries SET position"):
+            update_calls += 1
+            if update_calls == 2:
+                raise RuntimeError("boom")
+        return await real_execute(sql, params)
+
+    monkeypatch.setattr(entries_store._db, "execute", failing_execute)
+
+    with pytest.raises(RuntimeError):
+        await entries_store.reorder_entries(
+            "prj-1", "lst-1",
+            [{"id": a["id"], "position": 1}, {"id": b["id"], "position": 0}],
+        )
+    monkeypatch.undo()
+
+    # The half-applied first UPDATE must be gone immediately...
+    a_after = await entries_store.get_entry(a["id"])
+    b_after = await entries_store.get_entry(b["id"])
+    assert a_after["position"] == 0
+    assert b_after["position"] == 1
+
+    # ...and must NOT resurface when an unrelated write commits later.
+    await entries_store.add_entry(
+        list_id="lst-2", project_id="prj-1", text="Unrelated",
+        original_text="Unrelated", author_kind="agent", author_id="agent-1",
+    )
+    a_final = await entries_store.get_entry(a["id"])
+    assert a_final["position"] == 0

--- a/tests/projects/test_lists_store.py
+++ b/tests/projects/test_lists_store.py
@@ -395,3 +395,74 @@ async def test_reorder_entries_rolls_back_on_exception(entries_store, monkeypatc
     )
     a_final = await entries_store.get_entry(a["id"])
     assert a_final["position"] == 0
+
+
+@pytest.mark.asyncio
+async def test_reorder_entries_rolls_back_on_cancellation(entries_store, monkeypatch):
+    """CancelledError is not an Exception; the rollback guard must still fire."""
+    a = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="A", original_text="A",
+        author_kind="agent", author_id="agent-1",
+    )
+    b = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="B", original_text="B",
+        author_kind="agent", author_id="agent-1",
+    )
+
+    real_execute = entries_store._db.execute
+    update_calls = 0
+
+    async def cancelling_execute(sql, params=()):
+        nonlocal update_calls
+        if sql.startswith("UPDATE project_list_entries SET position"):
+            update_calls += 1
+            if update_calls == 2:
+                raise asyncio.CancelledError()
+        return await real_execute(sql, params)
+
+    monkeypatch.setattr(entries_store._db, "execute", cancelling_execute)
+
+    with pytest.raises(asyncio.CancelledError):
+        await entries_store.reorder_entries(
+            "prj-1", "lst-1",
+            [{"id": a["id"], "position": 1}, {"id": b["id"], "position": 0}],
+        )
+    monkeypatch.undo()
+
+    await entries_store.add_entry(
+        list_id="lst-2", project_id="prj-1", text="Unrelated",
+        original_text="Unrelated", author_kind="agent", author_id="agent-1",
+    )
+    assert (await entries_store.get_entry(a["id"]))["position"] == 0
+    assert (await entries_store.get_entry(b["id"]))["position"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reorder_entries_rolls_back_on_commit_failure(entries_store, monkeypatch):
+    a = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="A", original_text="A",
+        author_kind="agent", author_id="agent-1",
+    )
+    b = await entries_store.add_entry(
+        list_id="lst-1", project_id="prj-1", text="B", original_text="B",
+        author_kind="agent", author_id="agent-1",
+    )
+
+    async def failing_commit():
+        raise RuntimeError("commit boom")
+
+    monkeypatch.setattr(entries_store._db, "commit", failing_commit)
+
+    with pytest.raises(RuntimeError):
+        await entries_store.reorder_entries(
+            "prj-1", "lst-1",
+            [{"id": a["id"], "position": 1}, {"id": b["id"], "position": 0}],
+        )
+    monkeypatch.undo()
+
+    await entries_store.add_entry(
+        list_id="lst-2", project_id="prj-1", text="Unrelated",
+        original_text="Unrelated", author_kind="agent", author_id="agent-1",
+    )
+    assert (await entries_store.get_entry(a["id"]))["position"] == 0
+    assert (await entries_store.get_entry(b["id"]))["position"] == 1

--- a/tinyagentos/projects/lists_store.py
+++ b/tinyagentos/projects/lists_store.py
@@ -270,13 +270,15 @@ class ProjectListEntriesStore(BaseStore):
                 if cursor.rowcount == 0:
                     await self._db.rollback()
                     return False
-        except Exception:
+            await self._db.commit()
+        except BaseException:
             # Without this, the UPDATEs already issued stay pending on the
             # shared connection and the next unrelated commit() flushes a
-            # half-applied reorder. Roll back, then re-raise.
+            # half-applied reorder. BaseException, not Exception: task
+            # cancellation (CancelledError) must also roll back, and commit()
+            # itself is inside the guard for the same reason.
             await self._db.rollback()
             raise
-        await self._db.commit()
         return True
 
     async def _get_next_position(self, project_id: str, list_id: str) -> int:

--- a/tinyagentos/projects/lists_store.py
+++ b/tinyagentos/projects/lists_store.py
@@ -174,8 +174,9 @@ class ProjectListEntriesStore(BaseStore):
             row = await cur.fetchone()
             if row is None:
                 return None
-        keys = [d[0] for d in cur.description]
-        return dict(zip(keys, row))
+            # cur.description is only guaranteed while the cursor is open.
+            keys = [d[0] for d in cur.description]
+            return dict(zip(keys, row))
 
     async def list_entries(
         self,
@@ -259,15 +260,22 @@ class ProjectListEntriesStore(BaseStore):
         return cursor.rowcount == 1
 
     async def reorder_entries(self, project_id: str, list_id: str, entries: list[dict]) -> bool:
-        for entry in entries:
-            cursor = await self._db.execute(
-                "UPDATE project_list_entries SET position = ?, updated_at = ? "
-                "WHERE id = ? AND project_id = ? AND list_id = ?",
-                (entry["position"], time.time(), entry["id"], project_id, list_id),
-            )
-            if cursor.rowcount == 0:
-                await self._db.rollback()
-                return False
+        try:
+            for entry in entries:
+                cursor = await self._db.execute(
+                    "UPDATE project_list_entries SET position = ?, updated_at = ? "
+                    "WHERE id = ? AND project_id = ? AND list_id = ?",
+                    (entry["position"], time.time(), entry["id"], project_id, list_id),
+                )
+                if cursor.rowcount == 0:
+                    await self._db.rollback()
+                    return False
+        except Exception:
+            # Without this, the UPDATEs already issued stay pending on the
+            # shared connection and the next unrelated commit() flushes a
+            # half-applied reorder. Roll back, then re-raise.
+            await self._db.rollback()
+            raise
         await self._db.commit()
         return True
 


### PR DESCRIPTION
Lead completion of board card tsk-u23vjy (bounced PR #2359 — analysis there). Re-scoped against what is actually true on dev:

**Card defects 1 and 2 need no code.** Position-0 collision is already fixed on dev by #2265's atomic in-INSERT allocation, guarded by `test_concurrent_add_entry_distinct_positions` (which #2359 had rewritten into a sequential test — restored untouched here). NULL `list_id` rows are structurally impossible: the schema says `list_id TEXT NOT NULL`, so the IS-NULL branch the card asks for is dead code on arrival (proven: inserting `list_id=None` raises `IntegrityError`). `_get_next_position` itself has zero callers on dev. The card's acceptance criteria were written against the closed duplicate PR #2183's branch, where both defects were real.

**Defects 3 and 4 are real and land here.**

## Red-first evidence (lead-run at merge ref)

The rollback test executed against dev's unguarded `reorder_entries`:

```
FAILED tests/projects/test_lists_store.py::test_reorder_entries_rolls_back_on_exception
1 failed in 0.38s
```

The failure mode is the card's exact hazard: the first UPDATE stays pending on the shared connection after the exception, and the assertion catches the half-applied position. With the fix, 19/19 pass. The `get_entry` cursor fix is latent-hazard hardening (aiosqlite's closed cursor happens to retain `description` today), so no red is possible for it; stated honestly rather than manufactured.

## Timing/atomicity statement

`reorder_entries`' single-commit atomicity is untouched (the card forbids restructuring it); the change only adds rollback + re-raise on the failure path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project list entries can now be retrieved reliably.
  * Failed list reordering operations fully roll back partial changes, preventing incomplete ordering updates from being saved.

* **Tests**
  * Added regression coverage for entry retrieval and rollback behavior.

* **Documentation**
  * Added a changelog entry describing these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->