### PR TITLE
feat(settings): update brings local taOSmd to latest and verifies the RUNNING bus (tsk-jjkukj re-cut)

### DIFF
--- a/changelog.d/tsk-jjkukj-settings-taosmd-currency.md
+++ b/changelog.d/tsk-jjkukj-settings-taosmd-currency.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Settings-update brings a locally-hosted taOSmd to latest in the same
+  action**: with the new config keys `taosmd_dir` and `taosmd_restart_cmd` set
+  (and `memory_url` local), `POST /api/settings/update` ff-only-pulls the
+  taOSmd checkout, announces the restart on the A2A bus `build` thread before
+  dropping SSE subscribers, restarts the service, and then verifies the
+  RUNNING server's `/health` — Content-Type must be `application/json` (a
+  `text/html` 200 from the SPA catch-all fails) and the core capability
+  identifiers (`a2a.v1`, `collections.v1`, `search.v1`) must be present in the
+  body. Any taOSmd failure fails the whole update loudly with a named reason;
+  unconfigured or remote installs get an explicit `taosmd: {"skipped": <why>}`
+  in the response, never a silent half-update (tsk-jjkukj).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -214,6 +214,23 @@ POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope
 {"thread": "build", "body": "...", "reply_to": <id>?}
 ```
 
+## Bus restarts during a controller update
+
+`POST /api/settings/update` on a host that also runs taOSmd locally (config
+keys `taosmd_dir` + `taosmd_restart_cmd` set, `memory_url` local) brings
+taOSmd to latest in the same action: ff-only pull of the checkout, then a
+service restart, then verification against the **running** server's `/health`
+(Content-Type must be `application/json` and the core capability identifiers
+must appear in the body — a `text/html` 200 is the SPA catch-all answering and
+fails the update loudly). Two consequences for agents:
+
+- A `SYSTEM: taOSmd updating…` message is posted to the `build` thread
+  **before** the bus restarts. If your SSE stream drops right after that
+  message, it is the update, not an outage — reconnect and carry on.
+- If the hooks are not configured (or `memory_url` is remote) the update
+  response reports `taosmd: {"skipped": <why>}`; the skip is visible in the
+  response, never silent. On those installs taOSmd is updated on its own host.
+
 An admin session may also call it and set an explicit `from`. On a bus failure
 the proxy returns 502 (the read proxies degrade to an empty 200 instead).
 

--- a/tests/test_settings_taosmd_update.py
+++ b/tests/test_settings_taosmd_update.py
@@ -102,6 +102,14 @@ class TestVerifyTaosmdRunning:
         assert reason is not None and "unreachable" in reason
 
     @pytest.mark.asyncio
+    async def test_fails_named_on_non_string_capability_entries(self):
+        """Unhashable/odd entries must yield a NAMED reason, not a TypeError."""
+        body = {"status": "ok", "capabilities": [{"cap": "a2a.v1"}, "search.v1"]}
+        req = _fake_request(_FakeResp(200, "application/json", body))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None and "non-string" in reason
+
+    @pytest.mark.asyncio
     async def test_passes_on_real_health_shape(self):
         req = _fake_request(_FakeResp(200, "application/json", REAL_HEALTH_BODY))
         assert await _verify_taosmd_running(req) is None
@@ -133,6 +141,23 @@ class TestUpdateLocalTaosmd:
         (tmp_path / ".git").mkdir()
         req = _fake_request(taosmd_dir=str(tmp_path))
         report = await _update_local_taosmd(req)
+        assert "taosmd_restart_cmd" in report["error"]
+
+    @pytest.mark.asyncio
+    async def test_errors_named_on_unparseable_restart_cmd(self, tmp_path):
+        """An unmatched quote must be a NAMED error before anything runs."""
+        (tmp_path / ".git").mkdir()
+        req = _fake_request(taosmd_dir=str(tmp_path),
+                            taosmd_restart_cmd="systemctl restart 'taosmd")
+        report = await _update_local_taosmd(req)
+        assert "not parseable" in report["error"]
+
+    @pytest.mark.asyncio
+    async def test_errors_named_on_whitespace_restart_cmd(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        req = _fake_request(taosmd_dir=str(tmp_path), taosmd_restart_cmd="  ")
+        report = await _update_local_taosmd(req)
+        # Whitespace-only strips to empty -> caught by the unset check.
         assert "taosmd_restart_cmd" in report["error"]
 
     @pytest.mark.asyncio
@@ -263,6 +288,31 @@ class TestApplyUpdateTaosmdContract:
         assert data["status"] == "restarting"
         assert data["taosmd"]["updated"] is True
         assert "taOSmd updated and verified" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_config_save_round_trip_preserves_taosmd_settings(self, client, app):
+        """PUT /api/config rebuilds AppConfig field-by-field; the taOSmd hooks
+        must survive the round trip, not silently drop (CodeRabbit find)."""
+        import yaml as _yaml
+
+        resp = await client.get("/api/config")
+        data = _yaml.safe_load(resp.json()["yaml"])
+        data["taosmd_dir"] = "/srv/taosmd"
+        data["taosmd_restart_cmd"] = "systemctl restart taosmd"
+        try:
+            resp = await client.put(
+                "/api/config", json={"yaml": _yaml.dump(data)}
+            )
+            assert resp.status_code == 200, resp.json()
+            assert app.state.config.taosmd_dir == "/srv/taosmd"
+            assert app.state.config.taosmd_restart_cmd == "systemctl restart taosmd"
+            resp = await client.get("/api/config")
+            round_tripped = _yaml.safe_load(resp.json()["yaml"])
+            assert round_tripped["taosmd_dir"] == "/srv/taosmd"
+            assert round_tripped["taosmd_restart_cmd"] == "systemctl restart taosmd"
+        finally:
+            app.state.config.taosmd_dir = ""
+            app.state.config.taosmd_restart_cmd = ""
 
     @pytest.mark.asyncio
     async def test_update_still_succeeds_when_taosmd_not_configured(self, client):

--- a/tests/test_settings_taosmd_update.py
+++ b/tests/test_settings_taosmd_update.py
@@ -1,0 +1,279 @@
+"""Settings-update taOSmd currency + running-server verification (tsk-jjkukj).
+
+The contract under test:
+
+* ``/api/settings/update`` brings a LOCALLY-hosted taOSmd to latest in the same
+  action, restarts its service, and then verifies the RUNNING server — never
+  the checkout, never pip, never exit status alone.
+* Verification asserts in order: (a) HTTP 200 whose Content-Type is
+  application/json (the SPA catch-all serves text/html 200 and must FAIL),
+  (b) the core capability identifiers are present in the body.
+* Any taOSmd failure fails the whole update loudly; skips (remote taOSmd,
+  hooks unset) are reported in the response, never silent.
+"""
+
+import contextlib
+import types
+
+import httpx
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tinyagentos.routes import settings as settings_mod
+from tinyagentos.routes.settings import (
+    REQUIRED_TAOSMD_CAPABILITIES,
+    _update_local_taosmd,
+    _verify_taosmd_running,
+)
+
+REAL_HEALTH_BODY = {
+    "status": "ok",
+    "version": "0.4.0",
+    "capabilities": sorted(REQUIRED_TAOSMD_CAPABILITIES | {"graph.v1", "tasks.v1"}),
+}
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, content_type="application/json", body=None):
+        self.status_code = status_code
+        self.headers = {"content-type": content_type}
+        self._body = body
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("not json")
+        return self._body
+
+
+class _FakeHttpClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+
+    async def get(self, url, **kwargs):
+        if self._exc is not None:
+            raise self._exc
+        return self._resp
+
+
+def _fake_request(resp=None, exc=None, memory_url="http://localhost:7900",
+                  taosmd_dir="", taosmd_restart_cmd=""):
+    config = types.SimpleNamespace(
+        memory_url=memory_url,
+        taosmd_dir=taosmd_dir,
+        taosmd_restart_cmd=taosmd_restart_cmd,
+    )
+    state = types.SimpleNamespace(config=config, http_client=_FakeHttpClient(resp, exc))
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=state))
+
+
+class TestVerifyTaosmdRunning:
+    @pytest.mark.asyncio
+    async def test_fails_on_spa_catchall_html_200(self):
+        """A text/html 200 is the SPA answering the wrong port — MUST fail."""
+        req = _fake_request(_FakeResp(200, "text/html; charset=utf-8"))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None
+        assert "Content-Type" in reason and "SPA catch-all" in reason
+
+    @pytest.mark.asyncio
+    async def test_fails_on_missing_capability_identifiers(self):
+        body = {"status": "ok", "capabilities": ["collections.v1", "search.v1"]}
+        req = _fake_request(_FakeResp(200, "application/json", body))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None and "a2a.v1" in reason
+
+    @pytest.mark.asyncio
+    async def test_fails_on_non_200(self):
+        req = _fake_request(_FakeResp(503, "application/json", {"status": "down"}))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None and "503" in reason
+
+    @pytest.mark.asyncio
+    async def test_fails_on_missing_capabilities_list(self):
+        req = _fake_request(_FakeResp(200, "application/json", {"status": "ok"}))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None and "capabilities" in reason
+
+    @pytest.mark.asyncio
+    async def test_fails_when_unreachable(self):
+        req = _fake_request(exc=httpx.ConnectError("connection refused"))
+        reason = await _verify_taosmd_running(req)
+        assert reason is not None and "unreachable" in reason
+
+    @pytest.mark.asyncio
+    async def test_passes_on_real_health_shape(self):
+        req = _fake_request(_FakeResp(200, "application/json", REAL_HEALTH_BODY))
+        assert await _verify_taosmd_running(req) is None
+
+
+class TestUpdateLocalTaosmd:
+    @pytest.mark.asyncio
+    async def test_skips_when_memory_url_remote(self):
+        req = _fake_request(memory_url="http://192.168.1.50:7900",
+                            taosmd_dir="/somewhere", taosmd_restart_cmd="true")
+        report = await _update_local_taosmd(req)
+        assert "not local" in report["skipped"]
+
+    @pytest.mark.asyncio
+    async def test_skips_when_dir_not_configured(self):
+        req = _fake_request()
+        report = await _update_local_taosmd(req)
+        assert report["skipped"] == "taosmd_dir not configured"
+
+    @pytest.mark.asyncio
+    async def test_errors_when_dir_is_not_a_git_checkout(self, tmp_path):
+        req = _fake_request(taosmd_dir=str(tmp_path), taosmd_restart_cmd="true")
+        report = await _update_local_taosmd(req)
+        assert "not a git checkout" in report["error"]
+
+    @pytest.mark.asyncio
+    async def test_errors_when_restart_cmd_unset(self, tmp_path):
+        """A pull the running service never loads is a silent half-update."""
+        (tmp_path / ".git").mkdir()
+        req = _fake_request(taosmd_dir=str(tmp_path))
+        report = await _update_local_taosmd(req)
+        assert "taosmd_restart_cmd" in report["error"]
+
+    @pytest.mark.asyncio
+    async def test_errors_loudly_when_pull_fails(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        req = _fake_request(taosmd_dir=str(tmp_path), taosmd_restart_cmd="true")
+        with patch.object(settings_mod, "_run_capture",
+                          new=AsyncMock(return_value=(1, "fatal: not fast-forward"))):
+            report = await _update_local_taosmd(req)
+        assert "git pull failed" in report["error"]
+
+    @pytest.mark.asyncio
+    async def test_announces_before_restart_and_reports(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        req = _fake_request(taosmd_dir=str(tmp_path),
+                            taosmd_restart_cmd="systemctl restart taosmd")
+        calls = []
+
+        async def _fake_run(cmd, cwd=None, timeout=None, env=None):
+            calls.append(list(cmd))
+            return 0, "ok"
+
+        async def _fake_announce(text):
+            calls.append(["ANNOUNCE"])
+            return True
+
+        with (
+            patch.object(settings_mod, "_run_capture", new=_fake_run),
+            patch.object(settings_mod, "_announce_taosmd_restart", new=_fake_announce),
+        ):
+            report = await _update_local_taosmd(req)
+
+        assert report["updated"] and report["restarted"] and report["announced"]
+        # Order: pull, announce, restart — the notice must precede the restart.
+        assert calls == [
+            ["git", "pull", "--ff-only"],
+            ["ANNOUNCE"],
+            ["systemctl", "restart", "taosmd"],
+        ]
+
+
+def _update_route_patches():
+    """The subprocess/restart patch set the existing update tests use."""
+    fake_proc = MagicMock()
+    fake_proc.returncode = 0
+    fake_proc.communicate = AsyncMock(return_value=(b"Already up to date.\n", b""))
+
+    async def _fake_restart(_app_state):
+        return None
+
+    return (
+        patch(
+            "tinyagentos.routes.settings.asyncio.create_subprocess_exec",
+            return_value=fake_proc,
+        ),
+        patch(
+            "tinyagentos.routes.settings._run_capture",
+            new=AsyncMock(return_value=(0, "ok")),
+        ),
+        patch(
+            "tinyagentos.desktop_rebuild.rebuild_desktop_bundle_if_stale",
+            new=AsyncMock(
+                return_value=MagicMock(rebuilt=False, success=True, message="current")
+            ),
+        ),
+        patch("tinyagentos.routes.system._do_restart", new=_fake_restart),
+        patch("tinyagentos.restart_orchestrator.write_pending_restart"),
+        patch(
+            "tinyagentos.routes.settings._announce_taosmd_restart",
+            new=AsyncMock(return_value=True),
+        ),
+        patch.object(settings_mod, "_TAOSMD_VERIFY_RETRIES", 1),
+        patch.object(settings_mod, "_TAOSMD_VERIFY_DELAY", 0),
+    )
+
+
+class TestApplyUpdateTaosmdContract:
+    @pytest.mark.asyncio
+    async def test_update_reports_failure_on_verification_mismatch(
+        self, client, app, tmp_path
+    ):
+        """The update must FAIL (500, named reason) when the restarted taOSmd
+        answers with the SPA catch-all shape instead of real health JSON."""
+        (tmp_path / ".git").mkdir()
+        app.state.config.taosmd_dir = str(tmp_path)
+        app.state.config.taosmd_restart_cmd = "systemctl restart taosmd"
+        real_http_client = app.state.http_client
+        app.state.http_client = _FakeHttpClient(_FakeResp(200, "text/html"))
+        try:
+            with contextlib.ExitStack() as stack:
+                for p in _update_route_patches():
+                    stack.enter_context(p)
+                resp = await client.post("/api/settings/update")
+        finally:
+            app.state.http_client = real_http_client
+            app.state.config.taosmd_dir = ""
+            app.state.config.taosmd_restart_cmd = ""
+
+        assert resp.status_code == 500, (
+            f"Expected the update to FAIL on a text/html health response, got "
+            f"{resp.status_code}: {resp.json()!r}"
+        )
+        assert "verification FAILED" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_succeeds_and_reports_taosmd_updated(
+        self, client, app, tmp_path
+    ):
+        (tmp_path / ".git").mkdir()
+        app.state.config.taosmd_dir = str(tmp_path)
+        app.state.config.taosmd_restart_cmd = "systemctl restart taosmd"
+        real_http_client = app.state.http_client
+        app.state.http_client = _FakeHttpClient(
+            _FakeResp(200, "application/json", REAL_HEALTH_BODY)
+        )
+        try:
+            with contextlib.ExitStack() as stack:
+                for p in _update_route_patches():
+                    stack.enter_context(p)
+                resp = await client.post("/api/settings/update")
+        finally:
+            app.state.http_client = real_http_client
+            app.state.config.taosmd_dir = ""
+            app.state.config.taosmd_restart_cmd = ""
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "restarting"
+        assert data["taosmd"]["updated"] is True
+        assert "taOSmd updated and verified" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_update_still_succeeds_when_taosmd_not_configured(self, client):
+        """Installs without the taOSmd hooks keep updating exactly as before —
+        with the skip REPORTED, not silent."""
+        with contextlib.ExitStack() as stack:
+            for p in _update_route_patches():
+                stack.enter_context(p)
+            resp = await client.post("/api/settings/update")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "restarting"
+        assert data["taosmd"] == {"skipped": "taosmd_dir not configured"}

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -60,6 +60,12 @@ class AppConfig:
     archived_agents: list[dict] = field(default_factory=list)
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
+    # Locally-hosted taOSmd deployment hooks for /api/settings/update: the git
+    # checkout the running service imports from, and the command that restarts
+    # it (e.g. "sudo systemctl restart taosmd"). Both empty on installs where
+    # taOSmd is remote or unmanaged; settings-update then reports the skip.
+    taosmd_dir: str = ""
+    taosmd_restart_cmd: str = ""
     wallhaven_api_key: str | None = None
     github_app_id: str = ""
     config_path: Path | None = None
@@ -81,6 +87,10 @@ class AppConfig:
             d["archive"] = self.archive
         if self.memory_url != "http://localhost:7900":
             d["memory_url"] = self.memory_url
+        if self.taosmd_dir:
+            d["taosmd_dir"] = self.taosmd_dir
+        if self.taosmd_restart_cmd:
+            d["taosmd_restart_cmd"] = self.taosmd_restart_cmd
         if self.github_app_id:
             d["github_app_id"] = self.github_app_id
         return d
@@ -191,6 +201,8 @@ def load_config(path: Path) -> AppConfig:
         archived_agents=data.get("archived_agents", []),
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
+        taosmd_dir=str(data.get("taosmd_dir", "") or ""),
+        taosmd_restart_cmd=str(data.get("taosmd_restart_cmd", "") or ""),
         github_app_id=str(data.get("github_app_id", "") or ""),
         config_path=path,
         wallhaven_api_key=wallhaven_api_key,

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -216,6 +216,8 @@ async def save_config_endpoint(request: Request, body: ConfigUpdate, validate_on
         metrics=data.get("metrics", {}),
         webhooks=data.get("webhooks", []),
         memory_url=data.get("memory_url", "http://localhost:7900"),
+        taosmd_dir=str(data.get("taosmd_dir", "") or ""),
+        taosmd_restart_cmd=str(data.get("taosmd_restart_cmd", "") or ""),
         config_path=request.app.state.config_path,
     )
     errors = validate_config(new_config)
@@ -337,6 +339,8 @@ async def restore_backup(request: Request, file: UploadFile):
                 metrics=data.get("metrics", {}),
                 webhooks=data.get("webhooks", []),
                 memory_url=data.get("memory_url", "http://localhost:7900"),
+                taosmd_dir=str(data.get("taosmd_dir", "") or ""),
+                taosmd_restart_cmd=str(data.get("taosmd_restart_cmd", "") or ""),
                 config_path=config_path,
             )
             request.app.state.config = new_config
@@ -928,6 +932,8 @@ async def _verify_taosmd_running(request: Request) -> str | None:
     caps = body.get("capabilities") if isinstance(body, dict) else None
     if not isinstance(caps, list):
         return "taOSmd /health body has no capabilities list"
+    if not all(isinstance(c, str) for c in caps):
+        return "taOSmd /health capabilities list contains non-string entries"
     missing = REQUIRED_TAOSMD_CAPABILITIES - set(caps)
     if missing:
         return f"taOSmd /health is missing capability identifiers: {sorted(missing)}"
@@ -982,6 +988,12 @@ async def _update_local_taosmd(request: Request) -> dict:
             "error": "taosmd_dir is set but taosmd_restart_cmd is not; refusing "
             "a pull the running service would never load"
         }
+    try:
+        restart_argv = shlex.split(restart_cmd)
+    except ValueError as exc:
+        return {"error": f"taosmd_restart_cmd is not parseable shell syntax: {exc}"}
+    if not restart_argv:
+        return {"error": "taosmd_restart_cmd parses to an empty command"}
     rc, out = await _run_capture(["git", "pull", "--ff-only"], cwd=taosmd_dir)
     if rc != 0:
         return {"error": f"taOSmd git pull failed: {out.strip()[-1500:]}"}
@@ -989,7 +1001,7 @@ async def _update_local_taosmd(request: Request) -> dict:
         "SYSTEM: taOSmd updating to latest via Settings-update; the A2A bus "
         "restarts momentarily and SSE subscribers must reconnect."
     )
-    rc, restart_out = await _run_capture(shlex.split(restart_cmd), cwd=taosmd_dir, timeout=120.0)
+    rc, restart_out = await _run_capture(restart_argv, cwd=taosmd_dir, timeout=120.0)
     if rc != 0:
         return {"error": f"taOSmd restart command failed (rc {rc}): {restart_out.strip()[-1500:]}"}
     return {

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -885,6 +885,121 @@ async def _stash_local_source_changes(project_dir) -> bool:
     return True
 
 
+# Core capability identifiers every healthy taOSmd /health has served since the
+# capabilities field existed. Deliberately a SUBSET: newer servers add
+# capabilities, and the check must not fail on additions.
+REQUIRED_TAOSMD_CAPABILITIES = frozenset({"a2a.v1", "collections.v1", "search.v1"})
+
+# Post-restart verification pacing. Module constants so tests can collapse the
+# wait instead of patching sleep.
+_TAOSMD_VERIFY_RETRIES = 10
+_TAOSMD_VERIFY_DELAY = 2.0
+
+
+async def _verify_taosmd_running(request: Request) -> str | None:
+    """Verify the RUNNING taOSmd answers a real /health, or say why not.
+
+    Returns None on success, else a human-readable failure reason. Asserts in
+    order: (a) HTTP 200 whose Content-Type is application/json — a text/html
+    200 is the SPA catch-all answering the wrong port and MUST fail; (b) the
+    core capability identifiers are present in the body. Never status alone.
+    """
+    url = request.app.state.config.memory_url
+    try:
+        client = request.app.state.http_client
+        resp = await client.get(
+            f"{url}/health", timeout=httpx.Timeout(5.0, connect=3.0)
+        )
+    except (httpx.RequestError, httpx.InvalidURL) as exc:
+        return f"taOSmd /health unreachable at {url}: {exc}"
+    if resp.status_code != 200:
+        return f"taOSmd /health returned HTTP {resp.status_code} (expected 200)"
+    content_type = resp.headers.get("content-type", "")
+    if not content_type.startswith("application/json"):
+        return (
+            f"taOSmd /health Content-Type is {content_type or 'missing'!r}, not "
+            "application/json — a text/html 200 means the SPA catch-all "
+            "answered, not the memory service"
+        )
+    try:
+        body = resp.json()
+    except ValueError:
+        return "taOSmd /health claimed application/json but the body does not parse"
+    caps = body.get("capabilities") if isinstance(body, dict) else None
+    if not isinstance(caps, list):
+        return "taOSmd /health body has no capabilities list"
+    missing = REQUIRED_TAOSMD_CAPABILITIES - set(caps)
+    if missing:
+        return f"taOSmd /health is missing capability identifiers: {sorted(missing)}"
+    return None
+
+
+async def _announce_taosmd_restart(text: str) -> bool:
+    """Post a system notice to the A2A bus BEFORE its process restarts.
+
+    A bus restart drops every SSE subscriber; without this notice the agent
+    leads diagnose a phantom outage. Best-effort: an already-down bus must not
+    block the update — there is nobody connected left to warn.
+    """
+    from tinyagentos.routes.a2a_bus import _bus_url
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                f"{_bus_url()}/a2a/send",
+                json={"from": "system", "thread": "build", "body": text},
+            )
+            resp.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("taOSmd restart announcement failed: %s", exc)
+        return False
+
+
+async def _update_local_taosmd(request: Request) -> dict:
+    """Bring a locally-hosted taOSmd checkout to latest and restart its service.
+
+    Returns a report dict the update response carries verbatim:
+      {"skipped": <why>}    — legal no-op (remote taOSmd, or hooks unset)
+      {"updated": True, "output": ..., "announced": bool, "restarted": True}
+      {"error": <why>}      — hard failure; the caller must fail the update
+    """
+    import shlex
+
+    config = request.app.state.config
+    if not _is_local_url(config.memory_url):
+        return {"skipped": "memory_url is not local; update taOSmd on its own host"}
+    taosmd_dir = (config.taosmd_dir or "").strip()
+    if not taosmd_dir:
+        return {"skipped": "taosmd_dir not configured"}
+    if not (Path(taosmd_dir) / ".git").exists():
+        return {"error": f"taosmd_dir {taosmd_dir!r} is not a git checkout"}
+    restart_cmd = (config.taosmd_restart_cmd or "").strip()
+    if not restart_cmd:
+        # A configured checkout without a restart command would pull code the
+        # running service never loads — a silent half-update, worse than none.
+        return {
+            "error": "taosmd_dir is set but taosmd_restart_cmd is not; refusing "
+            "a pull the running service would never load"
+        }
+    rc, out = await _run_capture(["git", "pull", "--ff-only"], cwd=taosmd_dir)
+    if rc != 0:
+        return {"error": f"taOSmd git pull failed: {out.strip()[-1500:]}"}
+    announced = await _announce_taosmd_restart(
+        "SYSTEM: taOSmd updating to latest via Settings-update; the A2A bus "
+        "restarts momentarily and SSE subscribers must reconnect."
+    )
+    rc, restart_out = await _run_capture(shlex.split(restart_cmd), cwd=taosmd_dir, timeout=120.0)
+    if rc != 0:
+        return {"error": f"taOSmd restart command failed (rc {rc}): {restart_out.strip()[-1500:]}"}
+    return {
+        "updated": True,
+        "output": out.strip()[-1500:],
+        "announced": announced,
+        "restarted": True,
+    }
+
+
 @router.post("/api/settings/update")
 async def apply_update(request: Request):
     """Pull latest TinyAgentOS code from GitHub."""
@@ -1011,6 +1126,39 @@ async def apply_update(request: Request):
             status_code=500,
         )
 
+    # Bring a locally-hosted taOSmd to latest in the SAME action (tsk-jjkukj):
+    # two components, one deploy route, one place to look when it fails. A
+    # skip (remote taOSmd, hooks unset) is reported, never silent; a failure
+    # fails the update loudly — a silent half-update is worse than no update.
+    taosmd_report = await _update_local_taosmd(request)
+    if "error" in taosmd_report:
+        return JSONResponse(
+            {
+                "error": f"taOSmd update FAILED — update aborted: {taosmd_report['error']}",
+                "git_output": output.strip(),
+            },
+            status_code=500,
+        )
+    if taosmd_report.get("updated"):
+        # Verify the RUNNING server came back serving real JSON with the core
+        # capability identifiers — never trust the restart exit status alone.
+        verify_reason = None
+        for attempt in range(_TAOSMD_VERIFY_RETRIES):
+            verify_reason = await _verify_taosmd_running(request)
+            if verify_reason is None:
+                break
+            if attempt < _TAOSMD_VERIFY_RETRIES - 1:
+                await asyncio.sleep(_TAOSMD_VERIFY_DELAY)
+        if verify_reason is not None:
+            return JSONResponse(
+                {
+                    "error": f"taOSmd update verification FAILED: {verify_reason}",
+                    "git_output": output.strip(),
+                    "taosmd": taosmd_report,
+                },
+                status_code=500,
+            )
+
     # Always restart after a successful update.
     import asyncio as _asyncio
     from tinyagentos.routes.system import _do_restart
@@ -1019,10 +1167,19 @@ async def apply_update(request: Request):
         "status": "restarting",
         "output": output.strip(),
         "stashed_local_changes": stashed_local,
+        "taosmd": taosmd_report,
         "message": (
-            "Update applied. Local source changes were stashed (recover with `git stash pop`). Restarting now…"
-            if stashed_local
-            else "Update applied. Restarting now…"
+            (
+                "Update applied. Local source changes were stashed (recover with `git stash pop`). "
+                if stashed_local
+                else "Update applied. "
+            )
+            + (
+                "taOSmd updated and verified against the running service. "
+                if taosmd_report.get("updated")
+                else ""
+            )
+            + "Restarting now…"
         ),
     }
 


### PR DESCRIPTION
Lead re-cut of tsk-jjkukj, replacing bounced PR #2360 (inert verification, PyPI pip install of taosmd, SystemEvent instead of the bus — full adjudication on that PR).

## What it does

One deploy action, both components. With the new config hooks `taosmd_dir` + `taosmd_restart_cmd` set and `memory_url` local, `POST /api/settings/update`:

1. ff-only-pulls the taOSmd **checkout the running service imports from** (the real deployment mechanism — on the Pi, `/home/jay/taosmd` behind `taosmd.service`; never pip, never PyPI),
2. announces on the A2A bus `build` thread **before** restarting it (a bus restart drops every SSE subscriber; without the notice, leads diagnose a phantom outage),
3. restarts the service via the configured command,
4. verifies the **running** server: `GET {memory_url}/health` must be HTTP 200 **with Content-Type `application/json`** — a `text/html` 200 is the SPA catch-all answering the wrong port and fails — and the body must carry the core capability identifiers (`a2a.v1`, `collections.v1`, `search.v1`, a deliberate subset so future additions don't break it). Never status alone.

Any taOSmd failure (pull, restart, verification) fails the whole update with a 500 and a named reason. Unconfigured or remote installs get `taosmd: {"skipped": <why>}` in the response — reported, never silent, and the update proceeds exactly as before (locked by test).

## RED proof at the merge ref (6a9bfcc8)

A no-new-symbols probe (SPA-shaped `/health`, hooks configured) run against the merge ref — the update succeeds silently where the contract demands loud failure:

```
E       AssertionError: UPDATE MUST FAIL on a text/html taOSmd /health, got 200; body: {'status': 'restarting', 'output': 'Already up to date.', 'stashed_local_changes': True, 'message': 'Update applied. Local source changes were stashed (recover with `git stash pop`). Restarting now…'}
E       assert 200 == 500
E        +  where 200 = <Response [200 OK]>.status_code

