### PR TITLE
doc-gate: a RENAMED route module triggers no rule at all (structural change invisible to the gate)

### DIFF
--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -9,13 +9,13 @@ Two layers:
                  scripts/, tinyagentos/, docs/, desktop/ path mentioned in the
                  configured doc set actually exists on disk.
   diff-gate   -- path -> doc rule engine (Layer B). A configured rule fires
-                when a *structural* change matches one of its `when_changed`
-                globs. By default only added/deleted files (status A/D) are
-                structural; set `on_modify = true` on a rule to also count
-                plain modifications (status M) for that rule. Any changed
-                file (any status) can *trigger* a rule. Only ADDED or MODIFIED
-                files (status A/M) can *satisfy* a rule by matching a
-                require_doc glob; a deleted require_doc does NOT count.
+                 when a *structural* change matches one of its `when_changed`
+                 globs. By default added, deleted, renamed, and copied files
+                 (status A/D/R/C) are structural; set `on_modify = true` on a
+                 rule to also count plain modifications (status M) for that
+                 rule. Only ADDED or MODIFIED files (status A/M) can *satisfy*
+                 a rule by matching a require_doc glob; a renamed, copied, or
+                 deleted require_doc does NOT count.
 
 Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
 editing the TOML, no changes to this file required.
@@ -264,7 +264,7 @@ def evaluate_rules(
 
         rule_structural_paths = [
             path for status, path in changed_status
-            if (status in ("A", "D") or (on_modify and status == "M"))
+            if (status in ("A", "D", "R", "C") or (on_modify and status == "M"))
             and not _is_test_path(path)
         ]
 

--- a/tests/test_check_doc_gate.py
+++ b/tests/test_check_doc_gate.py
@@ -168,6 +168,59 @@ class TestEvaluateRulesEdgeCases:
         assert failures == []
 
 
+class TestEvaluateRulesRenameCopy:
+    """Rename (R) and copy (C) must trigger rules but must not satisfy require_doc."""
+
+    def test_rename_triggers_rule_by_name(self):
+        """A rename of a when_changed path must trigger the rule."""
+        config = _base_config()
+        changed = [("R", "tinyagentos/routes/themes.py")]
+        failures = evaluate_rules(changed, [], config)
+        assert len(failures) == 1
+        assert "test_route" in failures[0]
+
+    def test_copy_triggers_rule_by_name(self):
+        """A copy of a when_changed path must trigger the rule."""
+        config = _base_config()
+        changed = [("C", "tinyagentos/routes/themes.py")]
+        failures = evaluate_rules(changed, [], config)
+        assert len(failures) == 1
+        assert "test_route" in failures[0]
+
+    def test_deletion_still_triggers_rule(self):
+        """A deletion of a when_changed path must still trigger the rule (pinning)."""
+        config = _base_config()
+        changed = [("D", "tinyagentos/routes/themes.py")]
+        failures = evaluate_rules(changed, [], config)
+        assert len(failures) == 1
+        assert "test_route" in failures[0]
+
+    def test_rename_does_not_satisfy_require_doc(self):
+        """Renaming the require_doc does NOT satisfy it (pinning).
+
+        If the satisfaction set were widened to include R, this would pass
+        silently and the assertion below would fail.
+        """
+        config = _base_config()
+        changed = [
+            ("R", "tinyagentos/routes/themes.py"),
+            ("R", "CHANGELOG.md"),
+        ]
+        failures = evaluate_rules(changed, [], config)
+        assert len(failures) == 1
+        assert "test_route" in failures[0]
+
+    def test_rename_with_doc_added_passes(self):
+        """A route rename with the required doc added passes."""
+        config = _base_config()
+        changed = [
+            ("R", "tinyagentos/routes/themes.py"),
+            ("A", "CHANGELOG.md"),
+        ]
+        failures = evaluate_rules(changed, [], config)
+        assert failures == []
+
+
 class TestReferencedPathsScan:
     """Invariants layer: glob expansion, tombstones, extractor precision."""
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): doc-gate: a RENAMED route module triggers no rule at all (structural change invisible to the gate)

Autonomous build of board card tsk-gv6m6g.

git --name-status reports renames as R100/R087/... and copies as C100/...;
the parser truncates to the first character, so they arrive as R and C.
Those statuses were silently ignored by the trigger set, meaning a
renamed route module fired no rule and required no doc.

