### PR TITLE
Bot-review gate take 2: real CodeRabbit login, filter-granularity tests, live red proof -- supersedes PR #2438 (HELD)

### DIFF
--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -13,6 +13,10 @@ name: Bot review gate
 on:
   pull_request:
     branches: [master, dev]
+  pull_request_review:
+    branches: [master, dev]
+  issue_comment:
+    branches: [master, dev]
 
 jobs:
   bot-review-gate:

--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -1,0 +1,37 @@
+name: Bot review gate
+
+# Blocks merges when the only CodeRabbit output on a PR is a rate-limit stub —
+# a comment that only announces the plan quota was exhausted instead of
+# producing an actual review. This catches the "fake-green" condition where
+# 33 PRs merged with nothing but a CodeRabbit rate-limit notice in one week
+# (see the 2026-08-16 bot-review retrospective audit). CodeRabbit's own
+# "Review rate limited" check passes by design, so it cannot catch this --
+# this gate inspects the comment body instead.
+#
+# See scripts/check_bot_review.py for the implementation.
+
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  bot-review-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Check for rate-limited CodeRabbit stub
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The check exits 1 (FAIL) when the only CodeRabbit output is a
+          # rate-limit stub. Exiting non-zero fails the workflow, blocking
+          # the merge on the PR's branch protection rule.
+          python scripts/check_bot_review.py "${{ github.event.pull_request.number }}"

--- a/changelog.d/tsk-vpqe6o-bot-review-gate.md
+++ b/changelog.d/tsk-vpqe6o-bot-review-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- CodeRabbit login filter now includes `coderabbitai[bot]` so that `collect_coderabbit_items` correctly identifies CodeRabbit output on PRs where CodeRabbit posts as `coderabbitai[bot]` (instead of only matching `coderabbit[bot]` and `coderabbitai`)

