### PR TITLE
fix(tasks): unquarantine returns the card to a claimable pool

### DIFF
--- a/changelog.d/tsk-y6x6s4-unquarantine-claimer.md
+++ b/changelog.d/tsk-y6x6s4-unquarantine-claimer.md
@@ -5,4 +5,6 @@
   `claimed_by`, and `claim_task` requires an unclaimed row -- so a
   claimed-then-quarantined card came back permanently unclaimable.
   Un-quarantine now clears the claimer, matching `reopen_task` and
-  `release_task`.
+  `release_task`. The generic `update_task` edit path (owner/admin PATCH)
+  had the same gap when setting a claimed card's status back to `open`;
+  it now clears the claimer too.

--- a/changelog.d/tsk-y6x6s4-unquarantine-claimer.md
+++ b/changelog.d/tsk-y6x6s4-unquarantine-claimer.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Un-quarantined cards return to a genuinely claimable pool**:
+  `unquarantine_task` set the card back to `open` but kept the old
+  `claimed_by`, and `claim_task` requires an unclaimed row -- so a
+  claimed-then-quarantined card came back permanently unclaimable.
+  Un-quarantine now clears the claimer, matching `reopen_task` and
+  `release_task`.

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -153,6 +153,22 @@ async def test_reopen_task_is_noop_when_not_closed(store):
 
 
 @pytest.mark.asyncio
+async def test_unquarantine_returns_claimed_task_to_claimable_pool(store):
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    assert await store.quarantine_task(t["id"], actor="lead") is True
+    assert await store.unquarantine_task(t["id"], actor="lead") is True
+    back = await store.get_task(t["id"])
+    assert back["status"] == "open"
+    # unquarantined task must return to the claimable pool, so the old claimer clears
+    assert back["claimed_by"] is None
+    assert back["claimed_at"] is None
+    # the pool must be real: claim_task requires claimed_by IS NULL, so a stale
+    # claimer would leave the card open-but-unclaimable forever
+    assert await store.claim_task(t["id"], claimer_id="agent-2") is True
+
+
+@pytest.mark.asyncio
 async def test_add_relationship_and_list(store):
     a = await store.create_task(project_id="p", title="A", created_by="u")
     b = await store.create_task(project_id="p", title="B", created_by="u")

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -169,6 +169,20 @@ async def test_unquarantine_returns_claimed_task_to_claimable_pool(store):
 
 
 @pytest.mark.asyncio
+async def test_update_task_status_open_returns_task_to_claimable_pool(store):
+    # Same class via the generic edit path: the owner/admin PATCH route can
+    # set status='open' on a claimed card directly through update_task.
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    await store.update_task(t["id"], status="open")
+    back = await store.get_task(t["id"])
+    assert back["status"] == "open"
+    assert back["claimed_by"] is None
+    assert back["claimed_at"] is None
+    assert await store.claim_task(t["id"], claimer_id="agent-2") is True
+
+
+@pytest.mark.asyncio
 async def test_add_relationship_and_list(store):
     a = await store.create_task(project_id="p", title="A", created_by="u")
     b = await store.create_task(project_id="p", title="B", created_by="u")

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -287,6 +287,12 @@ class ProjectTaskStore(BaseStore):
                 patch["element_id"] = element_id
         if not sets:
             return
+        # A generic edit back to 'open' must also clear the claimer (as the
+        # dedicated to-open transitions do): claim_task requires
+        # claimed_by IS NULL, so a stale claimer leaves the card unclaimable.
+        if status == "open":
+            sets.append("claimed_by = ?"); params.append(None); patch["claimed_by"] = None
+            sets.append("claimed_at = ?"); params.append(None); patch["claimed_at"] = None
         sets.append("updated_at = ?"); params.append(time.time())
         params.append(task_id)
         await self._db.execute(

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -462,13 +462,15 @@ class ProjectTaskStore(BaseStore):
 
         This is the explicit un-quarantine / retry action: the card re-enters
         the ready pool so the fleet may pick it up again.  Strikes are cleared
-        so a fresh failure count starts from zero.  Only acts on a quarantined
-        task; returns False otherwise.
+        so a fresh failure count starts from zero, and the claimer clears (as
+        in ``reopen_task``) -- claim_task requires ``claimed_by IS NULL``, so
+        a stale claimer would leave the card open but unclaimable forever.
+        Only acts on a quarantined task; returns False otherwise.
         """
         now = time.time()
         cursor = await self._db.execute(
             """UPDATE project_tasks
-               SET status = 'open', updated_at = ?
+               SET status = 'open', claimed_by = NULL, claimed_at = NULL, updated_at = ?
                WHERE id = ? AND status = 'quarantined'""",
             (now, task_id),
         )


### PR DESCRIPTION
Lead build of board card tsk-y6x6s4 (found during #2366 bot-thread adjudication, proven from source).

`unquarantine_task` set the card back to `open` but never cleared `claimed_by`/`claimed_at`. `claim_task` requires `claimed_by IS NULL AND status = 'open'`, so a claimed-then-quarantined card returned from quarantine permanently unclaimable - by anyone, including the original claimer. `reopen_task` and `release_task` both already clear the claimer for exactly this reason.

## Red proof at merge base (card demands red-first)

New test `test_unquarantine_returns_claimed_task_to_claimable_pool` run against the unfixed store at `2eb1a8f6`:

```
>       assert back["claimed_by"] is None
E       AssertionError: assert 'agent-1' is None

tests/projects/test_task_store.py:164: AssertionError
FAILED tests/projects/test_task_store.py::test_unquarantine_returns_claimed_task_to_claimable_pool
1 failed in 0.38s
```

With the fix: 30 passed across `test_task_store.py` + `test_strike_wiring.py`. The test also proves the pool is real by having a second agent claim the card after un-quarantine (not just asserting NULL).

## Class sweep

All transitions back to `'open'` in `task_store.py` now clear the claimer (`release_task`, `reopen_task`, `unquarantine_task`). `element_store.py`'s only `status = 'open'` use is a COUNT, no claim mutation. `quarantine_task` deliberately keeps `claimed_by` - the audit's `from_status` derivation depends on it and this fix preserves that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Un-quarantining a claimed task now clears its claimant information.
  - The task returns to the open, claimable pool and can be claimed by another agent.
  - Behavior now aligns with reopening and releasing tasks.

- **Tests**
  - Added regression coverage to verify claim metadata is reset correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Second path (CodeRabbit finding, REAL, folded in da43b411)

The generic `update_task` edit path (owner/admin PATCH; agents are blocked from `status` by the field whitelist) had the same gap - it builds its SET dynamically, which is why the SQL-literal class sweep missed it. Red proven pre-fix:

```
>       assert back["claimed_by"] is None
E       AssertionError: assert 'agent-1' is None
FAILED tests/projects/test_task_store.py::test_update_task_status_open_returns_task_to_claimable_pool
```

Fixed by clearing claim metadata when a generic edit sets `status='open'` (also emitted in the `task.updated` patch). 27/27 green in the file post-fix.
