### PR TITLE
Deploy wizard offers an incoherent memory pair (Skip layer + mode both/taosmd)

### DIFF
--- a/changelog.d/tsk-m23asr-deploy-wizard-memory-pair.md
+++ b/changelog.d/tsk-m23asr-deploy-wizard-memory-pair.md
@@ -1,0 +1,2 @@
+### Fixed
+- Deploy wizard no longer lets the user reach the incoherent memory pair (skipped layer + `both`/`taosmd` mode) that triggered a 400 at the end of the wizard: clicking "Skip memory for this agent" now snaps the mode to `framework`, and the `both`/`taosmd` mode buttons are disabled with a "needs the taOSmd memory layer" tooltip while the layer is skipped. The same guard is mirrored in the agent Settings memory tab, which now sends `memory_mode: framework` when switching the plugin off. The server-side validation guard from #2405 remains in place.

--- a/desktop/src/apps/__tests__/DeployWizard.memory-pair.test.tsx
+++ b/desktop/src/apps/__tests__/DeployWizard.memory-pair.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * DeployWizard — memory mode + plugin pair coherence (tsk-m23asr).
+ *
+ * Verifies that skipping the taOSmd memory layer makes the "both" and
+ * "taosmd" memory_mode buttons unselectable (disabled) and that the
+ * wizard cannot produce the incoherent pair (null plugin + both/taosmd
+ * mode) that the server rejects with a 400.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("@/lib/framework-api", () => ({ fetchLatestFrameworks: async () => ({}) }));
+vi.mock("@/lib/models", () => ({
+  fetchClusterWorkers: async () => [],
+  workersToAggregated: () => [],
+  HOST_BADGE_CLASS: "",
+  CLOUD_PROVIDER_TYPES: [],
+}));
+vi.mock("@/lib/cluster", () => ({
+  availableKvQuantOptions: () => ({ k: ["fp16"], v: ["fp16"], boundary: false, flat: ["fp16"] }),
+}));
+vi.mock("@/lib/agent-emoji", () => ({ resolveAgentEmoji: () => "🤖" }));
+vi.mock("@/components/EmojiPicker", () => ({ EmojiPickerField: () => null }));
+vi.mock("@/components/ModelPickerModal", () => ({ ModelPickerModal: () => null }));
+vi.mock("@/lib/slug", () => ({
+  slugifyClient: (s: string) => s,
+  isValidSlug: () => true,
+  SLUG_REGEX: /^[a-z0-9][a-z0-9-]{0,62}$/,
+}));
+vi.mock("@/components/MigrationBanner", () => ({ MigrationBanner: () => null }));
+vi.mock("@/components/agent-settings/PersonaTab", () => ({ PersonaTab: () => null }));
+vi.mock("@/components/agent-settings/MemoryTab", () => ({ MemoryTab: () => null }));
+vi.mock("@/components/agent-settings/FrameworkTab", () => ({ FrameworkTab: () => null }));
+vi.mock("../AgentSkillsPanel", () => ({ AgentSkillsPanel: () => null }));
+vi.mock("../AgentMessagesPanel", () => ({ AgentMessagesPanel: () => null }));
+vi.mock("@/components/AgentShortcutRow", () => ({
+  AgentShortcutRow: () => null,
+}));
+vi.mock("@/stores/notification-store", () => ({
+  useNotificationStore: { getState: () => ({ addNotification: vi.fn() }) },
+}));
+
+// PersonaPicker that immediately auto-selects, advancing to step 1.
+vi.mock("@/components/persona-picker/PersonaPicker", () => ({
+  PersonaPicker: ({ onSelect }: { onSelect: (s: unknown) => void }) => {
+    React.useEffect(() => {
+      onSelect({ soul_md: "", agent_md: "", source_persona_id: null, save_to_library: null });
+    }, [onSelect]);
+    return null;
+  },
+}));
+
+// ModelPickerFlow that auto-selects a model when it renders (step 3).
+vi.mock("@/components/ModelPickerFlow", () => ({
+  ModelPickerFlow: ({ onSelect }: { onSelect: (s: string) => void }) => {
+    React.useEffect(() => {
+      onSelect("gpt-4o");
+    }, [onSelect]);
+    return null;
+  },
+}));
+
+vi.mock("@/components/ui", () => ({
+  Button: ({
+    children, onClick, className, disabled, variant, size, "aria-label": ariaLabel,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: React.ReactNode; variant?: string; size?: string;
+  }) => (
+    <button onClick={onClick} className={className} disabled={disabled} aria-label={ariaLabel} {...rest}>
+      {children}
+    </button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: { openWindow: ReturnType<typeof vi.fn> }) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+vi.mock("@/registry/app-registry", () => ({ getApp: () => null }));
+
+import { AgentsApp } from "../AgentsApp";
+
+const MOCK_FRAMEWORK = {
+  id: "openclaw",
+  name: "OpenClaw",
+  description: "General purpose agent",
+  verification_status: "beta",
+};
+
+const AGENTS_RESP = [{ name: "test", display_name: "Test", host: "", color: "#888", status: "running", model: "phi3" }];
+
+const makeFetch = vi.fn(async (url: string) => {
+  const u = String(url);
+  if (u.includes("/api/agents") && !u.includes("deploy")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => AGENTS_RESP };
+  }
+  if (u.includes("/api/agents/archived")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => [] };
+  }
+  if (u.includes("/api/frameworks")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => [MOCK_FRAMEWORK] };
+  }
+  if (u.includes("/api/taosmd/default")) {
+    return { ok: false, headers: { get: () => "application/json" }, json: async () => ({}) };
+  }
+  if (u.includes("/api/cluster/install-targets")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => [{ name: "local", friendly_name: "Controller", tier_id: "arm-vulkan-8gb" }] };
+  }
+  if (u.includes("/api/models")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => ({ models: [] }) };
+  }
+  if (u.includes("/api/providers")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => [] };
+  }
+  if (u.includes("/api/cluster/kv-quant-options")) {
+    return { ok: true, headers: { get: () => "application/json" }, json: async () => ({ k: ["fp16"], v: ["fp16"] }) };
+  }
+  return { ok: true, headers: { get: () => "application/json" }, json: async () => ({}) };
+});
+
+async function advanceToMemoryStep() {
+  global.fetch = makeFetch as unknown as typeof fetch;
+
+  render(
+    <AgentsApp
+      isActive={true}
+      isMobile={false}
+      onShortcutClick={() => {}}
+      activeShortcuts={[]}
+      onWindowOpen={() => {}}
+    />,
+  );
+
+  // Open wizard
+  const deployBtn = await screen.findByRole("button", { name: /new agent/i });
+  fireEvent.click(deployBtn);
+
+  // Step 0: PersonaPicker auto-advances to step 1
+  await waitFor(() => screen.getByPlaceholderText("my-agent"));
+
+  // Step 1: Name + Next
+  fireEvent.change(screen.getByPlaceholderText("my-agent"), { target: { value: "test-agent" } });
+  fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+  // Step 2: Framework — select the mocked framework, then Next
+  await waitFor(() => screen.getByRole("button", { name: /openclaw/i }));
+  fireEvent.click(screen.getByRole("button", { name: /openclaw/i }));
+  await waitFor(() => screen.getByRole("button", { name: /next/i }));
+  fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+  // Step 3: ModelPickerFlow auto-selects "gpt-4o" → Next becomes enabled
+  await waitFor(() => {
+    const nextBtn = screen.getByRole("button", { name: /next/i });
+    return expect(nextBtn).not.toBeDisabled();
+  });
+  fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+  // Step 4: Memory — wait for the Memory Mode heading
+  await waitFor(() => screen.getByText("Memory Mode"));
+}
+
+describe("DeployWizard — memory mode/plugin pair coherence", () => {
+  beforeEach(() => {
+    makeFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enables both and taosmd mode buttons when memory layer is on", async () => {
+    await advanceToMemoryStep();
+
+    const bothBtn = screen.getByText("Both").closest("button")!;
+    const taosmdBtn = screen.getByText("taOSmd only").closest("button")!;
+    expect(bothBtn).not.toBeDisabled();
+    expect(taosmdBtn).not.toBeDisabled();
+  });
+
+  it("disables both and taosmd mode buttons after clicking Skip memory", async () => {
+    await advanceToMemoryStep();
+
+    // Click "Skip memory for this agent" inside the MemoryWizardStep.
+    const skipLink = await screen.findByText(/skip memory for this agent/i);
+    fireEvent.click(skipLink);
+
+    // After the useEffect snaps memoryMode to "framework", both and taosmd
+    // buttons must be disabled, and "framework only" must be selected.
+    const bothBtn = screen.getByText("Both").closest("button")!;
+    const taosmdBtn = screen.getByText("taOSmd only").closest("button")!;
+    const fwBtn = screen.getByText("Framework only").closest("button")!;
+
+    await waitFor(() => {
+      expect(bothBtn).toBeDisabled();
+      expect(taosmdBtn).toBeDisabled();
+    });
+    expect(bothBtn).toHaveAttribute("title", "needs the taOSmd memory layer");
+    expect(taosmdBtn).toHaveAttribute("title", "needs the taOSmd memory layer");
+    expect(fwBtn).not.toBeDisabled();
+  });
+
+  it("does not allow selecting a disabled mode button via click", async () => {
+    await advanceToMemoryStep();
+
+    const skipLink = await screen.findByText(/skip memory for this agent/i);
+    fireEvent.click(skipLink);
+
+    const bothBtn = screen.getByText("Both").closest("button")!;
+    await waitFor(() => expect(bothBtn).toBeDisabled());
+
+    // Clicking a disabled button must not change the mode.
+    fireEvent.click(bothBtn);
+    await waitFor(() => {
+      const fwBtn = screen.getByText("Framework only").closest("button")!;
+      expect(fwBtn).toHaveClass("border-accent");
+    });
+  });
+
+  it("snaps the selected mode to framework after clicking Skip memory", async () => {
+    await advanceToMemoryStep();
+
+    // Initially "Both" is selected (default mode).
+    const bothBtn = screen.getByText("Both").closest("button")!;
+    expect(bothBtn).toHaveClass("border-accent");
+
+    // Click "Skip memory for this agent".
+    const skipLink = await screen.findByText(/skip memory for this agent/i);
+    fireEvent.click(skipLink);
+
+    // After the useEffect snaps memoryMode to "framework", the
+    // "Framework only" button must be the selected one.
+    const fwBtn = screen.getByText("Framework only").closest("button")!;
+    await waitFor(() => {
+      expect(fwBtn).toHaveClass("border-accent");
+    });
+  });
+});

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -416,6 +416,16 @@ export function DeployWizard({
   const [memorySetupError, setMemorySetupError] = useState<string | null>(null);
   const [memoryPickerMode, setMemoryPickerMode] = useState<"default" | "picker">("default");
 
+  // When the taOSmd memory layer is skipped, the only coherent mode is
+  // "framework". "both" and "taosmd" modes require the taOSmd plugin, so snap
+  // the mode whenever the plugin is null. This makes the pair unrepresentable
+  // instead of surfacing a 400 at deploy time.
+  useEffect(() => {
+    if (memoryPlugin === null) {
+      setMemoryMode("framework");
+    }
+  }, [memoryPlugin]);
+
   // Step 5 — Permissions
   const [canReadUserMemory, setCanReadUserMemory] = useState(false);
 
@@ -1312,21 +1322,30 @@ export function DeployWizard({
                   ["both", "Both", "Framework memory + taOSmd"],
                   ["framework", "Framework only", "Native memory, no taOSmd"],
                   ["taosmd", "taOSmd only", "Durable shared memory"],
-                ] as const).map(([value, label, desc]) => (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => setMemoryMode(value)}
-                    className={`p-2.5 rounded-lg border text-left transition-colors ${
-                      memoryMode === value
-                        ? "border-accent bg-accent/10"
-                        : "border-white/10 bg-shell-bg-deep hover:bg-white/5"
-                    }`}
-                  >
-                    <div className="text-xs font-semibold">{label}</div>
-                    <p className="text-[10px] text-shell-text-tertiary leading-tight mt-0.5">{desc}</p>
-                  </button>
-                ))}
+                ] as const).map(([value, label, desc]) => {
+                  const needsTaosmd = value === "both" || value === "taosmd";
+                  const disabled = needsTaosmd && memoryPlugin === null;
+                  const selected = (memoryPlugin === null ? "framework" : memoryMode) === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => setMemoryMode(value)}
+                      disabled={disabled}
+                      title={disabled ? "needs the taOSmd memory layer" : undefined}
+                      className={`p-2.5 rounded-lg border text-left transition-colors ${
+                        disabled
+                          ? "border-white/5 bg-shell-bg-deep opacity-50 cursor-not-allowed"
+                          : selected
+                            ? "border-accent bg-accent/10"
+                            : "border-white/10 bg-shell-bg-deep hover:bg-white/5"
+                      }`}
+                    >
+                      <div className="text-xs font-semibold">{label}</div>
+                      <p className="text-[10px] text-shell-text-tertiary leading-tight mt-0.5">{desc}</p>
+                    </button>
+                  );
+                })}
               </div>
 
               <div className="text-xs text-shell-text-tertiary">