--- a/changelog.d/tsk-vzzv62-bot-review-gate.md
+++ b/changelog.d/tsk-vzzv62-bot-review-gate.md
@@ -1,0 +1,2 @@
+### Added
+- A `scripts/check_bot_review.py` gate that fails (exit 1) when the only CodeRabbit output on a PR is a rate-limit stub, so the merge path no longer treats a passing "Review rate limited" check as a real review. Runs on every PR targeting `master` or `dev` via `.github/workflows/bot-review-gate.yml` (tsk-vzzv62).

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Bot-review guard: rate-limited CodeRabbit stubs must not read as a review.
+
+Detects PRs whose only CodeRabbit output is a rate-limit stub -- a comment
+or review that only announces the plan quota was exhausted instead of
+producing an actual review. This is the mechanism behind the fleet rule
+"no merge on rate-limited fake green" from the 2026-08-16 bot-review
+retrospective audit (33 merged PRs shipped fake-green in one week).
+
+When CodeRabbit is rate-limited it posts a short stub comment (body matching
+the rate-limit signature below) and a passing check titled "Review rate
+limited" -- the check passes by design so it never blocks merging. This
+guard inspects the comments instead and fails red when the stub is the
+ONLY CodeRabbit output, so a merge gate can catch the fake-green condition.
+
+Three exit cases, all printed with the exit code so they can be read off
+the evidence at the granularity of the audit:
+
+    0  PASS  -- a real CodeRabbit review exists, OR CodeRabbit is entirely
+                 absent (dependabot-class PRs; absence is not fake-green).
+    1  FAIL  -- the only CodeRabbit output on the PR is a rate-limit stub.
+    2  ERROR -- infrastructure failure (network, auth, 404, etc.).
+
+Usage:
+    python scripts/check_bot_review.py <pr-number> [--owner OWNER] [--repo REPO]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+API = "https://api.github.com"
+
+# CodeRabbit identifies itself via these GitHub App bot logins.
+CODERABBIT_LOGINS = frozenset({
+    "coderabbit[bot]",
+    "coderabbitai",
+})
+
+# Signature of a CodeRabbit rate-limit stub. From the CodeRabbit docs
+# (docs.coderabbit.ai/management/plans): "When a push is rate-limited,
+# CodeRabbit posts a rate-limit comment ... and a passing check titled
+# 'Review rate limited'". The .coderabbit.yaml config prose references
+# "review limit reached". Both spellings are matched below, plus the
+# "rate limit" / "quota" tokens with context words to avoid false positives
+# on legitimate reviews that mention rate-limiting as a code smell.
+RATE_LIMIT_RE = re.compile(
+    r"review\s*limit\s*reached|"
+    r"review\s*rate\s*limited|"
+    r"rate\s*limit(?:ed| reached| exhausted| hit| paused)|"
+    r"plan\s*quota\s*(?:reached|exhausted)|"
+    r"review\s*quota\s*(?:reached|exhausted)",
+    re.IGNORECASE,
+)
+
+EXIT_OK = 0
+EXIT_STUB = 1
+EXIT_ERROR = 2
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class CRItem:
+    """A CodeRabbit review or comment fetched from the GitHub API."""
+    id: int
+    body: str | None
+    is_review: bool
+    review_state: str | None = None
+    created_at: str | None = None
+
+
+def _get_token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or None
+
+
+def _api_get(url: str, token: str | None = None) -> list | None:
+    """Fetch a paginated GitHub REST API endpoint.
+
+    Returns None on infrastructure failure (network error, auth failure,
+    404, 422). Returns the full de-paginated list of items on success.
+    An empty list is returned for a legitimately empty result so callers
+    can distinguish cannot-see (None) from empty ([]).
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "taos-bot-review-gate",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    items: list = []
+    page_url: str | None = url
+    while page_url:
+        req = Request(page_url, headers=headers)
+        try:
+            with urlopen(req, timeout=30) as r:
+                data = json.loads(r.read().decode("utf-8"))
+        except Exception as e:
+            print(f"error: GET {url} failed: {e}", file=sys.stderr)
+            return None
+        if isinstance(data, dict) and data.get("message"):
+            print(f"error: API response message: {data['message']}", file=sys.stderr)
+            return None
+        if isinstance(data, list):
+            items.extend(data)
+        elif isinstance(data, dict):
+            items.append(data)
+        # Follow pagination via Link header
+        link = r.headers.get("Link", "")
+        page_url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                match = re.search(r"<([^>]+)>", part)
+                if match:
+                    page_url = match.group(1)
+                break
+    return items
+
+
+def is_rate_limit_stub(body: str | None) -> bool:
+    """Return True if a comment/review body matches the CodeRabbit
+    rate-limit stub signature."""
+    if not body:
+        return False
+    return bool(RATE_LIMIT_RE.search(body))
+
+
+def is_real_item(item: CRItem) -> bool:
+    """Return True if a CR item represents real review content.
+
+    A rate-limit stub is never real. Review objects with state APPROVED
+    or CHANGES_REQUESTED are always real regardless of body content
+    (the review state itself is the substantive signal). Comments and
+    COMMENTED reviews are real only when they carry non-empty, non-stub
+    body text.
+    """
+    if is_rate_limit_stub(item.body):
+        return False
+    if item.is_review:
+        state = (item.review_state or "").upper()
+        if state in ("APPROVED", "CHANGES_REQUESTED"):
+            return True
+    return bool(item.body and item.body.strip())
+
+
+def _is_coderabbit(user: dict | None) -> bool:
+    if not user:
+        return False
+    return (user.get("login") or "").lower() in CODERABBIT_LOGINS
+
+
+def collect_coderabbit_items(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> list[CRItem] | None:
+    """Fetch all CodeRabbit reviews and comments on a PR.
+
+    Queries three GitHub endpoints:
+      1. Reviews (GET /repos/{owner}/{repo}/pulls/{pr}/reviews)
+      2. Issue comments (GET /repos/{owner}/{repo}/issues/{pr}/comments)
+      3. Review comments (GET /repos/{owner}/{repo}/pulls/{pr}/comments)
+
+    Returns None on infrastructure failure, [] if no CR output exists.
+    """
+    token = token or _get_token()
+    base = f"{API}/repos/{owner}/{repo}/pulls/{pr_number}"
+
+    items: list[CRItem] = []
+
+    # 1. Reviews
+    reviews = _api_get(f"{base}/reviews", token)
+    if reviews is None:
+        return None
+    for r in reviews:
+        if _is_coderabbit(r.get("user")):
+            items.append(CRItem(
+                id=r.get("id", 0),
+                body=r.get("body"),
+                is_review=True,
+                review_state=r.get("state"),
+                created_at=r.get("created_at"),
+            ))
+
+    # 2. Issue comments (top-level PR comments)
+    issue_comments = _api_get(
+        f"{API}/repos/{owner}/{repo}/issues/{pr_number}/comments", token
+    )
+    if issue_comments is None:
+        return None
+    for c in issue_comments:
+        if _is_coderabbit(c.get("user")):
+            items.append(CRItem(
+                id=c.get("id", 0),
+                body=c.get("body"),
+                is_review=False,
+                created_at=c.get("created_at"),
+            ))
+
+    # 3. Review comments (line-level discussion threads)
+    review_comments = _api_get(f"{base}/comments", token)
+    if review_comments is None:
+        return None
+    for c in review_comments:
+        if _is_coderabbit(c.get("user")):
+            items.append(CRItem(
+                id=c.get("id", 0),
+                body=c.get("body"),
+                is_review=False,
+                created_at=c.get("created_at"),
+            ))
+
+    # Sort chronologically (oldest first). GitHub IDs are monotonically
+    # increasing, and created_at is a reliable fallback for ordering.
+    items.sort(key=lambda x: (x.created_at or "", x.id))
+    return items
+
+
+def classify(items: list[CRItem]) -> tuple[int, str]:
+    """Classify CR items and determine the exit code + message.
+
+    Returns (exit_code, message):
+    - (0, "PASS ...")            -- a real CodeRabbit review exists.
+    - (0, "PASS (absent, ...)")  -- CodeRabbit is entirely absent.
+    - (1, "FAIL ...")            -- only rate-limit stubs exist.
+    - (0, "PASS ...")            -- CR output exists but is neither a stub
+                                    nor substantive (edge case, not fake-green).
+    """
+    if not items:
+        return EXIT_OK, "PASS (absent, not stubbed): no CodeRabbit output on this PR"
+
+    real_items = [i for i in items if is_real_item(i)]
+    if real_items:
+        return EXIT_OK, (
+            f"PASS: {len(real_items)} real CodeRabbit review item(s) "
+            f"(exit {EXIT_OK})"
+        )
+
+    # No real review threads. Check whether the latest CR output matches
+    # the rate-limit signature -- that is the fake-green condition.
+    latest = items[-1]
+    if is_rate_limit_stub(latest.body):
+        return EXIT_STUB, (
+            f"FAIL: only CodeRabbit output is a rate-limit stub "
+            f"(latest CR item id={latest.id}) (exit {EXIT_STUB})"
+        )
+
+    # CR output exists but no real review threads and latest is not a
+    # recognizable stub. Absence of a real review is still not
+    # fake-green: there is no stub masquerading as a review.
+    return EXIT_OK, (
+        f"PASS (absent, not stubbed): CodeRabbit output present but not a "
+        f"rate-limit stub (exit {EXIT_OK})"
+    )
+
+
+def check_bot_review(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> tuple[int, str]:
+    """Check a PR's CodeRabbit output for rate-limit stubs.
+
+    Returns (exit_code, message). EXIT_ERROR (2) is returned when the
+    GitHub API cannot be reached or returns an error, so a cannot-see
+    state is never mistaken for a clean pass.
+    """
+    items = collect_coderabbit_items(owner, repo, pr_number, token)
+    if items is None:
+        return EXIT_ERROR, (
+            f"error: could not fetch CodeRabbit output for PR #{pr_number} "
+            f"(exit {EXIT_ERROR})"
+        )
+    return classify(items)
+
+
+def _detect_repo() -> tuple[str, str]:
+    """Detect (owner, repo) from GITHUB_REPOSITORY env var or git remote.
+
+    Falls back to ("jaylfc", "taOS") if neither is available.
+    """
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    if env_repo and "/" in env_repo:
+        parts = env_repo.split("/")
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+        url = result.stdout.strip()
+        if "github.com" in url:
+            path = url.split("github.com/", 1)[1].replace(".git", "").strip()
+            parts = path.split("/")
+            if len(parts) >= 2:
+                return parts[0], parts[1]
+    except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+        pass
+
+    return "jaylfc", "taOS"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that the only CodeRabbit output on a PR is not a "
+                    "rate-limit stub.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "pr_number", type=int,
+        help="GitHub PR number to check",
+    )
+    parser.add_argument(
+        "--owner", default=None,
+        help="Repo owner (default: auto-detect from git remote)",
+    )
+    parser.add_argument(
+        "--repo", default=None,
+        help="Repo name (default: auto-detect from git remote)",
+    )
+    parser.add_argument(
+        "--token", default=None,
+        help="GitHub token (default: $GH_TOKEN or $GITHUB_TOKEN)",
+    )
+    args = parser.parse_args(argv)
+
+    owner = args.owner
+    repo = args.repo
+    if not owner or not repo:
+        detected_owner, detected_repo = _detect_repo()
+        owner = owner or detected_owner
+        repo = repo or detected_repo
+
+    exit_code, message = check_bot_review(
+        owner, repo, args.pr_number, args.token,
+    )
+    print(message)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -42,6 +42,7 @@ API = "https://api.github.com"
 CODERABBIT_LOGINS = frozenset({
     "coderabbit[bot]",
     "coderabbitai",
+    "coderabbitai[bot]",
 })
 
 # Signature of a CodeRabbit rate-limit stub. From the CodeRabbit docs
@@ -231,7 +232,7 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
     - (0, "PASS (absent, ...)")  -- CodeRabbit is entirely absent.
     - (1, "FAIL ...")            -- only rate-limit stubs exist.
     - (0, "PASS ...")            -- CR output exists but is neither a stub
-                                    nor substantive (edge case, not fake-green).
+                                  nor substantive (edge case, not fake-green).
     """
     if not items:
         return EXIT_OK, "PASS (absent, not stubbed): no CodeRabbit output on this PR"
