### PR TITLE
Live windows S2: adopt useRefreshOnFocus in Tasks, Activity, Models, Notes

### DIFF
--- a/changelog.d/tsk-yf7boe-refresh-on-focus-s2.md
+++ b/changelog.d/tsk-yf7boe-refresh-on-focus-s2.md
@@ -1,0 +1,1 @@
+- Adopted `useRefreshOnFocus` in Tasks, Activity, Models, and Notes so each window refetches its current data on focus without requiring a reopen.

--- a/changelog.d/tsk-yf7boe-refresh-on-focus-s2.md
+++ b/changelog.d/tsk-yf7boe-refresh-on-focus-s2.md
@@ -1,1 +1,2 @@
 - Adopted `useRefreshOnFocus` in Tasks, Activity, Models, and Notes so each window refetches its current data on focus without requiring a reopen.
+- Fixed Routines (Tasks) blanking to "No scheduled routines" when a background refresh hits an unreachable backend; the routines already on screen are kept instead.

--- a/desktop/src/apps/ActivityApp.refresh-on-focus.test.tsx
+++ b/desktop/src/apps/ActivityApp.refresh-on-focus.test.tsx
@@ -1,0 +1,103 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ActivityApp } from "./ActivityApp";
+
+describe("ActivityApp refresh-on-focus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("refetches /api/activity on window focus with the same URL as mount", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      urls.push(String(url));
+      if (url === "/api/activity") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({
+            timestamp: Date.now(),
+            hardware: { cpu: { cores: 4, arch: "aarch64" }, ram_mb: 8192 },
+            cpu: { cores: [], overall_percent: 0 },
+            memory: { total_mb: 8192, used_mb: 4096, available_mb: 4096, percent: 50, swap_total_mb: 0, swap_used_mb: 0, swap_percent: 0 },
+            npu: { cores: [], freq_hz: 0, type: "none" },
+            gpu: { load: null, vram_percent: null, vram_used_mb: null, vram_total_mb: null, type: "none" },
+            thermal: [],
+            zram: [],
+            disk: { io_rate: { read_bps: 0, write_bps: 0 }, usage_percent: 0, total_gb: 32, used_gb: 18 },
+            network: [],
+            processes: [],
+          }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url === "/api/models/loaded") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ loaded: [] }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url === "/api/scheduler/stats") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ submitted: 0, completed: 0, errors: 0, rejected: 0, active: 0, resources: [] }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url === "/api/scheduler/tasks?limit=8") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ tasks: [] }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url === "/api/cluster/workers") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve([]),
+          text: () => Promise.resolve(""),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ActivityApp windowId="w1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const activityCalls = () => urls.filter((u) => u === "/api/activity");
+    expect(activityCalls().length).toBeGreaterThan(0);
+    const before = activityCalls().length;
+
+    window.dispatchEvent(new Event("focus"));
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    const after = activityCalls();
+    expect(after.length).toBe(before + 1);
+  });
+});

--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import {
   Activity, Cpu, MemoryStick, Zap, HardDrive, Thermometer, Network, CircuitBoard,
   Gauge, Layers, RefreshCw, Loader2, Server,
@@ -252,6 +253,8 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
     const interval = setInterval(fetchData, 2000);
     return () => clearInterval(interval);
   }, [fetchData]);
+
+  useRefreshOnFocus(fetchData);
 
   useEffect(() => {
     fetchCluster();

--- a/desktop/src/apps/ModelsApp.refresh-on-focus.test.tsx
+++ b/desktop/src/apps/ModelsApp.refresh-on-focus.test.tsx
@@ -1,0 +1,73 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ModelsApp } from "./ModelsApp";
+
+describe("ModelsApp refresh-on-focus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("refetches /api/models on window focus with the same URL as mount", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      urls.push(String(url));
+      if (url === "/api/models") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ models: [], downloaded_files: [], hardware_profile_id: "p1" }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url.startsWith("/api/models/downloads/")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ status: "complete", percent: 100 }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      if (url === "/api/models/download") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () => Promise.resolve({ status: "started", download_id: "dl-1" }),
+          text: () => Promise.resolve(""),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ModelsApp windowId="w1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const modelCalls = () => urls.filter((u) => u === "/api/models");
+    expect(modelCalls().length).toBeGreaterThan(0);
+    const before = modelCalls().length;
+
+    window.dispatchEvent(new Event("focus"));
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    const after = modelCalls();
+    expect(after.length).toBe(before + 1);
+  });
+});

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import { Brain, Search, Download, Trash2, HardDrive, X, Cloud } from "lucide-react";
 import {
   Button,
@@ -421,6 +422,8 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
   useEffect(() => {
     fetchModels();
   }, [fetchModels]);
+
+  useRefreshOnFocus(fetchModels);
 
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<Record<string, string>>({});

--- a/desktop/src/apps/NotesApp.refresh-on-focus.test.tsx
+++ b/desktop/src/apps/NotesApp.refresh-on-focus.test.tsx
@@ -1,0 +1,46 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NotesApp } from "./NotesApp";
+
+describe("NotesApp refresh-on-focus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("refetches /api/notes on window focus with the same URL as mount", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      urls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(""),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<NotesApp windowId="w1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const notesCalls = () => urls.filter((u) => u === "/api/notes");
+    expect(notesCalls().length).toBeGreaterThan(0);
+    const before = notesCalls().length;
+
+    window.dispatchEvent(new Event("focus"));
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    const after = notesCalls();
+    expect(after.length).toBe(before + 1);
+  });
+});

