### PR TITLE
generate_image: `seed` is documented but never forwarded (inert param)

### DIFF
--- a/changelog.d/tsk-47ix5m-forward-seed.md
+++ b/changelog.d/tsk-47ix5m-forward-seed.md
@@ -1,0 +1,2 @@
+### Fixed
+- The `seed` parameter for `generate_image` is now forwarded from the skill-exec runtime to the image generator and is advertised in the agent-facing tool schema, so reusing a returned seed to iterate on a liked image actually holds the seed instead of silently producing a fresh random one (#tsk-47ix5m).

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -245,3 +245,41 @@ async def test_skill_exec_image_generation_no_regression(app_with_store):
     data = resp.json()
     assert data["success"] is True
     assert data["image_b64"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_skill_exec_image_generation_forwards_seed(app_with_store):
+    """A seed passed through the skill-exec path must reach execute_image_generation
+    so the documented iterate-with-same-seed workflow works end to end.
+
+    Regression test for tsk-47ix5m: seed was documented but never forwarded by
+    _skill_image_generation, so an agent reusing a seed read back from the result
+    silently got a fresh random seed on every call.
+    """
+    store = app_with_store.state.skills
+    await store.assign_skill("don", "image_generation")
+
+    gen_payload = {"success": True, "image_ref": "gen.png", "seed": 123}
+
+    with patch(
+        "tinyagentos.tools.image_tool.execute_image_generation",
+        new_callable=AsyncMock,
+        return_value=gen_payload,
+    ) as mock_gen:
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_store), base_url="http://test"
+        ) as client:
+            resp_a = await client.post(
+                "/api/skill-exec/image_generation/call",
+                json={"args": {"prompt": "a red barn", "seed": 123}},
+            )
+            resp_b = await client.post(
+                "/api/skill-exec/image_generation/call",
+                json={"args": {"prompt": "a red barn at dusk", "seed": 123}},
+            )
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    assert mock_gen.await_count == 2
+    assert mock_gen.call_args_list[0].kwargs.get("seed") == 123
+    assert mock_gen.call_args_list[1].kwargs.get("seed") == 123

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -238,6 +238,7 @@ async def _skill_image_generation(args: dict, request: Request) -> dict:
             model=args.get("model") or None,
             guidance_scale=float(args.get("guidance_scale", 7.5)),
             negative_prompt=args.get("negative_prompt", ""),
+            seed=args.get("seed"),
         )
         return result
     except Exception as exc:

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -203,6 +203,8 @@ class SkillStore(BaseStore):
                         "properties": {
                             "prompt": {"type": "string"},
                             "size": {"type": "string", "default": "512x512"},
+                            "steps": {"type": "integer", "default": 4, "minimum": 1, "maximum": 8},
+                            "seed": {"type": "integer", "description": "Random seed for reproducibility (omit for a fresh image; reuse a returned seed to tweak a liked image)."},
                             "model": {"type": "string"},
                             "guidance_scale": {"type": "number", "default": 7.5},
                             "negative_prompt": {"type": "string", "default": ""},


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): generate_image: `seed` is documented but never forwarded (inert param)

Autonomous build of board card tsk-47ix5m.

_skill_image_generation forwarded prompt/size/steps/model/guidance_scale/negative_prompt
to execute_image_generation but not seed, so an agent reusing a returned seed to
tweak a liked image silently got a fresh random seed on every call.
execute_image_generation already honors an explicit seed (randomizing only when
None), so this is purely a forwarding gap in the dispatcher.

Also adds seed and steps to the image_generation tool_schema in skills.py so
agents are served the params the agent manual tells them they can use; previously
only prompt/size/model/guidance_scale/negative_prompt were advertised.

adds test_skill_exec_image_generation_forwards_seed which calls the skill-exec
image_generation path twice with an explicit seed and asserts the seed reaches
execute_image_generation both times. Fails on master before the fix.

Docs-Reviewed: tinyagentos/routes/skill_exec.py was modified but the skill-exec
tool-parameter surface is not described in docs/agent-coordination.md (it has no
mentions of skill-exec), so there is no route doc to update. The user-visible
behaviour is captured in changelog.d/tsk-47ix5m-forward-seed.md and the
iterate-with-seed workflow is already documented in docs/agent-manual/10-image-prompting.md.

Files:
 changelog.d/tsk-47ix5m-forward-seed.md |  2 ++
 tests/test_skill_runtime.py            | 38 ++++++++++++++++++++++++++++++++++
 tinyagentos/routes/skill_exec.py       |  1 +
 tinyagentos/skills.py                  |  2 ++
 4 files changed, 43 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation now supports optional `steps` and `seed` parameters.
  * Seeds are preserved across image-generation requests, enabling reproducible image iterations.

* **Bug Fixes**
  * Fixed image-generation requests so explicitly provided seeds are correctly forwarded.

* **Tests**
  * Added regression coverage for seeded image generation across multiple requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->