--- a/desktop/src/components/agent-settings/MemoryTab.test.tsx
+++ b/desktop/src/components/agent-settings/MemoryTab.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * MemoryTab — memory_mode sent alongside memory_plugin when skipping (tsk-m23asr).
+ *
+ * When the plugin is switched to "none" the tab must also send
+ * memory_mode: "framework" so the stored pair stays coherent.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/framework-api", () => ({
+  fetchFrameworkState: vi.fn(async () => ({
+    framework: "hermes",
+    installed: { tag: "v1", sha: "abc" },
+    latest: null,
+    update_available: false,
+    update_status: "idle",
+  })),
+  fetchPermittedModels: vi.fn(async () => ({
+    permitted: ["llama3", "qwen3"],
+    current: "llama3",
+  })),
+}));
+
+import { MemoryTab } from "./MemoryTab";
+
+const originalFetch = global.fetch;
+afterEach(() => { global.fetch = originalFetch; vi.clearAllMocks(); });
+
+describe("MemoryTab — plugin/memory_mode coherence", () => {
+  it("sends memory_mode: framework when switching plugin to none", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    render(<MemoryTab agent={{ name: "alpha", memory_plugin: "taosmd" }} onUpdated={() => {}} />);
+
+    const select = await screen.findByLabelText(/memory plugin/i);
+    fireEvent.change(select, { target: { value: "none" } });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/agents/alpha/memory",
+        expect.objectContaining({
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ memory_plugin: "none", memory_mode: "framework" }),
+        }),
+      );
+    });
+  });
+
+  it("does not send memory_mode when switching back to taosmd", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    render(<MemoryTab agent={{ name: "alpha", memory_plugin: "none" }} onUpdated={() => {}} />);
+
+    const select = await screen.findByLabelText(/memory plugin/i);
+    fireEvent.change(select, { target: { value: "taosmd" } });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/agents/alpha/memory",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ memory_plugin: "taosmd" }),
+        }),
+      );
+    });
+  });
+});

