### PR TITLE
Hailo backend slice 6: .hef model catalog (Qwen/Llama/DeepSeek)

### DIFF
--- a/app-catalog/catalog.yaml
+++ b/app-catalog/catalog.yaml
@@ -524,6 +524,38 @@ apps:
     name: Qwen 2.5 14B Instruct (RKLLM)
     description: "NPU-accelerated Qwen 2.5 14B on RK3588 32GB"
 
+  # --- Added: Hailo-10H NPU-accelerated (Hailo) ---
+  - id: qwen2-1.5b
+    type: model
+    version: 2.0.0
+    name: Qwen2 1.5B Instruct (HEF)
+    description: "Hailo-10H NPU-accelerated Qwen2 1.5B — Pi 5 + AI HAT+2"
+  - id: qwen2.5-1.5b
+    type: model
+    version: 2.5.0
+    name: Qwen 2.5 1.5B Instruct (HEF)
+    description: "Hailo-10H NPU-accelerated Qwen 2.5 1.5B — Pi 5 + AI HAT+2"
+  - id: qwen2.5-coder-1.5b
+    type: model
+    version: 2.5.0
+    name: Qwen 2.5 Coder 1.5B Instruct (HEF)
+    description: "Hailo-10H NPU-accelerated Qwen 2.5 Coder 1.5B — Pi 5 + AI HAT+2"
+  - id: qwen3
+    type: model
+    version: 3.0.0
+    name: Qwen 3 1.7B Instruct (HEF)
+    description: "Hailo-10H NPU-accelerated Qwen 3 1.7B — Pi 5 + AI HAT+2"
+  - id: llama3.2-1b
+    type: model
+    version: 3.2.0
+    name: Llama 3.2 1B Instruct (HEF)
+    description: "Hailo-10H NPU-accelerated Llama 3.2 1B — Pi 5 + AI HAT+2"
+  - id: deepseek-r1-1.5b
+    type: model
+    version: 1.5.0
+    name: DeepSeek R1 1.5B (HEF)
+    description: "Hailo-10H NPU-accelerated DeepSeek R1 1.5B — Pi 5 + AI HAT+2"
+
   # --- Existing (re-registered for completeness) ---
   - id: deepseek-r1-14b
     type: model

--- a/app-catalog/models/deepseek-r1-1.5b/manifest.yaml
+++ b/app-catalog/models/deepseek-r1-1.5b/manifest.yaml
@@ -1,0 +1,31 @@
+id: deepseek-r1-1.5b
+name: DeepSeek R1 1.5B (HEF)
+type: model
+version: 1.5.0
+description: "Hailo-10H NPU-accelerated DeepSeek R1 1.5B — reasoning model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+license: MIT
+capabilities:
+- chat
+- reasoning
+variants:
+- id: a8w4
+  name: A8W4 HEF (2.2GB, NPU)
+  format: hef
+  size_mb: 2261
+  min_ram_mb: 0
+  hef_h10h: 9c4506dda44d0a1730d939d4049a3cbf72d5179a88762ca551363db087adb38f
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/llama3.2-1b/manifest.yaml
+++ b/app-catalog/models/llama3.2-1b/manifest.yaml
@@ -1,0 +1,30 @@
+id: llama3.2-1b
+name: Llama 3.2 1B Instruct (HEF)
+type: model
+version: 3.2.0
+description: "Hailo-10H NPU-accelerated Llama 3.2 1B Instruct — Meta's lightest model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
+license: llama3.2
+capabilities:
+- chat
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.6GB, NPU)
+  format: hef
+  size_mb: 1600
+  min_ram_mb: 0
+  hef_h10h: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/qwen2-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2-1.5b/manifest.yaml
@@ -1,0 +1,30 @@
+id: qwen2-1.5b
+name: Qwen2 1.5B Instruct (HEF)
+type: model
+version: 2.0.0
+description: "Hailo-10H NPU-accelerated Qwen2 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen2-1.5B-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.6GB, NPU)
+  format: hef
+  size_mb: 1600
+  min_ram_mb: 0
+  hef_h10h: ab056548c60945cdf4fb30ca43fc7aeed2b9ffc751ad8d4c201dc4c4ab31e86a
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/qwen2.5-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b/manifest.yaml
@@ -32,11 +32,27 @@ variants:
       - cpu
       min_ram_mb: 2048
   sha256: 1adf0b11065d8ad2e8123ea110d1ec956dab4ab038eab665614adba04b6c3370
