### PR TITLE
tests: shortcuts wire test carries two 'no framework has shortcuts yet' skips while every test passes

### DIFF
--- a/tests/shortcuts/test_frameworks_wire.py
+++ b/tests/shortcuts/test_frameworks_wire.py
@@ -18,16 +18,12 @@ def _first_framework_with_shortcuts():
 def test_validate_accepts_shortcuts_field():
     """validate_framework_manifest must not raise when shortcuts are well-formed."""
     name, fw = _first_framework_with_shortcuts()
-    if fw is None:
-        pytest.skip("No framework has shortcuts yet — will pass after Task 11 adds them")
     validate_framework_manifest(name, fw)  # must not raise
 
 
 def test_validate_rejects_malformed_shortcut():
     """validate_framework_manifest raises ValueError for a bad shortcut entry."""
     name, fw = _first_framework_with_shortcuts()
-    if fw is None:
-        pytest.skip("No framework has shortcuts yet")
     bad = copy.deepcopy(fw)
     bad["shortcuts"][0].pop("kind")
     with pytest.raises(ValueError, match="missing 'kind'"):


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tests: shortcuts wire test carries two 'no framework has shortcuts yet' skips while every test passes

Autonomous build of board card tsk-umm65b.



Files:
 tests/shortcuts/test_frameworks_wire.py | 4 ----
 1 file changed, 4 deletions(-)