### PR TITLE
Projects Lists tab: stack the panels on mobile, and replace prompt/confirm/alert with real dialogs

### DIFF
--- a/changelog.d/2411-projects-lists-dialogs-mobile.md
+++ b/changelog.d/2411-projects-lists-dialogs-mobile.md
@@ -1,0 +1,2 @@
+### Fixed
+- Projects Lists tab no longer uses the browser's native `prompt`, `confirm` and `alert`: creating a list, deleting a list, removing an entry and viewing an entry's original text now use real in-app dialogs, so they are keyboard-accessible, themable and cannot be suppressed by the browser. The rail and entries panel also stack vertically under 768px instead of being squeezed side by side (#2411).

--- a/desktop/src/apps/ProjectsApp/CreateListDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateListDialog.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { projectsApi } from "@/lib/projects";
+
+interface CreateListDialogProps {
+  projectId: string;
+  onClose: () => void;
+  onCreated: (listId: string) => void;
+}
+
+export function CreateListDialog({ projectId, onClose, onCreated }: CreateListDialogProps) {
+  const [title, setTitle] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await projectsApi.lists.create(projectId, { title: trimmed });
+      onCreated(created.id);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="New list"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <form
+        onSubmit={onSubmit}
+        className="bg-zinc-900 p-4 rounded shadow w-full max-w-sm space-y-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-semibold">New list</h3>
+        <label className="block text-sm text-zinc-400">
+          Name
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            type="text"
+            autoFocus
+            required
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          />
+        </label>
+        {error && <div role="alert" className="text-sm text-red-400">{error}</div>}
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 text-sm text-zinc-300 hover:text-zinc-100 disabled:opacity-50">
+            Cancel
+          </button>
+          <button type="submit" disabled={submitting} className="px-3 py-1 bg-blue-600 rounded text-sm font-medium text-white disabled:opacity-50">
+            {submitting ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/desktop/src/apps/ProjectsApp/ProjectLists.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectLists.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { projectsApi, type Project, type ProjectList, type ProjectListEntry } from "@/lib/projects";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { CreateListDialog } from "./CreateListDialog";
 import styles from "./ProjectsApp.module.css";
 
 const STATUS_STYLE: Record<string, string> = {
@@ -19,6 +21,10 @@ export function ProjectLists({ project }: { project: Project }) {
   const [error, setError] = useState<string | null>(null);
   const [quickText, setQuickText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [removeConfirmEntry, setRemoveConfirmEntry] = useState<{ listId: string; entryId: string } | null>(null);
+  const [showOriginalId, setShowOriginalId] = useState<string | null>(null);
   const quickInputRef = useRef<HTMLInputElement>(null);
   // Current selection, readable from inside an async closure that captured an
   // older one. Assigned during render so it is correct before any effect runs.
@@ -109,22 +115,16 @@ export function ProjectLists({ project }: { project: Project }) {
     return () => { cancelled = true; };
   }, [selectedListId, refreshEntries]);
 
-  const createList = async () => {
-    // Trim BEFORE the empty check: "   " is truthy, so a whitespace-only
-    // answer used to reach the API as an empty title.
-    const title = prompt("New list name")?.trim();
-    if (!title) return;
-    try {
-      const created = await projectsApi.lists.create(project.id, { title });
-      await refreshLists();
-      setSelectedListId(created.id);
-    } catch (err) {
-      setError(String(err));
-    }
-  };
+  const handleCreatedList = useCallback((listId: string) => {
+    setCreateDialogOpen(false);
+    setSelectedListId(listId);
+    refreshLists();
+  }, [refreshLists]);
 
-  const deleteList = async (listId: string) => {
-    if (!confirm("Delete this list and all its entries?")) return;
+  const confirmDeleteList = useCallback(async () => {
+    if (!deleteConfirmId) return;
+    const listId = deleteConfirmId;
+    setDeleteConfirmId(null);
     try {
       await projectsApi.lists.remove(project.id, listId);
       if (selectedListId === listId) setSelectedListId(null);
@@ -132,7 +132,19 @@ export function ProjectLists({ project }: { project: Project }) {
     } catch (err) {
       setError(String(err));
     }
-  };
+  }, [deleteConfirmId, project.id, refreshLists, selectedListId]);
+
+  const confirmRemoveEntry = useCallback(async () => {
+    if (!removeConfirmEntry) return;
+    const { listId, entryId } = removeConfirmEntry;
+    setRemoveConfirmEntry(null);
+    try {
+      await projectsApi.lists.entries.remove(project.id, listId, entryId);
+      await refreshEntries();
+    } catch (err) {
+      setError(String(err));
+    }
+  }, [removeConfirmEntry, project.id, refreshEntries]);
 
   const createEntry = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -169,27 +181,17 @@ export function ProjectLists({ project }: { project: Project }) {
     }
   };
 
-  const removeEntry = async (entry: ProjectListEntry) => {
-    if (!confirm("Remove this entry?")) return;
-    try {
-      await projectsApi.lists.entries.remove(project.id, entry.list_id, entry.id);
-      await refreshEntries();
-    } catch (err) {
-      setError(String(err));
-    }
-  };
-
   const selectedList = lists.find((l) => l.id === selectedListId) ?? EMPTY_LIST;
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex flex-1 min-h-0 gap-3">
+      <div className={`${styles.listsContainer} flex flex-1 min-h-0 gap-3`}>
         <aside className={styles.listsRail} aria-label="Lists">
           <div className="flex items-center justify-between mb-2">
             <h2 className="text-sm font-semibold text-shell-text">Lists</h2>
             <button
               type="button"
-              onClick={createList}
+              onClick={() => setCreateDialogOpen(true)}
               aria-label="Create new list"
               className="rounded-full bg-accent/10 px-2 py-1 text-xs font-medium text-accent hover:bg-accent/20"
             >
@@ -216,7 +218,7 @@ export function ProjectLists({ project }: { project: Project }) {
                   <button
                     type="button"
                     aria-label={`Delete ${lst.title || "Untitled list"}`}
-                    onClick={(e) => { e.stopPropagation(); deleteList(lst.id); }}
+                    onClick={(e) => { e.stopPropagation(); setDeleteConfirmId(lst.id); }}
                     className="rounded p-0.5 text-shell-text-tertiary hover:text-red-400"
                   >
                     ×
@@ -301,20 +303,25 @@ export function ProjectLists({ project }: { project: Project }) {
                             {entry.status}
                           </span>
                           {tidied && (
-                            <span
-                              className="inline-flex items-center gap-1 text-xs text-shell-text-tertiary cursor-pointer hover:text-shell-text"
-                              title={entry.original_text}
-                              tabIndex={0}
-                              role="button"
-                              aria-label={`View original text for ${entry.text}`}
-                              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); alert(entry.original_text); } }}
-                              onClick={() => alert(entry.original_text)}
-                            >
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                                <circle cx="12" cy="12" r="3" />
-                              </svg>
-                              original
+                            <span className="relative inline-flex">
+                              <button
+                                type="button"
+                                className="inline-flex items-center gap-1 text-xs text-shell-text-tertiary hover:text-shell-text"
+                                title={entry.original_text}
+                                onClick={() => setShowOriginalId(showOriginalId === entry.id ? null : entry.id)}
+                                aria-label={`View original text for ${entry.text}`}
+                              >
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                                  <circle cx="12" cy="12" r="3" />
+                                </svg>
+                                original
+                              </button>
+                              {showOriginalId === entry.id && (
+                                <div className="absolute left-0 top-full mt-1 z-50 text-xs text-shell-text bg-shell-bg-deep border border-shell-border rounded-lg p-2.5 shadow-lg whitespace-pre-wrap max-w-[280px]" role="tooltip">
+                                  {entry.original_text}
+                                </div>
+                              )}
                             </span>
                           )}
                           <div className="ml-auto flex gap-2 text-xs">
@@ -331,7 +338,7 @@ export function ProjectLists({ project }: { project: Project }) {
                             </select>
                             <button
                               type="button"
-                              onClick={() => removeEntry(entry)}
+                              onClick={() => setRemoveConfirmEntry({ listId: entry.list_id, entryId: entry.id })}
                               aria-label={`Delete entry ${entry.text}`}
                               className="text-red-400 hover:underline"
                             >
@@ -351,6 +358,36 @@ export function ProjectLists({ project }: { project: Project }) {
           )}
         </main>
       </div>
+
+      {createDialogOpen && (
+        <CreateListDialog
+          projectId={project.id}
+          onClose={() => setCreateDialogOpen(false)}
+          onCreated={handleCreatedList}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!deleteConfirmId}
+        title="Delete list"
+        message="This will delete the list and all its entries. This cannot be undone."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={confirmDeleteList}
+        onCancel={() => setDeleteConfirmId(null)}
+      />
+
+      <ConfirmDialog
+        open={!!removeConfirmEntry}
+        title="Remove entry"
+        message="Remove this entry from the list?"
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={confirmRemoveEntry}
+        onCancel={() => setRemoveConfirmEntry(null)}
+      />
     </div>
   );
 }

--- a/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
+++ b/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
@@ -885,6 +885,13 @@
   min-height: 0;
 }
 
+.listsContainer {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: 12px;
+}
+
 .listsEntriesPanel {
   flex: 1;
   min-height: 0;
@@ -895,6 +902,9 @@
 }
 
 @media (max-width: 767px) {
+  .listsContainer {
+    flex-direction: column;
+  }
   .listsRail {
     width: 100%;
     min-height: auto;

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectLists.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, act, fireEvent, waitFor, within } from "@testing-librar
 import type { Project } from "@/lib/projects";
 import { ProjectLists } from "../ProjectLists";
 
+vi.mock("../../../hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+import { useIsMobile } from "../../../hooks/use-is-mobile";
+
 const fakeProject: Project = {
   id: "p1",
   slug: "p1",
@@ -144,15 +149,18 @@ describe("ProjectLists", () => {
   // (only the mount effect ever called setLists), so a created list never
   // appeared and a deleted one never left.
   it("a created list appears in the rail", async () => {
-    vi.stubGlobal("prompt", vi.fn(() => "New list"));
     await act(async () => {
       render(<ProjectLists project={fakeProject} />);
     });
     await act(async () => {
       fireEvent.click(screen.getByLabelText("Create new list"));
     });
-    // Scope to the rail: the entries header renders the selected list's title
-    // too, so a whole-document match could pass while the rail stayed stale.
+    const dialog = screen.getByRole("dialog", { name: /new list/i });
+    const input = within(dialog).getByRole("textbox");
+    fireEvent.change(input, { target: { value: "New list" } });
+    await act(async () => {
+      fireEvent.submit(input.closest("form")!);
+    });
     await waitFor(() => {
       const rail = screen.getByLabelText("Project lists");
       expect(within(rail).getByText("New list")).toBeInTheDocument();
@@ -177,12 +185,17 @@ describe("ProjectLists", () => {
   });
 
   it("a whitespace-only list name creates nothing", async () => {
-    vi.stubGlobal("prompt", vi.fn(() => "   "));
     await act(async () => {
       render(<ProjectLists project={fakeProject} />);
     });
     await act(async () => {
       fireEvent.click(screen.getByLabelText("Create new list"));
+    });
+    const dialog = screen.getByRole("dialog", { name: /new list/i });
+    const input = within(dialog).getByRole("textbox");
+    fireEvent.change(input, { target: { value: "   " } });
+    await act(async () => {
+      fireEvent.submit(input.closest("form")!);
     });
     const posted = fetchMock.mock.calls.find(([u, i]) => String(u) === "/api/projects/p1/lists" && (i as RequestInit | undefined)?.method === "POST");
     expect(posted).toBeUndefined();
@@ -227,7 +240,6 @@ describe("ProjectLists", () => {
   });
 
   it("a deleted list disappears from the rail", async () => {
-    vi.stubGlobal("confirm", vi.fn(() => true));
     await act(async () => {
       render(<ProjectLists project={fakeProject} />);
     });
@@ -235,6 +247,59 @@ describe("ProjectLists", () => {
     await act(async () => {
       fireEvent.click(screen.getByLabelText("Delete Shopping"));
     });
-    await waitFor(() => expect(screen.queryByText("Shopping")).not.toBeInTheDocument());
+    const confirmDialog = screen.getByRole("dialog", { name: /delete list/i });
+    expect(confirmDialog).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(within(confirmDialog).getByRole("button", { name: "Delete" }));
+    });
+    await waitFor(() => {
+      const rail = screen.queryByLabelText("Project lists");
+      if (rail) {
+        expect(within(rail).queryByText("Shopping")).not.toBeInTheDocument();
+      } else {
+        expect(screen.queryByText("Shopping")).not.toBeInTheDocument();
+      }
+    });
+  });
+
+  it("stacks the rail and entries panel on mobile", async () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    const container = document.querySelector("[class*='listsContainer']");
+    expect(container).toBeTruthy();
+    expect(screen.getByLabelText("Project lists")).toBeInTheDocument();
+    expect(screen.getByLabelText("List entries")).toBeInTheDocument();
+  });
+
+  it("removes an entry after confirming the delete dialog", async () => {
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    await waitFor(() => expect(screen.getByText("Milk")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("Delete entry Milk"));
+    });
+    const confirmDialog = screen.getByRole("dialog", { name: /remove entry/i });
+    expect(confirmDialog).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(within(confirmDialog).getByRole("button", { name: "Remove" }));
+    });
+    await waitFor(() => expect(screen.queryByText("Milk")).not.toBeInTheDocument());
+  });
+
+  it("shows the original text in a popover instead of alert when the original button is clicked", async () => {
+    const alertMock = vi.fn();
+    vi.stubGlobal("alert", alertMock);
+    await act(async () => {
+      render(<ProjectLists project={fakeProject} />);
+    });
+    await waitFor(() => expect(screen.getByText("original")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText("View original text for Bread"));
+    });
+    expect(screen.getByText("Whole grain bread")).toBeInTheDocument();
+    expect(alertMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Projects Lists tab: stack the panels on mobile, and replace prompt/confirm/alert with real dialogs

Autonomous build of board card tsk-7wwcdg.



Files:
 desktop/src/apps/ProjectsApp/CreateListDialog.tsx  |  70 ++++++++++++
 desktop/src/apps/ProjectsApp/ProjectLists.tsx      | 121 ++++++++++++++-------
 .../src/apps/ProjectsApp/ProjectsApp.module.css    |  10 ++
 .../ProjectsApp/__tests__/ProjectLists.test.tsx    |  77 ++++++++++++-
 4 files changed, 230 insertions(+), 48 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dialog for creating project lists with validation and error feedback.
  * Added confirmation dialogs for deleting lists and entries.
  * Added list refresh and selection updates after changes.
  * Added an inline popover for viewing original text.
  * Improved responsive layout for mobile screens.

* **Bug Fixes**
  * Replaced browser prompts and alerts with accessible in-app dialogs and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->