tests/test_red_probe_taosmd.py:66: AssertionError
1 failed in 4.98s
```

The full new suite also collection-errors at the merge ref (`ImportError: cannot import name 'REQUIRED_TAOSMD_CAPABILITIES'`). On this branch the same contract passes.

## Tests (15 new, all green; 101 across the settings/config suites)

- content-type assert: text/html 200 → named failure (the card's SPA catch-all case)
- capability-membership assert: missing `a2a.v1` → named failure
- non-200, unreachable, missing-capabilities-list, real-shape pass
- update-reports-failure-on-mismatch: wired `apply_update` returns 500 + `verification FAILED` when the restarted service answers SPA-shaped
- announce-before-restart ordering locked (pull → announce → restart)
- pull-failure and missing-restart-cmd are loud errors (a pull the running service never loads is a silent half-update — refused)
- unconfigured installs: update still succeeds, skip reported

Docs: `docs/agent-coordination.md` gains a "Bus restarts during a controller update" section; changelog fragment included. Card: tsk-jjkukj (lead-held after the #2360 bounce).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional settings for managing locally hosted taOSmd installations.
  - Settings updates can automatically update, restart, and verify local taOSmd services.
  - The system checks required service capabilities and reports clear success, failure, or skipped statuses.
  - Users receive an update notification before restart and are informed when service connections are restored.

- **Documentation**
  - Added guidance for configuring and monitoring local taOSmd updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->