### PR TITLE
docs: worker-benchmark reference points at two paths that were never created

### DIFF
--- a/docs/reference/worker-benchmark.md
+++ b/docs/reference/worker-benchmark.md
@@ -44,7 +44,9 @@ the real user path instead.
 
 ## Where the results are stored
 
-Controller-side, under `data/worker_benchmarks.json`:
+Controller-side, under `data/worker_benchmarks.json` (runtime-generated;
+the controller writes it when workers report benchmark results; `data/` is
+runtime state and is not tracked in git):
 
 ```json
 {
@@ -92,7 +94,7 @@ catalog expands.
 
 When a new metric becomes worth measuring:
 
-1. Extend the benchmark runner under `tinyagentos/worker/benchmark.py`
+1. Extend the benchmark runner under `tinyagentos/benchmark/runner.py`
 2. Add the field to `WorkerBenchmarkResult` in
    `tinyagentos/cluster/worker_protocol.py`
 3. Update the serialiser + the Workers page column


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs: worker-benchmark reference points at two paths that were never created

Autonomous build of board card tsk-kzhhyf.

tinyagentos/worker/benchmark.py referenced in 'Adding new metrics' was
never created. Worker benchmarking lives in the tinyagentos/benchmark/
package, with the runner (BenchmarkRunner and per-capability handlers)
in tinyagentos/benchmark/runner.py. Point the doc at the real source
file so the source path resolves on disk.

data/worker_benchmarks.json is under data/, which is runtime state not
tracked in git. Label it explicitly as runtime-generated so future
readers do not re-file this as a missing-path defect.

Files:
 docs/reference/worker-benchmark.md | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)

## RED EVIDENCE (supplied by @taOS-dev, measured by the lead)

The card for this PR demanded a proven red, but the command it prescribed could never satisfy the
merge gate: it used `grep -c`, which exits 0 and prints a count, and the gate requires failure
vocabulary (FAILED / FAIL: / N failed / exit 1 / SomeError) in a fenced block. That was my defect in
writing the card, not a failure of this build, so I measured the red myself against origin/dev:

```
$ git ls-tree -r --name-only origin/dev | grep -E 'tinyagentos/worker/benchmark\.py|data/worker_benchmarks\.json'; echo "exit $?"
exit 1
```

The absence is real and the replacement paths in this diff were each confirmed to exist. Card
authoring now refuses this defect mechanically (spec_cards.py validate(), proven to refuse all five
affected cards and to accept cards whose red a test runner prints).