### PR TITLE
docs: CONTRIBUTING and both skill docs send readers to tests/test_agents.py, which does not exist

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -149,7 +149,7 @@ deps the project does not pin set `check_upgrade = false`.
 - `conftest.py`: `tmp_data_dir` fixture creates temp config + SQLite
 - `app` fixture: `create_app(data_dir=tmp_data_dir)`
 - `client` fixture: `AsyncClient(transport=ASGITransport(app=app))` - async HTTP test client
-- Module mirroring: `tests/test_agents.py` tests `routes/agents.py`
+- Module mirroring: `tests/test_routes_agents.py` tests `routes/agents.py`
 - SPA stubs: conftest creates stub `index.html`/`sw.js` so tests don't need `npm run build`
 - E2E (Playwright) tests excluded from CI and local gate
 

--- a/.claude/skills/taos-development-skill/soul.md
+++ b/.claude/skills/taos-development-skill/soul.md
@@ -66,7 +66,7 @@ System-level recovery is a human decision.
 - Run targeted tests first, then the parallel gate. Never run the un-parallelised full suite
   locally - it takes far too long.
 - Canonical local gate: `uv run pytest tests/ --ignore=tests/e2e -n auto`
-- Tests mirror module structure: `tests/test_agents.py` tests `routes/agents.py`
+- Tests mirror module structure: `tests/test_routes_agents.py` tests `routes/agents.py`
 - Every fix gets a regression test. Every feature gets coverage.
 
 ## Documentation gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ The UI is a React SPA (`desktop/`) built with Vite. Static assets are served fro
 ### Tests
 
 - Use pytest; fixtures live in `tests/conftest.py` - use them
-- Mirror the module structure: `tinyagentos/routes/agents.py` -> `tests/test_agents.py`
+- Mirror the module structure: `tinyagentos/routes/agents.py` -> `tests/test_routes_agents.py`
 - All PRs must pass CI before merge
 
 ### Commits


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs: CONTRIBUTING and both skill docs send readers to tests/test_agents.py, which does not exist

Autonomous build of board card tsk-wnye2s.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

- CONTRIBUTING.md: update 'tests/test_agents.py' to 'tests/test_routes_agents.py'
- .claude/skills/taos-development-skill/SKILL.md: update 'tests/test_agents.py' to 'tests/test_routes_agents.py'
- .claude/skills/taos-development-skill/soul.md: update 'tests/test_agents.py' to 'tests/test_routes_agents.py'

Files:
 .claude/skills/taos-development-skill/SKILL.md | 2 +-
 .claude/skills/taos-development-skill/soul.md  | 2 +-
 CONTRIBUTING.md                                | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)

## RED EVIDENCE (supplied by @taOS-dev, measured by the lead)

The card for this PR demanded a proven red, but the command it prescribed could never satisfy the
merge gate: it used `grep -c`, which exits 0 and prints a count, and the gate requires failure
vocabulary (FAILED / FAIL: / N failed / exit 1 / SomeError) in a fenced block. That was my defect in
writing the card, not a failure of this build, so I measured the red myself against origin/dev:

```
$ git ls-tree -r --name-only origin/dev | grep '^tests/test_agents\.py$'; echo "exit $?"
exit 1
```

The absence is real and the replacement paths in this diff were each confirmed to exist. Card
authoring now refuses this defect mechanically (spec_cards.py validate(), proven to refuse all five
affected cards and to accept cards whose red a test runner prints).