--- a/desktop/src/components/agent-settings/MemoryTab.tsx
+++ b/desktop/src/components/agent-settings/MemoryTab.tsx
@@ -41,10 +41,14 @@ export function MemoryTab({ agent, onUpdated }: MemoryTabProps) {
 
   const changePlugin = async (p: string) => {
     setPlugin(p);
+    const body: Record<string, unknown> = { memory_plugin: p };
+    if (p === "none") {
+      body.memory_mode = "framework";
+    }
     await fetch(`/api/agents/${agent.name}/memory`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ memory_plugin: p }),
+      body: JSON.stringify(body),
     });
     onUpdated();
   };


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Deploy wizard offers an incoherent memory pair (Skip layer + mode both/taosmd)

Autonomous build of board card tsk-m23asr.

When the user clicks 'Skip memory for this agent', memory_mode now snaps
to 'framework' via a useEffect, and the 'both'/'taosmd' mode buttons are
disabled with a 'needs the taOSmd memory layer' tooltip. The same guard
is mirrored in the agent Settings memory tab, which now sends
memory_mode: framework when switching the plugin off. The server-side
validation from #2405 remains in place.

Files:
 .../tsk-m23asr-deploy-wizard-memory-pair.md        |   2 +
 .../__tests__/DeployWizard.memory-pair.test.tsx    | 249 +++++++++++++++++++++
 desktop/src/apps/agents/DeployWizard.tsx           |  49 ++--
 .../components/agent-settings/MemoryTab.test.tsx   |  76 +++++++
 .../src/components/agent-settings/MemoryTab.tsx    |   6 +-
 5 files changed, 366 insertions(+), 16 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved memory configuration handling in the deploy wizard and agent settings.
  * Automatically selects “Framework only” when the taOSmd memory layer is skipped.
  * Disables memory modes that require taOSmd and provides an explanation when they are unavailable.

* **Bug Fixes**
  * Prevented invalid combinations of skipped memory layers and memory modes.
  * Added validation to keep client and server memory settings consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->