### PR TITLE
VERIFY at next release: secret-material .gitignore is dev-ONLY, master has NO protection

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -452,6 +452,29 @@ trailer, which is logged by the gate:
 Store-Unwired-Intentionally: <ClassName>, <why>
 ```
 
+## Secret-ignores gate
+
+A gate (`.github/workflows/secret-ignores-gate.yml`, running `scripts/check_secret_ignores.py`)
+verifies that the committed `.gitignore` still protects known secret-shaped paths on every
+promotion target. A `.gitignore` rule is the kind of file a rebase conflict can quietly drop
+during a dev->master promotion while every test stays green and nothing builds red, so the
+protection is asserted here, not assumed. The gate runs on push to `master`, `dev` and
+`release/*` (a dropped rule fails the branch it lands on) and on PRs to those branches (a
+conflict-resolution loss fails before the merge, since the merge commit's `.gitignore` is what
+is checked).
+
+Two signals, defense in depth:
+
+- Every required protection rule must appear verbatim as an active line of `.gitignore`
+  (`*.key`, `identity.json`, `*.p8`, `*credentials.json`, `*creds*.json`, the `*_private.*`
+  key shapes, `secrets/`, `data/hub/`, and the rest listed in `REQUIRED_PATTERNS` in the
+  script). Comment prose and narrower sibling rules do not satisfy a rule.
+- A set of secret-shaped paths (`data/hub/identity.json`, `foo.key`, `creds.json`, `x.p8`,
+  `y_credentials.json`, ...) must all be reported ignored by `git check-ignore`.
+
+Removing any one protection pattern turns the gate red -- proven by a parametrized test that
+drops each pattern from a copy of the real `.gitignore` and asserts the guard fails.
+
 ## Upstream conventions (from CONTRIBUTING.md)
 
 - **Target branch is `dev`, not `master`.** `master` is the stable live-install track.

--- a/.github/workflows/secret-ignores-gate.yml
+++ b/.github/workflows/secret-ignores-gate.yml
@@ -1,0 +1,35 @@
+name: Secret-ignores gate
+
+# Verifies that the committed .gitignore still protects known secret-shaped
+# paths (data/hub/identity.json, foo.key, creds.json, x.p8, ...) on every
+# promotion target. A .gitignore is the kind of file a rebase conflict can
+# quietly drop during a dev->master promotion while every test still passes and
+# nothing builds red, so promotion is verified here, not assumed.
+#
+# Trigger scope is deliberate:
+#   - push to master/dev/release/* : a dropped pattern fails the branch it
+#     lands on (this is the post-promotion check from tsk-laezfg step 1).
+#   - pull_request to master/dev/release/* : a conflict-resolution loss fails
+#     BEFORE the merge, since the merge commit's .gitignore is what is checked.
+# The run is pure stdlib (~1s), so it carries no shard-timeout risk.
+#
+# See scripts/check_secret_ignores.py for REQUIRED_PATTERNS and SECRET_PATHS.
+
+on:
+  push:
+    branches: [master, dev, release/*]
+  pull_request:
+    branches: [master, dev, release/*]
+
+jobs:
+  secret-ignores-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Assert secret-shaped paths are ignored
+        run: python scripts/check_secret_ignores.py

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ data/.seeded-agent-tokens.json
 data/secrets.db*
 data/*.key
 data/*.token
+data/.litellm_master_key
 
 # Key material and secrets. Added 2026-07-27 after data/hub/identity.json was
 # committed to PR #2043 with signing_private and encryption_private in

--- a/changelog.d/tsk-laezfg-secret-ignores-gate.md
+++ b/changelog.d/tsk-laezfg-secret-ignores-gate.md
@@ -1,0 +1,12 @@
+### Security
+
+- **CI**: `secret-ignores-gate` workflow and `scripts/check_secret_ignores.py` now
+  assert, on push to `master`/`dev`/`release/*` and on PRs to those branches, that the
+  committed `.gitignore` still contains every secret-protection rule (`*.key`,
+  `*.p8`, `identity.json`, `*credentials.json`, `*creds*.json`, the `*_private.*` key
+  shapes, `secrets/`, `data/hub/`, and more) and that known secret-shaped paths
+  (`data/hub/identity.json`, `foo.key`, `creds.json`, `x.p8`, `y_credentials.json`,
+  ...) are all reported ignored by `git check-ignore`. Closes the "promotion must be
+  verified, not assumed" gap from #2171/#2173: a `.gitignore` conflict resolution can
+  quietly drop a key-material rule while every test stays green. Removing any one
+  pattern is proven to fail the gate by a parametrized test.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -40,7 +40,7 @@ did on `dev` -- `identity.json`, `*.key`, `*.p8`, `*credentials.json`, `*creds*.
 and the `*_private.*` key shapes, plus the `secrets/` and `data/hub/` rules. Re-run
 it by hand if a conflict resolution touched `.gitignore`:
 
-```
+```bash
 python3 scripts/check_secret_ignores.py
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,6 +34,20 @@ CI runs the backend pytest suite and frontend vitest on every PR; both must be g
 Once the PR is merged to `dev`, open a follow-up PR from `dev` to `master`.
 After that PR merges, the install-count telemetry at taos.my starts recording the new version for every fresh install.
 
+The `secret-ignores-gate` runs on the `master` push (and on the PR merge result)
+and confirms the promoted `.gitignore` still ignores every secret-shaped path it
+did on `dev` -- `identity.json`, `*.key`, `*.p8`, `*credentials.json`, `*creds*.json`
+and the `*_private.*` key shapes, plus the `secrets/` and `data/hub/` rules. Re-run
+it by hand if a conflict resolution touched `.gitignore`:
+
+```
+python3 scripts/check_secret_ignores.py
+```
+
+Do not skip this: a `.gitignore` conflict resolution can quietly drop a
+key-material rule while every test stays green. The gate is the verification, not
+an assumption.
+
 ### 5. Tag and create a GitHub Release
 
 On `master`, after the merge commit:

--- a/scripts/check_secret_ignores.py
+++ b/scripts/check_secret_ignores.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Secret-material ignore guard.
+
+Verifies that the committed `.gitignore` on the branch under test still
+protects known secret-shaped paths. After a dev->master promotion a
+`.gitignore` rule can be silently dropped during conflict resolution (a
+`.gitignore` is exactly the kind of file a rebase conflict quietly loses while
+every test still passes and nothing builds red), so this gate asserts the
+protection mechanically instead of assuming promotion carried it.
+
+The check runs on push to `master`, `dev` and `release/*` -- so a dropped
+pattern fails the branch it actually lands on -- and on PRs targeting those
+branches -- so a conflict-resolution loss fails BEFORE the merge. See
+`.github/workflows/secret-ignores-gate.yml`.
+
+Two independent signals, defense in depth:
+
+  1. REQUIRED_PATTERNS. Each entry must appear verbatim as an active rule line
+     in `.gitignore`. A rule line is a non-blank, non-comment line (comment =
+     first non-whitespace char is `#`). Matching the exact line (rather than a
+     loose substring across the file) is deliberate: it ignores the comment
+     prose that discusses these patterns and treats a different-but-similar
+     rule (e.g. `data/*.key`) as NOT satisfying the `master`-level `*.key` rule.
+     Removing any required rule line turns the gate red deterministically -- this
+     is the "prove it goes red by removing one pattern" mechanism.
+
+  2. SECRET_PATHS. Each path must be reported as ignored by `git check-ignore`,
+     i.e. the protection actually takes effect. This catches holes that line
+     presence cannot (a rule that is present but malformed, or a path that no
+     longer matches), and is the "secret-shaped paths are ALL ignored" check
+     from tsk-laezfg.
+
+Usage:
+    python scripts/check_secret_ignores.py
+    python scripts/check_secret_ignores.py --repo-root /path/to/repo
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GITIGNORE_NAME = ".gitignore"
+
+# Protection rules whose absence must fail the gate. These are the secret-
+# material rules added in response to data/hub/identity.json being committed to
+# PR #2043 with signing_private and encryption_private in plaintext (#2171,
+# #2173). Each is matched as an exact active rule line so a dropped rule is
+# detected even when its text is still mentioned in a comment or covered by a
+# narrower sibling rule.
+REQUIRED_PATTERNS = [
+    "*.key",
+    "*_private.pem",
+    "*_private.key",
+    "*_private.json",
+    "*_private_key*",
+    "identity.json",
+    "*.p8",
+    "*credentials.json",
+    "*creds*.json",
+    "secrets/",
+    "*.token",
+    "*.cred",
+    "data/.secrets_key",
+    "data/.seeded-agent-tokens.json",
+    "data/secrets.db*",
+    "data/*.key",
+    "data/*.token",
+    "data/hub/",
+]
+
+# Secret-shaped paths that must actually be ignored by `git check-ignore`. Each
+# is annotated with its primary protecting rule. Not every path is exclusive
+# (some are double-protected by design); the REQUIRED_PATTERNS check above is
+# what makes every single pattern's removal detectable. These paths assert the
+# protection has real teeth on the branch under test.
+SECRET_PATHS = [
+    "data/hub/identity.json",       # data/hub/ , identity.json
+    "identity.json",                # identity.json
+    "foo.key",                      # *.key
+    "x.p8",                         # *.p8
+    "creds.json",                   # *creds*.json
+    "y_credentials.json",           # *credentials.json (also *creds*.json)
+    "app_private.pem",              # *_private.pem
+    "app_private.json",             # *_private.json
+    "signing_private_key.pem",      # *_private_key*
+    "foo.token",                    # *.token
+    "foo.cred",                     # *.cred
+    "secrets/foo.token",            # secrets/
+    "data/.secrets_key",            # data/.secrets_key
+    "data/secrets.db-wal",          # data/secrets.db*
+]
+
+
+@dataclass
+class Violation:
+    kind: str  # "pattern" or "path"
+    detail: str
+
+
+def _run_git(args: list[str], repo_root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_gitignore(repo_root: Path) -> str:
+    path = repo_root / GITIGNORE_NAME
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _active_rule_lines(gitignore_text: str) -> list[str]:
+    """Return the active (non-blank, non-comment) rule lines, stripped.
+
+    A `.gitignore` rule line is an active rule unless it is blank or its first
+    non-whitespace character is `#` (a comment). Trailing/leading whitespace is
+    stripped so cosmetic reformatting does not make the gate trip.
+    """
+    lines: list[str] = []
+    for raw in gitignore_text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
+
+
+def check_patterns(gitignore_text: str) -> list[str]:
+    """Return the required patterns absent from the .gitignore text."""
+    active = _active_rule_lines(gitignore_text)
+    missing: list[str] = []
+    for pattern in REQUIRED_PATTERNS:
+        if pattern not in active:
+            missing.append(pattern)
+    return missing
+
+
+def is_path_ignored(path: str, repo_root: Path) -> bool:
+    """True if `git check-ignore` reports `path` as ignored on `repo_root`."""
+    result = _run_git(["check-ignore", "--quiet", path], repo_root)
+    return result.returncode == 0
+
+
+def check_paths(repo_root: Path) -> list[str]:
+    """Return secret-shaped paths that are NOT ignored on `repo_root`."""
+    not_ignored: list[str] = []
+    for path in SECRET_PATHS:
+        if not is_path_ignored(path, repo_root):
+            not_ignored.append(path)
+    return not_ignored
+
+
+def check_secret_ignores(repo_root: Path = REPO_ROOT) -> list[Violation]:
+    """Return all violations on `repo_root` (empty == clean)."""
+    text = _read_gitignore(repo_root)
+    violations: list[Violation] = [
+        Violation("pattern", p) for p in check_patterns(text)
+    ]
+    # `git check-ignore` requires a usable git directory; a missing .git is
+    # treated as "nothing is ignored" so every secret path is a violation.
+    if not is_usable_git_repo(repo_root):
+        violations.extend(Violation("path", p) for p in SECRET_PATHS)
+        return violations
+    violations.extend(Violation("path", p) for p in check_paths(repo_root))
+    return violations
+
+
+def is_usable_git_repo(repo_root: Path) -> bool:
+    """True if `repo_root` is a git working tree we can check-ignore against."""
+    result = _run_git(["rev-parse", "--is-inside-work-tree"], repo_root)
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=str(REPO_ROOT),
+        help="Repository root whose .gitignore to check (default: this checkout).",
+    )
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root)
+
+    violations = check_secret_ignores(repo_root)
+    if not violations:
+        print("secret-ignores-guard: clean")
+        return 0
+
+    patterns = sorted(v.detail for v in violations if v.kind == "pattern")
+    paths = sorted(v.detail for v in violations if v.kind == "path")
+    if patterns:
+        print("SECRET-IGNORE FAIL: .gitignore is missing required protection patterns:")
+        for p in patterns:
+            print(f"  - {p}")
+    if paths:
+        print("SECRET-IGNORE FAIL: these secret-shaped paths would NOT be ignored:")
+        for p in paths:
+            print(f"  - {p}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_secret_ignores.py
+++ b/scripts/check_secret_ignores.py
@@ -70,6 +70,10 @@ REQUIRED_PATTERNS = [
     "data/*.key",
     "data/*.token",
     "data/hub/",
+    # LiteLLM proxy master key: bare `_key` suffix, matched by NO glob above
+    # (data/*.key needs a `.key` suffix). It sat live and unignored on dev
+    # boxes until this rule (JAY-QUEUE item, 2026-08-08).
+    "data/.litellm_master_key",
 ]
 
 # Secret-shaped paths that must actually be ignored by `git check-ignore`. Each
@@ -92,6 +96,7 @@ SECRET_PATHS = [
     "secrets/foo.token",            # secrets/
     "data/.secrets_key",            # data/.secrets_key
     "data/secrets.db-wal",          # data/secrets.db*
+    "data/.litellm_master_key",     # data/.litellm_master_key (exact)
 ]
 
 

--- a/tests/test_check_secret_ignores.py
+++ b/tests/test_check_secret_ignores.py
@@ -1,0 +1,171 @@
+"""Tests for the secret-material ignore guard (scripts/check_secret_ignores.py).
+
+The guard asserts two things on the branch under test:
+  1. Every REQUIRED_PATTERN appears as an exact active rule line in .gitignore.
+  2. Every SECRET_PATH is reported ignored by `git check-ignore`.
+
+The headline guarantee from tsk-laezfg is "PROVEN to fail when a pattern is
+removed": a parametrized test builds a synthetic repo from a copy of the real
+.gitignore, drops ONE required pattern line, and asserts the guard goes red. A
+companion real-tree test asserts the committed .gitignore on this branch is
+green, so the gate is a live regression guard and not dead code.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a package; make it importable like the other scripts/*.py
+# gate tests (see tests/test_check_deleted_symbols.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import check_secret_ignores as csi  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REAL_GITIGNORE = REPO_ROOT / ".gitignore"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+    # No inherited global/system ignores -- the only ignores in the synthetic
+    # repo come from the .gitignore we write, so the gate's path assertions stay
+    # deterministic.
+    _git(repo, "config", "core.excludesFile", "/dev/null")
+    _git(repo, "branch", "-M", "main")
+
+
+def _commit_gitignore(repo: Path, text: str) -> None:
+    (repo / ".gitignore").write_text(text, encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "gitignore")
+
+
+def _gitignore_without(text: str, pattern: str) -> str:
+    """Return `text` with the exact active rule line `pattern` removed."""
+    kept: list[str] = []
+    for raw in text.splitlines():
+        if raw.strip() == pattern:
+            continue
+        kept.append(raw)
+    return "\n".join(kept) + ("\n" if text.endswith("\n") else "")
+
+
+# ---------------------------------------------------------------------------
+# Pattern-presence check (pure, no git)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPatterns:
+    def test_active_rule_lines_drops_comments_and_blanks(self):
+        text = (
+            "# a comment *.key\n"
+            "\n"
+            "  *.key  \n"
+            "data/hub/\n"
+        )
+        assert csi._active_rule_lines(text) == ["*.key", "data/hub/"]
+
+    def test_all_required_patterns_present_on_real_tree(self):
+        text = REAL_GITIGNORE.read_text(encoding="utf-8")
+        assert csi.check_patterns(text) == []
+
+    @pytest.mark.parametrize("pattern", csi.REQUIRED_PATTERNS)
+    def test_removing_a_single_pattern_is_detected(self, pattern: str):
+        """Dropping ONE required rule line turns the pattern check red for
+        exactly that pattern -- this is the core 'remove a pattern -> red'
+        proof, run against every required pattern."""
+        text = _gitignore_without(REAL_GITIGNORE.read_text(encoding="utf-8"), pattern)
+        missing = csi.check_patterns(text)
+        assert missing == [pattern]
+
+    def test_comment_mention_does_not_satisfy_a_pattern(self):
+        """A pattern name in a comment (#-prefixed) must not count as present."""
+        text = "# *.key is for key material\ndata/hub/\n"
+        assert "data/hub/" not in csi.check_patterns(text)
+        assert "*.key" in csi.check_patterns(text)
+
+    def test_narrow_rule_does_not_satisfy_a_root_rule(self):
+        """`data/*.key` must not satisfy the master-level `*.key` rule, and vice
+        versa -- matching is exact-line, not substring."""
+        assert "*.key" in csi.check_patterns("data/*.key\n")
+        assert "data/*.key" in csi.check_patterns("*.key\n")
+
+    def test_missing_gitignore_reports_all_patterns(self):
+        assert set(csi.REQUIRED_PATTERNS).issubset(set(csi.check_patterns("")))
+
+
+# ---------------------------------------------------------------------------
+# Path-check (git check-ignore), integration with synthetic repos
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPaths:
+    def test_secret_paths_ignored_on_real_gitignore(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_gitignore(repo, REAL_GITIGNORE.read_text(encoding="utf-8"))
+        assert csi.check_paths(repo) == []
+
+    def test_path_not_ignored_when_pattern_removed(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        text = _gitignore_without(
+            REAL_GITIGNORE.read_text(encoding="utf-8"), "*.key"
+        )
+        _commit_gitignore(repo, text)
+        assert "foo.key" in csi.check_paths(repo)
+
+    def test_path_under_ignored_dir_is_ignored(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_gitignore(repo, "data/hub/\nidentity.json\n")
+        assert csi.is_path_ignored("data/hub/identity.json", repo)
+
+
+# ---------------------------------------------------------------------------
+# Full guard: green on the real tree, red on a single removed pattern
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSecretIgnores:
+    def test_real_tree_passes(self):
+        assert csi.check_secret_ignores(REPO_ROOT) == []
+
+    @pytest.mark.parametrize("pattern", csi.REQUIRED_PATTERNS)
+    def test_real_gitignore_minus_one_pattern_fails(self, tmp_path: Path, pattern: str):
+        """PROVEN red: copy the committed .gitignore, drop ONE required pattern,
+        and the guard must report a violation."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        text = _gitignore_without(REAL_GITIGNORE.read_text(encoding="utf-8"), pattern)
+        _commit_gitignore(repo, text)
+
+        violations = csi.check_secret_ignores(repo)
+
+        pattern_violations = [v for v in violations if v.kind == "pattern"]
+        assert pattern_violations, f"removing {pattern!r} did not trip the pattern guard"
+        assert any(v.detail == pattern for v in pattern_violations)
+
+    def test_real_gitignore_missing_key_makes_foo_key_unignored(
+        self, tmp_path: Path
+    ):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        text = _gitignore_without(REAL_GITIGNORE.read_text(encoding="utf-8"), "*.key")
+        _commit_gitignore(repo, text)
+
+        violations = csi.check_secret_ignores(repo)
+
+        details = {v.detail for v in violations}
+        assert "*.key" in details
+        assert "foo.key" in details


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): VERIFY at next release: secret-material .gitignore is dev-ONLY, master has NO protection

Autonomous build of board card tsk-laezfg.

Add scripts/check_secret_ignores.py, which asserts that the committed
.gitignore (a) still contains every required secret-protection rule as an
active line and (b) ignores a canonical set of secret-shaped paths
(data/hub/identity.json, foo.key, creds.json, x.p8, y_credentials.json, ...)
via git check-ignore. Covered by tests/test_check_secret_ignores.py,
including a parametrized test that drops each required pattern from a copy of
the real .gitignore and proves the guard goes red, plus a real-tree
regression asserting this branch is green.

.github/workflows/secret-ignores-gate.yml runs the guard on push and PR to
master, dev, and release/*, so a dropped pattern fails the branch it lands on
rather than being assumed during dev->master promotion.

Docs: Secret-ignores gate section in the contributor skill and a
post-promotion verification step in docs/RELEASING.md. Changelog fragment
added.

Refs tsk-laezfg.

Files:
 .claude/skills/taos-development-skill/SKILL.md |  23 +++
 .github/workflows/secret-ignores-gate.yml      |  35 ++++
 changelog.d/tsk-laezfg-secret-ignores-gate.md  |  12 ++
 docs/RELEASING.md                              |  14 ++
 scripts/check_secret_ignores.py                | 211 +++++++++++++++++++++++++
 tests/test_check_secret_ignores.py             | 171 ++++++++++++++++++++
 6 files changed, 466 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added automated checks to ensure sensitive files and secret-like paths remain excluded from version control.
  * Added protection for the LiteLLM master key file.

* **Documentation**
  * Updated release guidance with secret-protection verification steps.
  * Added a changelog entry describing the new safeguards.

* **Tests**
  * Added coverage for missing ignore rules, unprotected secret paths, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Red-first evidence (lead-run)

The gate against a tree carrying `origin/dev`'s current `.gitignore` (the merge ref) goes red on the exact live hole this PR closes:

```
SECRET-IGNORE FAIL: .gitignore is missing required protection patterns:
  - data/.litellm_master_key
SECRET-IGNORE FAIL: these secret-shaped paths would NOT be ignored:
  - data/.litellm_master_key
exit=1
```

Against the `release/beta.44` lineage (what master promotes from), the gate reds on **all 19 required patterns and all 13 secret paths** — the card's premise ("secret-material .gitignore is dev-ONLY, master has NO protection") confirmed mechanically:

```
SECRET-IGNORE FAIL: .gitignore is missing required protection patterns:
  - *.cred
  - *.key
  - data/.litellm_master_key
  - data/hub/
  ... (19 total)
SECRET-IGNORE FAIL: these secret-shaped paths would NOT be ignored:
  - data/hub/identity.json
  ... (13 total)
exit=1
```

Per-pattern removal detection is additionally parameterized in `tests/test_check_secret_ignores.py` (removing any single rule turns the gate red).
