### PR TITLE
auth: allowlist agent Bearer access to task checklist routes

### DIFF
--- a/changelog.d/2430-auth-checklist-allowlist.md
+++ b/changelog.d/2430-auth-checklist-allowlist.md
@@ -1,0 +1,2 @@
+### Fixed
+- The auth middleware's agent Bearer allowlist now covers `GET`/`POST /api/projects/{project_id}/tasks/{task_id}/checklist-items`, so a registry JWT reaches the handlers' `project_tasks_create` scope check instead of being refused 401 at the gate. Inert until the checklist routes (#2415) merge; DELETE and per-item subpaths stay session-only (#2430).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -857,3 +857,22 @@ A `single_select` or `multi_select` decision can be answered off-menu by sending
 Work as jaylfc on all git and GitHub activity. Do not add AI attribution to
 commits, PRs, or issues. Do not use em dashes in any output: use commas, colons,
 or "--".
+
+## Agent-token API surface (Bearer allowlist)
+
+The auth middleware keeps an explicit allowlist of routes a registry JWT
+(agent Bearer token) may reach; everything else on `/api` requires a user
+session. When you change the allowlist in `tinyagentos/auth_middleware.py`,
+record the change here so the agent-facing surface stays reviewable in one
+place.
+
+Task checklist items (added with the OS-owned objective checklist, #2415):
+
+- `GET /api/projects/{project_id}/tasks/{task_id}/checklist-items` -- list;
+  Bearer-reachable so the handler's `project_tasks_create` scope check runs
+  instead of the middleware refusing 401 at the gate.
+- `POST /api/projects/{project_id}/tasks/{task_id}/checklist-items` -- create;
+  same scope check.
+- `DELETE` and per-item subpaths (`.../checklist-items/{item_id}`) stay
+  session-only: no agent-reachable handler exists, and the allowlist must not
+  widen past list + create.

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -11,6 +11,7 @@ from tinyagentos.auth_middleware import (
     AuthMiddleware,
     _is_agent_canvas_path,
     _is_agent_decisions_path,
+    _is_agent_task_path,
     _is_exempt,
     _is_loopback_client,
 )
@@ -382,6 +383,107 @@ class TestCanvasAgentTokenDispatch:
         req = _request(
             method="GET",
             path="/api/projects/proj-1/canvas/elements/el-1/extra",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        call_next.assert_not_awaited()
+
+
+class TestIsAgentTaskChecklistPath:
+    """The checklist-items list/create routes must be Bearer-reachable.
+
+    The handlers (PR #2415) authorize agents via project_tasks_create, but
+    without these allowlist entries the middleware refuses the registry JWT
+    401 before any scope check runs.
+    """
+
+    def test_list_checklist_items_get_allowed(self):
+        assert _is_agent_task_path("GET", "/api/projects/proj-1/tasks/tsk-1/checklist-items") is True
+
+    def test_create_checklist_item_post_allowed(self):
+        assert _is_agent_task_path("POST", "/api/projects/proj-1/tasks/tsk-1/checklist-items") is True
+
+    def test_delete_checklist_items_not_allowed(self):
+        # No DELETE handler exists; the allowlist must not widen past
+        # list + create.
+        assert _is_agent_task_path("DELETE", "/api/projects/proj-1/tasks/tsk-1/checklist-items") is False
+
+    def test_single_checklist_item_path_not_allowed(self):
+        # Sibling path with an extra {item_id} segment: no such route is
+        # agent-reachable (archiving is store-level only, no route).
+        assert _is_agent_task_path("GET", "/api/projects/proj-1/tasks/tsk-1/checklist-items/chk-1") is False
+        assert _is_agent_task_path("PATCH", "/api/projects/proj-1/tasks/tsk-1/checklist-items/chk-1") is False
+
+    def test_near_miss_sibling_not_allowed(self):
+        assert _is_agent_task_path("GET", "/api/projects/proj-1/tasks/tsk-1/checklists") is False
+
+
+class TestTaskChecklistAgentTokenDispatch:
+    @pytest.mark.asyncio
+    async def test_checklist_list_bearer_passes(self):
+        middleware = AuthMiddleware(app=MagicMock())
+        auth_mgr = _default_auth_mgr()
+        auth_mgr.validate_local_token.return_value = False
+        req = _request(
+            method="GET",
+            path="/api/projects/proj-1/tasks/tsk-1/checklist-items",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=auth_mgr,
+        )
+        call_next = AsyncMock(return_value=JSONResponse({"items": []}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 200
+        assert req.state.via == "registry_jwt_candidate"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_checklist_create_bearer_passes(self):
+        middleware = AuthMiddleware(app=MagicMock())
+        auth_mgr = _default_auth_mgr()
+        auth_mgr.validate_local_token.return_value = False
+        req = _request(
+            method="POST",
+            path="/api/projects/proj-1/tasks/tsk-1/checklist-items",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=auth_mgr,
+        )
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 200
+        assert req.state.via == "registry_jwt_candidate"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_checklist_delete_requires_session(self):
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="DELETE",
+            path="/api/projects/proj-1/tasks/tsk-1/checklist-items",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_checklist_item_subpath_requires_session(self):
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="GET",
+            path="/api/projects/proj-1/tasks/tsk-1/checklist-items/chk-1",
             headers={"authorization": "Bearer registry-jwt"},
             auth_mgr=_default_auth_mgr(),
         )

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -73,6 +73,13 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
+    # Task checklist items (list + create), gated by project_tasks_create in the
+    # handler (_authorize_task_actor). Reaching the handler is not
+    # authorisation: it then verifies the JWT, the project binding, and that
+    # scope. There is no archive route, so nothing beyond list + create is
+    # listed here.
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/checklist-items$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/checklist-items$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
     # PATCH (free task-field mutation) was intentionally NOT here: it is broader
     # than the "read + lifecycle + comments" the project_tasks scope documents.


### PR DESCRIPTION
## Why

The task checklist handlers in #2415 authorize agents via the `project_tasks_create` scope, and their docstrings advertise agent access — but `tinyagentos/auth_middleware.py` holds an exact `(method, path-regex)` Bearer allowlist (`_AGENT_TASK_ROUTES`) with no checklist pattern. A registry JWT is therefore refused `401 Authentication required` by the middleware BEFORE any scope check runs, making the agent-authorization branch in both handlers unreachable. This PR adds the two missing allowlist entries as their own diff, per the ruling on #2415.

Entries added (matching the anchoring and `_SEG` conventions of their neighbours):

```python
("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/checklist-items$")),
("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/checklist-items$")),
```

Nothing wider: DELETE on the same path and the `/checklist-items/{id}` sibling remain session-only (there is no archive route; archiving is store-level and verified+reported-gated).

## Proven red

The positive tests were run once against the UNPATCHED middleware (allowlist change stashed) before restoring it:

```
$ uv run --no-project --with pytest --with pytest-asyncio --with-editable . python -m pytest tests/test_auth_middleware.py -q -k Checklist
>       assert resp.status_code == 200
E       assert 401 == 200
E        +  where 401 = <starlette.responses.JSONResponse object at 0x709639b83250>.status_code
FAILED tests/test_auth_middleware.py::TestIsAgentTaskChecklistPath::test_list_checklist_items_get_allowed
FAILED tests/test_auth_middleware.py::TestIsAgentTaskChecklistPath::test_create_checklist_item_post_allowed
FAILED tests/test_auth_middleware.py::TestTaskChecklistAgentTokenDispatch::test_checklist_list_bearer_passes
FAILED tests/test_auth_middleware.py::TestTaskChecklistAgentTokenDispatch::test_checklist_create_bearer_passes
4 failed, 5 passed, 58 deselected in 0.55s
```

## Tests

Both halves at the granularity of the evidence, in `tests/test_auth_middleware.py`:

- `TestIsAgentTaskChecklistPath` — predicate-level: GET/POST checklist-items allowed; DELETE same path refused; `/checklist-items/{id}` (GET and PATCH) refused; `/checklists` near-miss sibling refused.
- `TestTaskChecklistAgentTokenDispatch` — middleware dispatch: a Bearer token on GET/POST checklist-items reaches `call_next` with `via == "registry_jwt_candidate"` (i.e. it reaches the handler's scope layer instead of the 401 gate); DELETE and the `{id}` subpath get 401 with `call_next` never awaited.

## Commands run

```
$ uv run --no-project --with pytest --with pytest-asyncio --with-editable . python -m pytest tests/test_auth_middleware.py -q
67 passed in 0.54s   (exit 0)
```

Red run above exited 1 (4 failed) against the unpatched file.

Unblocks #2415; patterns are inert until the checklist routes merge.
