### PR TITLE
fix(auth): consent-key passthrough for the /v1 agent-model surface (tsk-hfs6zv)

### DIFF
--- a/changelog.d/2363-v1-consent-key-passthrough.md
+++ b/changelog.d/2363-v1-consent-key-passthrough.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The Agent-as-a-Model surface (`GET /v1/models`, `POST /v1/chat/completions`)
+  is now reachable by external OpenAI-compatible clients: the auth middleware
+  passes exactly those two routes through to their own consent-key check
+  instead of rejecting every session-less caller before the handler ran. All
+  other `/v1` paths remain session-gated (tsk-hfs6zv).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -222,7 +222,17 @@ the proxy returns 502 (the read proxies degrade to an empty 200 instead).
 A registered external agent authenticates with its registry JWT
 (`Authorization: Bearer`) and reaches exactly the routes its granted SCOPES
 allow, nothing else: the middleware allowlist is a closed set, no skeleton key.
-The surface, by scope:
+
+A SEPARATE credential class exists for the Agent-as-a-Model surface:
+`GET /v1/models` and `POST /v1/chat/completions` are reachable without a
+session using a CONSENT KEY (`Authorization: Bearer sk-taosagent-...`, minted
+by an owner via `/api/agent-model-keys`), which the route itself validates —
+no key, no resolution, OpenAI-shaped 401 otherwise. Only those two exact
+method+path pairs pass the middleware; any other `/v1` path stays
+session-gated. `POST /v1/chat/completions` returns 501 for a valid key until
+the opencode host-server turn seam lands (decided 2026-06-23, unbuilt).
+
+The registry-JWT surface, by scope:
 
 - **project_tasks** (the kanban board): `GET /api/projects/{pid}/tasks`,
   `.../tasks/ready`, `.../tasks/{id}`, `.../tasks/{id}/comments` (GET + POST),

--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -145,3 +145,80 @@ async def test_chat_missing_model_is_openai_shaped_400(client):
     assert resp.status_code == 400
     # OpenAI envelope, not FastAPI's default {"detail": [...]} 422.
     assert resp.json()["error"]["type"] == "invalid_request_error"
+
+
+# ---------------------------------------------------------------------------
+# Middleware passthrough (tsk-hfs6zv): an EXTERNAL client (no session cookie)
+# must reach the /v1 handlers, whose consent-key check is the credential.
+# Before the exemption, the session gate 401d these requests before the
+# handler ran, so the surface was unreachable from outside by design-gap.
+# ---------------------------------------------------------------------------
+
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def bare_client(client):
+    """Session-less client against the same app: what an external
+    OpenAI-compatible caller looks like."""
+    app = client._transport.app
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_external_models_reaches_route_auth(bare_client):
+    """No session, no key: the 401 must be the ROUTE's OpenAI envelope,
+    not the middleware's generic 401."""
+    async with bare_client as c:
+        resp = await c.get("/v1/models")
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_external_chat_completions_reaches_route_auth(bare_client):
+    async with bare_client as c:
+        resp = await c.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer sk-taosagent-bogus"},
+            json={"model": "agent-a", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_external_valid_key_lists_models_end_to_end(client, bare_client):
+    """A minted consent key authenticates an external caller through the
+    middleware all the way to a 200 model list."""
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], ["memory_read"])
+    async with bare_client as c:
+        resp = await c.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    assert [m["id"] for m in resp.json()["data"]] == ["agent-a"]
+
+
+@pytest.mark.asyncio
+async def test_unlisted_v1_path_stays_session_gated(bare_client):
+    """The exemption is exact-path: any other /v1 path must still hit the
+    session gate, not fall through as a public 404."""
+    async with bare_client as c:
+        resp = await c.get("/v1/other")
+    assert resp.status_code == 401
+    # The middleware's generic 401 ({"error": "Authentication required"}),
+    # never the route's OpenAI envelope ({"error": {"code": ...}}).
+    assert not isinstance(resp.json().get("error"), dict)
+
+
+@pytest.mark.asyncio
+async def test_wrong_method_on_exempt_path_stays_gated(bare_client):
+    """Method-sensitivity: POST /v1/models and GET /v1/chat/completions are
+    not exempt."""
+    async with bare_client as c:
+        r1 = await c.post("/v1/models")
+        r2 = await c.get("/v1/chat/completions")
+    assert r1.status_code == 401
+    assert r2.status_code == 401
+    for r in (r1, r2):
+        assert not isinstance(r.json().get("error"), dict)

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -287,6 +287,15 @@ _CLUSTER_HEARTBEAT = "/api/cluster/heartbeat"
 _INVITE_REDEEM = "/api/projects/invites/redeem"
 _INVITE_INFO_PREFIX = "/i/"
 
+# Agent-model OpenAI-compatible surface (routes/agent_model_api.py): the
+# consent key IS the credential and the ROUTE enforces it — it never resolves
+# a model without a valid key and answers 401 in an OpenAI error envelope
+# otherwise (proven by tests/test_routes_agent_model_api.py). The middleware
+# exempts EXACTLY the two mounted routes, method-sensitive; every other /v1
+# path stays session-gated so the exemption cannot become a skeleton key.
+_AGENT_MODEL_MODELS = "/v1/models"
+_AGENT_MODEL_CHAT = "/v1/chat/completions"
+
 # Local-only shutdown drain: the systemd ExecStop hook (taos-graceful-stop)
 # POSTs this from localhost with no session cookie and no token, so it was
 # getting 401 and the in-app drain never ran. We exempt it ONLY for loopback
@@ -405,6 +414,12 @@ def _is_exempt(method: str, path: str) -> bool:
     # contract. The browser-friendly /i/ exact path stays session-gated so a
     # logged-out admin is not exposed, but the invite id form is exempt.
     if method == "GET" and path.startswith(_INVITE_INFO_PREFIX) and "/" not in path[len(_INVITE_INFO_PREFIX):]:
+        return True
+    # Agent-model surface — consent-key auth lives in the route (see the
+    # constants block above). Exact paths only; /v1/anything-else stays gated.
+    if method == "GET" and path == _AGENT_MODEL_MODELS:
+        return True
+    if method == "POST" and path == _AGENT_MODEL_CHAT:
         return True
     return False
 


### PR DESCRIPTION
Lead build of board card tsk-hfs6zv (lead-held: touches auth middleware allowlists). Origin: hermes's live probe (bus 2380) found `GET /v1/models` and `POST /v1/chat/completions` mounted and complete but 401ing at the session gate for every external caller — the routes' own consent-key auth never ran.

The exemption is exact and method-sensitive: only `GET /v1/models` and `POST /v1/chat/completions` pass through, and only to the route's own credential check (no key → OpenAI-shaped 401; the route never resolves a model without a valid key, per its existing tests). `/v1/anything-else` and wrong-method requests stay session-gated, both directions tested. `POST /v1/chat/completions` keeps its deliberate 501-until-turn-seam behavior (Jay decision 2026-06-23), untouched and now documented.

## Red-first evidence (lead-run at merge ref)

The three external-caller tests (session-less client) against the unmodified middleware:

```
FAILED tests/test_routes_agent_model_api.py::test_external_models_reaches_route_auth
FAILED tests/test_routes_agent_model_api.py::test_external_chat_completions_reaches_route_auth
FAILED tests/test_routes_agent_model_api.py::test_external_valid_key_lists_models_end_to_end
3 failed, 13 deselected
```

With the exemption: 74/74 across `test_routes_agent_model_api.py` + `test_auth_middleware.py`, including a minted-consent-key 200 end to end through the middleware.