+- id: a8w4
+  name: A8W4 HEF (2.2GB, NPU)
+  format: hef
+  size_mb: 2250
+  min_ram_mb: 0
+  hef_h10h: 5310176848638505fbc28add04ba60c97abe345cdb0ec7e3b8ffaa4b0a8c65dd
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
 hardware_tiers:
   arm-cpu-8gb:
     recommended: q4_k_m
+  arm-npu-8gb:
+    recommended: a8w4
   arm-npu-16gb:
-    recommended: q4_k_m
+    recommended: a8w4
   x86-vulkan-4gb:
     recommended: q4_k_m
   cpu-only:

--- a/app-catalog/models/qwen2.5-coder-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b/manifest.yaml
@@ -1,0 +1,32 @@
+id: qwen2.5-coder-1.5b
+name: Qwen 2.5 Coder 1.5B Instruct (HEF)
+type: model
+version: 2.5.0
+description: "Hailo-10H NPU-accelerated Qwen 2.5 Coder 1.5B — fast, small code-focused model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+- tool-calling
+- code
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.7GB, NPU)
+  format: hef
+  size_mb: 1675
+  min_ram_mb: 0
+  hef_h10h: 88aa7633ebe3385452430ae19f2b459b5a00791cab035576a3262a41ec1350f5
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/qwen3/manifest.yaml
+++ b/app-catalog/models/qwen3/manifest.yaml
@@ -1,0 +1,31 @@
+id: qwen3
+name: Qwen 3 1.7B Instruct (HEF)
+type: model
+version: 3.0.0
+description: "Hailo-10H NPU-accelerated Qwen 3 1.7B Instruct — tiny chat model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen3-1.7B-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+- tool-calling
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.8GB, NPU)
+  format: hef
+  size_mb: 1800
+  min_ram_mb: 0
+  hef_h10h: d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5
+  install:
+    method: hailo-ollama-pull
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/changelog.d/tsk-3t4b6j-hailo-hef-catalog.md
+++ b/changelog.d/tsk-3t4b6j-hailo-hef-catalog.md
@@ -1,0 +1,2 @@
+### Added
+- Hailo-10H .hef model catalog manifests for qwen2.5-1.5b, qwen3, qwen2.5-coder-1.5b, qwen2-1.5b, llama3.2-1b, and deepseek-r1-1.5b, using the hailo-ollama-pull install method instead of direct download.

--- a/docs/catalog-platform-status.md
+++ b/docs/catalog-platform-status.md
@@ -69,6 +69,19 @@ Pre-loaded by `install-rknpu.sh` (separate from Store install path):
 | `qwen3-reranker-0.6b` | ✅ | ✅ | embedded in rkllama default load |
 | `qmd-query-expansion` | ✅ | ✅ | embedded in rkllama default load |
 
+## LLM models — HEF format (Hailo-10H NPU)
+
+Catalog entries with `format: hef` + `backend: [hailo-ollama]`. Pulled via `hailo-ollama pull` (Ollama-compatible `/api/pull`).
+
+| Model | Pi-NPU-8GB | Pi-NPU-16GB | Source | Notes |
+|---|---|---|---|---|
+| `qwen2-1.5b` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | |
+| `qwen2.5-1.5b` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | |
+| `qwen2.5-coder-1.5b` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | |
+| `qwen3` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | 1.7B variant |
+| `llama3.2-1b` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | |
+| `deepseek-r1-1.5b` | ⏳ | ⏳ | dev-public.hailo.ai/v5.1.1 | reasoning |
+
 ## LLM models — GGUF format (rk-llama.cpp / Ollama / llama.cpp)
 
 GGUF-format models route through the resolver's `requires.backends` list — manifests pick `rk-llama-cpp` for Pi NPU and fall back to `ollama` / `llama-cpp` on other tiers.

