### PR TITLE
doc-gate: DELETING the required doc satisfies the rule (gate goes fully green on the change it exists to prevent)

### DIFF
--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -13,8 +13,9 @@ Two layers:
                 globs. By default only added/deleted files (status A/D) are
                 structural; set `on_modify = true` on a rule to also count
                 plain modifications (status M) for that rule. Any changed
-                file (any status) can *satisfy* a rule if it matches a
-                require_doc glob.
+                file (any status) can *trigger* a rule. Only ADDED or MODIFIED
+                files (status A/M) can *satisfy* a rule by matching a
+                require_doc glob; a deleted require_doc does NOT count.
 
 Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
 editing the TOML, no changes to this file required.
@@ -235,16 +236,17 @@ def evaluate_rules(
     By default only status "A" (added) or "D" (deleted) files count as
     structural change for triggering a rule. When a rule sets `on_modify =
     true`, status "M" (plain modification) also counts for that rule.
-    Any changed file (any status) can satisfy a rule if it matches a
-    require_doc glob. Test paths are never structural and are always
-    excluded.
+    Any added or modified file can satisfy a rule if it matches a
+    require_doc glob; a deleted require_doc does NOT count. Trigger scope (A/D,
+    plus M when on_modify is set) is separate from satisfaction scope (A/M only).
+    Test paths are never structural and are always excluded.
     commit_messages: full text of each commit message in range (empty list
     when there is no finalized commit yet, i.e. --staged mode).
     """
     trailer = get_trailer(config)
     rules = config.get("rules", [])
 
-    all_paths = [path for _status, path in changed_status]
+    all_paths = [path for status, path in changed_status if status in ("A", "M")]
 
     trailer_present = any(
         line.strip().startswith(trailer) and line.strip()[len(trailer):].strip()

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -606,3 +606,91 @@ class TestCommitsWithMessagesParsing:
 
     def test_empty_range_is_empty(self, monkeypatch):
         assert self._parse(monkeypatch, "") == []
+
+
+# A config mirroring the real interaction between the routes rule and the
+# user-visible-changelog rule: a route addition triggers BOTH rules, so the
+# changelog fragment satisfies the latter while only a doc edit can satisfy the
+# former. This is the shape that lets the deletion bypass hide -- the
+# user-visible-changelog rule is always satisfiable, so a deleted routes
+# require_doc only shows as a bug once every OTHER rule is also satisfied.
+ROUTES_AND_CHANGELOG_CONFIG = {
+    "gate": {"trailer": "Docs-Reviewed:"},
+    "rules": [
+        {
+            "name": "routes",
+            "on_modify": True,
+            "when_changed": ["tinyagentos/routes/*.py"],
+            "require_doc": ["docs/agent-coordination.md"],
+            "hint": "an API route module was added, removed, or modified",
+        },
+        {
+            "name": "user-visible-changelog",
+            "on_modify": True,
+            "when_changed": ["tinyagentos/**", "desktop/src/**"],
+            "require_doc": ["CHANGELOG.md", "changelog.d/*.md"],
+            "hint": "user-visible behaviour changed",
+        },
+    ],
+}
+
+
+def _failure_names(failures: list[str]) -> list[str]:
+    return [f.split(" -- ")[0] for f in failures]
+
+
+class TestDeletedRequireDocDoesNotSatisfy:
+    """A deleted require_doc must NOT satisfy a rule.
+
+    Bug: scripts/check_doc_gate.py line 247 ``all_paths`` discarded the git
+    status, so a ``git rm``'d require_doc was treated as having satisfied the
+    rule. These tests assert on the rule NAME in the failures list, not just
+    the exit code: with only the route add + doc deletion (no changelog
+    fragment) the routes failure is masked by a coinciding user-visible-changelog
+    failure, so an exit-code-only assertion stays green even while the bug is
+    live. Red-first: criterion 1 fails before the fix, passes after.
+    """
+
+    def test1_delete_require_doc_routes_still_fails(self):
+        """Criterion 1: add a when_changed path + delete the require_doc +
+        satisfy every other rule -- the routes rule MUST appear in failures."""
+        changed = [
+            ("A", "tinyagentos/routes/zzz_probe.py"),
+            ("D", "docs/agent-coordination.md"),
+            ("A", "changelog.d/9999-probe.md"),
+        ]
+        failures = dg.evaluate_rules(changed, [], ROUTES_AND_CHANGELOG_CONFIG)
+        names = _failure_names(failures)
+        assert "routes" in names
+        assert "user-visible-changelog" not in names
+
+    def test2_edit_require_doc_passes(self):
+        """Criterion 2: add a when_changed path + genuinely edit the require_doc
+        -> clean. Guards against fixing this by deadening satisfaction entirely."""
+        changed = [
+            ("A", "tinyagentos/routes/zzz_probe.py"),
+            ("M", "docs/agent-coordination.md"),
+            ("A", "changelog.d/9999-probe.md"),
+        ]
+        failures = dg.evaluate_rules(changed, [], ROUTES_AND_CHANGELOG_CONFIG)
+        assert failures == []
+
+    def test3_add_require_doc_as_new_file_passes(self):
+        """Criterion 3: add a when_changed path + ADD the require_doc as a new
+        file -> clean."""
+        changed = [
+            ("A", "tinyagentos/routes/zzz_probe.py"),
+            ("A", "docs/agent-coordination.md"),
+            ("A", "changelog.d/9999-probe.md"),
+        ]
+        failures = dg.evaluate_rules(changed, [], ROUTES_AND_CHANGELOG_CONFIG)
+        assert failures == []
+
+    def test4_delete_when_changed_path_still_triggers(self):
+        """Criterion 4: delete a when_changed path -- still triggers the rule,
+        unchanged from today. The triggering path must keep deletions; only
+        the satisfaction path must exclude them."""
+        changed = [("D", "tinyagentos/routes/zzz_probe.py")]
+        failures = dg.evaluate_rules(changed, [], ROUTES_AND_CHANGELOG_CONFIG)
+        names = _failure_names(failures)
+        assert "routes" in names


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): doc-gate: DELETING the required doc satisfies the rule (gate goes fully green on the change it exists to prevent)

Autonomous build of board card tsk-vs6c77.

A deleted require_doc path was counted as having satisfied its rule
because all_paths discarded the git status. Now only A/M paths satisfy;
D paths still trigger as before.

Files:
 scripts/check_doc_gate.py | 14 ++++----
 tests/test_doc_gate.py    | 88 +++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 96 insertions(+), 6 deletions(-)

---

## RED EVIDENCE (produced by @taOS-dev at review; the card demands it and the lane's body carried none)

Method: on the PR branch, revert ONLY `scripts/check_doc_gate.py` to the merge-base
(`5be88801`) and run the new tests against it. Test file unchanged, so this is the new
tests meeting the old code.

```
$ git checkout 5be88801 -- scripts/check_doc_gate.py
$ pytest tests/test_doc_gate.py::TestDeletedRequireDocDoesNotSatisfy -q

        changed = [
            ("A", "tinyagentos/routes/zzz_probe.py"),
            ("D", "docs/agent-coordination.md"),
            ("A", "changelog.d/9999-probe.md"),
        ]
        failures = dg.evaluate_rules(changed, [], ROUTES_AND_CHANGELOG_CONFIG)
        names = _failure_names(failures)
>       assert "routes" in names
E       AssertionError: assert 'routes' in []

tests/test_doc_gate.py:664: AssertionError
=========================== short test summary info ============================
FAILED tests/test_doc_gate.py::TestDeletedRequireDocDoesNotSatisfy::test1_delete_require_doc_routes_still_fails
1 failed, 3 passed in 0.50s
```

`assert 'routes' in []` is the defect stated exactly: a route module was ADDED and its
required doc was DELETED, and the gate returned an EMPTY failure list. Deleting the doc
satisfied the rule it exists to enforce.

**Only ONE of the four is red, and that is correct rather than a weak proof.** The other
three pass both ways BY DESIGN and are labelled as controls, not as red evidence:
criterion 2 (a genuine edit still satisfies) and criterion 3 (adding the doc as a new file
still satisfies) exist to stop this being "fixed" by deadening satisfaction entirely, so
they must be green before AND after. A test that only ever passes proves nothing on its
own; its job here is to fail if the fix over-corrects.

After the fix, on this branch: **65 passed** in `tests/test_doc_gate.py`.

Lead review with the five-status measurement, the scoping check, and the separately-carded
pre-existing rename hole (`tsk-gv6m6g`) is in the review comment above.
