### PR TITLE
decisions.py global grants: match with explicit IS NULL (CodeRabbit Critical, merged in #2417, unverified on dev - prove it first)

### DIFF
--- a/changelog.d/tsk-em3hhd-global-grant-null-project-filter.md
+++ b/changelog.d/tsk-em3hhd-global-grant-null-project-filter.md
@@ -1,0 +1,2 @@
+### Fixed
+- `GET /api/decisions/agent` no longer leaks project-scoped decisions to an agent holding only a global (null-project) `decisions_write` grant. The store layer now treats an explicit `project_id=None` as `IS NULL` instead of silently omitting the filter, so a global grant returns null-project decisions only. The human-facing `GET /api/decisions` route preserves its existing "no project filter" behaviour when `project_id` is absent from the query string.

--- a/tests/test_decision_store.py
+++ b/tests/test_decision_store.py
@@ -104,6 +104,19 @@ async def test_list_filter_from_agent(store):
 
 
 @pytest.mark.asyncio
+async def test_list_project_id_none_is_null(store):
+    """An explicit project_id=None must match only NULL-project decisions
+    (IS NULL), not all decisions.  A global grant filters to null-project
+    decisions only, per _resolve_decision_actor's posting rule."""
+    null_d = await store.create("@a", "q1", "approve_deny", user_id="u1")
+    proj_d = await store.create("@a", "q2", "approve_deny", project_id="p1", user_id="u1")
+    items = await store.list(project_id=None)
+    assert len(items) == 1
+    assert items[0]["id"] == null_d["id"]
+    assert items[0]["project_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_answer_source_persistence(store):
     """Answer source field is persisted and round-trips correctly."""
     d = await store.create("@a", "q", "approve_deny", user_id="u1")

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -554,6 +554,46 @@ async def test_agent_list_respects_project_grants(client):
     assert items[0]["project_id"] == pid_b
 
 
+@pytest.mark.asyncio
+async def test_agent_global_grant_lists_only_null_project_decisions(client):
+    """A global (null-project) grant must list only OS-level (null-project)
+    decisions, never project-scoped ones -- matching _resolve_decision_actor's
+    posting rule and the per-project isolation enforced on read/answer.
+
+    This is the agent-list counterpart to the global-grant post/answer
+    isolation tests above.  It FAILS if the store treats project_id=None as
+    'no filter' instead of 'IS NULL': the project-scoped decision leaks."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, None, ("decisions_write",))
+
+    # OS-level decision (project_id=None) attributed to the agent.
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=None, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Project-scoped decision attributed to the SAME agent.
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=pid, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Agent lists its own decisions with a global grant.
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    # Only the null-project decision should be visible under a global grant.
+    assert len(items) == 1, (
+        f"global grant leaked project-scoped decisions: {items}"
+    )
+    assert items[0]["project_id"] is None
+    assert items[0]["from_agent"] == cid
+
+
 class TestAuthRunsBeforeBodyValidation:
     """A bad bearer must 401 before Pydantic body validation can 422.
 

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -130,7 +130,7 @@ class DecisionStore(BaseStore):
         self,
         *,
         status: str | None = None,
-        project_id: str | None = _UNSET,
+        project_id: str | None | object = _UNSET,
         user_id: str | None = None,
         limit: int = 200,
         from_agent: str | None = None,

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -46,6 +46,12 @@ CREATE INDEX IF NOT EXISTS idx_decisions_user ON decisions(user_id, status);
 
 _JSON_FIELDS = ("options", "answer", "metadata")
 
+# Sentinel for "argument not supplied" -- distinguished from an explicit None,
+# which means "match NULL project_id" (IS NULL) rather than "no filter".
+# A bare ``project_id = ?`` with a NULL parameter matches nothing in SQL, so
+# callers that want null-project rows must emit IS NULL instead.
+_UNSET = object()
+
 
 def _row_to_decision(row, description) -> dict:
     d = dict(zip([c[0] for c in description], row))
@@ -124,7 +130,7 @@ class DecisionStore(BaseStore):
         self,
         *,
         status: str | None = None,
-        project_id: str | None = None,
+        project_id: str | None = _UNSET,
         user_id: str | None = None,
         limit: int = 200,
         from_agent: str | None = None,
@@ -133,7 +139,11 @@ class DecisionStore(BaseStore):
         if status is not None:
             conds.append("status = ?")
             params.append(status)
-        if project_id is not None:
+        if project_id is _UNSET:
+            pass  # no project filter
+        elif project_id is None:
+            conds.append("project_id IS NULL")
+        else:
             conds.append("project_id = ?")
             params.append(project_id)
         if user_id is not None:

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -289,7 +289,12 @@ async def list_decisions(
     store = request.app.state.decision_store
     # Non-admins see only their own decisions; admins see all.
     uid = None if user.is_admin else user.user_id
-    items = await store.list(status=status, project_id=project_id, user_id=uid, limit=limit)
+    # Only forward project_id when the caller specified one; an absent query
+    # param means "no project filter", which is the store's default (_UNSET).
+    kwargs: dict[str, object] = {"status": status, "user_id": uid, "limit": limit}
+    if project_id is not None:
+        kwargs["project_id"] = project_id
+    items = await store.list(**kwargs)
     return {"items": items}
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): decisions.py global grants: match with explicit IS NULL (CodeRabbit Critical, merged in #2417, unverified on dev - prove it first)

Autonomous build of board card tsk-em3hhd.

store.list treated project_id=None as 'no filter' (skip the WHERE
clause entirely) instead of 'match NULL project_id' (IS NULL).  This
meant GET /api/decisions/agent for an agent holding a global
(null-project) decisions_write grant returned ALL the agent's decisions
including project-scoped ones, leaking cross-project decisions.

Fix: introduce a _UNSET sentinel in DecisionStore.list so that
project_id=None emits IS NULL, while the default (not supplied)
remains 'no filter'.  The human-facing GET /api/decisions route is
updated to only forward project_id when the caller specified one,
preserving its existing no-filter behaviour on absent query param.

Tests:
- test_list_project_id_none_is_null (store level)
- test_agent_global_grant_lists_only_null_project_decisions (route level)

Docs-Reviewed: no docs/agent-coordination.md change needed -- the route
surface is unchanged, only the global-grant filtering now matches the
already-documented 'null-project decisions only' semantics.

Files:
 .../tsk-em3hhd-global-grant-null-project-filter.md |  2 ++
 tests/test_decision_store.py                       | 13 +++++++
 tests/test_routes_decisions_agent.py               | 40 ++++++++++++++++++++++
 tinyagentos/decisions/decision_store.py            | 14 ++++++--
 tinyagentos/routes/decisions.py                    |  7 +++-
 5 files changed, 73 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global decision listings now return only decisions without a project assignment.
  * Explicit project filters continue to return matching project-scoped decisions.
  * Requests without a project filter retain their existing unfiltered behavior where applicable.

* **Tests**
  * Added regression coverage for null-project filtering and agent decision listings.

* **Documentation**
  * Added a changelog entry describing the updated decision retrieval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->