Fix: add R and C to the trigger set alongside A and D. The satisfaction
set (all_paths) is intentionally left as A/M only so that a renamed
require_doc still does not count as a doc update.

Tests added:
- rename triggers rule by name
- copy triggers rule by name
- deletion still triggers (pinning)
- rename does not satisfy require_doc (pinning)
- rename plus added doc passes

Files:
 scripts/check_doc_gate.py    | 16 ++++++-------
 tests/test_check_doc_gate.py | 53 ++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 8 deletions(-)

---

## RED-FIRST EVIDENCE (produced by @taOS-dev, lead; card demands assert-on-rule-name)

Method: on the branch head, revert **only** `scripts/check_doc_gate.py` to the
merge-base `9550eed5` (leaving the new tests in place), then run the new class.

```
$ git checkout 9550eed5 -- scripts/check_doc_gate.py
$ pytest tests/test_check_doc_gate.py::TestEvaluateRulesRenameCopy -p no:randomly

>       assert len(failures) == 1
E       assert 0 == 1
E        +  where 0 = len([])
tests/test_check_doc_gate.py:189: AssertionError

FAILED tests/test_check_doc_gate.py::TestEvaluateRulesRenameCopy::test_rename_triggers_rule_by_name
FAILED tests/test_check_doc_gate.py::TestEvaluateRulesRenameCopy::test_copy_triggers_rule_by_name
FAILED tests/test_check_doc_gate.py::TestEvaluateRulesRenameCopy::test_rename_does_not_satisfy_require_doc
========================= 3 failed, 2 passed in 0.51s ==========================
```

Green with the fix restored, across **both** doc-gate test files:

```
$ git checkout HEAD -- scripts/check_doc_gate.py
$ pytest tests/test_check_doc_gate.py tests/test_doc_gate.py -q -p no:randomly
90 passed in 0.83s
```

### Honest reading of each of the five — 3 red, 2 controls

Two of the five pass both ways and are **not** evidence; stating which, rather
than reporting "3 failed" as though the class were uniformly red:

- `test_rename_triggers_rule_by_name` — **REAL RED.** R was in neither set.
- `test_copy_triggers_rule_by_name` — **REAL RED.** C likewise.
- `test_rename_does_not_satisfy_require_doc` — **RED, BUT NOT FOR ITS NAME'S
  REASON.** On the old code it fails because the rename never *triggers*
  (`0 == 1`), not because satisfaction was widened. It is still worth keeping:
  it pins the satisfaction set against a future widening, which is the failure
  mode #2392 closed. Its value is forward-looking, not as proof of this defect.
- `test_deletion_still_triggers_rule` — **CONTROL, passes both ways.** D already
  triggered. Present so a fix that rewrites the trigger set cannot drop D.
- `test_rename_with_doc_added_passes` — **CONTROL, and it passes for the WRONG
  REASON on the old code**: there it yields `[]` because nothing triggers at
  all, whereas on the fixed code it yields `[]` because the added doc satisfies
  a rule that did fire. Same output, opposite mechanism.

### Base-freshness re-check (the reason this PR was not merged on its first green)

Its first `deleted-symbols-gate` SUCCESS ran at 17:07:13Z; #2393 merged at
17:17:17Z — **ten minutes later**. That green was evaluated against a `dev`
that did not yet contain `EXIT_GIT_ERROR`, so it proved nothing, and the merge
was conflict-free, so nothing else objected either. Fixed by merging dev in
(795928f1), not by waiving. Verified in the merged tree:

```
$ grep -c 'status in ("A", "M")' scripts/check_doc_gate.py   # #2392's filter
1
$ grep -c 'EXIT_GIT_ERROR' scripts/check_doc_gate.py         # #2393's fix
2
```

`all_paths` is untouched at `("A", "M")`, so #2392's deleted-doc bypass stays
closed; only the trigger set widens, to `("A", "D", "R", "C")`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation checks now consistently recognize added, deleted, renamed, and copied files as structural changes.
  * Documentation requirements are satisfied only by newly added or modified matching documentation files, or by a valid trailer.

* **Tests**
  * Added coverage for rename, copy, deletion, and documentation requirement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->