### PR TITLE
agent_loop: subagent exceptions swallowed + await_subagent silent-None on failure (kilo CRITICAL, merged in #2337, still on dev)

### DIFF
--- a/changelog.d/tsk-j4dxux-subagent-failure-propagation.md
+++ b/changelog.d/tsk-j4dxux-subagent-failure-propagation.md
@@ -1,0 +1,2 @@
+### Fixed
+- Subagent worker exceptions are now propagated through `await_subagent` instead of being swallowed; a failed subagent raises the original exception at the caller, making failures observable rather than indistinguishable from success.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -365,11 +365,29 @@ async def test_subagent_failure_sets_state_to_failed():
         raise RuntimeError("kaboom")
 
     sub_id = await loop.spawn_subagent("doomed", worker)
-    await loop.await_subagent(sub_id)
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await loop.await_subagent(sub_id)
 
     handle = loop.get_subagent(sub_id)
     assert handle.state == "failed"
     assert "kaboom" in (handle.error or "")
+
+
+@pytest.mark.asyncio
+async def test_await_subagent_raises_on_worker_exception():
+    """A worker exception propagates through await_subagent, not swallowed."""
+    loop = AgentLoop()
+
+    async def worker(progress):
+        raise RuntimeError("subagent boom")
+
+    sub_id = await loop.spawn_subagent("doomed", worker)
+    with pytest.raises(RuntimeError, match="subagent boom"):
+        await loop.await_subagent(sub_id)
+
+    handle = loop.get_subagent(sub_id)
+    assert handle.state == "failed"
+    assert "subagent boom" in (handle.error or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -888,7 +888,8 @@ async def test_status_scopes_subagent_fields(client, app):
     ok_id = await loop.spawn_subagent("index files", ok_worker)
     bad_id = await loop.spawn_subagent("doomed job", bad_worker)
     await loop.await_subagent(ok_id)
-    await loop.await_subagent(bad_id)
+    with pytest.raises(RuntimeError, match="server-side error detail"):
+        await loop.await_subagent(bad_id)
 
     resp = await client.get("/api/taos-agent/status")
     assert resp.status_code == 200

--- a/tinyagentos/agent_loop.py
+++ b/tinyagentos/agent_loop.py
@@ -416,7 +416,8 @@ class AgentLoop:
 
         If the subagent was cancelled (e.g. via ``cancel_subagents`` or a
         redirect at a safe point), the handle state is ``"cancelled"`` and
-        the result (``None``) is returned without re-raising.
+        the result (``None``) is returned without re-raising. If the worker
+        raised, that exception is re-raised here at the caller.
 
         A *timeout* only limits how long this call waits. It does NOT cancel
         the subagent task. The subagent keeps running and can be awaited again
@@ -425,6 +426,7 @@ class AgentLoop:
         Raises:
             KeyError: if *sub_id* is unknown.
             asyncio.TimeoutError: if *timeout* is given and exceeded.
+            Exception: the worker's own exception, if the subagent failed.
         """
         async with self._lock:
             entry = self._subagents.get(sub_id)

--- a/tinyagentos/agent_loop.py
+++ b/tinyagentos/agent_loop.py
@@ -283,6 +283,7 @@ class AgentLoop:
                     handle.state = "failed"
                     handle.error = str(exc)
                 logger.exception("subagent %s (%s) failed", sub_id, task)
+                raise
 
         task_obj = _create_supervised_task(_runner(), self._subagent_tasks)
         task_obj.set_name(f"subagent:{sub_id}")
@@ -432,6 +433,8 @@ class AgentLoop:
         if entry.task_obj.done():
             if entry.handle.state == "cancelled":
                 return entry.handle.result
+            if entry.handle.state == "failed":
+                raise entry.task_obj.exception()
             return entry.handle.result
         done, pending = await asyncio.wait([entry.task_obj], timeout=timeout)
         if entry.task_obj in pending:
@@ -440,6 +443,8 @@ class AgentLoop:
             )
         if entry.handle.state == "cancelled":
             return entry.handle.result
+        if entry.handle.state == "failed":
+            raise entry.task_obj.exception()
         return entry.handle.result
 
     def get_subagent(self, sub_id: str) -> SubagentHandle | None:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): agent_loop: subagent exceptions swallowed + await_subagent silent-None on failure (kilo CRITICAL, merged in #2337, still on dev)

Autonomous build of board card tsk-j4dxux.

- re-raise caught exceptions in _runner so the task fails loudly
- await_subagent now raises the task exception when handle state is failed
- existing test updated to expect the exception; new test added for observability
- changelog fragment added

Files:
 .../tsk-j4dxux-subagent-failure-propagation.md       |  2 ++
 tests/test_agent_loop.py                             | 20 +++++++++++++++++++-
 tinyagentos/agent_loop.py                            |  5 +++++
 3 files changed, 26 insertions(+), 1 deletion(-)