### PR TITLE
feat(doc-gate): cover skills, agent manual, runbooks, worker README; extractor precision fixes

### DIFF
--- a/changelog.d/doc-gate-coverage.md
+++ b/changelog.d/doc-gate-coverage.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Doc-drift gate covers the full doc surface**: the invariants scan now
+  takes globs and checks every agent-manual page, runbook, OS skill
+  (`.claude/skills/*/SKILL.md`), the worker README, CONTRIBUTING and
+  RELEASING for references to files that no longer exist (with a documented
+  tombstone list for deliberate mentions of removed files). Three new
+  diff-gate rules: desktop-driving route changes require the taos-agent
+  skill / OS-control manual reviewed, update/release machinery changes
+  require RELEASING.md or a runbook reviewed, and worker-tree changes
+  require the worker README. RELEASING.md now documents the sync-branch
+  promotion pattern for a BEHIND dev->master PR, including the back-merge
+  and empty-tree-diff identity check.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,6 +34,21 @@ CI runs the backend pytest suite and frontend vitest on every PR; both must be g
 Once the PR is merged to `dev`, open a follow-up PR from `dev` to `master`.
 After that PR merges, the install-count telemetry at taos.my starts recording the new version for every fresh install.
 
+**If the dev→master PR reports `BEHIND`** (master protection requires branches
+up to date, and Dependabot merges land directly on master between releases),
+a direct promotion cannot merge. Use the sync-branch pattern (beta.45/46/48
+precedent):
+
+1. Branch from `dev` (e.g. `sync/dev-to-master-beta.N`), merge `master` into
+   it — the conflicts, if any, are lockfile-shaped (`uv.lock`,
+   `desktop/package-lock.json`). Re-verify the version lines survived the
+   merge (`test_version_lock_sync.py`).
+2. PR that branch → `master`, CI green, merge.
+3. **Back-merge master into dev** (PR `master` → `dev`) and confirm tree
+   identity: `git diff origin/dev origin/master` must be EMPTY after it
+   merges. Master-only content is an invisible surface — a promotion is not
+   done until that diff is empty.
+
 The `secret-ignores-gate` runs on the `master` push (and on the PR merge result)
 and confirms the promoted `.gitignore` still ignores every secret-shaped path it
 did on `dev` -- `identity.json`, `*.key`, `*.p8`, `*credentials.json`, `*creds*.json`

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -13,7 +13,25 @@
 trailer = "Docs-Reviewed:"
 
 [invariants]
-referenced_paths_scan = ["README.md", "docs/agent-coordination.md", "docs/agent-manual/index.md"]
+# Globs are expanded against the working tree, so new manual pages, runbooks
+# and skills are scanned without a config edit. Nested READMEs under app
+# trees are deliberately NOT scanned: their relative `scripts/` links point
+# inside their own directory and would false-positive against the repo root.
+referenced_paths_scan = [
+    "README.md",
+    "CONTRIBUTING.md",
+    "docs/agent-coordination.md",
+    "docs/AGENT_HANDOFF.md",
+    "docs/RELEASING.md",
+    "docs/contributor-pitfalls.md",
+    "docs/agent-manual/*.md",
+    "docs/runbooks/*.md",
+    ".claude/skills/*/SKILL.md",
+    "tinyagentos/worker/README.md",
+]
+# Deliberate tombstones: docs that explain a file was REMOVED must be able to
+# name it without failing the gate forever.
+ignore_tokens = ["docs/STATUS.md"]
 
 [[rules]]
 name = "apps"
@@ -87,3 +105,30 @@ on_modify = true
 when_changed = [".github/workflows/*.yml", "pyproject.toml", "CONTRIBUTING.md"]
 require_doc = [".claude/skills/taos-development-skill/*.md", "docs/*.md"]
 hint = "CI, packaging or contribution rules changed; review the contributor skill and docs (or add a Docs-Reviewed trailer explaining why not)"