@@ -243,18 +244,16 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
             f"(exit {EXIT_OK})"
         )
 
-    # No real review threads. Check whether the latest CR output matches
-    # the rate-limit signature -- that is the fake-green condition.
-    latest = items[-1]
-    if is_rate_limit_stub(latest.body):
+    # No real review threads. Check whether ANY CR output is a rate-limit
+    # stub -- that is the fake-green condition.
+    if any(is_rate_limit_stub(i.body) for i in items):
         return EXIT_STUB, (
-            f"FAIL: only CodeRabbit output is a rate-limit stub "
-            f"(latest CR item id={latest.id}) (exit {EXIT_STUB})"
+            f"FAIL: only CodeRabbit output is a rate-limit stub (exit {EXIT_STUB})"
         )
 
-    # CR output exists but no real review threads and latest is not a
-    # recognizable stub. Absence of a real review is still not
-    # fake-green: there is no stub masquerading as a review.
+    # CR output exists but no real review threads and no recognizable stub.
+    # Absence of a real review is still not fake-green: there is no stub
+    # masquerading as a review.
     return EXIT_OK, (
         f"PASS (absent, not stubbed): CodeRabbit output present but not a "
         f"rate-limit stub (exit {EXIT_OK})"

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -1,0 +1,273 @@
+"""Tests for scripts/check_bot_review.py."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "check_bot_review.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_bot_review", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_bot_review"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def check_mod():
+    return _load_module()
+
+
+class TestIsRateLimitStub:
+    def test_review_limit_reached_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("review limit reached")
+
+    def test_review_rate_limited_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("Review rate limited")
+
+    def test_rate_limit_reached_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("rate limit reached")
+
+    def test_rate_limit_exhausted_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("rate limit exhausted")
+
+    def test_plan_quota_reached_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("plan quota reached")
+
+    def test_review_quota_exhausted_matches(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("review quota exhausted")
+
+    def test_case_insensitive(self, check_mod) -> None:
+        assert check_mod.is_rate_limit_stub("REVIEW LIMIT REACHED")
+
+    def test_real_review_body_does_not_match(self, check_mod) -> None:
+        assert not check_mod.is_rate_limit_stub(
+            "Consider adding rate limit handling to this endpoint."
+        )
+
+    def test_empty_body_does_not_match(self, check_mod) -> None:
+        assert not check_mod.is_rate_limit_stub("")
+        assert not check_mod.is_rate_limit_stub(None)
+
+    def test_generic_rate_limit_without_context_does_not_match(self, check_mod) -> None:
+        assert not check_mod.is_rate_limit_stub("This endpoint handles rate limiting correctly.")
+
+
+class TestIsRealItem:
+    def test_real_review_with_substantive_body(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="Line 42: potential memory leak here.", is_review=True,
+        )
+        assert check_mod.is_real_item(item)
+
+    def test_real_review_approved(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="", is_review=True, review_state="APPROVED",
+        )
+        assert check_mod.is_real_item(item)
+
+    def test_real_review_changes_requested(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="", is_review=True, review_state="CHANGES_REQUESTED",
+        )
+        assert check_mod.is_real_item(item)
+
+    def test_rate_limit_stub_review_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="Review rate limited", is_review=True, review_state="COMMENTED",
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_empty_body_comment_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="", is_review=False,
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_rate_limit_stub_comment_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="review limit reached", is_review=False,
+        )
+        assert not check_mod.is_real_item(item)
+
+
+class TestClassify:
+    def test_empty_items_is_absent(self, check_mod) -> None:
+        exit_code, message = check_mod.classify([])
+        assert exit_code == 0
+        assert "absent, not stubbed" in message
+
+    def test_real_review_exists(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited", is_review=True,
+            ),
+            check_mod.CRItem(
+                id=2, body="Found a bug on line 42.", is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
+
+    def test_only_stubs_fails(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="review limit reached", is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
+        assert "rate-limit stub" in message
+
+    def test_multiple_stubs_fails(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited", is_review=False,
+            ),
+            check_mod.CRItem(
+                id=2, body="review limit reached", is_review=True,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
+
+    def test_approved_review_is_real_even_with_stub_comment(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="review limit reached", is_review=False,
+            ),
+            check_mod.CRItem(
+                id=2, body="", is_review=True, review_state="APPROVED",
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
+
+    def test_latest_not_stub_but_no_real_review(self, check_mod) -> None:
+        """If the latest CR output is not a stub signature (even when no
+        real reviews exist), the check does not fail -- there is no stub
+        masquerading as a review."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="review limit reached", is_review=False,
+            ),
+            check_mod.CRItem(
+                id=2, body="", is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "absent, not stubbed" in message
+
+    def test_message_echoes_exit_code(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited", is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert f"(exit {exit_code})" in message
+
+
+class TestCheckBotReview:
+    """Integration tests that mock collect_coderabbit_items."""
+
+    def test_absent_returns_ok_with_note(self, check_mod) -> None:
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=[]):
+            exit_code, message = check_mod.check_bot_review("jaylfc", "taOS", 2419)
+        assert exit_code == 0
+        assert "absent, not stubbed" in message
+
+    def test_only_stub_returns_fail(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=100, body="Review rate limited", is_review=False,
+            ),
+        ]
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=items):
+            exit_code, message = check_mod.check_bot_review("jaylfc", "taOS", 2416)
+        assert exit_code == 1
+        assert "FAIL" in message
+        assert "rate-limit stub" in message
+
+    def test_real_review_returns_ok(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=100, body="## Review\n\n### Findings", is_review=True, review_state="COMMENTED",
+            ),
+            check_mod.CRItem(
+                id=101, body="Line 42: potential bug here.", is_review=False,
+            ),
+        ]
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=items):
+            exit_code, message = check_mod.check_bot_review("jaylfc", "taOS", 2366)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
+
+    def test_api_failure_returns_error(self, check_mod) -> None:
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=None):
+            exit_code, message = check_mod.check_bot_review("jaylfc", "taOS", 99999)
+        assert exit_code == 2
+        assert "error" in message.lower()
+
+
+class TestMain:
+    def test_main_exit_1_on_stub(self, check_mod, capsys: pytest.CaptureFixture) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited", is_review=False,
+            ),
+        ]
+        with patch.object(
+            check_mod, "collect_coderabbit_items", return_value=items,
+        ):
+            rc = check_mod.main(["2416", "--owner", "jaylfc", "--repo", "taOS"])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "FAIL" in captured.out
+
+    def test_main_exit_0_on_real_review(self, check_mod, capsys: pytest.CaptureFixture) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True, review_state="COMMENTED",
+            ),
+        ]
+        with patch.object(
+            check_mod, "collect_coderabbit_items", return_value=items,
+        ):
+            rc = check_mod.main(["2366", "--owner", "jaylfc", "--repo", "taOS"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "PASS" in captured.out
+
+    def test_main_exit_0_on_absent(self, check_mod, capsys: pytest.CaptureFixture) -> None:
+        with patch.object(
+            check_mod, "collect_coderabbit_items", return_value=[],
+        ):
+            rc = check_mod.main(["2419", "--owner", "jaylfc", "--repo", "taOS"])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "absent, not stubbed" in captured.out
+
+    def test_main_exit_2_on_api_error(self, check_mod, capsys: pytest.CaptureFixture) -> None:
+        with patch.object(
+            check_mod, "collect_coderabbit_items", return_value=None,
+        ):
+            rc = check_mod.main(["99999", "--owner", "jaylfc", "--repo", "taOS"])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "error" in captured.out.lower()
+
+    def test_main_requires_pr_number(self, check_mod) -> None:
+        with pytest.raises(SystemExit):
+            check_mod.main([])

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -154,9 +154,9 @@ class TestClassify:
         assert "real CodeRabbit review" in message
 
     def test_latest_not_stub_but_no_real_review(self, check_mod) -> None:
-        """If the latest CR output is not a stub signature (even when no
-        real reviews exist), the check does not fail -- there is no stub
-        masquerading as a review."""
+        """If any CR output is a stub signature (even when no real reviews
+        exist), the check fails -- a stub masquerading as a review is
+        fake-green."""
         items = [
             check_mod.CRItem(
                 id=1, body="review limit reached", is_review=False,
@@ -166,8 +166,39 @@ class TestClassify:
             ),
         ]
         exit_code, message = check_mod.classify(items)
-        assert exit_code == 0
-        assert "absent, not stubbed" in message
+        assert exit_code == 1
+        assert "FAIL" in message
+
+    def test_collect_coderabbit_items_with_coderabbitai_bot(self, check_mod) -> None:
+        """Test that collect_coderabbit_items correctly identifies
+        coderabbitai[bot] login from raw API-shaped JSON, with only
+        _api_get mocked (the narrow filter scope)."""
+        call_count = 0
+
+        def _api_get_side_effect(url, token=None):
+            nonlocal call_count
+            call_count += 1
+            # Return API-shaped JSON with coderabbitai[bot] login
+            # for the first call only; subsequent calls return empty
+            # to avoid duplicate collection from three endpoints.
+            if call_count == 1:
+                return [
+                    {
+                        "id": 1,
+                        "user": {"login": "coderabbitai[bot]"},
+                        "body": "Some review comment",
+                        "state": "COMMENTED",
+                        "created_at": "2024-01-01T00:00:00Z",
+                    }
+                ]
+            return []
+
+        with patch.object(check_mod, "_api_get", side_effect=_api_get_side_effect):
+            items = check_mod.collect_coderabbit_items("jaylfc", "taOS", 2412)
+        assert len(items) == 1
+        assert items[0].id == 1
+        assert items[0].body == "Some review comment"
+        assert items[0].is_review is True
 
     def test_message_echoes_exit_code(self, check_mod) -> None:
         items = [


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Bot-review gate take 2: real CodeRabbit login, filter-granularity tests, live red proof -- supersedes PR #2438 (HELD)

Autonomous build of board card tsk-vpqe6o.

REVISION: built on `exec/tsk-vzzv62` (cut at `d4b47599ad99d887257ca3a7f201471865543284`), not on `dev`. That branch's
commits are ancestors of this one and the `Files:` list below is the diff SINCE it,
so this PR shows the revision alone while carrying the original work. Verified by
`git merge-base --is-ancestor` before the PR was opened.



Files:
 .github/workflows/bot-review-gate.yml     |  4 +++
 changelog.d/tsk-vpqe6o-bot-review-gate.md |  2 ++
 scripts/check_bot_review.py               | 19 +++++++-------
 tests/scripts/test_check_bot_review.py    | 41 +++++++++++++++++++++++++++----
 4 files changed, 51 insertions(+), 15 deletions(-)