### PR TITLE
Settings: Notifications pane with per-type toggles (disable e.g. task.claimed)

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -17,6 +17,7 @@ import {
   UserCircle,
   ScrollText,
   Save,
+  Bell,
 } from "lucide-react";
 import {
   Button,
@@ -36,12 +37,13 @@ import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
 import { UsersSection } from "@/apps/SettingsApp/UsersPanel";
 import { AccountSection } from "@/apps/SettingsApp/AccountPanel";
 import { LogsSection } from "@/apps/SettingsApp/LogsPanel";
+import { NotificationsPanel } from "@/apps/SettingsApp/NotificationsPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
-type Section = "account" | "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes" | "logs";
+type Section = "account" | "system" | "storage" | "memory" | "backup" | "updates" | "advanced" | "shortcuts" | "accessibility" | "desktop" | "users" | "themes" | "logs" | "notifications";
 
 interface SectionDef {
   id: Section;
@@ -83,6 +85,7 @@ const SECTIONS: SectionDef[] = [
   { id: "users", label: "Users", icon: Users },
   { id: "themes", label: "Themes", icon: Palette },
   { id: "logs", label: "Logs", icon: ScrollText },
+  { id: "notifications", label: "Notifications", icon: Bell },
 ];
 
 // Sections that require admin privileges to view (GHSA-47g9: backend already
@@ -936,6 +939,7 @@ export function SettingsApp({ windowId: _windowId, section: initialSection }: { 
     users: <UsersSection />,
     themes: <ThemesPanel />,
     logs: <LogsSection />,
+    notifications: <NotificationsPanel />,
   };
 
   const handleSelectSection = (id: Section) => {

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from "react";
+import { Card, Label, Switch } from "@/components/ui";
+
+interface NotifPref {
+  event_type: string;
+  muted: boolean;
+}
+
+const NOTIF_TYPES = [
+  { type: "worker.join", label: "Worker joined", desc: "A new worker connects to the cluster" },
+  { type: "worker.online", label: "Worker online", desc: "A worker comes online" },
+  { type: "worker.leave", label: "Worker left", desc: "A worker disconnects from the cluster" },
+  { type: "backend.up", label: "Backend up", desc: "A model backend comes online" },
+  { type: "backend.down", label: "Backend down", desc: "A model backend goes offline" },
+  { type: "training.complete", label: "Training complete", desc: "A training run finishes successfully" },
+  { type: "training.failed", label: "Training failed", desc: "A training run fails" },
+  { type: "app.installed", label: "App installed", desc: "A new app is installed" },
+  { type: "app.failed", label: "App install failed", desc: "An app installation fails" },
+  { type: "disk_quota", label: "Disk quota", desc: "Disk usage approaches the limit" },
+  { type: "task.claimed", label: "Task claimed", desc: "A task is claimed by a worker" },
+  { type: "task.closed", label: "Task closed", desc: "A task is closed" },
+];
+
+export function NotificationsPanel() {
+  const [prefs, setPrefs] = useState<NotifPref[] | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/notifications/prefs")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data && Array.isArray(data)) setPrefs(data);
+        else setError("Could not load notification preferences.");
+      })
+      .catch(() => setError("Could not reach backend."));
+  }, []);
+
+  const toggle = async (eventType: string, muted: boolean) => {
+    setSaving(eventType);
+    setError(null);
+    try {
+      const res = await fetch(`/api/notifications/prefs/${encodeURIComponent(eventType)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ muted }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || `Failed to save (${res.status})`);
+        return;
+      }
+      setPrefs((prev) =>
+        prev
+          ? prev.map((p) => (p.event_type === eventType ? { ...p, muted } : p))
+          : prev
+      );
+    } catch {
+      setError("Could not reach backend.");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (!prefs) {
+    return (
+      <section aria-label="Notification settings">
+        <h2 className="text-lg font-semibold mb-5">Notifications</h2>
+        <p className="text-sm text-shell-text-tertiary">Loading...</p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Notification settings">
+      <h2 className="text-lg font-semibold mb-2">Notifications</h2>
+      <p className="text-sm text-shell-text-tertiary mb-5">
+        Choose which notification types to receive. Disabled types are suppressed
+        everywhere -- no in-app notification, no web push.
+      </p>
+
+      {error && (
+        <p className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+          {error}
+        </p>
+      )}
+
+      <div className="space-y-2">
+        {NOTIF_TYPES.map((item) => {
+          const pref = prefs.find((p) => p.event_type === item.type);
+          const checked = pref ? !pref.muted : true;
+          const id = `notif-${item.type}`;
+          return (
+            <Card key={item.type} className="p-4 flex items-center justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <Label htmlFor={id} className="text-sm font-medium text-shell-text">
+                  {item.label}
+                </Label>
+                <p className="text-xs text-shell-text-tertiary mt-0.5">{item.desc}</p>
+              </div>
+              <Switch
+                id={id}
+                checked={checked}
+                onCheckedChange={(v) => toggle(item.type, !v)}
+                disabled={saving === item.type}
+                aria-label={`${item.label} notifications`}
+              />
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import aiosqlite
@@ -245,3 +246,66 @@ async def test_notification_api_archived_history(client):
     assert resp.status_code == 200
     data = resp.json()
     assert [d["title"] for d in data] == ["Kept"]
+
+
+@pytest.mark.asyncio
+async def test_muted_event_type_is_not_dispatched(tmp_path):
+    store = NotificationStore(tmp_path / "notif.db")
+    await store.init()
+    try:
+        await store.set_event_muted("task.claimed", True)
+
+        seen_push: list[dict] = []
+        seen_emit: list[dict] = []
+
+        async def push_sender(row: dict) -> None:
+            seen_push.append(row)
+
+        async def emitter(row: dict) -> None:
+            seen_emit.append(row)
+
+        store.set_push_sender(push_sender)
+        store.set_event_emitter(emitter)
+
+        await store.add(
+            "Task claimed",
+            "task-42 claimed by worker-1",
+            level="info",
+            source="task.claimed",
+        )
+        await asyncio.sleep(0)
+
+        assert await store.list() == []
+        assert seen_push == []
+        assert seen_emit == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_unmuted_event_type_is_dispatched(tmp_path):
+    store = NotificationStore(tmp_path / "notif.db")
+    await store.init()
+    try:
+        seen_push: list[dict] = []
+
+        async def push_sender(row: dict) -> None:
+            seen_push.append(row)
+
+        store.set_push_sender(push_sender)
+
+        await store.add(
+            "Task closed",
+            "task-42 closed",
+            level="info",
+            source="task.closed",
+        )
+        await asyncio.sleep(0)
+
+        items = await store.list()
+        assert len(items) == 1
+        assert items[0]["title"] == "Task closed"
+        assert len(seen_push) == 1
+        assert seen_push[0]["title"] == "Task closed"
+    finally:
+        await store.close()

--- a/tests/test_notifications_prefs.py
+++ b/tests/test_notifications_prefs.py
@@ -4,13 +4,16 @@ from tinyagentos.notifications import NotificationStore
 
 
 @pytest.mark.asyncio
-async def test_get_prefs_returns_all_event_types_default_unmuted(client):
+async def test_get_prefs_returns_all_event_types_with_correct_defaults(client):
     r = await client.get("/api/notifications/prefs")
     assert r.status_code == 200
     prefs = r.json()
     assert len(prefs) == len(NotificationStore.EVENT_TYPES)
     assert {p["event_type"] for p in prefs} == set(NotificationStore.EVENT_TYPES)
-    for pref in prefs:
+    task_claimed = next(p for p in prefs if p["event_type"] == "task.claimed")
+    assert task_claimed["muted"] is True
+    others = [p for p in prefs if p["event_type"] != "task.claimed"]
+    for pref in others:
         assert pref["muted"] is False
 
 

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -61,6 +61,7 @@ class NotificationStore(BaseStore):
         "training.complete", "training.failed", "app.installed", "app.failed",
         "disk_quota", "task.claimed", "task.closed",
     ]
+    _DEFAULT_MUTED: set[str] = {"task.claimed"}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -96,6 +97,8 @@ class NotificationStore(BaseStore):
 
     async def _dispatch_push(self, row: dict) -> None:
         """Run the web-push sender, isolating every failure from add()."""
+        if row.get("source") in self._DEFAULT_MUTED:
+            return
         try:
             await self._push_sender(row)
         except Exception:
@@ -161,6 +164,8 @@ class NotificationStore(BaseStore):
                 user id, web-push delivery fans out only to that user's
                 subscriptions.
         """
+        if source in self._DEFAULT_MUTED or await self._is_event_muted(source):
+            return
         ts = int(time.time())
         data_json = json.dumps(data) if data is not None else None
         cursor = await self._db.execute(
@@ -306,7 +311,9 @@ class NotificationStore(BaseStore):
             "SELECT muted FROM notification_prefs WHERE event_type = ?", (event_type,)
         ) as cursor:
             row = await cursor.fetchone()
-        return bool(row[0]) if row else False
+        if row is not None:
+            return bool(row[0])
+        return event_type in self._DEFAULT_MUTED
 
     async def set_event_muted(self, event_type: str, muted: bool) -> None:
         await self._db.execute(
@@ -322,6 +329,6 @@ class NotificationStore(BaseStore):
             rows = await cursor.fetchall()
         stored = {r[0]: bool(r[1]) for r in rows}
         return [
-            {"event_type": et, "muted": stored.get(et, False)}
+            {"event_type": et, "muted": stored.get(et, et in self._DEFAULT_MUTED)}
             for et in self.EVENT_TYPES
         ]


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Settings: Notifications pane with per-type toggles (disable e.g. task.claimed)

Autonomous build of board card tsk-t52zqq.

- Add _DEFAULT_MUTED set (task.claimed off by default) to NotificationStore
- Filter muted event types in NotificationStore.add() and _dispatch_push()
  so disabled types are suppressed at dispatch: no DB row, no in-app
  notification, no web push
- Update _is_event_muted() to fall back to _DEFAULT_MUTED for unstored types
- Update get_event_prefs() to report correct defaults for unstored types
- Update test_get_prefs_returns_all_event_types_with_correct_defaults to
  expect task.claimed muted by default
- Add test_muted_event_type_is_not_dispatched and
  test_unmuted_event_type_is_dispatched verifying the dispatch filter
- Add Settings > Notifications panel with per-type on/off toggles wired to
  /api/notifications/prefs GET/PUT endpoints (already present)

Files:
 desktop/src/apps/SettingsApp.tsx                   |   6 +-
 .../src/apps/SettingsApp/NotificationsPanel.tsx    | 114 +++++++++++++++++++++
 tests/test_notifications.py                        |  64 ++++++++++++
 tests/test_notifications_prefs.py                  |   7 +-
 tinyagentos/notifications.py                       |  11 +-
 5 files changed, 197 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Notifications section in Settings.
  * View supported notification types and toggle mute preferences.
  * Notification preference changes are saved automatically with loading and error feedback.

* **Bug Fixes**
  * Task-claimed notifications are muted by default.
  * Muted notifications are no longer saved or delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->