+
+# The OS-native agent drives the desktop ONLY through the surfaces the
+# taos-agent skill and the OS-control manual page describe. When those routes
+# change shape, an undocumented agent surface is a broken agent.
+[[rules]]
+name = "taos-agent-skill"
+on_modify = true
+when_changed = ["tinyagentos/routes/desktop.py", "tinyagentos/routes/desktop_control.py", "tinyagentos/routes/taos_agent.py"]
+require_doc = [".claude/skills/taos-agent/*.md", "docs/agent-manual/*.md"]
+hint = "the agent-facing desktop-driving surface changed; review the taos-agent skill and the OS-control manual pages (or add a Docs-Reviewed trailer explaining why not)"
+
+# Update/release machinery drifts from its runbooks silently: the beta.48
+# promotion (2026-08-12) needed a sync-branch pattern RELEASING.md did not
+# describe, and pi_update-style tooling broke against a moved deploy path.
+[[rules]]
+name = "release-runbook"
+on_modify = true
+when_changed = ["tinyagentos/update_runner.py", "tinyagentos/auto_update.py", "tinyagentos/restart_orchestrator.py", "scripts/collate_changelog.py"]
+require_doc = ["docs/RELEASING.md", "docs/runbooks/*.md", "docs/UPDATE_BREAKAGE_LOG.md", "docs/*.md"]
+hint = "update/release machinery changed; review docs/RELEASING.md and the runbooks (or add a Docs-Reviewed trailer explaining why not)"
+
+# The worker README is the operator-facing contract for worker nodes.
+[[rules]]
+name = "worker-readme"
+when_changed = ["tinyagentos/worker/**"]
+require_doc = ["tinyagentos/worker/README.md"]
+hint = "a worker component was added or removed; update tinyagentos/worker/README.md (or add a Docs-Reviewed trailer explaining why not)"

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -51,8 +51,11 @@ EXIT_CONFIG_ERROR = 3
 # matching a prefix that is actually embedded inside a larger path (e.g. the
 # "tinyagentos/" inside "/home/<user>/tinyagentos/data/" in a deploy-layout
 # table), which would otherwise falsely flag deploy-time paths that never
-# exist in the repo itself.
-_TOKEN_RE = re.compile(r"(?<![\w/])(?:scripts|tinyagentos|docs|desktop)/[^\s`\"'|]+")
+# exist in the repo itself. `-` is in the lookbehind for the same reason:
+# home-dir slugs like "-*-tinyagentos/memory/MEMORY.md" embed a repo prefix
+# after a hyphen, and the glob `*` sits BEFORE the match so the glob filter
+# never sees it.
+_TOKEN_RE = re.compile(r"(?<![\w/-])(?:scripts|tinyagentos|docs|desktop)/[^\s`\"'|]+")
 
 # Chars that mark a token as a glob pattern or a <placeholder> rather than a
 # concrete repo path -- these are never asserted to exist.
@@ -66,7 +69,8 @@ def _clean_token(raw: str) -> str | None:
     """Normalize a raw regex match into a bare repo-relative path, or None
     if it should be ignored (glob, placeholder, anchor/query fragment)."""
     token = raw
-    for sep in ("#", "?"):
+    # "::" is a symbol reference (file.py::function), not part of the path.
+    for sep in ("#", "?", "::"):
         if sep in token:
             token = token.split(sep, 1)[0]
     while token and token[-1] in _TRAILING_PUNCT:
@@ -119,20 +123,41 @@ def _validate_config(config: dict) -> None:
     scan = invariants.get("referenced_paths_scan", [])
     if not isinstance(scan, list):
         raise ValueError("'invariants.referenced_paths_scan' must be a list")