--- a/tests/catalog/test_resolver_hailo.py
+++ b/tests/catalog/test_resolver_hailo.py
@@ -7,6 +7,7 @@ requires.backends entry has no targets, so no device can ever resolve it.
 """
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tinyagentos.catalog.resolver import DeviceCapability, ResolveErr, ResolveOk, resolve
@@ -71,4 +72,63 @@ class TestHailoManifestResolves:
         result = resolve(manifest, "a8w4", device)
         assert isinstance(result, ResolveErr), (
             f"expected ResolveErr on a CPU-only x86 device, got {result!r}"
+        )
+
+
+class TestHailoNewManifestsResolve:
+    """Slice-S6 coverage: every new Hailo-10H .hef manifest resolves to hailo-ollama."""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "qwen2.5-1.5b",
+            "qwen3",
+            "qwen2.5-coder-1.5b",
+            "qwen2-1.5b",
+            "llama3.2-1b",
+            "deepseek-r1-1.5b",
+        ],
+    )
+    def test_pi5_hailo_resolves_to_hailo_ollama(self, model_id):
+        manifest = _load_manifest(model_id)
+        targets = hardware_to_targets(_pi5_hailo_hardware())
+        device = DeviceCapability(
+            device_id="pi5-hailo",
+            targets=tuple(targets),
+            total_ram_mb=8192,
+            total_vram_mb=0,
+            free_disk_mb=50_000,
+            installed_backends=(),
+        )
+        result = resolve(manifest, "a8w4", device)
+        assert isinstance(result, ResolveOk), (
+            f"expected ResolveOk on a Hailo-10H device for {model_id}, got {result!r}"
+        )
+        assert result.backend_id == "hailo-ollama"
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "qwen2.5-1.5b",
+            "qwen3",
+            "qwen2.5-coder-1.5b",
+            "qwen2-1.5b",
+            "llama3.2-1b",
+            "deepseek-r1-1.5b",
+        ],
+    )
+    def test_cpu_only_x86_cannot_resolve_new_hailo_manifest(self, model_id):
+        manifest = _load_manifest(model_id)
+        targets = hardware_to_targets(_x86_cpu_only_hardware())
+        device = DeviceCapability(
+            device_id="x86-cpu-only",
+            targets=tuple(targets),
+            total_ram_mb=16384,
+            total_vram_mb=0,
+            free_disk_mb=50_000,
+            installed_backends=(),
+        )
+        result = resolve(manifest, "a8w4", device)
+        assert isinstance(result, ResolveErr), (
+            f"expected ResolveErr on a CPU-only x86 device for {model_id}, got {result!r}"
         )

--- a/tests/test_model_manifest_integrity.py
+++ b/tests/test_model_manifest_integrity.py
@@ -71,19 +71,36 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                         errors.append(
                             f"{mid}/{vid}: backend {backend.get('id')!r} has unknown targets {unknown}"
                         )
-            # Rule 2: sha256 is a 64-char lowercase hex string.
-            sha256 = variant.get("sha256")
-            if not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
-                if not allowed_sha256:
+            # Rule 2a: for HEF variants installed via hailo-ollama-pull, the
+            # content hash lives in hef_h10h (not sha256); skip the sha256
+            # check and enforce hef_h10h instead.
+            is_hef_ollama_pull = (
+                variant.get("format") == "hef"
+                and (variant.get("install") or {}).get("method") == "hailo-ollama-pull"
+            )
+            if is_hef_ollama_pull:
+                hef_h10h = variant.get("hef_h10h")
+                if not re.fullmatch(r"[0-9a-f]{64}", hef_h10h or ""):
                     errors.append(
-                        f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        f"{mid}/{vid}: hef_h10h must be a 64-char lowercase hex string "
+                        f"(got {hef_h10h!r})"
                     )
-            # Rule 3: download_url is non-empty and parses as https.
-            url = variant.get("download_url", "")
-            if not url or not url.startswith("https://"):
-                errors.append(
-                    f"{mid}/{vid}: download_url must be a non-empty https URL (got {url!r})"
-                )
+            else:
+                sha256 = variant.get("sha256")
+                if not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
+                    if not allowed_sha256:
+                        errors.append(
+                            f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        )
+            # Rule 3a: HEF hailo-ollama-pull variants do not carry a plain
+            # download_url (the model is pulled via the backend). All other
+            # variants still require a non-empty https download_url.
+            if not is_hef_ollama_pull:
+                url = variant.get("download_url", "")
+                if not url or not url.startswith("https://"):
+                    errors.append(
+                        f"{mid}/{vid}: download_url must be a non-empty https URL (got {url!r})"
+                    )
             # Rule 4: size_mb is a positive int.
             size_mb = variant.get("size_mb")
             if not isinstance(size_mb, int) or size_mb <= 0:

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -43,18 +43,22 @@ router = APIRouter()
 _KNOWN_BACKENDS = {
     "rkllama", "rk-llama-cpp", "ollama", "llama-cpp",
     "mlx", "vllm", "comfyui", "transformers",
+    "hailo-ollama",
 }
 
 # Backend ID → install method known to get_installer().
 # rkllama has a purpose-built installer (calls /api/pull, manages symlinks,
 # restarts systemd units). rk-llama-cpp models are downloaded to disk and
 # loaded by the rk-llama-cpp runtime on demand, same as other backends.
+# hailo-ollama is Ollama-compatible, so it reuses the ollama installer which
+# calls POST /api/pull on the hailo-ollama daemon (port 7836).
 # Future per-backend installers (OllamaInstaller using `ollama pull`, etc.)
 # can land as follow-ups; download is the safest default in the meantime.
 _BACKEND_TO_METHOD: dict[str, str] = {
     "rkllama": "rkllama",
     "rk-llama-cpp": "rkllamacpp",
     "ollama": "ollama",
+    "hailo-ollama": "ollama",
     "llama-cpp": "download",
     "mlx": "download",
     "vllm": "download",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Hailo backend slice 6: .hef model catalog (Qwen/Llama/DeepSeek)

Autonomous build of board card tsk-3t4b6j.

Adds catalog manifests for qwen2.5-1.5b, qwen3, qwen2.5-coder-1.5b,
qwen2-1.5b, llama3.2-1b, and deepseek-r1-1.5b under app-catalog/models/.
Each manifest mirrors the qwen2.5-1.5b-rkllm shape but targets the
hailo-ollama backend with the hailo-ollama-pull install method and a
hef_h10h content hash instead of a plain download_url+sha256.

Updates test_model_manifest_integrity.py to allow the new HEF install
format, adds resolver coverage for all six manifests in
test_resolver_hailo.py, and maps hailo-ollama to the ollama installer
in store_install.py.

Docs-Reviewed: catalog manifest additions are reflected in catalog-platform-status.md and the changelog fragment

Files:
 .../models/qwen2.5-coder-1.5b/manifest.yaml        | 32 ++++++++++++
 app-catalog/models/qwen3/manifest.yaml             | 31 +++++++++++
 changelog.d/tsk-3t4b6j-hailo-hef-catalog.md        |  2 +
 docs/catalog-platform-status.md                    | 13 +++++
 tests/catalog/test_resolver_hailo.py               | 60 ++++++++++++++++++++++
 tests/test_model_manifest_integrity.py             | 39 ++++++++++----
 tinyagentos/routes/store_install.py                |  4 ++
 12 files changed, 310 insertions(+), 12 deletions(-)