--- a/desktop/src/apps/NotesApp.tsx
+++ b/desktop/src/apps/NotesApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import {
   StickyNote,
   Plus,
@@ -1047,6 +1048,8 @@ function DocsApp({ config }: { config: DocKindConfig }) {
   useEffect(() => {
     loadNotes();
   }, [loadNotes]);
+
+  useRefreshOnFocus(loadNotes);
 
   function handleCreated(doc: NoteDoc) {
     setNotes((prev) => [doc, ...prev]);

--- a/desktop/src/apps/TasksApp.refresh-failure.test.tsx
+++ b/desktop/src/apps/TasksApp.refresh-failure.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TasksApp } from "./TasksApp";
+
+describe("TasksApp refresh-on-focus failure handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the loaded routines when a focus refetch fails", async () => {
+    let tasksFail = false;
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === "/api/tasks" && tasksFail) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          headers: { get: () => "text/html" },
+          json: () => Promise.reject(new Error("not json")),
+          text: () => Promise.resolve("gateway down"),
+        });
+      }
+      if (url === "/api/tasks") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: () => "application/json" },
+          json: () =>
+            Promise.resolve([
+              {
+                id: 1,
+                name: "Nightly backup",
+                agent_name: null,
+                schedule: "0 3 * * *",
+                command: "backup.sh",
+                description: "",
+                enabled: true,
+                last_run: null,
+              },
+            ]),
+          text: () => Promise.resolve(""),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(""),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TasksApp windowId="w1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The routine the user is looking at.
+    expect(screen.getByText("Nightly backup")).toBeTruthy();
+
+    // Backend blips, then the window regains focus.
+    tasksFail = true;
+    window.dispatchEvent(new Event("focus"));
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    // A failed background refetch must not replace real data with the
+    // "No scheduled routines" empty state.
+    expect(screen.queryByText("No scheduled routines")).toBeNull();
+    expect(screen.getByText("Nightly backup")).toBeTruthy();
+  });
+});

--- a/desktop/src/apps/TasksApp.refresh-on-focus.test.tsx
+++ b/desktop/src/apps/TasksApp.refresh-on-focus.test.tsx
@@ -1,0 +1,46 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TasksApp } from "./TasksApp";
+
+describe("TasksApp refresh-on-focus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("refetches /api/tasks on window focus with the same URL as mount", async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      urls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(""),
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TasksApp windowId="w1" />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const taskCalls = () => urls.filter((u) => u === "/api/tasks");
+    expect(taskCalls().length).toBeGreaterThan(0);
+    const before = taskCalls().length;
+
+    window.dispatchEvent(new Event("focus"));
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    const after = taskCalls();
+    expect(after.length).toBe(before + 1);
+  });
+});

--- a/desktop/src/apps/TasksApp.tsx
+++ b/desktop/src/apps/TasksApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import { CalendarClock, Plus, Edit, Trash2, Play, Pause, X } from "lucide-react";
 import {
   Button,
@@ -121,6 +122,8 @@ export function TasksApp({ windowId: _windowId }: { windowId: string }) {
     fetchTasks();
     fetchPresets();
   }, [fetchTasks, fetchPresets]);
+
+  useRefreshOnFocus(fetchTasks);
 
   useEffect(() => {
     (async () => {

--- a/desktop/src/apps/TasksApp.tsx
+++ b/desktop/src/apps/TasksApp.tsx
@@ -97,7 +97,10 @@ export function TasksApp({ windowId: _windowId }: { windowId: string }) {
         }
       }
     } catch { /* fall through */ }
-    setTasks([]);
+    // Keep whatever is on screen. This path now runs on every window focus, so
+    // wiping here turns a transient backend blip into "No scheduled routines"
+    // over routines that exist. At mount `tasks` is already [], so the empty
+    // state still renders exactly as before.
     setLoading(false);
   }, []);
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Live windows S2: adopt useRefreshOnFocus in Tasks, Activity, Models, Notes

Autonomous build of board card tsk-yf7boe.



Files:
 desktop/src/apps/ActivityApp.tsx                   |   3 +
 .../src/apps/ModelsApp.refresh-on-focus.test.tsx   |  73 +++++++++++++++
 desktop/src/apps/ModelsApp.tsx                     |   3 +
 .../src/apps/NotesApp.refresh-on-focus.test.tsx    |  46 +++++++++
 desktop/src/apps/NotesApp.tsx                      |   3 +
 .../src/apps/TasksApp.refresh-on-focus.test.tsx    |  46 +++++++++
 desktop/src/apps/TasksApp.tsx                      |   3 +
 9 files changed, 281 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks, Activity, Models, and Notes now automatically refresh when the app window regains focus.

* **Bug Fixes**
  * Keeps the existing task list visible when a background refresh fails.
  * Helps ensure views show up-to-date information after returning to the application.

* **Tests**
  * Added coverage for focus-triggered refreshes and failed-refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->