### PR TITLE
PWA install: exempt manifest + icons from auth middleware

### DIFF
--- a/changelog.d/tsk-dk5v6d-pwa-manifest-auth-exempt.md
+++ b/changelog.d/tsk-dk5v6d-pwa-manifest-auth-exempt.md
@@ -1,0 +1,2 @@
+### Fixed
+- PWA manifest (`manifest-desktop.json`) and every icon it references are now individually exempt from the auth middleware, so Chrome on Android can install taOS as a PWA without 401 errors on the manifest or icon fetches

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,6 +1,8 @@
 """Unit tests for auth_middleware allow/deny logic."""
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -81,6 +83,50 @@ class TestIsExempt:
 
     def test_protected_api_not_exempt(self):
         assert _is_exempt("GET", "/api/system") is False
+
+
+class TestPwaManifestExempt:
+    """PWA manifest and every icon it references must be fetchable without auth.
+
+    Chrome on Android aborts the install flow if the manifest or any icon it
+    references returns 401. These paths are exempted individually in
+    EXEMPT_PATHS -- not via a blanket /static/ prefix -- so only PWA-critical
+    assets are public.
+    """
+
+    _REPO_ROOT = Path(__file__).resolve().parent.parent
+    _MANIFEST_URL = "/static/manifest-desktop.json"
+
+    @classmethod
+    def _pwa_asset_paths(cls) -> set[str]:
+        """Read the real desktop PWA manifest and return every URL path it
+        references: the manifest itself plus all icon srcs."""
+        manifest_file = cls._REPO_ROOT / "static" / "manifest-desktop.json"
+        data = json.loads(manifest_file.read_text(encoding="utf-8"))
+        paths = {cls._MANIFEST_URL}
+        for icon in data.get("icons", []):
+            paths.add(icon["src"])
+        return paths
+
+    def test_manifest_exempt(self):
+        assert _is_exempt("GET", self._MANIFEST_URL) is True
+
+    def test_every_icon_referenced_by_manifest_exempt(self):
+        for path in self._pwa_asset_paths():
+            assert _is_exempt("GET", path) is True
+
+    @pytest.mark.asyncio
+    async def test_manifest_and_icons_pass_without_auth(self):
+        for path in self._pwa_asset_paths():
+            middleware = AuthMiddleware(app=MagicMock())
+            req = _request(method="GET", path=path, auth_mgr=_default_auth_mgr())
+            call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+            resp = await middleware.dispatch(req, call_next)
+
+            assert resp.status_code == 200, f"{path} must pass without auth"
+            assert req.state.via == "exempt"
+            call_next.assert_awaited_once()
 
 
 class TestIsLoopbackClient:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -11,7 +11,11 @@ from starlette.responses import RedirectResponse
 
 from tinyagentos.device_store import DEVICE_TOKEN_PREFIX
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/api/share/destinations"}
+# PWA manifest and every icon it references must be fetchable without auth.
+# Chrome on Android aborts the PWA install flow if the manifest or any icon
+# gets a 401. These paths are listed individually -- NOT via the /static/
+# prefix in EXEMPT_PREFIXES -- so the exemption is explicit and reviewable.
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/api/share/destinations", "/static/manifest-desktop.json", "/static/manifest-chat.json", "/static/icon-192.png", "/static/icon-512.png"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
 # When a Bearer token is present for these paths the request bypasses the


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): PWA install: exempt manifest + icons from auth middleware

Autonomous build of board card tsk-dk5v6d.

Chrome on Android aborts PWA installation when the manifest or any
icon it references returns 401. Add /static/manifest-desktop.json,
/static/manifest-chat.json, /static/icon-192.png and
/static/icon-512.png to EXEMPT_PATHS individually so the exemption
is explicit and reviewable (not a blanket /static/ prefix).

Files:
 changelog.d/tsk-dk5v6d-pwa-manifest-auth-exempt.md |  2 +
 tests/test_auth_middleware.py                      | 46 ++++++++++++++++++++++
 tinyagentos/auth_middleware.py                     |  6 ++-
 3 files changed, 53 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Android Chrome PWA installation by allowing access to PWA manifests and required icons without authentication.
  - Prevented authentication errors when loading PWA resources.

- **Tests**
  - Added coverage verifying PWA manifests and icons are publicly accessible and return successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->