### PR TITLE
Verify the 4 remaining Hailo .hef sha256 values in the model catalog

### DIFF
--- a/app-catalog/models/llama-3.2-3b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/llama-3.2-3b-instruct-hef/manifest.yaml
@@ -14,7 +14,7 @@ variants:
   size_mb: 3214
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/Llama-3_2-3B-Instruct.hef
   # Accuracy is under active optimization in the v5.1.1 Hailo Model Zoo release.
-  sha256: 1129f5f8384e4e45c5890104dc4ec1aee77e800ce1484ddc3aa942399aada425
+  sha256: 7fc9c7723282482cc3acf08244212668f8b7684deb792b791504ab7f68a83708
   requires:
     backends:
     - id: hailo-ollama

--- a/changelog.d/tsk-nvnc5n-model-catalog-sha256-fix.md
+++ b/changelog.d/tsk-nvnc5n-model-catalog-sha256-fix.md
@@ -1,0 +1,2 @@
+### Fixed
+- Llama 3.2 3B Instruct HEF model sha256 corrected in manifest after verification against upstream download


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Verify the 4 remaining Hailo .hef sha256 values in the model catalog

Autonomous build of board card tsk-nvnc5n.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 app-catalog/models/llama-3.2-3b-instruct-hef/manifest.yaml | 2 +-
 changelog.d/tsk-nvnc5n-model-catalog-sha256-fix.md         | 2 ++
 2 files changed, 3 insertions(+), 1 deletion(-)