+    ignore = invariants.get("ignore_tokens", [])
+    if not isinstance(ignore, list):
+        raise ValueError("'invariants.ignore_tokens' must be a list")
 
 
 def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: dict) -> list[str]:
     """Layer A: every scripts/tinyagentos/docs/desktop path token mentioned in
     the configured doc set must exist on disk. A scan-target file that itself
     does not exist (e.g. a local-only, gitignored doc) is silently skipped
-    rather than treated as a failure."""
-    failures: list[str] = []
+    rather than treated as a failure.
+
+    Scan entries may be globs (``docs/agent-manual/*.md``) — expanded against
+    the working tree, so a newly added manual page or skill is scanned without
+    a config edit. ``invariants.ignore_tokens`` lists tokens that are
+    deliberate tombstones (docs that EXPLAIN a file was removed must be able
+    to name it without failing the gate forever).
+    """
+    ignore = set(config.get("invariants", {}).get("ignore_tokens", []))
+    expanded: list[str] = []
     for rel in files_to_scan:
+        if any(c in "*?[]" for c in rel):
+            expanded.extend(
+                sorted(str(p.relative_to(repo_root)) for p in repo_root.glob(rel) if p.is_file())
+            )
+        else:
+            expanded.append(rel)
+    failures: list[str] = []
+    for rel in expanded:
         doc_path = repo_root / rel
         if not doc_path.is_file():
             continue
         text = doc_path.read_text(encoding="utf-8", errors="ignore")
         for token in extract_path_tokens(text):
+            if token in ignore:
+                continue
             if not (repo_root / token).exists():
                 failures.append(f"{rel} references '{token}' which does not exist in the repo")
     return failures

--- a/tests/test_check_doc_gate.py
+++ b/tests/test_check_doc_gate.py
@@ -166,3 +166,53 @@ class TestEvaluateRulesEdgeCases:
         changed = [("M", "tinyagentos/routes/themes.py")]
         failures = evaluate_rules(changed, [], config)
         assert failures == []
+
+
+class TestReferencedPathsScan:
+    """Invariants layer: glob expansion, tombstones, extractor precision."""
+
+    def _write(self, root: Path, rel: str, text: str) -> None:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+
+    def test_glob_scan_targets_are_expanded(self, tmp_path):
+        """docs/runbooks/*.md style entries must scan every matching file."""
+        self._write(tmp_path, "docs/runbooks/one.md", "see tinyagentos/nope.py")
+        self._write(tmp_path, "docs/runbooks/two.md", "all good here")
+        fails = _MOD.check_referenced_paths(
+            tmp_path, ["docs/runbooks/*.md"], {}
+        )
+        assert len(fails) == 1 and "docs/runbooks/one.md" in fails[0]
+
+    def test_ignore_tokens_tombstone(self, tmp_path):
+        """A doc explaining a removal may name the removed file - but ONLY
+        the listed tombstone is exempt, other dead paths still fail."""
+        self._write(
+            tmp_path, "docs/guide.md",
+            "docs/STATUS.md was removed. Also see tinyagentos/gone.py",
+        )
+        cfg = {"invariants": {"ignore_tokens": ["docs/STATUS.md"]}}
+        fails = _MOD.check_referenced_paths(tmp_path, ["docs/guide.md"], cfg)
+        assert len(fails) == 1 and "tinyagentos/gone.py" in fails[0]
+        # Red half: without the tombstone the STATUS.md mention fails too.
+        fails = _MOD.check_referenced_paths(tmp_path, ["docs/guide.md"], {})
+        assert len(fails) == 2
+
+    def test_missing_scan_target_is_skipped(self, tmp_path):
+        """A local-only (gitignored) doc absent from the tree is skipped."""
+        fails = _MOD.check_referenced_paths(tmp_path, ["docs/AGENT_HANDOFF.md"], {})
+        assert fails == []
+
+    def test_extractor_strips_symbol_suffix(self):
+        toks = _MOD.extract_path_tokens(
+            "wire it in tinyagentos/routes/__init__.py::register_all_routers()"
+        )
+        assert toks == ["tinyagentos/routes/__init__.py"]
+
+    def test_extractor_ignores_hyphen_glued_prefix(self):
+        """A repo prefix embedded in a home-dir slug is not a repo path."""
+        toks = _MOD.extract_path_tokens(
+            "read ~/.claude/projects/-home-x-tinyagentos/memory/MEMORY.md at start"
+        )
+        assert toks == []


### PR DESCRIPTION
Per Jay's directive: the doc-drift checks must cover READMEs, changelogs, agent guides/rules, skills and runbooks — mechanically, not as a habit.

## What was covered before vs now

Before: invariants scanned 3 docs (README, agent-coordination, manual index); rules pointed at README/changelog/manual/contributor-skill only. The taos-agent skill, 12 of 13 agent-manual pages, all 10 runbooks, RELEASING.md and the worker README had NO mechanical check.

Now:
- **Invariants scan takes globs** — `docs/agent-manual/*.md`, `docs/runbooks/*.md`, `.claude/skills/*/SKILL.md` expand against the tree, so a NEW page/skill/runbook is scanned with no config edit. 31 docs scanned, clean at this ref.
- **`ignore_tokens` tombstones** — docs that explain a file was removed (AGENT_HANDOFF's docs/STATUS.md notes) may name it without failing forever.
- **Extractor precision**: `file.py::symbol` suffixes stripped; repo prefixes glued after a hyphen (home-dir slugs like `-*-tinyagentos/memory/MEMORY.md`) no longer match. Both were live false positives found by dry-running the wider scan.
- **3 new rules**, each red-proven by probe at this ref:
  - `taos-agent-skill`: desktop.py / desktop_control.py / taos_agent.py changes require the taos-agent skill or an agent-manual page reviewed → probe FAIL fired
  - `release-runbook`: update_runner / auto_update / restart_orchestrator / collate_changelog changes require RELEASING.md or a runbook reviewed → probe FAIL fired
  - `worker-readme`: worker-tree structural changes require the worker README → probe FAIL fired; negative probe (change + README edit) passes clean
- **RELEASING.md drift fixed**: documents the sync-branch promotion for a BEHIND dev→master PR (the exact path beta.48 needed tonight), including the master→dev back-merge and the empty `git diff dev master` identity check.

## Red evidence (probes at this ref)

```
DOC-GATE FAIL: taos-agent-skill -- the agent-facing desktop-driving surface changed; review the taos-agent skill and the OS-control manual pages ...
DOC-GATE FAIL: release-runbook -- update/release machinery changed; review docs/RELEASING.md and the runbooks ...
DOC-GATE FAIL: worker-readme -- a worker component was added or removed; update tinyagentos/worker/README.md ...
DOC-GATE FAIL: .claude/skills/taos-agent/SKILL.md references 'tinyagentos/nonexistent_probe.py' which does not exist in the repo
DOC-GATE FAIL: docs/runbooks/controller-rescue.md references 'tinyagentos/nonexistent_probe.py' which does not exist in the repo
```

Tombstone red-half is unit-tested (without the ignore entry, the STATUS.md mention fails; with it, only genuinely dead paths fail). 52 tests green across both doc-gate suites.

Docs-Reviewed: this PR is itself the doc review — gate config, gate script, RELEASING.md and tests move together.