### PR TITLE
Route the doc-gate changelog prerequisite into a file agents actually load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+Harness-agnostic entry point: read by any agent harness that loads `AGENTS.md`
+(kilo, opencode, Claude, Cursor, ...).
+
+## Changelog fragments
+
+A non-test change under `tinyagentos/` or `desktop/src/` requires a
+`changelog.d/<pr>-<slug>.md` fragment (or a `CHANGELOG.md` line) in the same
+PR. The single-source rule lives in [`docs/changelog-fragments.md`](docs/changelog-fragments.md)
+and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Changelog" section).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+Loaded by the Claude CLI / Claude Code agent when present at the repo root.
+
+## Changelog fragments
+
+A non-test change under `tinyagentos/` or `desktop/src/` requires a
+`changelog.d/<pr>-<slug>.md` fragment (or a `CHANGELOG.md` line) in the same
+PR. The single-source rule lives in [`docs/changelog-fragments.md`](docs/changelog-fragments.md)
+and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Changelog" section).


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Route the doc-gate changelog prerequisite into a file agents actually load

Autonomous build of board card tsk-pto4bl.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

Add AGENTS.md (harness-agnostic entry point) and create CLAUDE.md, each
carrying a short pointer to the single-source changelog-fragment rule in
docs/changelog-fragments.md and CONTRIBUTING.md. The pointer states the
trigger (a non-test change under tinyagentos/ or desktop/src/ requires a
changelog.d/ fragment) and links the canonical doc without restating the
rule in full. No other files are modified and the gate is satisfied.

Files:
 AGENTS.md | 11 +++++++++++
 CLAUDE.md | 10 ++++++++++
 2 files changed, 21 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance explaining when changelog entries are required for non-test changes.
  * Linked the guidance to the detailed changelog policy and contribution instructions.
  * Provided consistent documentation entry points for different development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->