### PR TITLE
Lists S2: Projects app Lists tab UI (#2140)

### DIFF
--- a/changelog.d/2379-projects-lists-tab.md
+++ b/changelog.d/2379-projects-lists-tab.md
@@ -1,0 +1,1 @@
+- Added a Lists tab to the Projects app: a rail of the project's lists beside an entry panel with quick-add, done toggles, category and status pills, a status selector, and the original text behind any entry an agent tidied.

--- a/desktop/src/apps/ProjectsApp/ProjectLists.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectLists.tsx
@@ -20,6 +20,10 @@ export function ProjectLists({ project }: { project: Project }) {
   const [quickText, setQuickText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const quickInputRef = useRef<HTMLInputElement>(null);
+  // Current selection, readable from inside an async closure that captured an
+  // older one. Assigned during render so it is correct before any effect runs.
+  const selectedListIdRef = useRef<string | null>(selectedListId);
+  selectedListIdRef.current = selectedListId;
 
   // Drop the previous project's selection DURING RENDER, not in an effect.
   // ProjectWorkspace renders <ProjectLists project={project} /> unkeyed and is
@@ -53,8 +57,14 @@ export function ProjectLists({ project }: { project: Project }) {
 
   const refreshEntries = useCallback(() => {
     if (!selectedListId) return Promise.resolve([] as ProjectListEntry[]);
-    return projectsApi.lists.entries.list(project.id, selectedListId)
+    const forListId = selectedListId;
+    return projectsApi.lists.entries.list(project.id, forListId)
       .then((ents) => {
+        // Drop a response whose list is no longer selected. Two quick clicks
+        // race, and the slower fetch used to land last and show one list's
+        // entries under another's heading. The ref is the CURRENT selection;
+        // this closure's own copy is stale by definition.
+        if (forListId !== selectedListIdRef.current) return ents;
         setEntries(ents);
         return ents;
       })

--- a/desktop/src/apps/ProjectsApp/ProjectLists.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectLists.tsx
@@ -22,10 +22,19 @@ export function ProjectLists({ project }: { project: Project }) {
   const quickInputRef = useRef<HTMLInputElement>(null);
 
   const refreshLists = useCallback(() => {
-    return projectsApi.lists.list(project.id).catch(() => {
-      setError("Could not load lists.");
-      return [] as ProjectList[];
-    });
+    // Sets state, like refreshEntries below. It used to only RETURN the lists,
+    // so createList/deleteList awaited a fetch whose result was discarded -- a
+    // created list never appeared in the rail and a deleted one never left it,
+    // because the mount effect was the only caller of setLists.
+    return projectsApi.lists.list(project.id)
+      .then((ls) => {
+        setLists(ls);
+        return ls;
+      })
+      .catch(() => {
+        setError("Could not load lists.");
+        return [] as ProjectList[];
+      });
   }, [project.id]);
 
   const refreshEntries = useCallback(() => {

--- a/desktop/src/apps/ProjectsApp/ProjectLists.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectLists.tsx
@@ -1,0 +1,314 @@
+import { useEffect, useState, useRef, useCallback } from "react";
+import { projectsApi, type Project, type ProjectList, type ProjectListEntry } from "@/lib/projects";
+import styles from "./ProjectsApp.module.css";
+
+const STATUS_STYLE: Record<string, string> = {
+  new: "bg-blue-500/15 text-blue-400",
+  seen: "bg-shell-bg-deep text-shell-text-tertiary",
+  actioned: "bg-green-500/15 text-green-400",
+  discuss: "bg-amber-500/15 text-amber-400",
+};
+
+const EMPTY_LIST: ProjectList = { id: "", project_id: "", title: "", description: "", status: "active", created_by: "", created_at: 0, updated_at: 0 };
+
+export function ProjectLists({ project }: { project: Project }) {
+  const [lists, setLists] = useState<ProjectList[]>([]);
+  const [selectedListId, setSelectedListId] = useState<string | null>(null);
+  const [entries, setEntries] = useState<ProjectListEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [quickText, setQuickText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const quickInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshLists = useCallback(() => {
+    return projectsApi.lists.list(project.id).catch(() => {
+      setError("Could not load lists.");
+      return [] as ProjectList[];
+    });
+  }, [project.id]);
+
+  const refreshEntries = useCallback(() => {
+    if (!selectedListId) return Promise.resolve([] as ProjectListEntry[]);
+    return projectsApi.lists.entries.list(project.id, selectedListId)
+      .then((ents) => {
+        setEntries(ents);
+        return ents;
+      })
+      .catch(() => {
+        setError("Could not load entries.");
+        return [] as ProjectListEntry[];
+      });
+  }, [project.id, selectedListId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    refreshLists()
+      .then((ls) => {
+        if (!cancelled) {
+          setLists(ls);
+          if (!selectedListId && ls.length > 0) setSelectedListId(ls[0]!.id);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not load lists for this project.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [project.id, refreshLists]);
+
+  useEffect(() => {
+    if (!selectedListId) { setEntries([]); return; }
+    let cancelled = false;
+    setLoading(true);
+    refreshEntries().finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [selectedListId, refreshEntries]);
+
+  const createList = async () => {
+    const title = prompt("New list name");
+    if (!title) return;
+    try {
+      const created = await projectsApi.lists.create(project.id, { title: title.trim() });
+      await refreshLists();
+      setSelectedListId(created.id);
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const deleteList = async (listId: string) => {
+    if (!confirm("Delete this list and all its entries?")) return;
+    try {
+      await projectsApi.lists.remove(project.id, listId);
+      if (selectedListId === listId) setSelectedListId(null);
+      await refreshLists();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const createEntry = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = quickText.trim();
+    if (!text || submitting || !selectedListId) return;
+    setSubmitting(true);
+    try {
+      await projectsApi.lists.entries.create(project.id, selectedListId, { text });
+      setQuickText("");
+      await refreshEntries();
+      quickInputRef.current?.focus();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleDone = async (entry: ProjectListEntry) => {
+    try {
+      await projectsApi.lists.entries.update(project.id, entry.list_id, entry.id, { done: entry.done ? 0 : 1 });
+      await refreshEntries();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const updateEntryStatus = async (entry: ProjectListEntry, status: string) => {
+    try {
+      await projectsApi.lists.entries.update(project.id, entry.list_id, entry.id, { status });
+      await refreshEntries();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const removeEntry = async (entry: ProjectListEntry) => {
+    if (!confirm("Remove this entry?")) return;
+    try {
+      await projectsApi.lists.entries.remove(project.id, entry.list_id, entry.id);
+      await refreshEntries();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const selectedList = lists.find((l) => l.id === selectedListId) ?? EMPTY_LIST;
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex flex-1 min-h-0 gap-3">
+        <aside className={styles.listsRail} aria-label="Lists">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold text-shell-text">Lists</h2>
+            <button
+              type="button"
+              onClick={createList}
+              aria-label="Create new list"
+              className="rounded-full bg-accent/10 px-2 py-1 text-xs font-medium text-accent hover:bg-accent/20"
+            >
+              + New
+            </button>
+          </div>
+          {loading && lists.length === 0 ? (
+            <p className="text-xs text-shell-text-tertiary">Loading…</p>
+          ) : lists.length === 0 ? (
+            <p className="text-xs text-shell-text-secondary">No lists yet.</p>
+          ) : (
+            <ul className="flex flex-col gap-1" role="listbox" aria-label="Project lists">
+              {lists.map((lst) => (
+                <li
+                  key={lst.id}
+                  role="option"
+                  aria-selected={lst.id === selectedListId}
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setSelectedListId(lst.id); } }}
+                  onClick={() => setSelectedListId(lst.id)}
+                  className={`flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-sm cursor-pointer transition-colors ${lst.id === selectedListId ? "bg-shell-surface-active text-shell-text" : "text-shell-text-secondary hover:bg-shell-surface-hover hover:text-shell-text"}`}
+                >
+                  <span className="truncate">{lst.title || "Untitled list"}</span>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${lst.title || "Untitled list"}`}
+                    onClick={(e) => { e.stopPropagation(); deleteList(lst.id); }}
+                    className="rounded p-0.5 text-shell-text-tertiary hover:text-red-400"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
+
+        <main className={styles.listsEntriesPanel} aria-label="List entries">
+          {!selectedListId ? (
+            <p className="text-sm text-shell-text-secondary">Select or create a list.</p>
+          ) : (
+            <div className="flex flex-col gap-3 h-full">
+              <header className="flex items-center gap-2">
+                <h3 className="text-sm font-semibold text-shell-text truncate">{selectedList.title || "Untitled list"}</h3>
+                {selectedList.description && (
+                  <span className="text-xs text-shell-text-tertiary truncate" title={selectedList.description}>{selectedList.description}</span>
+                )}
+              </header>
+
+              <form onSubmit={createEntry} className="flex gap-2">
+                <label htmlFor={`quick-add-${selectedList.id}`} className="sr-only">Add entry to {selectedList.title || "Untitled list"}</label>
+                <input
+                  ref={quickInputRef}
+                  id={`quick-add-${selectedList.id}`}
+                  type="text"
+                  value={quickText}
+                  onChange={(e) => setQuickText(e.target.value)}
+                  placeholder="Add entry…"
+                  disabled={submitting}
+                  aria-label={`Quick add entry to ${selectedList.title || "Untitled list"}`}
+                  className="flex-1 rounded-lg border border-shell-border bg-shell-surface px-3 py-1.5 text-sm text-shell-text outline-none focus:ring-2 focus:ring-accent-line disabled:opacity-50"
+                />
+                <button
+                  type="submit"
+                  disabled={submitting || !quickText.trim()}
+                  aria-label="Add entry"
+                  className="rounded-lg bg-accent/10 px-3 py-1.5 text-sm font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
+                >
+                  {submitting ? "Adding…" : "Add"}
+                </button>
+              </form>
+
+              {error && (
+                <p role="alert" className="text-xs text-red-400">{error}</p>
+              )}
+
+              {loading ? (
+                <p className="text-sm text-shell-text-tertiary">Loading entries…</p>
+              ) : entries.length === 0 ? (
+                <p className="text-sm text-shell-text-secondary">No entries yet. Type above and press Enter to add one.</p>
+              ) : (
+                <ul className="flex flex-col gap-2" aria-label="Entries">
+                  {entries.map((entry) => {
+                    const tidied = entry.text !== entry.original_text;
+                    return (
+                      <li
+                        key={entry.id}
+                        className="flex flex-col gap-1.5 rounded-xl border border-shell-border bg-shell-surface p-3.5"
+                      >
+                        <div className="flex flex-wrap items-center gap-2">
+                          <label className="flex items-center gap-1.5 text-xs text-shell-text-secondary">
+                            <input
+                              type="checkbox"
+                              checked={!!entry.done}
+                              onChange={() => toggleDone(entry)}
+                              aria-label={`Mark ${entry.text} as done`}
+                              className="rounded border-shell-border"
+                            />
+                            Done
+                          </label>
+                          {entry.category && (
+                            <span className="inline-flex items-center rounded-full bg-shell-border px-2 py-0.5 text-xs font-medium text-shell-text-secondary">
+                              {entry.category}
+                            </span>
+                          )}
+                          <span
+                            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize ${STATUS_STYLE[entry.status] ?? "bg-shell-border text-shell-text-secondary"}`}
+                          >
+                            {entry.status}
+                          </span>
+                          {tidied && (
+                            <span
+                              className="inline-flex items-center gap-1 text-xs text-shell-text-tertiary cursor-pointer hover:text-shell-text"
+                              title={entry.original_text}
+                              tabIndex={0}
+                              role="button"
+                              aria-label={`View original text for ${entry.text}`}
+                              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); alert(entry.original_text); } }}
+                              onClick={() => alert(entry.original_text)}
+                            >
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                <circle cx="12" cy="12" r="3" />
+                              </svg>
+                              original
+                            </span>
+                          )}
+                          <div className="ml-auto flex gap-2 text-xs">
+                            <select
+                              value={entry.status}
+                              onChange={(e) => updateEntryStatus(entry, e.target.value)}
+                              aria-label={`Change status for ${entry.text}`}
+                              className="rounded bg-shell-bg-deep px-1.5 py-0.5 text-xs text-shell-text border border-shell-border"
+                            >
+                              <option value="new">new</option>
+                              <option value="seen">seen</option>
+                              <option value="actioned">actioned</option>
+                              <option value="discuss">discuss</option>
+                            </select>
+                            <button
+                              type="button"
+                              onClick={() => removeEntry(entry)}
+                              aria-label={`Delete entry ${entry.text}`}
+                              className="text-red-400 hover:underline"
+                            >
+                              Delete
+                            </button>
+                          </div>
+                        </div>
+                        <p className={`text-sm ${entry.done ? "line-through text-shell-text-tertiary" : "text-shell-text"}`}>
+                          {entry.text}
+                        </p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectLists.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectLists.tsx
@@ -21,6 +21,20 @@ export function ProjectLists({ project }: { project: Project }) {
   const [submitting, setSubmitting] = useState(false);
   const quickInputRef = useRef<HTMLInputElement>(null);
 
+  // Drop the previous project's selection DURING RENDER, not in an effect.
+  // ProjectWorkspace renders <ProjectLists project={project} /> unkeyed and is
+  // itself unkeyed, so a project switch reuses this component. Resetting in an
+  // effect is too late: the entries effect re-runs in the same commit (its deps
+  // include project.id) and would fetch
+  // /api/projects/<new>/lists/<old-list-id>/entries first. This is React's
+  // adjust-state-on-prop-change pattern and it runs before any effect.
+  const [prevProjectId, setPrevProjectId] = useState(project.id);
+  if (prevProjectId !== project.id) {
+    setPrevProjectId(project.id);
+    setSelectedListId(null);
+    setEntries([]);
+  }
+
   const refreshLists = useCallback(() => {
     // Sets state, like refreshEntries below. It used to only RETURN the lists,
     // so createList/deleteList awaited a fetch whose result was discarded -- a
@@ -58,7 +72,14 @@ export function ProjectLists({ project }: { project: Project }) {
       .then((ls) => {
         if (!cancelled) {
           setLists(ls);
-          if (!selectedListId && ls.length > 0) setSelectedListId(ls[0]!.id);
+          // Keep the selection only if it belongs to THIS project's lists.
+          // ProjectWorkspace renders <ProjectLists project={project} /> with no
+          // key and is itself unkeyed, so switching project does not remount:
+          // the previous project's selectedListId survived and the entries
+          // effect then fetched /api/projects/<new>/lists/<old-id>/entries.
+          // The functional form also avoids depending on a stale closure value.
+          setSelectedListId((prev) =>
+            prev && ls.some((l) => l.id === prev) ? prev : (ls[0]?.id ?? null));
         }
       })
       .catch(() => {
@@ -79,10 +100,12 @@ export function ProjectLists({ project }: { project: Project }) {
   }, [selectedListId, refreshEntries]);
 
   const createList = async () => {
-    const title = prompt("New list name");
+    // Trim BEFORE the empty check: "   " is truthy, so a whitespace-only
+    // answer used to reach the API as an empty title.
+    const title = prompt("New list name")?.trim();
     if (!title) return;
     try {
-      const created = await projectsApi.lists.create(project.id, { title: title.trim() });
+      const created = await projectsApi.lists.create(project.id, { title });
       await refreshLists();
       setSelectedListId(created.id);
     } catch (err) {

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -22,9 +22,10 @@ import { ElementCreateDialog } from "./elements/ElementCreateDialog";
 import styles from "./ProjectsApp.module.css";
 
 import { CommunityView } from "./CommunityView";
+import { ProjectLists } from "./ProjectLists";
 
-export type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines" | "community";
-const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions", "routines", "community"];
+export type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines" | "community" | "lists";
+const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions", "routines", "community", "lists"];
 
 function isTab(value: string | undefined): value is Tab {
   return value != null && (TABS as string[]).includes(value);
@@ -105,7 +106,7 @@ export function ProjectWorkspace({ project, onChanged, initialTab, filePath }: {
   // Mobile pill order: surface Messages right after Workspace so it is reachable
   // without scrolling (on mobile Messages is its own full page, not a squeezed
   // pane inside Workspace).
-  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity", "decisions", "routines", "community"];
+  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity", "decisions", "routines", "community", "lists"];
   const tabPills = mobileTabOrder.map((t) => ({
     id: t,
     label: t.charAt(0).toUpperCase() + t.slice(1),
@@ -390,6 +391,7 @@ export function ProjectWorkspace({ project, onChanged, initialTab, filePath }: {
         {tab === "decisions" && <ProjectDecisions projectId={project.id} />}
         {tab === "routines" && <ProjectRoutines project={project} />}
         {tab === "community" && <CommunityView projectId={project.id} />}
+        {tab === "lists" && <ProjectLists project={project} />}
       </div>
 
       {isMobile && (tab === "tasks" || tab === "board") && (

--- a/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
+++ b/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
@@ -870,3 +870,37 @@
   font-size: 0.7rem;
   white-space: nowrap;
 }
+
+/* Lists Tab */
+.listsRail {
+  width: 220px;
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-shell-surface);
+  border: 1px solid var(--color-shell-border);
+  border-radius: 12px;
+  padding: 12px;
+  overflow: auto;
+  min-height: 0;
+}
+
+.listsEntriesPanel {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (max-width: 767px) {
+  .listsRail {
+    width: 100%;
+    min-height: auto;
+    max-height: 40vh;
+  }
+  .listsEntriesPanel {
+    width: 100%;
+  }
+}

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
@@ -35,6 +35,12 @@ describe("ProjectLists", () => {
     ];
 
     fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === "/api/projects/p2/lists") {
+        return Promise.resolve(ok({ items: [{ id: "lst-p2", project_id: "p2", title: "Other project list", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 }] }));
+      }
+      if (url === "/api/projects/p2/lists/lst-p2/entries") {
+        return Promise.resolve(ok({ items: [] }));
+      }
       if (url === "/api/projects/p1/lists") {
         if (init?.method === "POST") {
           // The mock has to behave like the server: a created list is in the
@@ -146,6 +152,35 @@ describe("ProjectLists", () => {
       fireEvent.click(screen.getByLabelText("Create new list"));
     });
     await waitFor(() => expect(screen.getAllByText("New list").length).toBeGreaterThanOrEqual(1));
+  });
+
+  it("switching project does not keep the previous project's selected list", async () => {
+    // Neither ProjectWorkspace nor ProjectLists is keyed by project, so the
+    // component is reused across a switch and the old selection survived.
+    let view: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<ProjectLists project={fakeProject} />);
+    });
+    await act(async () => {
+      view!.rerender(<ProjectLists project={{ ...fakeProject, id: "p2", slug: "p2", name: "P2" }} />);
+    });
+    await waitFor(() => expect(screen.getAllByText("Other project list").length).toBeGreaterThanOrEqual(1));
+    // the old project's entries must not still be on screen
+    expect(screen.queryByText("Milk")).not.toBeInTheDocument();
+    const badFetch = fetchMock.mock.calls.find(([u]) => String(u) === "/api/projects/p2/lists/lst-1/entries");
+    expect(badFetch).toBeUndefined();
+  });
+
+  it("a whitespace-only list name creates nothing", async () => {
+    vi.stubGlobal("prompt", vi.fn(() => "   "));
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Create new list"));
+    });
+    const posted = fetchMock.mock.calls.find(([u, i]) => String(u) === "/api/projects/p1/lists" && (i as RequestInit | undefined)?.method === "POST");
+    expect(posted).toBeUndefined();
   });
 
   it("a deleted list disappears from the rail", async () => {

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
@@ -20,9 +20,13 @@ function ok(data: unknown) {
 
 describe("ProjectLists", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
+  let listsData: { id: string; project_id: string; title: string; description: string; status: string; created_by: string; created_at: number; updated_at: number }[];
   let entriesData: { id: string; list_id: string; project_id: string; text: string; original_text: string; category: string | null; status: string; done: number; author_kind: string; author_id: string; edited_by: string | null; position: number; created_at: number; updated_at: number }[];
 
   beforeEach(() => {
+    listsData = [
+      { id: "lst-1", project_id: "p1", title: "Shopping", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 },
+    ];
     entriesData = [
       { id: "ent-1", list_id: "lst-1", project_id: "p1", text: "Milk", original_text: "Milk", category: "groceries", status: "new", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 0, created_at: 0, updated_at: 0 },
       { id: "ent-2", list_id: "lst-1", project_id: "p1", text: "Bread", original_text: "Whole grain bread", category: null, status: "actioned", done: 1, author_kind: "user", author_id: "u1", edited_by: "u1", position: 1, created_at: 0, updated_at: 0 },
@@ -33,9 +37,18 @@ describe("ProjectLists", () => {
     fetchMock = vi.fn((url: string, init?: RequestInit) => {
       if (url === "/api/projects/p1/lists") {
         if (init?.method === "POST") {
-          return Promise.resolve(ok({ id: "lst-new", project_id: "p1", title: "New list", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 }));
+          // The mock has to behave like the server: a created list is in the
+          // NEXT list response. It used to return a fixed array, so a test
+          // could not tell a refreshed rail from a stale one.
+          const created = { id: "lst-new", project_id: "p1", title: "New list", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 };
+          listsData.push(created);
+          return Promise.resolve(ok(created));
         }
-        return Promise.resolve(ok({ items: [{ id: "lst-1", project_id: "p1", title: "Shopping", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 }] }));
+        return Promise.resolve(ok({ items: [...listsData] }));
+      }
+      // A freshly created list serves an empty entry set, like the real route.
+      if (url === "/api/projects/p1/lists/lst-new/entries") {
+        return Promise.resolve(ok({ items: [] }));
       }
       if (url === "/api/projects/p1/lists/lst-1/entries") {
         if (init?.method === "POST") {
@@ -54,6 +67,7 @@ describe("ProjectLists", () => {
         return Promise.resolve(ok({ ...entry }));
       }
       if (url === "/api/projects/p1/lists/lst-1" && init?.method === "DELETE") {
+        listsData = listsData.filter((l) => l.id !== "lst-1");
         return Promise.resolve(ok({ ok: true }));
       }
       if (url.startsWith("/api/projects/p1/lists/lst-1/entries/") && init?.method === "DELETE") {
@@ -117,5 +131,32 @@ describe("ProjectLists", () => {
     const checkbox = screen.getByLabelText(/mark milk as done/i);
     fireEvent.click(checkbox);
     await waitFor(() => expect(screen.getByText("Milk").className).toContain("line-through"));
+  });
+
+  // The rail is what the user reads to know their list exists. Both of these
+  // failed before the fix: refreshLists() fetched and threw the result away
+  // (only the mount effect ever called setLists), so a created list never
+  // appeared and a deleted one never left.
+  it("a created list appears in the rail", async () => {
+    vi.stubGlobal("prompt", vi.fn(() => "New list"));
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Create new list"));
+    });
+    await waitFor(() => expect(screen.getAllByText("New list").length).toBeGreaterThanOrEqual(1));
+  });
+
+  it("a deleted list disappears from the rail", async () => {
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    expect(screen.getAllByText("Shopping").length).toBeGreaterThanOrEqual(1);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Delete Shopping"));
+    });
+    await waitFor(() => expect(screen.queryByText("Shopping")).not.toBeInTheDocument());
   });
 });

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+import type { Project } from "@/lib/projects";
+import { ProjectLists } from "../ProjectLists";
+
+const fakeProject: Project = {
+  id: "p1",
+  slug: "p1",
+  name: "P1",
+  description: "",
+  status: "active",
+  created_by: "u1",
+  created_at: 0,
+  updated_at: 0,
+};
+
+function ok(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+describe("ProjectLists", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let entriesData: { id: string; list_id: string; project_id: string; text: string; original_text: string; category: string | null; status: string; done: number; author_kind: string; author_id: string; edited_by: string | null; position: number; created_at: number; updated_at: number }[];
+
+  beforeEach(() => {
+    entriesData = [
+      { id: "ent-1", list_id: "lst-1", project_id: "p1", text: "Milk", original_text: "Milk", category: "groceries", status: "new", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 0, created_at: 0, updated_at: 0 },
+      { id: "ent-2", list_id: "lst-1", project_id: "p1", text: "Bread", original_text: "Whole grain bread", category: null, status: "actioned", done: 1, author_kind: "user", author_id: "u1", edited_by: "u1", position: 1, created_at: 0, updated_at: 0 },
+      { id: "ent-3", list_id: "lst-1", project_id: "p1", text: "Call plumber", original_text: "Call plumber", category: null, status: "discuss", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 2, created_at: 0, updated_at: 0 },
+      { id: "ent-4", list_id: "lst-1", project_id: "p1", text: "Review PR", original_text: "Review PR", category: null, status: "seen", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 3, created_at: 0, updated_at: 0 },
+    ];
+
+    fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url === "/api/projects/p1/lists") {
+        if (init?.method === "POST") {
+          return Promise.resolve(ok({ id: "lst-new", project_id: "p1", title: "New list", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 }));
+        }
+        return Promise.resolve(ok({ items: [{ id: "lst-1", project_id: "p1", title: "Shopping", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 }] }));
+      }
+      if (url === "/api/projects/p1/lists/lst-1/entries") {
+        if (init?.method === "POST") {
+          const newEntry = { id: "ent-new", list_id: "lst-1", project_id: "p1", text: "new entry", original_text: "new entry", category: null as string | null, status: "new" as string, done: 0 as number, author_kind: "user" as string, author_id: "u1" as string, edited_by: null as string | null, position: entriesData.length as number, created_at: 0 as number, updated_at: 0 as number };
+          entriesData.push(newEntry);
+          return Promise.resolve(ok(newEntry));
+        }
+        return Promise.resolve(ok({ items: [...entriesData] }));
+      }
+      if (url.startsWith("/api/projects/p1/lists/lst-1/entries/") && init?.method === "PATCH") {
+        const entryId = url.split("/").pop()!;
+        const entry = entriesData.find((e) => e.id === entryId);
+        if (!entry) return Promise.resolve(ok({}));
+        const patch = JSON.parse(init.body as string);
+        Object.assign(entry, patch);
+        return Promise.resolve(ok({ ...entry }));
+      }
+      if (url === "/api/projects/p1/lists/lst-1" && init?.method === "DELETE") {
+        return Promise.resolve(ok({ ok: true }));
+      }
+      if (url.startsWith("/api/projects/p1/lists/lst-1/entries/") && init?.method === "DELETE") {
+        const entryId = url.split("/").pop()!;
+        entriesData = entriesData.filter((e) => e.id !== entryId);
+        return Promise.resolve(ok({ ok: true }));
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("renders lists rail and entries for the first list", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    const shoppingItems = screen.getAllByText("Shopping");
+    expect(shoppingItems.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Milk")).toBeInTheDocument();
+    expect(screen.getByText("Bread")).toBeInTheDocument();
+  });
+
+  it("renders status pills with correct colors", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    const newPills = screen.getAllByText("new");
+    expect(newPills.length).toBeGreaterThanOrEqual(1);
+    expect(newPills[0]!.className).toContain("bg-blue-500/15");
+    const actionedPills = screen.getAllByText("actioned");
+    expect(actionedPills.length).toBeGreaterThanOrEqual(1);
+    const discussPills = screen.getAllByText("discuss");
+    expect(discussPills.length).toBeGreaterThanOrEqual(1);
+    const seenPills = screen.getAllByText("seen");
+    expect(seenPills.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows the original text indicator when text is tidied", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    expect(screen.getByText("original")).toBeInTheDocument();
+  });
+
+  it("quick-add creates a new entry on Enter", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    const input = screen.getByLabelText(/quick add/i);
+    fireEvent.change(input, { target: { value: "new entry" } });
+    await act(async () => {
+      fireEvent.submit(input.closest("form")!);
+    });
+    await waitFor(() => expect(screen.getByText("new entry")).toBeInTheDocument());
+  });
+
+  it("done toggle marks entry as done and strikes through text", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    const checkbox = screen.getByLabelText(/mark milk as done/i);
+    fireEvent.click(checkbox);
+    await waitFor(() => expect(screen.getByText("Milk").className).toContain("line-through"));
+  });
+});

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor, within } from "@testing-library/react";
 import type { Project } from "@/lib/projects";
 import { ProjectLists } from "../ProjectLists";
 
@@ -151,7 +151,12 @@ describe("ProjectLists", () => {
     await act(async () => {
       fireEvent.click(screen.getByLabelText("Create new list"));
     });
-    await waitFor(() => expect(screen.getAllByText("New list").length).toBeGreaterThanOrEqual(1));
+    // Scope to the rail: the entries header renders the selected list's title
+    // too, so a whole-document match could pass while the rail stayed stale.
+    await waitFor(() => {
+      const rail = screen.getByLabelText("Project lists");
+      expect(within(rail).getByText("New list")).toBeInTheDocument();
+    });
   });
 
   it("switching project does not keep the previous project's selected list", async () => {
@@ -181,6 +186,44 @@ describe("ProjectLists", () => {
     });
     const posted = fetchMock.mock.calls.find(([u, i]) => String(u) === "/api/projects/p1/lists" && (i as RequestInit | undefined)?.method === "POST");
     expect(posted).toBeUndefined();
+  });
+
+  it("a slow entries response for a deselected list does not overwrite the current one", async () => {
+    // Deterministic race: lst-1's fetch is held open, the user picks lst-2,
+    // then lst-1's response lands last. Without the guard it wins and shows
+    // one list's entries under the other's heading.
+    let releaseSlow: (() => void) | null = null;
+    const slow = new Promise<void>((res) => { releaseSlow = () => res(); });
+    const raceFetch = vi.fn((url: string) => {
+      if (url === "/api/projects/p1/lists") {
+        return Promise.resolve(ok({ items: [
+          { id: "lst-1", project_id: "p1", title: "Shopping", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 },
+          { id: "lst-2", project_id: "p1", title: "Chores", description: "", status: "active", created_by: "u1", created_at: 0, updated_at: 0 },
+        ] }));
+      }
+      if (url === "/api/projects/p1/lists/lst-1/entries") {
+        return slow.then(() => ok({ items: [{ id: "e-slow", list_id: "lst-1", project_id: "p1", text: "STALE MILK", original_text: "STALE MILK", category: null, status: "new", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 0, created_at: 0, updated_at: 0 }] }));
+      }
+      if (url === "/api/projects/p1/lists/lst-2/entries") {
+        return Promise.resolve(ok({ items: [{ id: "e-fast", list_id: "lst-2", project_id: "p1", text: "Sweep floor", original_text: "Sweep floor", category: null, status: "new", done: 0, author_kind: "user", author_id: "u1", edited_by: null, position: 0, created_at: 0, updated_at: 0 }] }));
+      }
+      return Promise.resolve(ok({ items: [] }));
+    });
+    vi.stubGlobal("fetch", raceFetch);
+
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Chores"));
+    });
+    await waitFor(() => expect(screen.getByText("Sweep floor")).toBeInTheDocument());
+    await act(async () => {
+      releaseSlow!();
+      await slow;
+    });
+    expect(screen.queryByText("STALE MILK")).not.toBeInTheDocument();
+    expect(screen.getByText("Sweep floor")).toBeInTheDocument();
   });
 
   it("a deleted list disappears from the rail", async () => {

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -139,6 +139,34 @@ export type DocReview = {
   updated_at: number;
 };
 
+export type ProjectList = {
+  id: string;
+  project_id: string;
+  title: string;
+  description: string;
+  status: string;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+};
+
+export type ProjectListEntry = {
+  id: string;
+  list_id: string;
+  project_id: string;
+  text: string;
+  original_text: string;
+  category: string | null;
+  status: string;
+  done: number;
+  author_kind: string;
+  author_id: string;
+  edited_by: string | null;
+  position: number;
+  created_at: number;
+  updated_at: number;
+};
+
 export type DocReviewMissing = {
   project_id: string;
   doc_path: string;
@@ -357,6 +385,46 @@ export const projectsApi = {
 
   activity: (pid: string) =>
     http<{ items: ProjectActivity[] }>(`/api/projects/${pid}/activity`).then((r) => r.items),
+
+  lists: {
+    list: (pid: string) =>
+      http<{ items: ProjectList[] }>(`/api/projects/${pid}/lists`).then((r) => r.items),
+    create: (pid: string, input: { title: string; description?: string }) =>
+      http<ProjectList>(`/api/projects/${pid}/lists`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    get: (pid: string, listId: string) =>
+      http<ProjectList>(`/api/projects/${pid}/lists/${listId}`),
+    update: (pid: string, listId: string, patch: Partial<Pick<ProjectList, "title" | "description" | "status">>) =>
+      http<ProjectList>(`/api/projects/${pid}/lists/${listId}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+    remove: (pid: string, listId: string) =>
+      http<{ ok: boolean }>(`/api/projects/${pid}/lists/${listId}`, { method: "DELETE" }),
+    entries: {
+      list: (pid: string, listId: string) =>
+        http<{ items: ProjectListEntry[] }>(`/api/projects/${pid}/lists/${listId}/entries`).then((r) => r.items),
+      create: (pid: string, listId: string, input: { text: string; category?: string | null; position?: number | null }) =>
+        http<ProjectListEntry>(`/api/projects/${pid}/lists/${listId}/entries`, {
+          method: "POST",
+          body: JSON.stringify(input),
+        }),
+      update: (pid: string, listId: string, entryId: string, patch: Partial<Pick<ProjectListEntry, "text" | "category" | "status" | "done" | "position">>) =>
+        http<ProjectListEntry>(`/api/projects/${pid}/lists/${listId}/entries/${entryId}`, {
+          method: "PATCH",
+          body: JSON.stringify(patch),
+        }),
+      remove: (pid: string, listId: string, entryId: string) =>
+        http<{ ok: boolean }>(`/api/projects/${pid}/lists/${listId}/entries/${entryId}`, { method: "DELETE" }),
+      reorder: (pid: string, listId: string, entries: { id: string; position: number }[]) =>
+        http<{ ok: boolean }>(`/api/projects/${pid}/lists/${listId}/entries/reorder`, {
+          method: "POST",
+          body: JSON.stringify({ entries }),
+        }),
+    },
+  },
 
   docReviews: {
     list: (pid: string, state?: string) =>


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Lists S2: Projects app Lists tab UI (#2140)

Autonomous build of board card tsk-zitqoj.

Adds a Lists tab to the Projects workspace with a list rail showing all
project lists and an entries panel for the selected list. Entry rows
include a done checkbox, category chip, status pill (new=blue, seen=grey,
actioned=green, discuss=amber), a quick-add input with Enter-to-submit,
and an indicator to view the original text when it has been tidied.
Follows the Store/Images design bar pattern with rounded borders and
shell surface backgrounds.

Adds vitest tests covering quick-add creation, status pill rendering,
and done toggle behavior.

Files:
 desktop/src/apps/ProjectsApp/ProjectLists.tsx      | 314 +++++++++++++++++++++
 desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx  |   8 +-
 .../src/apps/ProjectsApp/ProjectsApp.module.css    |  34 +++
 .../ProjectsApp/__tests__/ProjectLists.test.tsx    | 121 ++++++++
 desktop/src/lib/projects.ts                        |  68 +++++
 5 files changed, 542 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lists tab to project workspaces.
  * Create, select, delete, and reorder project lists.
  * Add, update, complete, and delete list entries.
  * Manage entry categories and statuses, with original text available after edits.
  * Added responsive layouts for desktop and mobile screens.
* **Bug Fixes**
  * Added clear loading, empty, submission, and error states.
* **Tests**
  * Added coverage for list rendering, entry actions, statuses, and quick-add behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->