### PR TITLE
Move lane-runnable agent tooling into a repo (it has blocked delegation 3x in 2 days)

### DIFF
--- a/changelog.d/tsk-cvnqmk-move-fleet-tooling.md
+++ b/changelog.d/tsk-cvnqmk-move-fleet-tooling.md
@@ -1,0 +1,2 @@
+### Fixed
+- Moved lane-runnable agent tooling (`red_first.sh`, `prove_red_first.sh`, `resume_arm_time.py`, `test_resume_arm_time.py`, `liveness_check.py`, `orphan_check.sh`, `verify_routes.py`) from `~/.taos-team` and `~/.taos-website-agent` into `tools/` in jaylfc/taOS, so lanes can review and change them in a normal PR. Shims left at the old paths redirect to the canonical copies.

--- a/tools/liveness_check.py
+++ b/tools/liveness_check.py
@@ -1,0 +1,36 @@
+import os, sys
+def running(script):
+    """True iff some process has `script` as an EXACT argv element (not a substring
+    of a shell's command text). Compares whole argv entries, so a tool shell whose
+    cmdline merely CONTAINS the path cannot match."""
+    hits = []
+    for pid in os.listdir('/proc'):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(f'/proc/{pid}/cmdline', 'rb') as fh:
+                argv = [a.decode('utf-8', 'replace') for a in fh.read().split(b'\0') if a]
+        except (OSError, IOError):
+            continue
+        if not argv or len(argv) < 2:
+            continue
+        exe = os.path.basename(argv[0])
+        if exe not in ('bash', 'sh', 'python3', 'python'):
+            continue
+        # argv[1:] compared as WHOLE elements; skip interpreter flags like -u
+        if any(a == script for a in argv[1:]):
+            hits.append(pid)
+    return hits
+
+T = '/home/jay/.taos-team/'
+checks = [T+'a2a_watch.sh', T+'pr_watch.py', T+'lead_bus_watch.sh', T+'dispatch_loop.sh']
+bad = 0
+for c in checks:
+    h = running(c)
+    print(f"{'OK ' if h else 'DEAD'}  {os.path.basename(c):20s} pids={','.join(h) if h else '-'}")
+    if not h:
+        bad += 1
+# NEGATIVE CONTROL in the same run: a script that cannot be running
+ctrl = running(T+'DEFINITELY_NOT_RUNNING.sh')
+print(f"CONTROL nonexistent watcher -> {'FALSE POSITIVE (check is broken)' if ctrl else 'correctly not found'}")
+sys.exit(2 if ctrl else (1 if bad else 0))

--- a/tools/orphan_check.sh
+++ b/tools/orphan_check.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# ORPHAN CHECK: reconcile a BOARD against a REPO, in three directions.
+#
+# Usage:  ORPHAN_REPO=jaylfc/taOS ORPHAN_PID=prj-5y722y ./orphan_check.sh
+# Exit:   0 = clean, 1 = findings, 3 = UNREADABLE (never silently "clean")
+#
+# WHY BOTH MUST BE PASSED (@taOS-website-dev, A2A 2230, 2026-08-06).
+# v1 parameterised the REPO but took the BOARD from taos_team.pid(), which
+# resolves from the SHARED ~/.taos-team/config. So `ORPHAN_REPO=jaylfc/taos-website`
+# compared WEBSITE PRs against taOS CARDS. No website card id can appear in a taOS
+# id set, so both directions were empty BY CONSTRUCTION and it exited 0 clean --
+# on a board with real orphans on it. It was live in the hourly sweep for both
+# repos, answering the question so nobody would look again.
+#
+# THE RED-PROOF DID NOT CATCH IT, and that is the lesson worth keeping. v1's
+# proof inverted the CLOSED set and confirmed direction B fired. But both sets
+# came from the same wrong board, so THE PROOF MOVED WITH THE BUG. Proving the
+# matcher fires says nothing about whether it was handed the right inputs.
+# Hence: the board is now required, pinned, and ASSERTED against what came back.
+#
+# THE THREE DIRECTIONS. Every check we had walks ONE list; orphans live in the gap.
+#   A. OPEN card whose PR already MERGED    -> lane rebuilds a landed fix.
+#      Can be LOAD-BEARING: tsk-bgznuk also blocked tsk-l6gqvw for 9 days.
+#   B. OPEN PR whose card is CLOSED         -> board thinks it shipped while a PR,
+#      often an EXTERNAL contributor's, sits untracked. PR #2208 (hognek), 9 days.
+#   C. OPEN card whose ONLY guard is an OPEN PR (@taOS-website-dev's find).
+#      next_card.py excludes cards with an open exec PR, but that exclusion is
+#      INCIDENTAL: close the PR and the card is claimable again. If the card was
+#      SUPERSEDED rather than finished, a lane then rebuilds the replacement.
+#
+# Read-only on purpose. Every direction has a legitimate benign explanation, so
+# it prints and exits; it never closes or reopens anything.
+#
+# VERIFY FINDINGS ON ORIGIN, NEVER ON A LOCAL TREE: a tree 5 commits behind made
+# a merged fix look unlanded (@taOS-website-dev, same day).
+set -uo pipefail
+REPO="${ORPHAN_REPO:-}"
+PID="${ORPHAN_PID:-}"
+if [ -z "$REPO" ] || [ -z "$PID" ]; then
+  echo "usage: ORPHAN_REPO=<owner/repo> ORPHAN_PID=<prj-...> $0"
+  echo "  Both are REQUIRED. ORPHAN_PID must never be allowed to default."
+  exit 64
+
+# EXIT CONTRACT (full): 0 = clean; 1 = A/B findings (real orphans);
+# 2 = C watch-list only (cards guarded solely by an open PR - informational);
+# 3 = REFUSED or unreadable; 64 = usage. Treat 3 and 64 as failures, never
+# clean. 2 is NOT an anomaly - it was undocumented until 2026-08-09 and got
+# itself investigated twice.
+fi
+
+# REPO <-> BOARD PAIRING, asserted.
+#
+# Requiring ORPHAN_PID is necessary but NOT SUFFICIENT, which I only found by
+# testing the fix: passing the WRONG-but-valid pid reproduces the original false
+# clean exactly. `ORPHAN_REPO=jaylfc/taos-website ORPHAN_PID=prj-5y722y` still
+# printed "211 open / 419 closed ... none ... exit 0", because the tasks really
+# do belong to the board that was asked for -- the mismatch is between the REPO
+# and the BOARD, and no amount of validating the board against itself sees it.
+# So the pairing itself has to be the assertion.
+case "$REPO" in
+  jaylfc/taOS)         EXPECT=prj-5y722y ;;
+  jaylfc/taos-website) EXPECT=prj-utbsh7 ;;
+  *)                   EXPECT="" ;;
+esac
+if [ -z "$EXPECT" ]; then
+  echo "REFUSING: no known board for repo '$REPO'. Add the pairing to this script"
+  echo "          rather than guessing; a wrong pairing reports a confident clean."
+  exit 3
+fi
+if [ "$PID" != "$EXPECT" ]; then
+  echo "REFUSING: repo '$REPO' pairs with board '$EXPECT', but ORPHAN_PID='$PID'."
+  echo "          Comparing a repo against another repo's board is empty BY"
+  echo "          CONSTRUCTION and exits 0 clean. That is the bug this guards."
+  exit 3
+fi
+
+set -a; . "$HOME/.taos-team/config"; . "$HOME/.taos-team/taos-dev.cred"; set +a
+
+python3 - "$REPO" "$PID" <<'PY'
+import sys, os, pathlib, subprocess, json, re
+repo, pid = sys.argv[1], sys.argv[2]
+sys.path.insert(0, str(pathlib.Path.home()/".taos-team"))
+import taos_team
+
+# TEST SEAM (@taOS-website-dev, A2A 2234). Opt-in, ENV-ONLY, never read from a
+# config file, and the cron must never set it -- it substitutes the input the
+# whole check depends on, so if it ever leaked into a real run it would mask real
+# data. It is a seam, not a switch.
+#
+# It exists because the refusal paths below are otherwise unreachable: no
+# genuinely empty board is obtainable, and my token 404s on any board but my own,
+# so the wrong-board and missing-field guards could never be watched refusing.
+# I had asserted those "fail closed by construction" without ever seeing one
+# fire, which is the exact shape we spent today finding in each other's tools.
+fxt = os.environ.get("ORPHAN_FIXTURE_TASKS")
+if fxt:
+    # MARK EVERY OUTPUT *LINE*, NOT EVERY print CALL (@taOS-website-dev, A2A 2236).
+    # A single banner line looked marked when eyeballed and was not: 10 of 11 lines
+    # came out bare, and a fixture run still matched `grep '^orphan-check repo='`,
+    # the exact grep the marking exists to defeat. Several prints here also start
+    # with "\n" for spacing, so prefixing the CALL would put the marker on the blank
+    # line and leave the verdict bare -- their failure, which mine was a worse
+    # version of. Split on newlines and prefix each.
+    # Test, whatever the implementation:  <fixture run> | grep -vc '^\[FIXTURE\]'  == 0
+    _emit = print
+    def print(*a, **k):  # noqa: A001 - deliberate shadow, fixture mode only
+        text = " ".join(str(x) for x in a)
+        _emit("\n".join("[FIXTURE] " + ln for ln in text.split("\n")), **k)
+    print(f"board read replaced by {fxt} -- TEST MODE, not a real result")
+    tasks = bare_tasks = json.load(open(fxt))
+else:
+    try:
+        taos_team.login()
+        res  = taos_team._req(taos_team.API, f"/api/projects/{pid}/tasks?limit=5000")
+        bare = taos_team._req(taos_team.API, f"/api/projects/{pid}/tasks")
+    except Exception as e:
+        print(f"UNREADABLE board {pid}: {type(e).__name__}: {e}")
+        print("An unreadable board is NOT an empty one. Refusing to report clean.")
+        sys.exit(3)
+    tasks, bare_tasks = res.get("items", []), bare.get("items", [])
+if not tasks:
+    print(f"UNREADABLE: board {pid} returned ZERO tasks. Refusing to report clean.")
+    sys.exit(3)
+if len(tasks) != len(bare_tasks):
+    print(f"WARNING: limit=5000 returned {len(tasks)} but bare read returned "
+          f"{len(bare_tasks)}; one of them is truncating. Using the larger.")
+    if len(bare_tasks) > len(tasks):
+        tasks = bare_tasks
+
+# ASSERT THE BOARD IS THE ONE ASKED FOR. This is the check v1 lacked entirely.
+wrong = {t.get("project_id") for t in tasks} - {pid}
+if wrong:
+    print(f"UNREADABLE: asked for board {pid} but tasks carry {sorted(wrong)}. "
+          "Refusing to compare a repo against someone else's board.")
+    sys.exit(3)
+
+by_id  = {t.get("id"): t for t in tasks}
+CLOSED = {"done", "closed", "cancelled"}
+open_ids   = {i for i, t in by_id.items() if str(t.get("status", "")).lower() not in CLOSED}
+closed_ids = {i for i, t in by_id.items() if str(t.get("status", "")).lower() in CLOSED}
+
+def prs(state, limit):
+    out = subprocess.run(["gh", "pr", "list", "--repo", repo, "--state", state,
+                          "--limit", str(limit), "--json", "number,title,headRefName"],
+                         capture_output=True, text=True).stdout
+    return json.loads(out or "[]")
+
+def cards_in(p):
+    return set(re.findall(r"tsk-[a-z0-9]{6}",
+                          (p.get("headRefName") or "") + " " + (p.get("title") or "")))
+
+def dependents(cid):
+    return [i for i, t in by_id.items()
+            if i in open_ids and f"blocked-on:{cid}" in (t.get("labels") or [])]
+
+# EXIT CODES SPLIT (@taOS-website-dev, A2A 2232). C was setting the same code as
+# A and B, so on any board with several open exec PRs this went PERMANENTLY red
+# -- 10 of 10 on taOS -- and a check that is always red teaches its reader to
+# skip it. A signal that is always on is the same as no signal, which is the
+# failure mode we keep finding arriving by a new road.
+#   0 clean | 1 TRUE orphans (A/B), act | 2 only C's watch list, review | 3 unreadable
+ab = 0
+c_only = 0
+print(f"orphan-check repo={repo} board={pid} ({len(open_ids)} open / {len(closed_ids)} closed)")
+
+print("\nA. OPEN card whose PR already MERGED")
+merged = {}
+for p in prs("merged", 400):
+    for c in cards_in(p):
+        merged.setdefault(c, p["number"])
+hits = sorted(open_ids & merged.keys())
+for c in hits:
+    dep = dependents(c)
+    extra = f"  [LOAD-BEARING: also blocking {', '.join(dep)}]" if dep else ""
+    print(f"   {c} <- PR #{merged[c]} MERGED :: {str(by_id[c].get('title'))[:52]}{extra}")
+    ab = 1
+print("   none" if not hits else "   -> confirm the merge commit is an ancestor of origin/dev before closing")
+
+open_prs = prs("open", 200)
+
+print("\nB. OPEN PR whose card is CLOSED")
+hits2 = [(p["number"], c, p["title"][:52]) for p in open_prs
+         for c in cards_in(p) if c in closed_ids]
+for n, c, t in hits2:
+    print(f"   PR #{n} OPEN <- card {c} CLOSED :: {t}")
+    ab = 1
+print("   none" if not hits2 else "   -> confirm the fix is ACTUALLY absent from origin/dev before reopening")
+
+print("\nC. OPEN card whose ONLY guard against dispatch is an OPEN PR")
+guarded = [(c, p["number"]) for p in open_prs for c in cards_in(p) if c in open_ids]
+for c, n in sorted(set(guarded)):
+    lbl = by_id[c].get("labels") or []
+    claimable = any(str(x).endswith("claimable") for x in lbl)
+    print(f"   {c} held only by open PR #{n}{' [CLAIMABLE the moment it closes]' if claimable else ''}"
+          f" :: {str(by_id[c].get('title'))[:44]}")
+    c_only = 1
+print("   none" if not guarded else
+      "   -> C is a WATCH LIST, not an alarm. Scan it for SUPERSESSION only; its LENGTH is not a finding count.")
+sys.exit(1 if ab else (2 if c_only else 0))
+PY

