### PR TITLE
docs: the GPU work-queue plan names 7 files that were never created and reads as current

### DIFF
--- a/docs/design/2026-07-17-gpu-work-queue.md
+++ b/docs/design/2026-07-17-gpu-work-queue.md
@@ -1,3 +1,5 @@
+> **Status (2026-08-14): Not implemented.** The file paths referenced below are proposed, not present in the codebase.
+
 # Unified GPU Work Queue — Design Specification
 
 - **Issue:** #1864 ("Follow-up: model loads as evictable submit_gpu tasks (arbiter Option B)"), evolved per owner direction into a broader feature.

--- a/docs/design/plans/2026-07-17-gpu-work-queue-plan.md
+++ b/docs/design/plans/2026-07-17-gpu-work-queue-plan.md
@@ -1,3 +1,5 @@
+> **Status (2026-08-14): Not implemented.** The file paths referenced below are proposed, not present in the codebase.
+
 # Unified GPU Work Queue (taOS #1864) Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan slice-by-slice. Steps use checkbox (`- [ ]`) syntax for tracking.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs: the GPU work-queue plan names 7 files that were never created and reads as current

Autonomous build of board card tsk-jshxc5.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 docs/design/2026-07-17-gpu-work-queue.md            | 2 ++
 docs/design/plans/2026-07-17-gpu-work-queue-plan.md | 2 ++
 2 files changed, 4 insertions(+)

## RED EVIDENCE (supplied by @taOS-dev, measured by the lead)

The card for this PR demanded a proven red, but the command it prescribed could never satisfy the
merge gate: it printed a `grep -c` count per path, and the gate requires failure vocabulary
(FAILED / FAIL: / N failed / exit 1 / SomeError) in a fenced block. That was my defect in writing the
card, not a failure of this build, so I measured the red myself against origin/dev:

```
$ for p in tinyagentos/scheduler/gpu_residency.py tinyagentos/backend_unload.py tinyagentos/routes/gpu_gateway.py tinyagentos/routes/gpu_queue.py tinyagentos/benchmark/gpu_rollup.py desktop/src/stores/gpu-queue-store.ts; do git ls-tree -r --name-only origin/dev | grep -q "^$p$"; echo "$p exit $?"; done
tinyagentos/scheduler/gpu_residency.py exit 1
tinyagentos/backend_unload.py exit 1
tinyagentos/routes/gpu_gateway.py exit 1
tinyagentos/routes/gpu_queue.py exit 1
tinyagentos/benchmark/gpu_rollup.py exit 1
desktop/src/stores/gpu-queue-store.ts exit 1
```

All six paths are genuinely absent, so the NOT-IMPLEMENTED banner this PR adds is correct and no
path in either document was altered, per the card's acceptance line.
