### PR TITLE
tests+docs: pin the revocation feed as agent-scoped by decision, not by accident

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -76,7 +76,8 @@ Minted by `ensure_native_agent_identity()` in `tinyagentos/native_agent_identity
 
 **Scopes are deliberately minimal.** Bus participation only. Anything further goes through the normal user-mediated scope-request flow; a first-boot mint that silently granted file or task access would be a privilege grant nobody approved.
 
-**Two boundaries worth knowing before you build on this:**
+**Three boundaries worth knowing before you build on this:**
 
 - The token does **not** authenticate desktop control. `/api/desktop/*` resolves the acting user from a session, and the middleware sets `user_id = None` for registry JWTs, so a registry token arrives there as nobody. Desktop control still uses the session or the host local token.
+- **The revocation feed covers agent identities only, and that is a decision rather than a gap.** `GET /api/agents/registry/revoked` reads `agent_registry` and returns `{canonical_id, revoked_at}` per entry. Human credential withdrawal is handled through the session/auth layer, so humans will never appear here. Decided 2026-08-13, after a downstream spec was written assuming the opposite. If you are building something that needs to learn a *human's* credential was withdrawn, this feed is the wrong source and the requirement should be raised rather than implemented against it — `tests/test_agent_registry.py::test_revoked_feed_shape` fails if the feed is widened, deliberately.
 - **Nothing in the chat runtime reads the token yet.** The identity is minted; wiring it into what the agent sends is a separate change. It is deliberately absent from the agent manual until then — the manual is injected into the agent's prompt and sits at its size ceiling, so it should not describe a capability the agent does not yet have.

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -560,7 +560,15 @@ class TestAgentRegistryRoutes:
     # -- Revoked feed --------------------------------------------------------
 
     async def test_revoked_feed_shape(self, registry_client):
-        """GET /api/agents/registry/revoked returns {revoked: [{canonical_id, revoked_at}]}."""
+        """GET /api/agents/registry/revoked returns {revoked: [{canonical_id, revoked_at}]}.
+
+        The exact-keys assertion below is a deliberate scope guard, not just a shape
+        check. Decided 2026-08-13: the revocation feed covers agent identities ONLY,
+        and human credential withdrawal is handled through the session/auth layer.
+        Adding a principal_kind or subject_type field to the feed will fail here, which
+        is the point -- widening it is a design decision that must be taken explicitly
+        rather than arrived at by editing a serializer.
+        """
         reg_resp = await registry_client.post(
             "/api/agents/registry/register",
             json={"framework": "openclaw", "display_name": "To Revoke"},
@@ -573,29 +581,6 @@ class TestAgentRegistryRoutes:
         data = resp.json()
         assert "revoked" in data
         assert isinstance(data["revoked"], list)
-        assert len(data["revoked"]) >= 1
-        entry = next(e for e in data["revoked"] if e["canonical_id"] == cid)
-        assert set(entry.keys()) == {"canonical_id", "revoked_at"}
-        assert entry["revoked_at"] is not None
-
-    async def test_revoked_feed_scoped_to_agent_identities_only(self, registry_client):
-        """Guard: the revocation feed covers agent identities only.
-
-        Decided 2026-08-13. Human credential withdrawal lives in the
-        session/auth layer, not this feed. Each entry must have exactly
-        canonical_id and revoked_at.
-        """
-        reg_resp = await registry_client.post(
-            "/api/agents/registry/register",
-            json={"framework": "openclaw", "display_name": "Boundary"},
-        )
-        cid = reg_resp.json()["canonical_id"]
-        await registry_client.delete(f"/api/agents/registry/{cid}")
-
-        resp = await registry_client.get("/api/agents/registry/revoked")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "revoked" in data
         assert len(data["revoked"]) >= 1
         entry = next(e for e in data["revoked"] if e["canonical_id"] == cid)
         assert set(entry.keys()) == {"canonical_id", "revoked_at"}

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -578,6 +578,29 @@ class TestAgentRegistryRoutes:
         assert set(entry.keys()) == {"canonical_id", "revoked_at"}
         assert entry["revoked_at"] is not None
 
+    async def test_revoked_feed_scoped_to_agent_identities_only(self, registry_client):
+        """Guard: the revocation feed covers agent identities only.
+
+        Decided 2026-08-13. Human credential withdrawal lives in the
+        session/auth layer, not this feed. Each entry must have exactly
+        canonical_id and revoked_at.
+        """
+        reg_resp = await registry_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Boundary"},
+        )
+        cid = reg_resp.json()["canonical_id"]
+        await registry_client.delete(f"/api/agents/registry/{cid}")
+
+        resp = await registry_client.get("/api/agents/registry/revoked")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "revoked" in data
+        assert len(data["revoked"]) >= 1
+        entry = next(e for e in data["revoked"] if e["canonical_id"] == cid)
+        assert set(entry.keys()) == {"canonical_id", "revoked_at"}
+        assert entry["revoked_at"] is not None
+
     async def test_revoked_route_not_captured_as_canonical_id(self, registry_client):
         """Route ordering regression: /revoked must hit the feed, not the single-entry route."""
         resp = await registry_client.get("/api/agents/registry/revoked")

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -647,6 +647,21 @@ class TestListRevoked:
         assert revoked[0]["revoked_at"] is not None
 
     @pytest.mark.asyncio
+    async def test_revoked_feed_scoped_to_agent_identities_only(self, store):
+        """Guard: the revocation feed covers agent identities only.
+
+        Decided 2026-08-13. Human credential withdrawal lives in the
+        session/auth layer, not this feed. Each entry must have exactly
+        canonical_id and revoked_at.
+        """
+        r1 = await store.register(framework="openclaw", display_name="Boundary")
+        await store.revoke(r1["canonical_id"])
+        revoked = await store.list_revoked()
+        assert len(revoked) == 1
+        assert revoked[0]["canonical_id"] == r1["canonical_id"]
+        assert set(revoked[0].keys()) == {"canonical_id", "revoked_at"}
+
+    @pytest.mark.asyncio
     async def test_not_initialized_raises(self, tmp_path):
         s = AgentRegistryStore(tmp_path / "not_init.db")
         with pytest.raises(RuntimeError, match="not initialised"):

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -801,7 +801,14 @@ class AgentRegistryStore(BaseStore):
         return [_row_to_dict(r) for r in rows]
 
     async def list_revoked(self) -> list[dict]:
-        """Return [{canonical_id, revoked_at}] for all revoked entries (back-compat feed)."""
+        """Return [{canonical_id, revoked_at}] for all revoked agent identities.
+
+        This feed is deliberately scoped to agent identities only, as decided on
+        2026-08-13. Human credential withdrawal is handled through the
+        session/auth layer and does not appear here. Do not extend this feed to
+        include human principals or subject_type fields without a new design
+        decision.
+        """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
         cursor = await self._db.execute(

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -505,7 +505,12 @@ async def get_pubkey(request: Request):
 
 @router.get("/api/agents/registry/revoked")
 async def list_revoked_entries(request: Request):
-    """Return the global revocation feed: [{canonical_id, revoked_at}, ...].
+    """Return the global revocation feed for agent identities: [{canonical_id, revoked_at}, ...].
+
+    This feed is scoped to agent identities only, as decided on 2026-08-13.
+    Human credential withdrawal is handled through the session/auth layer and
+    does not appear here. Do not extend this feed to include human principals
+    or subject_type fields without a new design decision.
 
     Accessible to admin sessions/local-token OR a registry JWT whose
     canonical_id holds an active ``registry_feeds_read`` grant.  The grant is


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tests+docs: pin the revocation feed as agent-scoped by decision, not by accident

Autonomous build of board card tsk-b24au3.

Updated list_revoked() docstring in agent_registry_store.py and the
GET /api/agents/registry/revoked route docstring to state the feed is
scoped to agent identities only, decided 2026-08-13, because human
credential withdrawal lives in the session/auth layer.

Added store-level test test_revoked_feed_scoped_to_agent_identities_only
in tests/test_agent_registry_store.py and route-level test
test_revoked_feed_scoped_to_agent_identities_only in
tests/test_agent_registry.py. Each test revokes an agent, asserts it
appears in the feed, and asserts the response entry keys are EXACTLY
canonical_id and revoked_at. That exact-keys assertion is the guard that
forces anyone adding principal_kind or subject_type to confront this
decision instead of widening the feed quietly.

Evidence: temporarily widening the feed to include principal_kind caused
both new tests to fail with AssertionError (Extra items in the left set:
principal_kind). Reverting the simulated boundary violation restored
both tests to passing. Full suite: 196 passed.

Files:
 tests/test_agent_registry.py         | 23 +++++++++++++++++++++++
 tests/test_agent_registry_store.py   | 15 +++++++++++++++
 tinyagentos/agent_registry_store.py  |  9 ++++++++-
 tinyagentos/routes/agent_registry.py |  7 ++++++-
 4 files changed, 52 insertions(+), 2 deletions(-)

*(Body above is the lane's original text, restored verbatim after I blanked it with a bad API call. The file stats predate the lead commit below.)*

---

## LEAD-COMPLETED at ffac1163 (@taOS-dev)

The lane exited before this review existed, so the change it asked for was made here rather than bounced.

**What changed and why.** The route-level test this PR added was a verbatim duplicate of
`test_revoked_feed_shape` (tests/test_agent_registry.py:562), which already asserts the exact key
set -- and it dropped that test's `isinstance(data["revoked"], list)` check. Measured, not assumed:
the same feed-widening mutation fails both. So the route-level guard the card asked for already
existed; only the recorded reason was missing. The duplicate is removed and the rationale now lives
on the existing test's docstring.

The store-level test is KEPT unchanged. The pre-existing `test_lists_revoked` passes under the same
mutation, so its exact-keys assertion is real new coverage.

`docs/agent-coordination.md` now carries the boundary as a third entry in the identity-boundaries
list, so an agent building against the feed meets it where it will look.

### Red proof (the card demands it fenced)

Mutation: `list_revoked()` widened with `"principal_kind": "agent"`.

```
### RED (feed widened with principal_kind) ###
E       AssertionError: assert {'canonical_i... 'revoked_at'} == {'canonical_id', 'revoked_at'}
tests/test_agent_registry_store.py:662: AssertionError
E       AssertionError: assert {'canonical_i... 'revoked_at'} == {'canonical_id', 'revoked_at'}
tests/test_agent_registry.py:586: AssertionError
FAILED tests/test_agent_registry_store.py::TestListRevoked::test_revoked_feed_scoped_to_agent_identities_only
FAILED tests/test_agent_registry.py::TestAgentRegistryRoutes::test_revoked_feed_shape
2 failed in 4.24s
```

And the pre-existing store test is blind to that same mutation, which is what makes the new one worth keeping:

```
tests/test_agent_registry_store.py::TestListRevoked::test_lists_revoked  1 passed
```

### Green after revert

```
### GREEN (feed unchanged) ###
...................                                                      [100%]
19 passed in 21.55s
```

19 rather than 20 because the duplicate is gone.

**Harness note for anyone reproducing this locally:** run `.venv/bin/python -m pytest`, not the
`.venv/bin/pytest` console script. From a git worktree the console script imports the package from
the MAIN checkout (editable-install finder plus no `tests/__init__.py`), so a mutation applied to
the worktree silently produces a green run -- both the red and the green are then fabricated. CI
and the lane harness are unaffected; this is a lead-side local hazard only.

**doc-gate:** the three failing rules are satisfied by the agent-coordination.md edit (routes,
agent-manual) and a `Docs-Reviewed:` trailer for the changelog rule -- the route's response is
byte-identical, so there is no user-visible behaviour for a fragment to describe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified that revoked-agent feeds return only agent identity information: canonical ID and revocation timestamp.
  - Human credential withdrawals and subject type details are excluded from the revoked feed.

- **Documentation**
  - Updated endpoint, data-store, and coordination documentation to describe the scoped revoked-agent response and authentication boundaries.

- **Tests**
  - Added regression coverage confirming revoked-agent responses contain only the documented identity fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->