--- a/tools/prove_red_first.sh
+++ b/tools/prove_red_first.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# PROVE red_first.sh in every direction, against the LIVE script, unmodified.
+# Same PATH-shim discipline as prove_gate_merge.sh / prove_test_delta.sh /
+# prove_health.sh. This was the LAST tool in this pack with no harness.
+#
+# WHY A REAL GIT REPO AND NOT A SHIM. Every other prover in this pack shims the
+# outside world. This one cannot: red_first.sh's entire mechanism IS git
+# (worktree, merge-base, checkout-a-path-at-a-rev), so a git shim would prove the
+# shim. Only `gh` is shimmed, for the one baseRefName read. Each case builds a
+# throwaway repo with a real bare "origin" carrying a real refs/pull/N/head.
+#
+# WHAT THIS HARNESS EXISTS TO SETTLE (tsk-wyfp6q): red_first.sh proves red by
+# reverting SOURCE to the merge-base, so a PR that changes NO source has no path
+# to satisfy a red-first demand. Proven live on #144, where a correct test-only
+# build was refused. The two shapes are cases 12 and 13 below.
+#
+# Run after ANY edit to red_first.sh. Exit 0 = all paths proved, 1 = regression.
+#   bash prove_red_first.sh                     prove the live script
+#   bash prove_red_first.sh --red A             prove the harness catches break A
+#   bash prove_red_first.sh --red all           every break, must all be caught
+set -uo pipefail
+SRC="${RF_SRC:-$(cd "$(dirname "$0")" && pwd)/red_first.sh}"
+[ -r "$SRC" ] || { echo "FAILED: no readable $SRC"; exit 3; }
+
+T=$(mktemp -d); trap 'rm -rf "$T"' EXIT
+mkdir -p "$T/bin"
+
+# ---------------------------------------------------------------- gh shim
+# red_first.sh makes exactly one gh call: pr view --json baseRefName. The shim
+# records EVERY invocation, so a shim that is never reached is loud rather than
+# silently bypassed (the sweep.sh PATH-prepend trap: a shim that is silently
+# bypassed is indistinguishable from a shim that works).
+cat > "$T/bin/gh" <<'SHIM'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_CALLS"
+case "$*" in
+  *"pr view"*baseRefName*) cat "$FX/baseref"; exit "$(cat "$FX/baseref.rc" 2>/dev/null || echo 0)" ;;
+  *) echo "SHIM: unhandled gh call: $*" >&2; exit 97 ;;
+esac
+SHIM
+chmod +x "$T/bin/gh"
+export GH_CALLS="$T/gh.calls"
+
+fail=0; passes=0
+check() { if [ "$2" = "$3" ]; then printf "  PASS  %-52s exit %s\n" "$1" "$3"; passes=$((passes+1))
+  else printf "  FAIL  %-52s exit %s (wanted %s)\n" "$1" "$3" "$2"
+       sed 's/^/          /' "$T/out" | head -6; fail=1; fi }
+has() { n=$(grep -cF -- "$2" "$T/out" 2>/dev/null); n=${n:-0}
+  if [ "$n" -ge 1 ]; then printf "  PASS  %-52s\n" "$1"; passes=$((passes+1))
+  else printf "  FAIL  %-52s (absent: %s)\n" "$1" "$2"
+       sed 's/^/          /' "$T/out" | head -6; fail=1; fi }
+hasnt() { n=$(grep -cF -- "$2" "$T/out" 2>/dev/null); n=${n:-0}
+  if [ "$n" -eq 0 ]; then printf "  PASS  %-52s\n" "$1"; passes=$((passes+1))
+  else printf "  FAIL  %-52s (present, wanted absent: %s)\n" "$1" "$2"; fail=1; fi }
+
+# ------------------------------------------------------------ repo fixture
+# Builds: origin.git (bare) + repo (working). Commit M is the merge-base on main,
+# commit P is the PR head, published as refs/pull/99/head exactly as GitHub does.
+#   $1 = src.py content at M    $2 = src.py content at P
+#   $3 = t.sh content at P      $4 = extra eval'd before P    $5 = extra eval'd before M
+# t.sh does not exist at M, so every fixture here is a PR that adds its own test,
+# which is the normal shape and the one the tool was written for.
+mkrepo() {
+  local m_src="$1" p_src="$2" p_test="$3" extra="${4:-}" extra_m="${5:-}"
+  rm -rf "$T/repo" "$T/origin.git"
+  git init -q --bare "$T/origin.git"
+  git init -q -b main "$T/repo"
+  (
+    cd "$T/repo"
+    git config user.email t@t; git config user.name t; git config commit.gpgsign false
+    printf '%s' "$m_src" > src.py
+    [ -n "$extra_m" ] && eval "$extra_m"
+    git add -A && git commit -qm "M: merge-base"
+    git remote add origin "$T/origin.git"
+    git push -q origin main
+    # --- the PR head, a child of M
+    printf '%s' "$p_src" > src.py
+    printf '%s' "$p_test" > t.sh
+    [ -n "$extra" ] && eval "$extra"
+    git add -A && git commit -qm "P: the PR"
+    git push -q origin "HEAD:refs/pull/99/head"
+    git checkout -q main
+    git reset -q --hard origin/main
+  )
+  mkdir -p "$T/fx"; printf 'main' > "$T/fx/baseref"; rm -f "$T/fx/baseref.rc"
+  : > "$GH_CALLS"
+}
+
+# Invoke the script under test FROM the repo, with only gh shimmed.
+run() {
+  ( cd "$T/repo" && FX="$T/fx" PATH="$T/bin:$PATH" bash "$RUN_SRC" "$@" ) >"$T/out" 2>&1
+  echo $?
+}
+
+# t.sh variants. GREP: genuinely exercises src.py. TRUE: exercises nothing.
+T_GREP='grep -q FIXED src.py
+'
+T_TRUE='true
+'
+T_FALSE='false
+'
+# Fails on every call after the first. Lets run 3 diverge from run 1 with the
+# same tree, which is the only honest way to reach the restore-failed path.
+T_ONCE='n=$(cat "$RF_CNT" 2>/dev/null || echo 0); n=$((n+1)); echo $n > "$RF_CNT"; [ "$n" -eq 1 ]
+'
+
+# ---------------------------------------------------------------- the cases
+prove() {
+RUN_SRC="$1"
+echo "proving $(basename "$SRC") ${2:-}   ($(stat -c %y "$SRC" | cut -d. -f1))"
+echo
+
+echo "THE CYCLE ITSELF"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "pass/fail/pass on a real source change"        0 "$(run --suite r/r 99 src.py -- 'bash t.sh')"
+  has   "...and names the merge-base it reverted to"    "merge-base"
+  has   "...and prints all three runs"                  "run 3 restored"
+  # assert the shim was reached rather than bypassed
+  if [ -s "$GH_CALLS" ]; then printf "  PASS  %-52s\n" "...gh shim reached (not bypassed)"; passes=$((passes+1))
+  else printf "  FAIL  %-52s\n" "...gh shim NEVER reached: PATH bypassed"; fail=1; fi
+
+echo
+echo "IT MUST REFUSE -- the dangerous direction is a wrong shape reading as a pass"
+mkrepo 'BUGGY' 'FIXED' "$T_TRUE"
+  check "DECORATIVE tests: green with the change reverted" 4 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and says green here means nothing"          "means nothing"
+mkrepo 'BUGGY' 'FIXED' "$T_FALSE"
+  check "PR is RED before the experiment starts"        3 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and says nothing was learned"               "red before the experiment"
+RF_CNT="$T/cnt"; export RF_CNT
+mkrepo 'BUGGY' 'FIXED' "$T_ONCE"
+  rm -f "$T/cnt"
+  check "RESTORE run does not return to green"          5 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and says run 2 is not attributable"         "not attributable"
+unset RF_CNT
+
+echo
+echo "USAGE -- a malformed call must never look like a verdict"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "no arguments at all"                           2 "$(run)"
+  check "repo only"                                     2 "$(run r/r)"
+  check "no -- separator (test cmd swallowed as a path)" 2 "$(run r/r 99 src.py 'bash t.sh')"
+  check "-- present but no test command"                2 "$(run r/r 99 src.py --)"
+  check "-- present but no source paths"                2 "$(run r/r 99 -- 'bash t.sh')"
+
+echo
+echo "CANNOT SEE -- setup failure must FAIL CLOSED, never 'pass'"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "PR ref does not exist on origin"               6 "$(run r/r 4242 src.py -- 'bash t.sh')"
+  has   "...and says which PR it could not fetch"       "cannot fetch PR"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"; : > "$T/fx/baseref"
+  check "gh cannot report the base ref"                 6 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and names the base-ref read"                "cannot read base ref"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"; printf 'no-such-branch' > "$T/fx/baseref"
+  check "base ref names a branch origin does not have" 6 "$(run r/r 99 src.py -- 'bash t.sh')"
+
+echo
+echo "THE SHAPES tsk-wyfp6q IS ABOUT -- a PR with NO source change to revert"
+# 12. TEST-ONLY: src.py identical at M and P; the PR adds only a test. This is
+#     #144's shape. Reverting src.py is a no-op, so run 2 passes and the tool
+#     accuses a correct build of having decorative tests.
+mkrepo 'FIXED' 'FIXED' "$T_GREP"
+  check "TEST-ONLY PR is not accused of decorative tests" 7 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and says red-first does not apply here"     "does not apply"
+  hasnt "...and does NOT claim the tests are decorative" "means nothing"
+# 13. NEW-FILE: the PR adds a source file absent at the merge-base. The correct
+#     revert is a DELETE, which `git checkout MB -- newfile` cannot express, so
+#     the experiment used to be unreachable and reported as a setup failure.
+#     t.sh greps the NEW file, so deleting it must genuinely go red.
+mkrepo 'BUGGY' 'FIXED' 'grep -q NEW newmod.py
+' "printf 'NEW' > newmod.py"
+  check "NEW source file: revert is a delete, and runs"  0 "$(run --suite r/r 99 newmod.py -- 'bash t.sh')"
+  has   "...and says it deleted rather than reverted"   "deleted (added by this PR)"
+# 14. A path that exists at NEITHER end is a typo, and a typo must not be
+#     absorbed by exit 7 as a clean 'not applicable'.
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "path exists at neither end (typo) is a usage error" 2 "$(run r/r 99 srk.py -- 'bash t.sh')"
+  has   "...and names the path it could not find"       "srk.py"
+  hasnt "...and does NOT read as not-applicable"        "NOT APPLICABLE"
+
+echo
+echo "AND IT MUST STILL FIRE AFTERWARDS -- a fix that refuses everything is worse"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "a real source change still proves red-first"   0 "$(run --suite r/r 99 src.py -- 'bash t.sh')"
+mkrepo 'BUGGY' 'FIXED' "$T_TRUE"
+  check "decorative tests are still caught"             4 "$(run r/r 99 src.py -- 'bash t.sh')"
+# One path changed, one identical: SOME source moved, so the cycle is expressible
+# and must run normally. Only ALL-identical is inexpressible. other.py is present
+# and byte-identical at BOTH ends, which is what makes this the mixed case rather
+# than the new-file case (my first fixture created it only at P and therefore
+# tested case 13 again under case 15's name).
+mkrepo 'BUGGY' 'FIXED' "$T_GREP" "" "printf 'SAME' > other.py"
+  check "mixed paths: one changed, one identical, runs"  0 "$(run --suite r/r 99 src.py other.py -- 'bash t.sh')"
+# One changed, one ADDED: the added file used to fail the whole checkout and take
+# a valid experiment down with it.
+mkrepo 'BUGGY' 'FIXED' "$T_GREP" "printf 'NEW' > newmod.py"
+  check "mixed paths: one changed, one ADDED, runs"      0 "$(run --suite r/r 99 src.py newmod.py -- 'bash t.sh')"
+
+echo
+echo "ATTRIBUTION: a SUITE-LEVEL red is not evidence about a NAMED test"
+echo "  (this is why the tool returned 0 on #146 while carrying a test that passed"
+echo "   against the correct and the broken implementation alike)"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "a bare suite command does NOT read as proved"  8 "$(run r/r 99 src.py -- 'bash t.sh')"
+  has   "...and says the red is not attributable"       "not attributable"
+  has   "...and says how to discharge it"               "naming ONE test"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "naming ONE test proves red-first"              0 "$(run r/r 99 src.py -- 'bash t.sh -k mytest')"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "a pytest ::selector also counts as specific"   0 "$(run r/r 99 src.py -- 'bash t.sh tests/t.py::mytest')"
+mkrepo 'BUGGY' 'FIXED' "$T_GREP"
+  check "--suite accepts the weaker verdict explicitly" 0 "$(run --suite r/r 99 src.py -- 'bash t.sh')"
+  has   "...and SAYS the verdict is weaker"             "NOT attributable to a named test"
+# The attribution gate must weaken ONLY the success verdict. Every diagnostic code
+# is exactly as informative at suite level, and preempting them would trade a real
+# finding for a procedural complaint.
+mkrepo 'BUGGY' 'FIXED' "$T_TRUE"
+  check "decorative tests still exit 4, not 8"          4 "$(run r/r 99 src.py -- 'bash t.sh')"
+mkrepo 'BUGGY' 'FIXED' "$T_FALSE"
+  check "a red PR still exits 3, not 8"                 3 "$(run r/r 99 src.py -- 'bash t.sh')"
+mkrepo 'FIXED' 'FIXED' "$T_GREP"
+  check "a test-only PR still exits 7, not 8"           7 "$(run r/r 99 src.py -- 'bash t.sh')"
+}
+
+# ------------------------------------------------------------ red variants
+# A break the harness does not catch is a path the harness does not test.
+# Every variant asserts its own changed-line count first: 0 lines changed means
+# the variant is INERT and proves nothing, which has bitten this pack five times.
+red_variant() {
+  local name="$1" sed_prog="$2" want_desc="$3"
+  local V="$T/red_$name.sh"
+  sed "$sed_prog" "$SRC" > "$V"
+  local delta; delta=$(diff <(cat "$SRC") <(cat "$V") | grep -c '^[<>]')
+  echo "=== RED $name: $want_desc"
+  echo "    changed lines: $delta   (0 would mean the variant is INERT)"
+  if [ "$delta" -eq 0 ]; then echo "    FAILED: variant changed nothing; it cannot prove anything"; return 1; fi
+  local out; out=$(prove "$V" "[RED $name]" 2>&1)
+  if printf '%s' "$out" | grep -q '^  FAIL'; then
+    echo "    CAUGHT by: $(printf '%s' "$out" | grep '^  FAIL' | head -3 | sed 's/^  FAIL  /                /')"
+    return 0
+  fi
+  echo "    NOT CAUGHT -- the harness passes a broken script. This is the finding."
+  printf '%s\n' "$out" | tail -5
+  return 1
+}
+
+if [ "${1:-}" = "--red" ]; then
+  which="${2:-all}"; rfail=0
+  # A: the decorative-test guard removed. The dangerous direction.
+  [ "$which" = all ] || [ "$which" = A ] && { red_variant A 's/^if \[ \$rev_rc -eq 0 \]; then/if false; then/' \
+      "exit 4 guard disabled: decorative tests read as a pass" || rfail=1; echo; }
+  # B: the head-run guard removed, so a broken PR proceeds into the experiment.
+  [ "$which" = all ] || [ "$which" = B ] && { red_variant B 's/^if \[ \$head_rc -ne 0 \]; then/if false; then/' \
+      "exit 3 guard disabled: a red PR is experimented on anyway" || rfail=1; echo; }
+  # C: the restore check removed, so run 2's failure stops being attributable.
+  [ "$which" = all ] || [ "$which" = C ] && { red_variant C 's/^if \[ \$res_rc -ne 0 \]; then/if false; then/' \
+      "exit 5 guard disabled: an unrestorable tree reads as a pass" || rfail=1; echo; }
+  # D: the tsk-wyfp6q fix removed, reverting to the behaviour that refused #144.
+  # D targets ONLY the exit, not the whole classification block: deleting the
+  # block would break the script loudly under `set -u` (unset REVERT/NEWPATH),
+  # which the harness would catch for the wrong reason and tell me nothing.
+  [ "$which" = all ] || [ "$which" = D ] && { red_variant D 's/^  exit 7$/  : # RED D/' \
+      "exit 7 neutered: a test-only PR is accused of decorative tests again" || rfail=1; echo; }
+  # E: the typo guard neutered, so a mistyped path is absorbed by exit 7 and
+  # reads as a clean 'not applicable' instead of a usage error.
+  [ "$which" = all ] || [ "$which" = E ] && { red_variant E 's/^  exit 2$/  : # RED E/' \
+      "typo guard neutered: a bad pathspec reads as not-applicable" || rfail=1; echo; }
+  # F: the attribution gate neutered, so a suite-level red reads as proof about a
+  # named test again -- the exact miss on #146.
+  [ "$which" = all ] || [ "$which" = F ] && { red_variant F 's/^  exit 8$/  : # RED F/' \
+      "attribution gate neutered: a suite-level red reads as proved" || rfail=1; echo; }
+  [ "$rfail" -eq 0 ] && { echo "SUCCESS: every red variant was caught"; exit 0; }
+  echo "FAILED: a red variant slipped through"; exit 1
+fi
+
+prove "$SRC"
+echo
+echo "  paths asserted: $passes"
+if [ "$fail" -eq 0 ]; then echo "SUCCESS: every path proved against the CURRENT script"; exit 0; fi
+echo "FAILED: a path regressed"; exit 1

