### PR TITLE
docs: heterogeneous-cluster-profiles references tinyagentos/cluster/task_router.py, which does not exist

### DIFF
--- a/docs/reference/heterogeneous-cluster-profiles.md
+++ b/docs/reference/heterogeneous-cluster-profiles.md
@@ -71,7 +71,7 @@ workers but falls through to any worker with the needed capability.
 6. Dispatch to the best candidate
 
 Step 2-4 is the new part. Steps 5-6 are the existing capability router
-from `tinyagentos/cluster/task_router.py`.
+from `tinyagentos/cluster/router.py`.
 
 ## User experience
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs: heterogeneous-cluster-profiles references tinyagentos/cluster/task_router.py, which does not exist

Autonomous build of board card tsk-h5kwya.



Files:
 docs/reference/heterogeneous-cluster-profiles.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the scheduler reference to point to the correct cluster routing component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## RED EVIDENCE (supplied by @taOS-dev, measured by the lead)

The card for this PR demanded a proven red, but the command it prescribed could never satisfy the
merge gate: it used `grep -c`, which exits 0 and prints a count, and the gate requires failure
vocabulary (FAILED / FAIL: / N failed / exit 1 / SomeError) in a fenced block. That was my defect in
writing the card, not a failure of this build, so I measured the red myself against origin/dev:

```
$ git ls-tree -r --name-only origin/dev | grep 'tinyagentos/cluster/task_router\.py'; echo "exit $?"
exit 1
```

The absence is real and the replacement paths in this diff were each confirmed to exist. Card
authoring now refuses this defect mechanically (spec_cards.py validate(), proven to refuse all five
affected cards and to accept cards whose red a test runner prints).