### PR TITLE
tests: the user_shares skip guards are stale and would hide a rename as a GREEN skip

### DIFF
--- a/tests/test_user_shares_routes.py
+++ b/tests/test_user_shares_routes.py
@@ -16,6 +16,7 @@ import secrets
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from tinyagentos.user_shares_store import UserSharesStore
 
 
 # ---------------------------------------------------------------------------
@@ -25,11 +26,6 @@ from httpx import ASGITransport, AsyncClient
 @pytest_asyncio.fixture
 async def shares_client(client, tmp_data_dir):
     """Async client with user_shares store initialised + CSRF tokens, as admin."""
-    try:
-        from tinyagentos.user_shares_store import UserSharesStore
-    except ImportError:
-        pytest.skip("UserSharesStore not merged yet (depends on #1897)")
-        return  # unreachable; keeps type-checkers happy
 
     app = client._transport.app
 

--- a/tests/test_user_shares_store.py
+++ b/tests/test_user_shares_store.py
@@ -1,12 +1,7 @@
 """Tests for UserSharesStore — user-to-user resource sharing persistence."""
 
 import pytest
-
-_user_shares_module = pytest.importorskip(
-    "tinyagentos.user_shares_store",
-    reason="UserSharesStore not merged yet (depends on #1897)",
-)
-UserSharesStore = _user_shares_module.UserSharesStore
+from tinyagentos.user_shares_store import UserSharesStore
 
 
 def _require_method(obj, name: str, pr: str) -> None:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tests: the user_shares skip guards are stale and would hide a rename as a GREEN skip

Autonomous build of board card tsk-gdpn7t.



Files:
 tests/test_user_shares_routes.py | 6 +-----
 tests/test_user_shares_store.py  | 7 +------
 2 files changed, 2 insertions(+), 11 deletions(-)