--- a/tools/red_first.sh
+++ b/tools/red_first.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# red_first.sh <repo> <pr> <src-path>... -- <test-cmd>
+# Mechanizes the pass/fail/pass cycle. Spec: @taOS-dev tsk-3oaabh part 2 of 3,
+# relayed verbatim on the bus at 1854; implementation notes from the same message
+# so the fleet keeps ONE definition of red-first.
+#
+# WHAT IT GUARDS. The tests-green-through-the-regression class: on taOS,
+# reintroducing a closed PR's exact defect left 87 tests green because the test
+# helper bypassed the layer the fix lives in. A test that passes with the fix
+# reverted is not testing the fix.
+#
+# CYCLE, in a throwaway worktree at the PR head:
+#   1. run test-cmd            -> must PASS
+#   2. revert ONLY the named source paths to the MERGE-BASE, rerun -> must FAIL
+#   3. restore, rerun          -> must PASS
+# Reverting to the merge-base (not the base branch tip) keeps unrelated drift on
+# main out of the experiment, and checking out only the named paths leaves the
+# PR's own tests in place, which is the whole point.
+#
+# Exit codes are deliberately distinct so a wrong-shape outcome can never read as
+# a pass, and the first line is always SUCCESS:/FAILED: so a timeout cannot either.
+#   0 = pass/fail/pass, the tests genuinely exercise the change
+#   2 = usage error (includes a named path that exists at NEITHER end)
+#   3 = head run FAILED (the PR is broken before we start; nothing was learned)
+#   4 = revert run PASSED  <-- THE DANGEROUS ONE: tests are decorative
+#   5 = restore run FAILED (the script left the tree dirty; do not trust run 2)
+#   6 = setup failure (fetch/worktree/merge-base unreadable) -- FAIL CLOSED
+#   7 = NOT APPLICABLE: no named source moved between merge-base and head, so
+#       this cycle cannot be run at all. NOT a verdict about the tests.
+#   8 = RED, BUT SUITE-LEVEL: the cycle passed and the red is not attributable to
+#       any particular test. NOT a failure, and NOT proof about a named test.
+#
+# WHY 8 EXISTS, and it cost a real miss. `run()` evaluates ONE test command and
+# judges the whole invocation by its exit code, so A SUITE-LEVEL RED IS SATISFIABLE
+# BY A TEST OTHER THAN THE ONE THE ACCEPTANCE CRITERION IS ABOUT. On PR #146 I named
+# three source paths and a suite command: other tests genuinely went red, the cycle
+# returned 0, and the one test named for the property -- which passed against the
+# correct AND the broken implementation alike -- hid behind its neighbours. The tool
+# proved "this SUITE exercises this change" and I read it as "this TEST does".
+#
+# Discharge it by naming ONE test, one invocation per property. Pass --suite to
+# accept the weaker verdict deliberately; that is a legitimate choice, but it must
+# be a CHOICE and not the default reading of a 0.
+#
+# HONEST LIMIT OF THE DETECTION: this pattern-matches the command for a per-test
+# selector. It does not understand the test runner, and a selector that matches many
+# tests still reads as specific. It cannot be fooled in the direction that matters
+# (a bare suite command is never mistaken for a named test), which is the only
+# direction that produced the miss.
+set -uo pipefail
+[ "${1:-}" = "--help" ] && { echo "usage: red_first.sh [--suite] <repo> <pr> <src-path>... -- <test-cmd>"; exit 0; }
+SUITE_OK=0
+[ "${1:-}" = "--suite" ] && { SUITE_OK=1; shift; }
+REPO="${1:-}"; PR="${2:-}"; shift 2 2>/dev/null || { echo "FAILED: usage: red_first.sh [--suite] <repo> <pr> <src-path>... -- <test-cmd>"; exit 2; }
+SRC=(); while [ $# -gt 0 ] && [ "$1" != "--" ]; do SRC+=("$1"); shift; done
+[ "${1:-}" = "--" ] && shift
+TEST_CMD="$*"
+[ -z "$REPO" ] || [ -z "$PR" ] || [ ${#SRC[@]} -eq 0 ] || [ -z "$TEST_CMD" ] && {
+  echo "FAILED: usage: red_first.sh <repo> <pr> <src-path>... -- <test-cmd>"; exit 2; }
+
+WT="$(mktemp -d -p "${TMPDIR:-/tmp}" redfirst-XXXXXX)"
+cleanup(){ git worktree remove --force "$WT" >/dev/null 2>&1; git worktree prune >/dev/null 2>&1; }
+trap cleanup EXIT
+
+git fetch -q origin "refs/pull/$PR/head:redfirst-$PR" --force 2>/dev/null || { echo "FAILED: cannot fetch PR #$PR"; exit 6; }
+BASE_REF="$(gh pr view "$PR" --repo "$REPO" --json baseRefName -q .baseRefName 2>/dev/null)"
+[ -z "$BASE_REF" ] && { echo "FAILED: cannot read base ref for #$PR"; exit 6; }
+git fetch -q origin "$BASE_REF" 2>/dev/null
+MB="$(git merge-base "origin/$BASE_REF" "redfirst-$PR" 2>/dev/null)"
+[ -z "$MB" ] && { echo "FAILED: cannot compute merge-base of origin/$BASE_REF and PR head"; exit 6; }
+git worktree add -q --detach "$WT" "redfirst-$PR" 2>/dev/null || { echo "FAILED: cannot create worktree"; exit 6; }
+
+run(){ ( cd "$WT" && eval "$TEST_CMD" ) >"$WT/.rf.log" 2>&1; return $?; }
+
+# --- CLASSIFY THE NAMED PATHS BEFORE RUNNING ANYTHING ----------------------
+# NO SOURCE MOVED is not the same as DECORATIVE TESTS, and conflating the two is
+# how PR #144 -- a correct test-only build restoring a dropped test -- was told
+# "the tests do NOT exercise this change". The revert was a no-op, so run 2
+# passed, so the tool blamed the tests for the tool's own inability to express
+# the experiment. A demand that cannot be satisfied is malformed; it needs its
+# own exit code, not the nearest-looking verdict.
+REVERT=(); NEWPATH=(); MISSING=()
+for p in "${SRC[@]}"; do
+  at_mb=0; at_head=0
+  git cat-file -e "$MB:$p" 2>/dev/null && at_mb=1
+  git cat-file -e "redfirst-$PR:$p" 2>/dev/null && at_head=1
+  if [ $at_mb -eq 0 ] && [ $at_head -eq 0 ]; then MISSING+=("$p")
+  elif [ $at_mb -eq 0 ]; then NEWPATH+=("$p")
+  else REVERT+=("$p"); fi
+done
+# A typo must not be absorbed by exit 7 as "not applicable" -- that would turn a
+# mistyped path into a clean-looking outcome, which is the failure mode this
+# whole exit code exists to prevent.
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "FAILED: named path(s) exist at NEITHER the merge-base nor the PR head: ${MISSING[*]}"
+  echo "        Nothing to revert; check the path spelling against the PR's file list."
+  exit 2
+fi
+# The PR ADDS these files, so the correct revert is to DELETE them. `git checkout
+# <rev> -- <path>` cannot express a deletion, and it fails the WHOLE invocation,
+# so one added file among N named paths used to kill an otherwise valid run.
+if ! git diff --quiet "$MB" "redfirst-$PR" -- "${SRC[@]}" 2>/dev/null; then
+  :
+else
+  echo "  merge-base ${MB:0:8} | named paths: ${SRC[*]}"
+  echo "NOT APPLICABLE: none of the named source paths differ between the merge-base"
+  echo "        and the PR head, so there is nothing to revert and the pass/fail/pass"
+  echo "        cycle does not apply. This is NOT a finding about the tests."
+  echo "        A test-only PR satisfies red-first by mutating the source the test"
+  echo "        covers and pasting that run, not by reverting a change it never made."
+  exit 7
+fi
+
+run; head_rc=$?
+if [ $head_rc -ne 0 ]; then
+  echo "FAILED: run 1 (PR head) FAILED rc=$head_rc. The PR is red before the experiment starts."
+  tail -5 "$WT/.rf.log" | sed 's/^/    /'
+  exit 3
+fi
+
+if [ ${#REVERT[@]} -gt 0 ]; then
+  ( cd "$WT" && git checkout -q "$MB" -- "${REVERT[@]}" ) 2>/dev/null || {
+    echo "FAILED: cannot revert named paths to merge-base ${MB:0:8}: ${REVERT[*]}"; exit 6; }
+fi
+if [ ${#NEWPATH[@]} -gt 0 ]; then
+  ( cd "$WT" && rm -rf -- "${NEWPATH[@]}" ) || {
+    echo "FAILED: cannot delete PR-added paths: ${NEWPATH[*]}"; exit 6; }
+fi
+run; rev_rc=$?
+
+( cd "$WT" && git checkout -q "redfirst-$PR" -- "${SRC[@]}" ) 2>/dev/null || { echo "FAILED: cannot restore paths"; exit 5; }
+run; res_rc=$?
+
+echo "  merge-base ${MB:0:8} | reverted: ${REVERT[*]:-none}${NEWPATH:+ | deleted (added by this PR): ${NEWPATH[*]}}"
+echo "  run 1 head    rc=$head_rc  (want pass)"
+echo "  run 2 reverted rc=$rev_rc  (want FAIL)"
+echo "  run 3 restored rc=$res_rc  (want pass)"
+
+if [ $rev_rc -eq 0 ]; then
+  echo "FAILED: run 2 PASSED with the change reverted. The tests do NOT exercise this change."
+  echo "        This is the decorative-test case: green here means nothing."
+  exit 4
+fi
+if [ $res_rc -ne 0 ]; then
+  echo "FAILED: run 3 did not return to green (rc=$res_rc); run 2's failure is not attributable."
+  exit 5
+fi
+# ATTRIBUTION, checked only here. Every diagnostic code above (3/4/5/6/7) stays
+# exactly as informative at suite level, so this must not preempt them -- it only
+# ever weakens the SUCCESS verdict, which is the one that was being over-read.
+case " $TEST_CMD " in
+  *"::"*|*" -k "*|*" -run "*|*" --test "*|*" --filter "*|*"--gtest_filter"*) SPECIFIC=1;;
+  *) SPECIFIC=0;;
+esac
+if [ "$SPECIFIC" -eq 0 ] && [ "$SUITE_OK" -eq 0 ]; then
+  echo "RED IS SUITE-LEVEL: pass/fail/pass held, but the test command names no single"
+  echo "        test, so run 2's failure is not attributable to any particular one."
+  echo "        A test that discriminates nothing passes run 2 unnoticed while its"
+  echo "        neighbours go red. That is how #146 returned 0 carrying a test that"
+  echo "        passed against the correct and the broken code alike."
+  echo "        Re-run naming ONE test (one invocation per property), or pass --suite"
+  echo "        to accept the weaker verdict deliberately."
+  exit 8
+fi
+[ "$SUITE_OK" -eq 1 ] && [ "$SPECIFIC" -eq 0 ] && \
+  echo "  NOTE: --suite given, so this red is NOT attributable to a named test."
+echo "SUCCESS: pass/fail/pass. The tests genuinely exercise the reverted source."
+exit 0

--- a/tools/resume_arm_time.py
+++ b/tools/resume_arm_time.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""Derive the resume-pair PRIMARY arm time from the usage watcher's ACTUAL cron spec.
+
+Usage:  resume_arm_time.py <resets_at ISO8601> [margin_seconds]
+Prints: the arm instant (UTC), the 5-field cron line for a one-shot, and the
+        evidence it used, so the caller can check the derivation rather than
+        trust the number.
+
+WHY THIS EXISTS (2026-08-16, bus 2774/2776/2777/2779, @taOSc-dev).
+The resume pair kept waking inside the window where /home/jay/.taos-usage/current.json
+still reports the PREVIOUS window's utilization. The gate read a file written by a
+different component on its own schedule, so the wake landed in the gap by construction.
+
+We fixed it three times and the first two fixes were the same mistake at different
+scales:
+  +2min  - tuned to nothing, always wrong.
+  +7min  - tuned to the two instances in hand; still fails for r in {6,7,8} and is
+           marginal at r=9, which is where BOTH real windows sit.
+  +11min - correct for TODAY, but it is only `cadence + 1`. Nothing at the three
+           hardcoded sites pointed back at the crontab line that made it true, so
+           widening that cron to */15 would silently re-create the bug with no
+           constant appearing to change.
+
+So this script does not encode an offset at all. It reads the watcher's real cron
+spec and arms strictly after the FIRST TICK FOLLOWING THE RESET, which is correct
+for any phase AND any cadence, including a NON-UNIFORM tick list. Note the minute
+field is an enumeration (`6,16,26,36,46,56`), not `*/10`: its uniformity is
+incidental and must not be assumed.
+
+It FAILS LOUD if it cannot find the watcher line. A gate whose PASS is reachable
+from zero data is not a gate: silently falling back to a constant is exactly the
+failure this replaces.
+
+The offset is a LATENCY property, not the correctness fix. The correctness fix is
+to gate on the STDOUT of usage_publish.sh and never on a re-read of current.json,
+because that script does not write current.json at all.
+
+MARGIN, and it is measured rather than assumed (2026-08-16). The margin only has to
+cover the watcher's own run duration, i.e. the gap between the tick firing and
+current.json being fully written. Two samples of that gap, taken from the file's
+mtime against its tick: 2.336s (tick :56:00) and 1.755s (tick :36:00). So the write
+lands about 2 seconds after its tick and the 60s default is roughly 25x headroom.
+This also retires an open worry: the earlier +7 arm was NOT in fact racing the write
+at r=9 (it woke 59s after the tick, which is ~28x the observed write time). +7's real
+and sufficient defect was that it fails OUTRIGHT for r in {6,7,8}, which is a phase
+error, not a race. Do not carry "+7 was marginal" forward as a race claim; it was
+wrong for a different reason.
+"""
+import datetime
+import getpass
+import re
+import subprocess
+import sys
+import time
+
+# The two tunables, each stating WHAT IT IS A FUNCTION OF. That is the whole point of
+# this file: a constant whose dependency is unnamed is the bug it exists to prevent.
+#
+# MARGIN_SECONDS is a function of the WATCHER'S WRITE DURATION, and it is MEASURED:
+# current.json's mtime landed 2.336s and 1.755s after its tick in two samples
+# (2026-08-16). 60s is ~25x that. Re-measure if watch.sh grows work.
+MARGIN_SECONDS = 60
+#
+# RETRY_LEAD_SECONDS is a function of THE PRIMARY'S FIRE-TO-DELETE LATENCY: how long the
+# primary wake needs, from the instant cron fires it, to delete the retry. The retry must
+# not fire before that deletion. MEASURED (2026-08-14..16, from JSONL session transcripts,
+# 2646 scanned): primary cron fire -> CronDelete of the retry.
+#   2026-08-14T11:02:00.636Z -> 11:02:08.861Z  =   8.225s  (retry 006c193f, 11:00Z 5h reset, 9a70afb2)
+#   2026-08-14T16:02:00.600Z -> 16:02:50.329Z  =  49.729s  (retry 8fc267d6, 16:00Z 5h reset, 6c6b87ec)
+#   2026-08-14T21:02:00.422Z -> 21:02:03.874Z  =   3.452s  (retry 537c3e51, 21:00Z 5h reset, 6c6b87ec)
+#   2026-08-15T02:02:00.790Z -> 02:02:24.992Z  =  24.202s  (retry 1b93ed60, 02:00Z 7d reset, f03f3af1)
+#   2026-08-16T02:02:00.849Z -> 02:02:04.960Z  =   4.111s  (retry 5ff29d1b, 01:59:59Z 7d reset, f03f3af1)
+#   2026-08-16T03:02:00.293Z -> 03:02:04.895Z  =   4.602s  (retry 8ea092dd, 03:00Z 5h reset, 179fcc0b)
+#   2026-08-16T08:11:00.322Z -> 08:11:16.318Z  =  15.996s  (retry 649adf47, 07:59:59Z 5h reset, 85a5f4a)
+# Max observed: 49.729s (the 16:02Z wake, 6c6b87ec). 60s is above the max.
+# Re-measure when the primary's wake path changes: each sample is a primary-wake ->
+# first-CronDelete pair from a resume JSONL transcript.
+#
+# THE TABLE ABOVE IS EVIDENCE I HAVE NOT INDEPENDENTLY RE-DERIVED. It arrived by an
+# unattributed write into this shared directory and is kept as documentation, NOT as the
+# justification for a value change. A previous version of this block cited "the RED witness in
+# test_resume_arm_time.py"; that witness does not exist in that file, and the suite stayed
+# GREEN over the dangling citation (@taOSmd-dev, bus 2840). Citation removed rather than left
+# pointing at nothing.
+#
+# THE LEAD IS NOT THE GAP, and both @taOSmd-dev and I argued about the wrong quantity first.
+# retry_after() does not place the retry at primary+lead; it walks to the next WATCHER TICK
+# whose fire clears the lead, so the tick lattice quantises the result. Reproduced here at the
+# production spec (*/10 offset 6, reset 13:00Z, primary fire 13:07Z):
+#     lead 0 / 60 / 599 / 600  -> retry 13:17Z, armed gap  600s   (identical)
+#     lead 601                 -> retry 13:27Z, armed gap 1200s
+# One boundary in the whole range. The suite already said so and we both read past it:
+# "lead=-900: retry STILL lands after the primary" is lattice dominance, stated as a PASS.
+#
+# 60s is the smallest lead the production lattice can satisfy (the next tick is always >= 60s
+# away) and is above the measured max of 49.729s. Under a dense spec where gap can equal lead,
+# 60 leaves headroom against the observed max. Re-measure if the primary's wake path changes.
+RETRY_LEAD_SECONDS = 60
+#
+# MIN_LEAD_SECONDS is a function of UPSTREAM ROLLOVER PROPAGATION: how long after the
+# nominal reset instant the usage API actually serves the new window. That quantity is
+# NOT MEASURED and 30 is a guess, stated as one rather than dressed as a derivation
+# (@taOSc-dev, bus 2782, correctly noting it names nothing). It only binds when a tick
+# falls within 30s of a reset, which the current 6-mod-10 spec never does; it was added
+# for wide/aligned specs like */15 where a tick can land 0.2s after the reset. TO
+# MEASURE: at a reset boundary, poll the API each second and record when the returned
+# window flips. Until then this is the one honestly-unfounded number in the file.
+MIN_LEAD_SECONDS = 30
+#
+# SCHEDULER_EARLY_JITTER_SECONDS is a function of THE SCHEDULER'S OWN CONTRACT, which is a
+# layer MARGIN_SECONDS never named and which can undo it entirely. CronCreate documents:
+# "one-shot tasks landing on :00 or :30 fire up to 90 s early". The resume pair are
+# one-shots. So an arm computed at :00 or :30 with a 60s margin can fire 90s early, i.e.
+# 30s BEFORE its own tick - exactly the race the margin exists to prevent, reintroduced by
+# a dependency the margin did not declare.
+# MEASURED by enumeration, not assumed: with ticks at :29 or :59 and the default margin the
+# derived arm lands on :30 / :00 with a 60s lead, and 4 of the 6 reachable
+# (tick, margin) combinations have a lead under the 90s jitter. TODAY'S REAL SPEC IS SAFE
+# (ticks 6..56 arm at :07..:57, none jittered), which is precisely why this went unnoticed:
+# correct by instance again. Found by reading the scheduler contract after @taOSc-dev
+# (bus 2795) argued the conversion might not need to exist at all.
+SCHEDULER_EARLY_JITTER_SECONDS = 90
+JITTERED_MINUTES = (0, 30)
+#
+# A FOURTH LAYER, NAMED BUT NOT MODELLED (@taOSc-dev, bus 2798 (2); recorded here at the
+# 08:4xZ retrospective, which caught that I had promised to record it HERE and had instead
+# recorded it only on the bus and in my handoff - the two places nobody editing this file
+# reads). DELIVERY: the scheduler states "Jobs only fire while the REPL is idle (not
+# mid-query)." An arm derived correctly, encoded correctly, and jittered inside its declared
+# 90s is still not delivered at its denoted instant if the REPL is busy then.
+#
+# Two asymmetries make this worse than the jitter, and neither is handled below:
+#   - MARGIN_SECONDS is a ONE-SIDED guard. It buys clearance so the wake lands AFTER the
+#     watcher's write, i.e. it bounds EARLY. Idle-gating is purely LATE, and unlike the 90s
+#     the contract states NO BOUND on it at all.
+#   - The inversion refusal in main() is a DERIVATION-time check on two cron lines. It can
+#     only assert that the DENOTED order is primary-then-retry. IT CANNOT ASSERT THE FIRE
+#     ORDER. What happens when two one-shots come due during one non-idle stretch and are
+#     released together is NOT MEASURED and is not asserted here either way.
+#
+# Deliberately NOT fixed: every previous round of this file was made worse by acting on a
+# mechanism nobody had read. TO MEASURE: arm two one-shots a minute apart, hold the REPL
+# busy across both, and record the delivered order and lag.
+
+# All FIVE cron fields are captured, not just the minute. The first version consumed
+# hour/dom/month/dow as unanchored \S+ and never looked at them, so an hour-restricted or
+# weekday-only watcher line matched, nothing failed, and the script derived an arm time
+# asserting a write that never happens (@taOSc-dev, bus 2785; reproduced: a `... 8 * * *`
+# watcher yielded a derived tick at 15:06 while the watcher only runs at hour 8). That is
+# the ORIGINAL staleness bug rebuilt, with `EVIDENCE (read, not assumed)` printed above it.
+# We do not model those fields, so we REFUSE them rather than model them wrong.
+WATCHER_RE = re.compile(
+    r"^([0-9,\-*/]+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+.*taos-usage/watch\.sh")
+
+
+def parse_minutes(spec, line):
+    """The minute field -> a sorted tick list, REFUSING anything it does not model.
+
+    (@taOSc-dev, bus 2790 (A); every case below reproduced before fixing.) WATCHER_RE
+    admits `[0-9,\\-*/]+`, which is a strictly larger language than this parser models.
+    Previously anything in the gap either reduced to an empty set and fell out of the
+    caller's loop into "the crontab WAS read, but it contains no watch.sh line" - FALSE,
+    the line is right there and it matched - or died on a bare ValueError with no
+    diagnosis at all:
+        `5-2`   -> range(5,3) -> empty -> the false watcher-gone message
+        `*/0`   -> ValueError: range() arg 3 must not be zero
+        `-` `,,` `1--2` -> ValueError from int()/unpack
+    That is exactly the collapse this module refuses 60 lines earlier for the crontab
+    read: telling the operator the staleness model is GONE when the model is intact and
+    it is the PARSE that failed sends them to re-derive something that is fine. The
+    split is only worth having if every failure lands in the right half, so an
+    unmodelled spec now gets its own refusal naming the spec, and the caller's
+    fall-through is reachable ONLY when no line matched.
+    """
+    def bad(why):
+        return SystemExit(
+            f"FAIL: the watcher line MATCHED but its minute field {spec!r} is not one\n"
+            f"this script models ({why}).\n"
+            f"  line: {line}\n"
+            "This is NOT 'the watcher is gone' and NOT 'the crontab is unreadable'. The\n"
+            "schedule is present and the PARSE failed, so the staleness model is intact\n"
+            "and does not need re-deriving. Modelled forms: `*`, `M`, `A-B` (A<=B),\n"
+            "`*/S` (S>=1), and comma-separated combinations of those.\n"
+            "REFUSING to guess a tick list rather than derive an arm time from one."
+        )
+    mins = set()
+    for part in spec.split(","):
+        if part == "":
+            raise bad(f"empty element in {spec!r}")
+        if part == "*":
+            mins.update(range(60))
+        elif part.startswith("*/"):
+            step = part[2:]
+            if not step.isdigit() or int(step) < 1:
+                raise bad(f"step {step!r} is not a positive integer")
+            mins.update(range(0, 60, int(step)))
+        elif "-" in part:
+            halves = part.split("-")
+            if len(halves) != 2 or not all(h.isdigit() for h in halves):
+                raise bad(f"range {part!r} is not exactly two integers")
+            a, b = int(halves[0]), int(halves[1])
+            if a > b:
+                raise bad(f"range {part!r} is descending, which cron does not accept")
+            if b > 59:
+                raise bad(f"range {part!r} exceeds minute 59")
+            mins.update(range(a, b + 1))
+        elif part.isdigit():
+            if int(part) > 59:
+                raise bad(f"minute {part!r} exceeds 59")
+            mins.add(int(part))
+        else:
+            raise bad(f"element {part!r} is not a minute, a range, or a step")
+    if not mins:
+        raise bad("it yields no ticks at all")
+    return sorted(mins)
+
+
+def watcher_minutes():
+    """(minutes, evidence_line). Raises if the watcher line is absent.
+
+    The two failure modes below are deliberately NOT collapsed (@taOSc-dev, bus 2782).
+    An unreadable crontab and a deleted watcher line both yield empty stdout, but they
+    call for opposite responses: the first means this script cannot see the schedule,
+    the second means the schedule is gone. Reporting "the staleness model is gone" when
+    the crontab merely could not be read tells the operator to re-derive a model that is
+    fully intact. @taOSc-dev hit exactly this from the other side: `crontab` is not in
+    their permission set, so they saw the watcher-is-gone text while the watcher ran fine.
+    """
+    proc = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SystemExit(
+            "FAIL: could not READ the crontab (`crontab -l` exited "
+            f"{proc.returncode}: {proc.stderr.strip() or 'no stderr'}).\n"
+            "This is NOT the same as the watcher being gone, and it does NOT mean the\n"
+            "staleness model is invalid. It means THIS PROCESS cannot see the schedule:\n"
+            "wrong user, no crontab binary, or a sandboxed/systemd context with no HOME.\n"
+            f"Running as user: {getpass.getuser()!r}. The watcher line lives in jay's crontab."
+        )
+    out = proc.stdout
+    matches = []
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("#"):
+            continue
+        m = WATCHER_RE.match(line)
+        if not m:
+            continue
+        matches.append((m, line))
+
+    # More than one watcher line is a schedule this script does not model. The union
+    # would arm EARLIER than one of them writes, so it is not safely mergeable without
+    # knowing which line actually maintains current.json (@taOSc-dev, bus 2785 (C)).
+    if len(matches) > 1:
+        raise SystemExit(
+            f"FAIL: {len(matches)} taos-usage/watch.sh lines in the crontab. This script\n"
+            "models exactly one writer and cannot tell which maintains current.json.\n"
+            + "".join(f"  {ln}\n" for _, ln in matches) +
+            "Resolve to a single watcher line, or teach this script which one wins."
+        )
+
+    for m, line in matches:
+        spec = m.group(1)
+        # Fields 2-5 must be unrestricted. See WATCHER_RE.
+        FIELDS = (("hour", m.group(2)), ("day-of-month", m.group(3)),
+                  ("month", m.group(4)), ("day-of-week", m.group(5)))
+        restricted = [(name, val) for name, val in FIELDS if val != "*"]
+        if restricted:
+            raise SystemExit(
+                "FAIL: the watcher line restricts cron fields this script does not model:\n"
+                + "".join(f"  {name} = {val!r}\n" for name, val in restricted) +
+                f"  line: {line}\n"
+                "Only the MINUTE field is modelled; the tick generator assumes the watcher\n"
+                "runs every hour of every day. With a restriction present it would derive an\n"
+                "arm time asserting a write that never happens, which is exactly the\n"
+                "staleness bug this script exists to prevent. REFUSING to model it wrong."
+            )
+        return parse_minutes(spec, line), line
+    raise SystemExit(
+        "FAIL: the crontab WAS read, but it contains no taos-usage/watch.sh line.\n"
+        f"(read successfully as user {getpass.getuser()!r}; the watcher line lives in jay's.)\n"
+        "REFUSING to guess an offset. The whole point of this script is that the arm\n"
+        "time is derived from the watcher's real schedule. If the watcher is genuinely\n"
+        "gone, the staleness model is gone too and the caller must re-derive it rather\n"
+        "than fall back to a constant."
+    )
+
+
+def first_tick_after(when, minutes, min_lead=MIN_LEAD_SECONDS):
+    """First cron tick at least `min_lead` seconds after `when`.
+
+    NOT merely "strictly after". Found by the script's own RED test (2026-08-16):
+    under a */15 spec the first tick after a 07:59:59 reset is 08:00:00, i.e. 0.2s
+    later, and a watcher firing 0.2s after the reset instant is racing the upstream
+    rollover rather than observing it. That is a DIFFERENT failure from the phase bug
+    this script was written for, and "strictly after" does not exclude it. Skipping to
+    the next tick costs one cadence of latency and removes the race.
+    """
+    t = when.replace(second=0, microsecond=0)
+    for _ in range(60 * 25):  # a day of minutes, far past any real gap
+        t += datetime.timedelta(minutes=1)
+        if t.minute in minutes and (t - when).total_seconds() >= min_lead:
+            return t
+    raise SystemExit("FAIL: no tick found within 24h of the reset.")
+
+
+def fire_time(tick, margin):
+    """The instant cron ACTUALLY fires for a given tick and margin.
+
+    CEIL to the next whole minute. cron has minute resolution, so truncating here
+    silently DISCARDS the margin: a 30s margin printed an ARM AT of :06:30 and a cron
+    line of :06, which fires AT THE TICK with an effective margin of 0s against a
+    ~2.3s write. The two lines contradicted each other on the same run
+    (@taOSc-dev, bus 2782; reproduced before fixing). Rounding down is the one
+    direction that reintroduces the exact race the margin exists to prevent.
+
+    Factored out so the PRIMARY and the RETRY cannot round differently. Two copies of
+    a rounding rule is the duplicate-definition trap of tsk-djcab7: both would be
+    individually correct and no gate we run would see them diverge.
+    """
+    arm = tick + datetime.timedelta(seconds=margin)
+    fire = arm.replace(second=0, microsecond=0)
+    if arm.second or arm.microsecond:
+        fire += datetime.timedelta(minutes=1)
+    return arm, fire
+
+
+def cron_fields(fire):
+    """The four numeric fields this script emits, from an aware instant."""
+    local = fire.astimezone()
+    return local.minute, local.hour, local.day, local.month
+
+
+def check_round_trip(fire, label):
+    """Refuse to emit a cron line that does not denote the instant it was derived from.
+
+    (@taOSc-dev, bus 2790 (B).) The UTC->local CONVERSION was already correct; the
+    REPRESENTATION is what leaks. A local wall clock is not a bijection with instants:
+
+      - DST fall-back. In the repeated hour the emitted line denotes TWO instants and
+        cron fires the EARLIER one, so the wake lands an hour BEFORE the tick it was
+        derived from. That is the original staleness bug with a correct derivation
+        sitting upstream of it, and early is the dangerous direction.
+      - DST spring-forward. In the skipped hour the line denotes NO instant.
+
+    MEASURED before fixing, with TZ=America/New_York and a reset inside the 2026-11-01
+    fold: derived fire 06:07:00Z, emitted line `7 1 1 11`, which denotes 05:07:00Z.
+    Sixty minutes early. This box is UTC so it round-trips today BY INSTANCE, in exactly
+    the way `+11` was right by instance.
+
+    The check models none of that. It rebuilds the instant from the four fields actually
+    printed and compares, without knowing what DST is: REFUSE WHAT YOU DO NOT MODEL,
+    applied to output instead of input.
+
+    WHAT IT ACTUALLY COVERS, corrected after writing the test rather than claimed from
+    the design: the FOLD, yes, measured above. The GAP, no - and it cannot, from this
+    direction. `fire.astimezone()` always yields a wall clock that EXISTS, so no derived
+    instant can land in the skipped hour, and the spring-forward case is unreachable here
+    rather than caught. The docstring said "the fold, the gap, and any dropped field"
+    until the test showed otherwise. A guard advertising coverage it does not have is the
+    same defect as a gate whose PASS is reachable from zero data.
+
+    NOT CAUGHT, and stated rather than papered over: a 5-field cron line carries no YEAR,
+    so this cannot detect a line left in place until next year. The one-shot semantics
+    live at the scheduler layer (CronCreate with recurring=false), not in these five
+    fields, so the representation is only complete in company with that flag.
+    """
+    err = round_trip_error(fire, label)
+    if err:
+        raise SystemExit(err)
+
+
+def round_trip_error(fire, label):
+    """None if the emitted fields denote `fire`, else the reason as a string."""
+    mi, ho, dy, mo = cron_fields(fire)
+    local = fire.astimezone()
+    # fold=0 is deliberate: it is the EARLIER of a repeated wall clock, which is the one
+    # cron fires. Reconstructing with fold=1 would hide the very failure being checked.
+    rebuilt = datetime.datetime(local.year, mo, dy, ho, mi)
+    denoted = rebuilt.astimezone()
+    if denoted != fire:
+        drift = (denoted - fire).total_seconds() / 60
+        # NAME THE NONEXISTENT WALL CLOCK RATHER THAN REPORTING IT AS DRIFT
+        # (@taOSc-dev, bus 2795 (1)). If a field were dropped or mutated the rebuilt wall
+        # clock can be one that does not exist (the spring-forward gap). Python does not
+        # raise there, it normalises off the pre-transition offset, so the refusal is still
+        # correct but would be REPORTED as an hour of drift - the right refusal wearing a
+        # misleading reason, which is the shape of the margin=0 test I had to fix.
+        # A wall clock exists iff rendering its own denoted instant back reproduces it.
+        exists = denoted.replace(tzinfo=None) == rebuilt
+        cause = ("that wall clock DOES NOT EXIST in this zone (a spring-forward gap); it was\n"
+                 "normalised onto the pre-transition offset rather than rejected"
+                 if not exists else
+                 "that wall clock is AMBIGUOUS in this zone (a fall-back fold): it denotes two\n"
+                 "instants and cron fires the earlier")
+        return (
+            f"FAIL: the {label} cron line `{mi} {ho} {dy} {mo} *` does not denote the\n"
+            f"instant it was derived from.\n"
+            f"  derived : {fire.isoformat()}  ({fire.astimezone(datetime.timezone.utc)} UTC)\n"
+            f"  denotes : {denoted.isoformat()}  "
+            f"({denoted.astimezone(datetime.timezone.utc)} UTC)\n"
+            f"  drift   : {drift:+.0f} min\n"
+            f"  cause   : {cause}\n"
+            f"Local zone {time.tzname} does not render this instant and that wall clock as a\n"
+            "pair, so the four fields cannot carry it. REFUSING to emit this line."
+        )
+
+
+def unsafe_reason(tick, margin):
+    """None if a wake armed off `tick` is safe to emit, else why not.
+
+    One predicate for every way an arm can be wrong, so the primary and the retry cannot
+    disagree about what "safe" means. Three ways, and they come from three different
+    layers, which is the whole lesson of this file:
+      1. the ARITHMETIC layer  - the ceil could put the fire at or before the tick;
+      2. the SCHEDULER layer   - a one-shot on :00/:30 fires up to 90s early, which can
+                                 undo a margin that only ever declared the watcher;
+      3. the REPRESENTATION    - the four emitted fields may not denote the instant.
+    """
+    arm, fire = fire_time(tick, margin)
+    if fire <= tick:
+        return arm, fire, (f"fire {fire.isoformat()} is not after tick {tick.isoformat()}")
+    lead = (fire - tick).total_seconds()
+    if fire.astimezone().minute in JITTERED_MINUTES and lead <= SCHEDULER_EARLY_JITTER_SECONDS:
+        return arm, fire, (
+            f"fires on local minute :{fire.astimezone().minute:02d}, where the scheduler "
+            f"fires one-shots up to {SCHEDULER_EARLY_JITTER_SECONDS}s EARLY, which exceeds "
+            f"this arm's {lead:.0f}s lead over its tick and can land it BEFORE the write")
+    err = round_trip_error(fire, "candidate")
+    if err:
+        return arm, fire, "the emitted fields do not denote it (DST); " + err.splitlines()[0]
+    return arm, fire, None
+
+
+def next_safe_tick(after, minutes, margin, min_lead, skips):
+    """First tick at least `min_lead` after `after` whose ARM is safe to emit.
+
+    ADVANCING RATHER THAN REFUSING (@taOSc-dev, bus 2795 (2)). Refusing on the DST fold
+    was correct but incomplete: it turns "fires 60 minutes early" into "does not fire at
+    all", which is a strict improvement and still not a working wake, and on those two
+    days a year the resume arm simply would not be scheduled. Every unsafe condition here
+    is a property of a PARTICULAR tick, so the next one is usually fine: advancing costs
+    a bounded amount of latency and produces a wake. Skips are recorded and PRINTED, never
+    silent - a tool that quietly moved the wake would be worse than one that refused.
+    """
+    t = after.replace(second=0, microsecond=0)
+    for _ in range(60 * 25):
+        t += datetime.timedelta(minutes=1)
+        if t.minute not in minutes or (t - after).total_seconds() < min_lead:
+            continue
+        arm, fire, why = unsafe_reason(t, margin)
+        if why is None:
+            return t, arm, fire
+        skips.append((t, why))
+    raise SystemExit(
+        "FAIL: no tick within 24h yields a safe arm.\n"
+        + "".join(f"  skipped {t.isoformat()}: {w}\n" for t, w in skips[:8]) +
+        f"REFUSING to emit any of them.\n"
+        f"REMEDY when every skip cites the scheduler's early-fire jitter: raise the margin "
+        f"so the\narm clears the jittered minute. A watcher on :29/:59 with the default "
+        f"{MARGIN_SECONDS}s lands\nevery arm on :30/:00; margin 120 moves them to :31/:01 "
+        f"and derives normally. Pass it as\nargv[2]. The margin is a floor on the lead, not "
+        f"a target, so raising it costs only latency.")
+
+
+def retry_after(primary_fire, minutes, margin, lead=RETRY_LEAD_SECONDS):
+    """First tick whose FIRE lands at least `lead` seconds after the primary FIRES.
+
+    WHY THE RETRY IS DERIVED TOO (tsk-fd3kes, 2026-08-16). The primary became a
+    function of the watcher's cron spec while the retry stayed a flat resets_at+22min.
+    That is not merely inelegant, it silently re-creates the ORIGINAL bug: widen the
+    watcher to */30 and the derived primary moves to 08:31 while the retry sits at
+    08:21, so THE RETRY FIRES FIRST. The safety net becomes the primary, at a time
+    derived from nothing, i.e. inside the stale window - and it looks fine, because
+    the primary next to it is visibly derived. RED-tested: */30 inverts under the flat
+    rule and does not under this one.
+
+    The constraint is stated on the FIRE times rather than the ticks, because the
+    ceil-to-minute is what cron actually obeys and it can move a tick across the bound.
+
+    Note this composes TWO dependencies without conflating them: WHICH INSTANTS are
+    available comes from the watcher's cron spec (so the retry, like the primary, reads
+    a freshly-written file), while HOW LONG TO WAIT comes from the primary's
+    fire-to-delete latency. Neither is the other's function.
+    """
+    t = primary_fire
+    for _ in range(60 * 25):  # a day of minutes, far past any real gap
+        t += datetime.timedelta(minutes=1)
+        if t.minute not in minutes:
+            continue
+        arm, fire, why = unsafe_reason(t, margin)
+        if why is None and (fire - primary_fire).total_seconds() >= lead:
+            return t, arm, fire
+    raise SystemExit(
+        f"FAIL: no watcher tick within 24h of the primary fire {primary_fire.isoformat()} "
+        f"leaves the required {lead}s retry lead. REFUSING to emit an unordered pair."
+    )
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    raw = sys.argv[1]
+    try:
+        resets_at = datetime.datetime.fromisoformat(raw)
+    except ValueError as e:
+        raise SystemExit(
+            f"FAIL: could not parse {raw!r} as an ISO 8601 timestamp ({e}).\n"
+            "Note a trailing 'Z' only parses on Python 3.11+; on older interpreters pass\n"
+            "'+00:00' instead. Running: " + sys.version.split()[0]
+        )
+    # REJECT naive input rather than assuming UTC. The old `.replace(tzinfo=utc)` was an
+    # unnamed assumption of exactly the kind this file exists to eliminate: it is correct
+    # only because this box is UTC, and a caller passing naive LOCAL time on any other host
+    # would shift the whole derivation by the offset with no constant appearing to change
+    # (@taOSc-dev, bus 2785 (B)). The output side already learned to state its timezone;
+    # this is the input side learning the same thing.
+    if resets_at.tzinfo is None:
+        raise SystemExit(
+            f"FAIL: {raw!r} has no timezone. REFUSING to assume UTC.\n"
+            "This script emits a LOCAL cron line from a UTC-anchored computation, so an\n"
+            "ambiguous input silently shifts every armed wake by the host's offset.\n"
+            "Pass an explicit offset, e.g. '2026-08-16T07:59:59+00:00'. The usage API's\n"
+            "resets_at already carries one."
+        )
+    # argv[2] gets the SAME named-failure treatment as argv[1] (@taOSc-dev, bus 2790 (C)).
+    # It was a bare `int(sys.argv[2])` three lines under the block that catches argv[1] and
+    # names the interpreter version: `... abc` was an unhandled ValueError traceback, and a
+    # NEGATIVE margin was caught only by the `fire <= tick` assert, so the operator passing
+    # -30 was told "computed fire is not after tick" - the right refusal for the wrong
+    # reason, which is the same shape as (A). Reproduced for 'abc', '1e3', '' and '-30'
+    # before fixing.
+    if len(sys.argv) > 2:
+        raw_margin = sys.argv[2]
+        if not raw_margin.lstrip("-").isdigit():
+            raise SystemExit(
+                f"FAIL: margin {raw_margin!r} is not an integer number of seconds.\n"
+                "It is argv[2] and it is optional; omit it to use the default "
+                f"{MARGIN_SECONDS}s.\n"
+                "Note '1e3' and '60.0' are REFUSED on purpose rather than coerced: a margin\n"
+                "is the one knob that decides whether the armed wake clears the watcher's\n"
+                "write, so it is not a place to guess what the caller meant."
+            )
+        margin = int(raw_margin)
+        if margin < 1:
+            raise SystemExit(
+                f"FAIL: margin {margin}s is not positive.\n"
+                "The margin exists to clear the watcher's write, which lands ~2.3s after\n"
+                "its tick. A zero or negative margin arms AT or BEFORE the tick, which is\n"
+                "precisely the race this script was written to remove.\n"
+                "(Previously this was caught only by the fire-vs-tick assert, which told\n"
+                "you the computed fire was wrong rather than that YOUR INPUT was.)"
+            )
+    else:
+        margin = MARGIN_SECONDS
+
+    minutes, evidence = watcher_minutes()
+    skips = []
+    tick, arm, fire = next_safe_tick(resets_at, minutes, margin, MIN_LEAD_SECONDS, skips)
+
+    # cron reads LOCAL time; every instant above is UTC. This box is UTC so the two
+    # coincided, which made the dependency invisible. Convert explicitly and print the
+    # zone, so the cron line is correct by construction rather than by instance.
+    fire_local = fire.astimezone()
+
+    # `or 60` because a wrap-around gap of 0 means a SINGLE tick per hour, i.e. the
+    # widest cadence, and reporting it as the narrowest inverts the evidence line.
+    gaps = [((minutes[(i + 1) % len(minutes)] - minutes[i]) % 60) or 60
+            for i in range(len(minutes))]
+
+    if fire <= tick:
+        raise SystemExit(f"FAIL: computed fire {fire.isoformat()} is not after tick "
+                         f"{tick.isoformat()}. Refusing to emit a racing cron line.")
+
+    print("EVIDENCE (read, not assumed):")
+    print("  crontab: " + evidence)
+    print(f"  read as user={getpass.getuser()!r}  local_tz={time.tzname}  "
+          f"utc_offset={fire_local.strftime('%z')}")
+    print(f"  ticks={minutes}  gaps={gaps}  uniform={len(set(gaps)) == 1}  max_gap={max(gaps)}")
+    print(f"  margin={margin}s (fn of watcher write duration, MEASURED ~2.3s)  "
+          f"min_lead={MIN_LEAD_SECONDS}s (fn of upstream rollover, UNMEASURED)")
+    for t, why in skips:
+        print(f"SKIPPED    {t.isoformat()}: {why}")
+    print(f"RESET      {resets_at.isoformat()}")
+    print(f"FIRST TICK {tick.isoformat()}   (>= {MIN_LEAD_SECONDS}s after the reset)")
+    print(f"ARM AT     {arm.isoformat()}   (tick + {margin}s margin)")
+    print(f"FIRES AT   {fire.isoformat()}   (ceiled to the minute; cron has no seconds)")
+    print(f"           {fire_local.isoformat()}   (LOCAL, which is what cron reads)")
+    print(f"EFFECTIVE  {(fire - tick).total_seconds():.0f}s after the tick   "
+          f"(this, not the margin, is what actually protects the read)")
+    print(f"WAIT       {(fire - resets_at).total_seconds() / 60:.1f} min after reset")
+    check_round_trip(fire, "PRIMARY")
+    print("CRON       " + "{} {} {} {} *".format(*cron_fields(fire)))
+
+    # THE RETRY, derived from the same crontab read as the primary. Deriving it in a
+    # SECOND invocation would leave the pair's ordering resting on the crontab not
+    # changing in between, which is an unnamed dependency of exactly the kind this file
+    # exists to remove. One read, one ordering, both lines.
+    r_tick, r_arm, r_fire = retry_after(fire, minutes, margin)
+    r_local = r_fire.astimezone()
+
+    # The pair MUST be ordered. With RETRY_LEAD_SECONDS at 900 this is implied, but the
+    # assert is the thing that survives someone editing the constant, and an unordered
+    # pair is silent: both crons exist, both fire, and the wake still appears to work.
+    if r_fire <= fire:
+        raise SystemExit(
+            f"FAIL: retry {r_fire.isoformat()} does not fire after primary "
+            f"{fire.isoformat()}. REFUSING to emit an inverted pair: the retry would "
+            "become the primary, at a time derived from nothing."
+        )
+
+    print(f"RETRY TICK {r_tick.isoformat()}   (first tick clearing the lead)")
+    print(f"RETRY ARM  {r_arm.isoformat()}   (tick + {margin}s margin)")
+    print(f"RETRY FIRE {r_fire.isoformat()}   (ceiled; same rounding as the primary)")
+    print(f"           {r_local.isoformat()}   (LOCAL, which is what cron reads)")
+    print(f"RETRY GAP  {(r_fire - fire).total_seconds() / 60:.1f} min after the PRIMARY   "
+          f"(lead={RETRY_LEAD_SECONDS}s, fn of the primary's fire-to-delete latency, "
+          "MEASURED)")
+    print(f"RETRY WAIT {(r_fire - resets_at).total_seconds() / 60:.1f} min after reset   "
+          "(was a flat 22; it is no longer a constant)")
+    check_round_trip(r_fire, "RETRY")
+    print("RETRY CRON " + "{} {} {} {} *".format(*cron_fields(r_fire)))
+    print("ONE-SHOT   both lines carry NO YEAR (5-field cron has no such field), so they\n"
+          "           are only one-shots in company with the scheduler's recurring=false.\n"
+          "           Left recurring, each re-fires on this day next year.")
+    # DURABILITY, and it is the half the ONE-SHOT line above does NOT cover
+    # (@taOSc-dev, bus 2798 (1)). A reader who supplies recurring=false correctly still
+    # gets an arm that dies at session exit, and nothing printed said so. CronCreate:
+    # "All jobs are session-only (in-memory, gone when this Claude session ends)."
+    # For a RESUME pair that is the failure domain, not a footnote: the retry exists to
+    # cover a primary that did not fire, and if the primary did not fire BECAUSE the
+    # session ended, the retry ended with it. The safety net is stored inside the thing
+    # it is meant to survive. VERIFIED for this seat 2026-08-16: all four jobs list as
+    # [session-only] and `crontab -l` contains no resume line (positive control: the
+    # crontab reads fine, 28 lines, and the backup watcher is on line 8).
+    print("DURABILITY if armed via CronCreate these are SESSION-ONLY: in-memory, gone when\n"
+          "           the session ends. THE RETRY THEREFORE CANNOT COVER SESSION DEATH - it\n"
+          "           dies with the primary it is insuring. It covers only a wake that failed\n"
+          "           while the session lived. Session death is covered, if at all, by\n"
+          "           something in the SYSTEM crontab, outside the component that failed.\n"
+          "           If instead you write these lines into a crontab, durability is fine but\n"
+          "           recurring=false does not exist there, so re-read the ONE-SHOT line.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_resume_arm_time.py
+++ b/tools/test_resume_arm_time.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Surface-enumerating tests for resume_arm_time.py.  Run: python3 test_resume_arm_time.py
+
+WHY THIS FILE EXISTS, and why it is shaped this way (@taOSc-dev, bus 2785).
+
+Four review rounds found nine defects in this helper. Every one was found by an
+adversarial READER, none by my own RED tests. I concluded that argued for review over
+tests. That was the wrong half of a true observation, and the rebuttal is the reason
+this file exists:
+
+  Review is not durable. "Get an adversarial reader" makes correctness a function of
+  one agent's availability, which is an UNNAMED DEPENDENCY AT THE SITE - the exact
+  finding this helper was rewritten four times to eliminate. It would not be accepted
+  anywhere else in the file, so it is not accepted here.
+
+The other half: my RED tests were not weak because they were self-written, they were
+weak because of what GENERATED them. They enumerated the scenarios I already suspected
+(missing watcher, widened cadence), so they encoded the same model as the code. Every
+defect the reviewer found came from a different generator, and a mechanical one:
+
+  ENUMERATE THE SURFACE THE CODE EXPOSES, NOT THE SCENARIOS YOU SUSPECT.
+
+The surface is defined by the code, not by anyone's model of the input. That is why it
+finds things the author's imagination does not. Concretely, one test per:
+  - command-line ARGUMENT, including its degenerate values
+  - BRANCH of every parse
+  - FIELD of every subprocess result
+  - FIELD that gets PRINTED (the evidence lines are output, so they are surface)
+
+So: a spec the script does not model must be REJECTED, and that test is written by
+reading the regex, not by predicting what the crontab will say.
+"""
+import datetime
+import importlib.util
+import os
+import subprocess
+import sys
+
+spec = importlib.util.spec_from_file_location("m", os.path.join(os.path.dirname(os.path.abspath(__file__)), "resume_arm_time.py"))
+M = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(M)
+
+RESET = "2026-08-16T07:59:59+00:00"
+GOOD = "6,16,26,36,46,56 * * * * /usr/bin/bash /home/jay/.taos-usage/watch.sh --once\n"
+
+FAILS = []
+
+
+def check(name, cond, detail=""):
+    print(("  PASS  " if cond else "  FAIL  ") + name + (f"   {detail}" if detail else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+class Proc:
+    def __init__(self, rc, out, err=""):
+        self.returncode, self.stdout, self.stderr = rc, out, err
+
+
+def with_crontab(text, rc=0):
+    M.subprocess.run = lambda *a, **k: Proc(rc, text)
+
+
+def run_cli(args, crontab=GOOD, rc=0):
+    """Run main() as the CLI does, capturing stdout / SystemExit."""
+    import io
+    import contextlib
+    with_crontab(crontab, rc)
+    old = sys.argv
+    sys.argv = ["resume_arm_time.py"] + args
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            M.main()
+        return 0, buf.getvalue()
+    except SystemExit as e:
+        return 1, str(e) if not isinstance(e.code, int) else buf.getvalue()
+    finally:
+        sys.argv = old
+
+
+print("SURFACE: subprocess result fields")
+rc, out = run_cli([RESET], crontab="", rc=1)
+check("crontab unreadable (returncode != 0) is rejected", rc == 1 and "could not READ" in out)
+check("  ...and is NOT diagnosed as watcher-gone", "staleness model is gone" not in out)
+rc, out = run_cli([RESET], crontab="17 */2 * * * /other/thing.py\n")
+check("crontab readable but no watcher line is rejected", rc == 1 and "WAS read" in out)
+check("  ...with a DIFFERENT diagnosis from the unreadable case", "could not READ" not in out)
+rc, out = run_cli([RESET], crontab=GOOD + "3,33 * * * * /bin/bash /home/jay/.taos-usage/watch.sh --once\n")
+check("two watcher lines are rejected, not silently first-wins", rc == 1 and "models exactly one writer" in out)
+
+print("SURFACE: the five cron fields (one test per field)")
+for field, line in [
+    ("hour", "6,16 8 * * * /bin/bash /home/jay/.taos-usage/watch.sh\n"),
+    ("day-of-month", "6,16 * 3 * * /bin/bash /home/jay/.taos-usage/watch.sh\n"),
+    ("month", "6,16 * * 4 * /bin/bash /home/jay/.taos-usage/watch.sh\n"),
+    ("day-of-week", "6,16 * * * 1-5 /bin/bash /home/jay/.taos-usage/watch.sh\n"),
+]:
+    rc, out = run_cli([RESET], crontab=line)
+    check(f"restricted {field} is REFUSED (not modelled)", rc == 1 and field in out)
+rc, out = run_cli([RESET], crontab=GOOD)
+check("all-wildcard fields 2-5 are accepted", rc == 0)
+
+print("SURFACE: minute-field parse branches")
+for spec_txt, want in [("*/15", 0), ("6-9", 0), ("6,16,26,36,46,56", 0), ("*", 0)]:
+    rc, out = run_cli([RESET], crontab=f"{spec_txt} * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+    check(f"minute spec {spec_txt!r} parses", rc == want)
+
+print("SURFACE: argv[1] resets_at")
+rc, out = run_cli(["2026-08-16T07:59:59"])
+check("NAIVE timestamp is REFUSED, not assumed UTC", rc == 1 and "REFUSING to assume UTC" in out)
+rc, out = run_cli(["not-a-timestamp"])
+check("unparseable timestamp fails with a named reason", rc == 1 and "ISO 8601" in out)
+
+print("SURFACE: argv[2] margin (the knob no earlier test ever varied)")
+rc, out = run_cli([RESET, "0"])
+# The refusal was always correct; it used to come from the fire-vs-tick assert, so it
+# blamed the COMPUTED FIRE for what was an INPUT error (@taOSc-dev, bus 2790 (C)).
+# Now it names the argument. Pinning the reason, not just the exit.
+check("margin=0 is REFUSED (arming at the tick races the write)",
+      rc == 1 and "is not positive" in out)
+check("  ...and blames the INPUT, not the computed fire", "not after tick" not in out)
+for margin in ["1", "30", "59", "60", "61", "600"]:
+    rc, out = run_cli([RESET, margin])
+    tick = [l for l in out.splitlines() if l.startswith("FIRST TICK")][0].split()[2]
+    fire = [l for l in out.splitlines() if l.startswith("FIRES AT")][0].split()[2]
+    eff = int([l for l in out.splitlines() if l.startswith("EFFECTIVE")][0].split()[1].rstrip("s"))
+    t = datetime.datetime.fromisoformat(tick)
+    f = datetime.datetime.fromisoformat(fire)
+    check(f"margin={margin}: fires STRICTLY after the tick", f > t, f"tick={tick} fire={fire}")
+    check(f"margin={margin}: effective margin is never 0", eff > 0, f"effective={eff}s")
+    check(f"margin={margin}: effective covers the measured ~2.3s write", eff >= 3, f"effective={eff}s")
+
+print("SURFACE: every printed evidence field")
+rc, out = run_cli([RESET])
+for field in ["EVIDENCE", "crontab:", "read as user=", "local_tz=", "ticks=", "gaps=",
+              "max_gap=", "margin=", "min_lead=", "RESET", "FIRST TICK", "ARM AT",
+              "FIRES AT", "EFFECTIVE", "WAIT", "CRON"]:
+    check(f"prints {field!r}", field in out)
+cron = [l for l in out.splitlines() if l.startswith("CRON")][0].split()
+fire_local = [l for l in out.splitlines() if l.strip().startswith("2026") and "LOCAL" not in l]
+check("CRON minute matches the FIRES AT local minute",
+      cron[1] == str(datetime.datetime.fromisoformat(
+          [l for l in out.splitlines() if l.startswith("FIRES AT")][0].split()[2]
+      ).astimezone().minute))
+
+print("SURFACE: gaps evidence for degenerate tick sets")
+rc, out = run_cli([RESET], crontab="6 * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+check("single-tick spec reports max_gap=60, not 0", "max_gap=60" in out,
+      [l for l in out.splitlines() if "gaps=" in l][0].strip())
+
+
+# ---------------------------------------------------------------------------
+# THE RETRY (tsk-fd3kes). Same generator as everything above: enumerate what the
+# new code EXPOSES - one constant, two functions with three branches between them,
+# seven printed fields, and one ordering assert - not the ways I imagine it failing.
+# ---------------------------------------------------------------------------
+
+def lines(out):
+    return {l.split("  ")[0].strip(): l for l in out.splitlines()}
+
+
+def field(out, prefix):
+    return [l for l in out.splitlines() if l.startswith(prefix)][0]
+
+
+def stamp(out, prefix):
+    return datetime.datetime.fromisoformat(field(out, prefix).split()[2])
+
+
+print("SURFACE: every printed RETRY field")
+rc, out = run_cli([RESET])
+for f in ["RETRY TICK", "RETRY ARM", "RETRY FIRE", "RETRY GAP", "RETRY WAIT", "RETRY CRON"]:
+    check(f"prints {f!r}", f in out)
+check("RETRY CRON minute matches the RETRY FIRE local minute",
+      field(out, "RETRY CRON").split()[2] == str(stamp(out, "RETRY FIRE").astimezone().minute))
+
+print("SURFACE: the two REPRESENTATION-COMPLETENESS lines (both are printed output)")
+rc, out = run_cli([RESET])
+check("prints ONE-SHOT (the year is not in the five fields)", "ONE-SHOT" in out)
+check("prints DURABILITY (@taOSc-dev bus 2798: a correct recurring=false still dies "
+      "at session exit)", "DURABILITY" in out)
+check("  ...and says the retry cannot cover SESSION DEATH", "CANNOT COVER SESSION DEATH" in out)
+check("  ...and points at the SYSTEM crontab as the layer that can", "SYSTEM crontab" in out)
+
+print("SURFACE: the retry is DERIVED, not an offset (the whole point of the card)")
+rc, out = run_cli([RESET])
+ticks = eval(field(out, "  ticks=").split("ticks=")[1].split("  ")[0])
+check("RETRY TICK is one of the watcher's real ticks", stamp(out, "RETRY TICK").minute in ticks,
+      f"retry tick minute={stamp(out, 'RETRY TICK').minute} ticks={ticks}")
+check("RETRY FIRE is strictly after RETRY TICK (margin not truncated away)",
+      stamp(out, "RETRY FIRE") > stamp(out, "RETRY TICK"))
+check("RETRY WAIT is no longer the flat 22", "22.0 min after reset" not in field(out, "RETRY WAIT"))
+
+print("SURFACE: ordering across EVERY minute-spec parse branch (RED case included)")
+for spec_txt in ["*/30", "*/15", "6,16,26,36,46,56", "6-9", "*", "6", "30"]:
+    rc, out = run_cli([RESET], crontab=f"{spec_txt} * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+    p, r = stamp(out, "FIRES AT"), stamp(out, "RETRY FIRE")
+    check(f"spec {spec_txt!r}: retry fires AFTER primary", r > p,
+          f"primary={p:%H:%M} retry={r:%H:%M}")
+    check(f"spec {spec_txt!r}: retry lands on a real tick",
+          stamp(out, "RETRY TICK").minute in eval(field(out, "  ticks=").split("ticks=")[1].split("  ")[0]))
+    check(f"spec {spec_txt!r}: gap is at least the declared lead",
+          (r - p).total_seconds() >= M.RETRY_LEAD_SECONDS,
+          f"gap={(r - p).total_seconds():.0f}s lead={M.RETRY_LEAD_SECONDS}s")
+
+print("SURFACE: the RED case this card was filed for")
+rc, out = run_cli([RESET], crontab="*/30 * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+p, r = stamp(out, "FIRES AT"), stamp(out, "RETRY FIRE")
+flat22 = datetime.datetime.fromisoformat(RESET) + datetime.timedelta(minutes=22)
+check("under */30 the OLD flat +22 retry WOULD have inverted (the defect is real)", flat22 < p,
+      f"flat+22={flat22:%H:%M} primary={p:%H:%M}")
+check("  ...and the derived retry does NOT invert", r > p, f"primary={p:%H:%M} retry={r:%H:%M}")
+
+print("SURFACE: argv[2] margin interacts with BOTH halves of the pair")
+for margin in ["1", "30", "59", "60", "61", "600"]:
+    rc, out = run_cli([RESET, margin])
+    p, r = stamp(out, "FIRES AT"), stamp(out, "RETRY FIRE")
+    check(f"margin={margin}: pair stays ordered", r > p, f"primary={p:%H:%M} retry={r:%H:%M}")
+    check(f"margin={margin}: retry fires strictly after its own tick",
+          r > stamp(out, "RETRY TICK"))
+
+print("SURFACE: fire_time is SHARED, so the two halves cannot round differently")
+for margin in [1, 30, 59, 60, 61, 600]:
+    t = datetime.datetime.fromisoformat("2026-08-16T08:06:00+00:00")
+    a1, f1 = M.fire_time(t, margin)
+    a2, f2 = M.fire_time(t, margin)
+    check(f"fire_time margin={margin} is deterministic and ceils", f1 >= a1 and f1 == f2,
+          f"arm={a1:%H:%M:%S} fire={f1:%H:%M}")
+
+print("SURFACE: retry_after branches")
+mins = [6, 16, 26, 36, 46, 56]
+pf = datetime.datetime.fromisoformat("2026-08-16T08:07:00+00:00")
+tk, ar, fr = M.retry_after(pf, mins, 60, lead=1)
+check("lead=1 still skips to a real tick (not primary+1s)", fr > pf and tk.minute in mins,
+      f"tick={tk:%H:%M} fire={fr:%H:%M}")
+# The loop scans 60*25 minutes, so a lead of EXACTLY 25h is still satisfiable on the
+# last minute it examines. Found by writing this test with 25h and watching it not
+# raise. Both sides of that boundary are pinned, because the interesting thing about a
+# bound is where it stops being one, and a test that only probes the safe side would
+# have recorded the wrong number as the cliff.
+tk, ar, fr = M.retry_after(pf, mins, 60, lead=60 * 60 * 25)
+check("lead of exactly 25h is still satisfiable (the loop's last minute)",
+      (fr - pf).total_seconds() >= 60 * 60 * 25, f"gap={(fr - pf).total_seconds():.0f}s")
+try:
+    M.retry_after(pf, mins, 60, lead=60 * 60 * 26)
+    check("lead beyond the scan window raises rather than returning an unordered pair", False)
+except SystemExit as e:
+    check("lead beyond the scan window raises rather than returning an unordered pair",
+          "REFUSING to emit an unordered pair" in str(e))
+
+
+# ---------------------------------------------------------------------------
+# THE SECOND HALF OF THE RULE (@taOSc-dev, bus 2790). Enumerating the surface is
+# not enough if every element is enumerated to its PLAUSIBLE value. My margin set
+# was {0,1,30,59,60,61,600} and the single degenerate member found the single bug;
+# my minute-spec set was four specs the parser MODELS and none it merely ADMITS.
+# The code was blind and the suite was blind in the same shape, because one
+# enumeration generated both. Degenerate values are mechanical too: for an int
+# argument they are 0, negative and non-numeric; for a regex-admitted field they
+# are the strings the regex accepts and the parser does not.
+# ---------------------------------------------------------------------------
+
+print("SURFACE: minute specs WATCHER_RE admits but parse_minutes does not model")
+for bad_spec in ["5-2", "*/0", "-", ",,", "1--2", "99", "6-99", "*/", "1-2-3"]:
+    rc, out = run_cli([RESET], crontab=f"{bad_spec} * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+    check(f"spec {bad_spec!r} is REFUSED by name", rc == 1 and "is not one" in out,
+          out.strip().splitlines()[0][:60] if out.strip() else "(empty)")
+    check(f"  ...NOT misdiagnosed as watcher-gone", "no taos-usage/watch.sh line" not in out)
+    check(f"  ...and not a bare traceback", "Traceback" not in out and rc == 1)
+for good_spec in ["*", "6", "6,16", "6-9", "*/15", "0-59", "*/1"]:
+    rc, out = run_cli([RESET], crontab=f"{good_spec} * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+    check(f"POSITIVE CONTROL: modelled spec {good_spec!r} still derives", rc == 0,
+          "" if rc == 0 else out.strip().splitlines()[0][:60])
+
+print("SURFACE: argv[2] margin DEGENERATE values (not just plausible ones)")
+for bad_margin, want in [("abc", "not an integer"), ("1e3", "not an integer"),
+                         ("", "not an integer"), ("60.0", "not an integer"),
+                         ("-30", "not positive"), ("0", "not positive")]:
+    rc, out = run_cli([RESET, bad_margin])
+    check(f"margin={bad_margin!r} refused with the RIGHT reason", rc == 1 and want in out,
+          out.strip().splitlines()[0][:60] if out.strip() else "(empty)")
+    check(f"  ...names the INPUT, not the computed fire", "not after tick" not in out)
+
+print("SURFACE: the emitted cron line must DENOTE the derived instant (round-trip)")
+import os
+import time as _time
+
+
+def with_tz(tz, fn):
+    old = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    _time.tzset()
+    try:
+        return fn()
+    finally:
+        if old is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old
+        _time.tzset()
+
+
+# US fall-back 2026-11-01: 02:00 EDT -> 01:00 EST, so local 01:00-01:59 occurs TWICE
+# and cron fires the earlier. MEASURED before the fix: the line denoted an instant
+# 60 minutes early, i.e. BEFORE the tick it was derived from.
+# CHANGED (@taOSc-dev, bus 2795 (2)): the fold used to be REFUSED. Refusing turned
+# "fires 60 min early" into "does not fire at all", which on those two days a year meant
+# no resume arm was scheduled. Unsafety is a property of a PARTICULAR tick, so it now
+# ADVANCES to the next encodable one and PRINTS every skip. Asserting the stronger
+# property: it emits, AND what it emits denotes the instant it derived.
+rc, out = with_tz("America/New_York",
+                  lambda: run_cli(["2026-11-01T06:00:30+00:00"]))
+check("DST fall-back fold now ADVANCES and still emits a wake", rc == 0,
+      out.strip().splitlines()[0][:60] if out.strip() else "(empty)")
+check("  ...skipping the unencodable ticks LOUDLY, never silently", "SKIPPED" in out)
+check("  ...and the skip names DST as the reason", "do not denote" in out)
+
+
+def denotes(out, fire_prefix, cron_prefix):
+    """Rebuild the instant from the fields actually printed, as cron would read them."""
+    f = stamp(out, fire_prefix)
+    c = field(out, cron_prefix).split()
+    n = 1 if cron_prefix == "CRON" else 2
+    mi, ho, dy, mo = int(c[n]), int(c[n + 1]), int(c[n + 2]), int(c[n + 3])
+    return datetime.datetime(f.astimezone().year, mo, dy, ho, mi).astimezone(), f
+
+
+for fp, cp in [("FIRES AT", "CRON"), ("RETRY FIRE", "RETRY CRON")]:
+    den, f = with_tz("America/New_York", lambda: denotes(
+        with_tz("America/New_York", lambda: run_cli(["2026-11-01T06:00:30+00:00"]))[1], fp, cp))
+    check(f"  ...and the advanced {cp} line DENOTES its own {fp} exactly", den == f,
+          f"denotes={den} fire={f}")
+rc, out = with_tz("UTC", lambda: run_cli([RESET]))
+check("POSITIVE CONTROL: a UTC box round-trips and still emits", rc == 0)
+rc, out = with_tz("Asia/Tokyo", lambda: run_cli([RESET]))
+check("POSITIVE CONTROL: a non-UTC zone with no DST still emits", rc == 0)
+# The spring-forward GAP is NOT reachable from this direction and the test says so
+# rather than pretending to cover it: `fire.astimezone()` always yields a wall clock
+# that EXISTS, so no derived instant can land in the skipped hour. Recorded because a
+# test suite claiming coverage it does not have is the thing this file is against.
+rc, out = with_tz("America/New_York", lambda: run_cli(["2026-03-08T06:30:00+00:00"]))
+check("spring-forward window: derivation still round-trips (gap unreachable here)",
+      rc == 0, "documented as unreachable, not as covered")
+
+print("SURFACE: the SCHEDULER layer, which MARGIN_SECONDS never declared")
+# CronCreate: "one-shot tasks landing on :00 or :30 fire up to 90 s early". The resume
+# pair ARE one-shots, so a 60s margin on those two minutes can fire 30s BEFORE its tick,
+# which is the race the margin exists to prevent, reintroduced by a layer the margin did
+# not name. Found by reading the scheduler contract, not by imagining a case.
+rc, out = run_cli([RESET], crontab="29,59 * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+check("a spec that arms ONLY on :30/:00 is refused, not armed into the jitter",
+      rc == 1 and "90s EARLY" in out,
+      out.strip().splitlines()[0][:60] if out.strip() else "(empty)")
+check("  ...and the refusal names the REMEDY (raise the margin)", "REMEDY" in out)
+rc, out = run_cli([RESET, "120"], crontab="29,59 * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+check("  ...and that remedy actually works", rc == 0)
+check("  ...clearing the jitter with room", rc == 0 and
+      int(field(out, "EFFECTIVE").split()[1].rstrip("s")) > M.SCHEDULER_EARLY_JITTER_SECONDS,
+      field(out, "EFFECTIVE").strip() if rc == 0 else "")
+# A tick whose arm lands on a jittered minute is skipped while its neighbours are not.
+rc, out = run_cli([RESET], crontab="29,40 * * * * /bin/bash /home/jay/.taos-usage/watch.sh\n")
+check("a jittered tick is SKIPPED while a safe neighbour still derives", rc == 0 and "SKIPPED" in out,
+      field(out, "CRON").strip() if rc == 0 else out.strip().splitlines()[0][:50])
+check("  ...and the surviving arm is NOT on a jittered minute",
+      rc == 0 and stamp(out, "FIRES AT").astimezone().minute not in M.JITTERED_MINUTES)
+for m in [0, 30]:
+    check(f"minute :{m:02d} is declared jittered", m in M.JITTERED_MINUTES)
+
+print("SURFACE: retry lead DEGENERATE values")
+pf2 = datetime.datetime.fromisoformat("2026-08-16T08:07:00+00:00")
+for lead in [0, -900]:
+    tk, ar, fr = M.retry_after(pf2, mins, 60, lead=lead)
+    check(f"lead={lead}: retry STILL lands after the primary (never before)", fr > pf2,
+          f"primary={pf2:%H:%M} retry={fr:%H:%M}")
+    check(f"lead={lead}: retry still lands on a real tick", tk.minute in mins)
+
+print("RED DIRECTION: lead below the measured maximum admits the race it guards against")
+measured_max = 49.729
+pf = datetime.datetime.fromisoformat("2026-08-16T08:07:00+00:00")
+primary_delete = pf + datetime.timedelta(seconds=measured_max)
+for lead in [40, 49]:
+    tk, ar, fr = M.retry_after(pf, mins, 60, lead=lead)
+    gap = (fr - pf).total_seconds()
+    check(f"lead={lead}: gap {gap:.0f}s >= lead {lead}s (contract holds)",
+          gap >= lead,
+          f"gap={gap:.0f}s")
+    # The retry_after contract guarantees gap >= lead. With lead < measured_max,
+    # the guaranteed minimum gap is less than the primary's observed delete time.
+    # A retry at primary + lead fires BEFORE the delete at primary + 49.729s.
+    retry_time = pf + datetime.timedelta(seconds=lead)
+    check(f"lead={lead}: retry at {retry_time.isoformat()} fires BEFORE delete at {primary_delete.isoformat()}",
+          retry_time < primary_delete,
+          f"retry={retry_time.isoformat()} delete={primary_delete.isoformat()}")
+check("RETRY_LEAD_SECONDS=60 is above the measured max (the race is bounded)",
+      M.RETRY_LEAD_SECONDS >= measured_max)
+
+print()
+if FAILS:
+    print(f"FAILED {len(FAILS)}:")
+    for f in FAILS:
+        print("  -", f)
+    sys.exit(1)
+print("ALL SURFACE TESTS PASS")

--- a/tools/verify_routes.py
+++ b/tools/verify_routes.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Check every /api/ path cited in a doc against the routes actually declared
+in tinyagentos/routes/*.py.
+
+Restoring deleted documentation reintroduces whatever drift accumulated while
+it was gone. Kilo found one stale path by review; this finds the rest by
+construction.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+doc = Path(sys.argv[1]).read_text()
+
+# --- declared routes -------------------------------------------------------
+DECL = re.compile(r'@router\.(get|post|put|patch|delete)\(\s*[\'"]([^\'"]+)[\'"]')
+declared = set()
+for f in sorted((REPO / "tinyagentos" / "routes").glob("*.py")):
+    for m in DECL.finditer(f.read_text()):
+        declared.add(m.group(2))
+# Some routers are mounted with a prefix; collect those too.
+for f in sorted((REPO / "tinyagentos").rglob("*.py")):
+    try:
+        txt = f.read_text()
+    except Exception:
+        continue
+    for m in re.finditer(r'include_router\([^)]*prefix\s*=\s*[\'"]([^\'"]+)[\'"]', txt):
+        pass  # prefixes noted below if needed
+
+
+def norm(p):
+    """Collapse path params so {slug} and {id} compare equal."""
+    p = p.rstrip("/")
+    p = re.sub(r"\{[^}]*\}", "{}", p)
+    return p
+
+
+declared_norm = {norm(d) for d in declared}
+
+# --- cited paths -----------------------------------------------------------
+# Only take paths in code spans or after an HTTP verb, to avoid prose noise.
+cited = set()
+for m in re.finditer(r"`([A-Z]+ )?(/api/[^`\s]+)`", doc):
+    cited.add(m.group(2))
+for m in re.finditer(r"\b(?:GET|POST|PUT|PATCH|DELETE)\s+(/api/[^\s`,)]+)", doc):
+    cited.add(m.group(1))
+
+missing = []
+for c in sorted(cited):
+    base = c.split("?")[0].rstrip(".,;:")
+    n = norm(base)
+    if n in declared_norm:
+        continue
+    # tolerate a documented parent of a real subtree (e.g. /api/desktop/*)
+    if base.endswith("/*") and any(d.startswith(norm(base[:-2])) for d in declared_norm):
+        continue
+    if any(d == n or d.startswith(n + "/") for d in declared_norm):
+        continue
+    missing.append(c)
+
+print(f"declared routes: {len(declared)}   cited in doc: {len(cited)}")
+if missing:
+    print(f"\nCITED BUT NOT DECLARED ({len(missing)}):")
+    for m_ in missing:
+        print(f"  {m_}")
+    # Offer the closest declared match to make each one actionable.
+    import difflib
+    print("\nclosest declared match per miss:")
+    for m_ in missing:
+        base = norm(m_.split("?")[0].rstrip(".,;:"))
+        near = difflib.get_close_matches(base, sorted(declared_norm), n=2, cutoff=0.6)
+        print(f"  {m_}  ->  {near}")
+    sys.exit(1)
+print("all cited /api/ paths are declared")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Move lane-runnable agent tooling into a repo (it has blocked delegation 3x in 2 days)

Autonomous build of board card tsk-cvnqmk.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

Scripts that live in ~/.taos-team and ~/.taos-website-agent sit outside any
repo a lane can check out, forcing hand-authored lead edits. Move the
lane-runnable subset into tools/ so lanes can review and change them in a
normal PR.

In scope: red_first.sh, prove_red_first.sh, resume_arm_time.py,
test_resume_arm_time.py, liveness_check.py, orphan_check.sh, verify_routes.py.

Out of scope (stay outside the repo): credentials (*.cred), config,
fleet.env, and RESUME-*.md checkpoints.

Shim/pointer files left at each old path redirect to the canonical copy in
tools/ via TAOS_REPO (default /home/jay/Development/tinyagentos). Internal
references updated: prove_red_first.sh SRC, test_resume_arm_time.py path to
sibling resume_arm_time.py, verify_routes.py REPO resolution. red_first.sh
gains --help so the acceptance command exits 0.

Files:
 tools/liveness_check.py                      |  36 ++
 tools/orphan_check.sh                        | 200 +++++++++
 tools/prove_red_first.sh                     | 280 ++++++++++++
 tools/red_first.sh                           | 168 +++++++
 tools/resume_arm_time.py                     | 645 +++++++++++++++++++++++++++
 tools/test_resume_arm_time.py                | 404 +++++++++++++++++
 tools/verify_routes.py                       |  75 ++++
 8 files changed, 1810 insertions(+)