### PR TITLE
Time-of-day flake: test_update_routine_cron_expr_recomputes_next_fire reds every CI run in the 02:55-03:00Z window

### DIFF
--- a/tests/projects/test_routines_store.py
+++ b/tests/projects/test_routines_store.py
@@ -212,6 +212,7 @@ async def test_update_routine_changes_fields(store):
 
 @pytest.mark.asyncio
 async def test_update_routine_cron_expr_recomputes_next_fire(store):
+    store._clock = staticmethod(lambda: 43200.0)
     r = await store.create_routine(
         project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
     )

--- a/tinyagentos/projects/routines_store.py
+++ b/tinyagentos/projects/routines_store.py
@@ -57,6 +57,7 @@ def _compute_next_fire(cron_expr: str, base_ts: float) -> float:
 
 class RoutineStore(BaseStore):
     SCHEMA = ROUTINES_SCHEMA
+    _clock = staticmethod(time.time)
 
     async def create_routine(
         self,
@@ -77,7 +78,7 @@ class RoutineStore(BaseStore):
             _validate_cron(cron_expr)
 
         rid = new_id("rtn")
-        now = time.time()
+        now = self._clock()
         webhook_token = secrets.token_urlsafe(32) if trigger_kind == "webhook" else None
         next_fire = _compute_next_fire(cron_expr, now) if trigger_kind == "cron" and enabled else None
 
@@ -183,7 +184,7 @@ class RoutineStore(BaseStore):
         # Recompute next_fire whenever the schedule or enabled flag could have
         # changed what "due" means for this routine.
         if existing["trigger_kind"] == "cron" and (cron_expr is not None or enabled is not None):
-            next_fire = _compute_next_fire(new_cron_expr, time.time()) if new_enabled and new_cron_expr else None
+            next_fire = _compute_next_fire(new_cron_expr, self._clock()) if new_enabled and new_cron_expr else None
             sets.append("next_fire = ?")
             params.append(next_fire)
 
@@ -191,7 +192,7 @@ class RoutineStore(BaseStore):
             return existing
 
         sets.append("updated_at = ?")
-        params.append(time.time())
+        params.append(self._clock())
         params.append(routine_id)
         await self._db.execute(
             f"UPDATE routines SET {', '.join(sets)} WHERE id = ?", params


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Time-of-day flake: test_update_routine_cron_expr_recomputes_next_fire reds every CI run in the 02:55-03:00Z window

Autonomous build of board card tsk-kboqzh.

- add _clock seam to RoutineStore (defaults to time.time)
- use frozen clock in test to avoid 02:55-03:00Z collision window

Files:
 tests/projects/test_routines_store.py  | 1 +
 tinyagentos/projects/routines_store.py | 7 ++++---
 2 files changed, 5 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routine scheduling consistency by ensuring timestamps and schedule calculations use a consistent clock.
  * Fixed timing-sensitive behavior that could produce inconsistent cron updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Red proof at merge base (card demand: 02:57:30Z window)

Clock frozen at 2026-08-12T02:57:30Z (epoch 1786503450.0) via a pytest plugin monkeypatching `time.time`; run at merge base `7d38483e` (pre-fix):

```
$ PYTHONPATH=. pytest tests/projects/test_routines_store.py::test_update_routine_cron_expr_recomputes_next_fire -p fake_time_plugin
>       assert updated["next_fire"] != old_next
E       assert 1786503600.0 != 1786503600.0
tests/projects/test_routines_store.py:221: AssertionError
FAILED tests/projects/test_routines_store.py::test_update_routine_cron_expr_recomputes_next_fire
1 failed in 0.55s
```

Both `0 3 * * *` and `*/5 * * * *` compute next_fire 1786503600.0 (03:00:00Z) inside the 02:55-03:00Z window, exactly the carded flake. Same frozen-clock run at PR head `b2be024e`: 27 passed in the full file — which also proves the `_clock` seam is live, since an inert seam would fail identically to base.
