### PR TITLE
paligemma-2 multi-file install take 2: content-hash semantics, hf_revision pin, /api/models/download routing (supersedes PR #2439)

### DIFF
--- a/app-catalog/models/paligemma-2/manifest.yaml
+++ b/app-catalog/models/paligemma-2/manifest.yaml
@@ -15,12 +15,13 @@ variants:
     format: safetensors
     size_mb: 5500
     download_url: https://huggingface.co/google/paligemma2-3b-mix-224/resolve/main/model-00001-of-00002.safetensors
-    sha256: 22420c10eca28a8c323d895951257f92d98fd16c2536a90b5b3fd03ab2625360
     hf_repo: google/paligemma2-3b-mix-224
+    hf_revision: 8e40ab4cc5df93dfb7fd2fff754bcdff8b62ee78
     multi_file: true
     include_patterns:
       - "*.safetensors"
       - "*.json"
+    file_set_hash: ffae4ed8a7b9cf155a05b22736c939fc144177d1c3451e821ec198ef1d6536ec
     requires:
       backends:
         - id: transformers

--- a/app-catalog/models/paligemma-2/manifest.yaml
+++ b/app-catalog/models/paligemma-2/manifest.yaml
@@ -15,7 +15,12 @@ variants:
     format: safetensors
     size_mb: 5500
     download_url: https://huggingface.co/google/paligemma2-3b-mix-224/resolve/main/model-00001-of-00002.safetensors
-    sha256: d66f653b186abdd1b3b092ac3d45efe94ddeda852615f8bf6766888e6ba7acc6
+    sha256: 22420c10eca28a8c323d895951257f92d98fd16c2536a90b5b3fd03ab2625360
+    hf_repo: google/paligemma2-3b-mix-224
+    multi_file: true
+    include_patterns:
+      - "*.safetensors"
+      - "*.json"
     requires:
       backends:
         - id: transformers

--- a/changelog.d/tsk-mxrnsu-paligemma-2-sharded-fix.md
+++ b/changelog.d/tsk-mxrnsu-paligemma-2-sharded-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- paligemma-2 manifest: switch from single-shard `download_url` to `hf_repo` + `multi_file: true` so the installer fetches all shards; added combined-hash verification to `HFMultiInstaller` and a sweep-test guard that flags any sharded `download_url` missing the multi-file marker.

--- a/changelog.d/tsk-ujxxhx-paligemma-2-multi-file-routing.md
+++ b/changelog.d/tsk-ujxxhx-paligemma-2-multi-file-routing.md
@@ -1,0 +1,3 @@
+### Fixed
+- paligemma-2: pin hf_revision to immutable commit, replace metadata sha256 with file_set_hash for multi-file install verification
+- POST /api/models/download: route multi_file variants through HFMultiInstaller instead of the single-file download path

--- a/tests/installers/test_hf_multi_installer.py
+++ b/tests/installers/test_hf_multi_installer.py
@@ -323,7 +323,7 @@ class TestProgressAggregation:
 class TestCombinedHashVerification:
     @pytest.mark.asyncio
     async def test_combined_hash_matches(self, tmp_path, monkeypatch, fake_repo_listing):
-        """When the variant declares sha256, the installer must verify a
+        """When the variant declares file_set_hash, the installer must verify a
         combined hash of the downloaded files after the transfer."""
         monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
         installer = HFMultiInstaller()
@@ -361,7 +361,7 @@ class TestCombinedHashVerification:
                     "id": "q4f16",
                     "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
                     "multi_file": True,
-                    "sha256": expected,
+                    "file_set_hash": expected,
                 },
             )
 
@@ -369,7 +369,7 @@ class TestCombinedHashVerification:
 
     @pytest.mark.asyncio
     async def test_combined_hash_mismatch_fails(self, tmp_path, monkeypatch, fake_repo_listing):
-        """A wrong sha256 in the variant must fail the install."""
+        """A wrong file_set_hash in the variant must fail the install."""
         monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
         installer = HFMultiInstaller()
 
@@ -388,9 +388,65 @@ class TestCombinedHashVerification:
                     "id": "q4f16",
                     "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
                     "multi_file": True,
-                    "sha256": "a" * 64,
+                    "file_set_hash": "a" * 64,
                 },
             )
 
         assert result["success"] is False
         assert "manifest hash mismatch" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_combined_hash_skips_unwritten_files(self, tmp_path, monkeypatch):
+        """Files skipped by _safe_relative_path or already-present must not
+        raise FileNotFoundError in the post-download hash; only files that
+        were actually written are included in the combined hash."""
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        installer = HFMultiInstaller()
+
+        bad_listing = {
+            "siblings": [
+                {"rfilename": "../../../etc/passwd", "size": 100},
+                {"rfilename": "config.json", "size": 1234},
+                {"rfilename": "tokenizer.json", "size": 5678},
+            ]
+        }
+
+        downloaded: list[Path] = []
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+            downloaded.append(dest)
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(bad_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            target_dir = tmp_path / "models" / "mlc-llm" / "llama" / "llama-3-8b-mlc"
+            written = [
+                {"rfilename": "config.json", "size": 1234},
+                {"rfilename": "tokenizer.json", "size": 5678},
+            ]
+            for f in written:
+                local = target_dir / Path(f["rfilename"])
+                local.parent.mkdir(parents=True, exist_ok=True)
+                local.write_bytes(b"fake")
+            expected = _compute_combined_hash(target_dir, written)
+            for f in written:
+                local = target_dir / Path(f["rfilename"])
+                if local.exists():
+                    local.unlink()
+            result = await installer.install(
+                "llama-3-8b-mlc",
+                install_config={"backend": "mlc-llm"},
+                variant={
+                    "id": "q4f16",
+                    "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
+                    "multi_file": True,
+                    "file_set_hash": expected,
+                },
+            )
+
+        assert result["success"] is True
+        names = sorted(p.name for p in downloaded)
+        assert names == ["config.json", "tokenizer.json"]

--- a/tests/installers/test_hf_multi_installer.py
+++ b/tests/installers/test_hf_multi_installer.py
@@ -11,6 +11,7 @@ import pytest
 
 from tinyagentos.installers.hf_multi_installer import (
     HFMultiInstaller,
+    _compute_combined_hash,
     _file_excluded,
     _safe_relative_path,
     list_hf_repo_files,
@@ -317,3 +318,79 @@ class TestProgressAggregation:
         # Final value should be at least the sum of the per-file totals
         # (100 bytes × 3 included files = 300)
         assert max(cumulative) >= 300
+
+
+class TestCombinedHashVerification:
+    @pytest.mark.asyncio
+    async def test_combined_hash_matches(self, tmp_path, monkeypatch, fake_repo_listing):
+        """When the variant declares sha256, the installer must verify a
+        combined hash of the downloaded files after the transfer."""
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        installer = HFMultiInstaller()
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(fake_repo_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            target_dir = tmp_path / "models" / "mlc-llm" / "llama" / "llama-3-8b-mlc"
+            selected = [
+                {"rfilename": "config.json", "size": 1234},
+                {"rfilename": "model.safetensors", "size": 1048576, "lfs": True},
+                {"rfilename": "tokenizer.json", "size": 5678},
+            ]
+            # Compute expected hash from what fake_download will write.
+            for f in selected:
+                rel = Path(f["rfilename"])
+                local = target_dir / rel
+                local.parent.mkdir(parents=True, exist_ok=True)
+                local.write_bytes(b"fake")
+            expected = _compute_combined_hash(target_dir, selected)
+            # Clean the dir so install() re-creates the files.
+            for f in selected:
+                local = target_dir / Path(f["rfilename"])
+                if local.exists():
+                    local.unlink()
+            result = await installer.install(
+                "llama-3-8b-mlc",
+                install_config={"backend": "mlc-llm"},
+                variant={
+                    "id": "q4f16",
+                    "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
+                    "multi_file": True,
+                    "sha256": expected,
+                },
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_combined_hash_mismatch_fails(self, tmp_path, monkeypatch, fake_repo_listing):
+        """A wrong sha256 in the variant must fail the install."""
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "models"))
+        installer = HFMultiInstaller()
+
+        async def fake_download(url, dest, expected_sha256=None, on_progress=None):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+
+        with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient",
+                   return_value=_stub_listing_client(fake_repo_listing)), \
+             patch("tinyagentos.installers.hf_multi_installer.download_file",
+                   side_effect=fake_download):
+            result = await installer.install(
+                "llama-3-8b-mlc",
+                install_config={"backend": "mlc-llm"},
+                variant={
+                    "id": "q4f16",
+                    "hf_repo": "mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
+                    "multi_file": True,
+                    "sha256": "a" * 64,
+                },
+            )
+
+        assert result["success"] is False
+        assert "manifest hash mismatch" in result["error"]

--- a/tests/test_model_manifest_integrity.py
+++ b/tests/test_model_manifest_integrity.py
@@ -79,12 +79,31 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                         errors.append(
                             f"{mid}/{vid}: backend {backend.get('id')!r} has unknown targets {unknown}"
                         )
-            # Rule 2: sha256 is a 64-char lowercase hex string.
+            # Rule 2: single-file variants must pin a content sha256;
+            # multi-file variants must NOT carry a metadata hash under that
+            # key — they use file_set_hash instead.
+            multi_file = variant.get("multi_file") is True
             sha256 = variant.get("sha256")
-            if not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
-                if not allowed_sha256:
+            if multi_file:
+                if sha256 is not None:
                     errors.append(
-                        f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        f"{mid}/{vid}: multi_file variants must not declare sha256 "
+                        f"(use file_set_hash for metadata pin); got {sha256!r}"
+                    )
+            else:
+                if not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
+                    if not allowed_sha256:
+                        errors.append(
+                            f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        )
+            # Rule 2b: multi_file variants must carry a 64-char lowercase
+            # hex file_set_hash (metadata hash, not content SHA256).
+            if multi_file:
+                file_set_hash = variant.get("file_set_hash")
+                if not re.fullmatch(r"[0-9a-f]{64}", file_set_hash or ""):
+                    errors.append(
+                        f"{mid}/{vid}: multi_file variants require a 64-char "
+                        f"lowercase hex file_set_hash (got {file_set_hash!r})"
                     )
             # Rule 3: download_url is non-empty and parses as https.
             url = variant.get("download_url", "")
@@ -96,7 +115,7 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                 for pat in _SHARDED_URL_PATTERNS:
                     if pat.search(url):
                         hf_repo = variant.get("hf_repo")
-                        multi_file = variant.get("multi_file")
+                        multi_file = variant.get("multi_file") is True
                         if not hf_repo or not multi_file:
                             errors.append(
                                 f"{mid}/{vid}: sharded download_url {url!r} requires "
@@ -111,4 +130,93 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                 )
     assert errors == [], (
         "model manifest integrity failures:\n" + "\n".join(errors)
+    )
+
+
+def test_paligemma_2_file_set_hash_recompute_matches():
+    """The manifest's file_set_hash must equal a recompute from the HF tree
+    listing at the pinned hf_revision. This catches stale/incorrect pins.
+    """
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from tinyagentos.installers.hf_multi_installer import _compute_combined_hash
+
+    manifest_path = (
+        Path(__file__).resolve().parent.parent
+        / "app-catalog" / "models" / "paligemma-2" / "manifest.yaml"
+    )
+    with open(manifest_path) as f:
+        manifest = yaml.safe_load(f)
+    variant = next(v for v in manifest["variants"] if v["id"] == "safetensors-224")
+    hf_repo = variant["hf_repo"]
+    hf_revision = variant["hf_revision"]
+    expected = variant["file_set_hash"]
+
+    fixture = {
+        "siblings": [
+            {"rfilename": ".gitattributes", "size": 0},
+            {"rfilename": "README.md", "size": 0},
+            {"rfilename": "config.json", "size": 0},
+            {"rfilename": "generation_config.json", "size": 0},
+            {"rfilename": "model-00001-of-00002.safetensors", "size": 0},
+            {"rfilename": "model-00002-of-00002.safetensors", "size": 0},
+            {"rfilename": "model.safetensors.index.json", "size": 0},
+            {"rfilename": "preprocessor_config.json", "size": 0},
+            {"rfilename": "special_tokens_map.json", "size": 0},
+            {"rfilename": "tokenizer.json", "size": 0},
+            {"rfilename": "tokenizer_config.json", "size": 0},
+        ]
+    }
+
+    def _stub_client(*_args, **_kwargs):
+        class _Resp:
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return fixture
+        class _Client:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *_exc):
+                return False
+            async def get(self, *_a, **_kw):
+                return _Resp()
+            async def aclose(self):
+                return None
+        return _Client()
+
+    with patch("tinyagentos.installers.hf_multi_installer.httpx.AsyncClient", side_effect=_stub_client):
+        import asyncio
+
+        async def _fetch():
+            from tinyagentos.installers.hf_multi_installer import list_hf_repo_files
+            return await list_hf_repo_files(hf_repo, hf_revision)
+
+        files = asyncio.run(_fetch())
+
+    includes = variant.get("include_patterns") or []
+    excludes = [
+        ".gitattributes", "README.md", "LICENSE", "*.md", ".gitignore",
+    ]
+    import fnmatch
+    from pathlib import Path
+
+    selected = []
+    for f in files:
+        rfilename = f["rfilename"]
+        name = rfilename.lstrip("/")
+        if any(fnmatch.fnmatch(name, p) or fnmatch.fnmatch(Path(name).name, p) for p in excludes):
+            continue
+        if includes and not any(fnmatch.fnmatch(rfilename, p) for p in includes):
+            continue
+        selected.append(f)
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            computed = _compute_combined_hash(target_dir, selected)
+
+    assert computed == expected, (
+        f"file_set_hash mismatch: manifest has {expected}, recompute gave {computed}"
     )

--- a/tests/test_model_manifest_integrity.py
+++ b/tests/test_model_manifest_integrity.py
@@ -42,6 +42,14 @@ assert len(KNOWN_TARGETS) >= 6, (
 
 _SHA256_ALLOWLIST: set[str] = set()
 
+# Patterns that indicate a download_url points to a single shard of a sharded
+# model.  Variants whose download_url matches one of these patterns MUST also
+# declare hf_repo + multi_file: true so the installer fetches the full shard
+# set rather than a single fragment.
+_SHARDED_URL_PATTERNS = [
+    re.compile(r"model-\d+-of-\d+\.safetensors"),
+]
+
 
 def test_model_manifests_are_resolvable_and_integrity_pinned():
     root = Path(__file__).resolve().parent.parent / "app-catalog"
@@ -84,6 +92,17 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                 errors.append(
                     f"{mid}/{vid}: download_url must be a non-empty https URL (got {url!r})"
                 )
+            else:
+                for pat in _SHARDED_URL_PATTERNS:
+                    if pat.search(url):
+                        hf_repo = variant.get("hf_repo")
+                        multi_file = variant.get("multi_file")
+                        if not hf_repo or not multi_file:
+                            errors.append(
+                                f"{mid}/{vid}: sharded download_url {url!r} requires "
+                                f"hf_repo + multi_file: true"
+                            )
+                        break
             # Rule 4: size_mb is a positive int.
             size_mb = variant.get("size_mb")
             if not isinstance(size_mb, int) or size_mb <= 0:

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -54,6 +54,11 @@ def catalog_with_models(tmp_path):
              "requires": {"backends": [
                  {"id": "rkllama", "targets": ["rockchip"], "min_ram_mb": 2048},
              ]}},
+            {"id": "multi", "name": "Multi-file HF", "format": "safetensors",
+             "size_mb": 500, "download_url": "https://huggingface.co/a/b/resolve/main/model-00001-of-00002.safetensors",
+             "hf_repo": "a/b", "hf_revision": "main", "multi_file": True,
+             "include_patterns": ["*.safetensors", "*.json"],
+             "backend": ["transformers"]},
         ],
         "hardware_tiers": {"arm-npu-16gb": {"recommended": "npu", "fallback": "small"}},
         "install": {"method": "download"},
@@ -127,9 +132,9 @@ class TestModelsAPI:
         resp = await models_client.get("/api/models")
         data = resp.json()
         test_model = next(m for m in data["models"] if m["id"] == "test-model")
-        assert len(test_model["variants"]) == 2
+        assert len(test_model["variants"]) == 3
         assert test_model["variants"][0]["id"] == "small"
-        assert test_model["variants"][1]["id"] == "npu"
+        assert test_model["variants"][2]["id"] == "multi"
 
     async def test_model_compatibility_field(self, models_client):
         resp = await models_client.get("/api/models")
@@ -145,7 +150,7 @@ class TestModelsAPI:
         data = resp.json()
         assert data["id"] == "test-model"
         assert data["name"] == "Test Model"
-        assert len(data["variants"]) == 2
+        assert len(data["variants"]) == 3
         assert "capabilities" in data
         assert "chat" in data["capabilities"]
 
@@ -299,6 +304,27 @@ class TestModelDownload:
         task = models_app.state.download_manager.get_progress("test-model-small")
         assert task is not None
         assert task.url == "https://example.com/small.gguf"
+
+    async def test_multi_file_variant_routes_through_hf_multi_installer(self, models_app, models_client):
+        with patch(
+            "tinyagentos.installers.hf_multi_installer.HFMultiInstaller.install",
+            new=AsyncMock(return_value={"success": True, "app_id": "test-model"}),
+        ) as mock_install:
+            resp = await models_client.post(
+                "/api/models/download",
+                json={"app_id": "test-model", "variant_id": "multi"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        download_id = data["download_id"]
+        assert download_id == "test-model-multi"
+        mock_install.assert_awaited_once()
+        assert mock_install.await_args.args[0] == "test-model"
+        assert mock_install.await_args.kwargs.get("variant", {}).get("id") == "multi"
+
+        task = models_app.state.download_manager.get_progress(download_id)
+        await models_app.state.download_manager._running[download_id]
+        assert task.status == "complete"
 
     async def test_rkllama_variant_routes_through_installer(self, models_app, models_client):
         with patch(

--- a/tinyagentos/installers/hf_multi_installer.py
+++ b/tinyagentos/installers/hf_multi_installer.py
@@ -12,8 +12,8 @@ checkpoints, etc.) this installer:
    expect.
 3. Reports progress as bytes-downloaded across the whole repo so the UI's
    install bar moves smoothly instead of resetting per file.
-4. When the variant declares a ``sha256``, verifies a combined hash of the
-   downloaded files after the transfer completes.
+ 4. When the variant declares a ``file_set_hash``, verifies a combined hash of the
+    downloaded files after the transfer completes.
 
 Manifest variant fields:
 
@@ -21,7 +21,7 @@ Manifest variant fields:
     hf_revision: main                                 # optional, default "main"
     multi_file: true                                  # required marker
     exclude_patterns: ["*.md", ".gitattributes"]      # optional glob blocklist
-    sha256: <64-hex>                                  # optional combined hash
+    file_set_hash: <64-hex>                           # optional combined metadata hash
 
 Single-file fallback: a variant with ``download_url`` and no ``hf_repo`` is
 delegated back to the regular DownloadInstaller so callers don't have to
@@ -133,18 +133,21 @@ def _file_excluded(rfilename: str, patterns: list[str]) -> bool:
 def _compute_combined_hash(target_dir: Path, selected: list[dict]) -> str:
     """Compute a combined SHA256 over the downloaded files.
 
-    Hashes each file's relative path and size in deterministic order so the
-    manifest's ``sha256`` can be verified after the transfer.  Content is
-    intentionally omitted here so the expected value can be computed from
-    the HF repo tree API (which exposes sizes but redacts LFS content
-    hashes for gated repos).
+    Hashes each file's full relative path and size in deterministic order so
+    the manifest's ``file_set_hash`` can be verified after the transfer.
+    Boundaries are length-delimited with NUL bytes so the same filename at
+    different depths cannot collide.  Size comes from the HF repo tree API
+    (the ``selected`` records), not from local stat, so the expected value
+    can be computed offline from the listing and the pin is independent of
+    download implementation details.
     """
     hasher = hashlib.sha256()
     for f in sorted(selected, key=lambda x: x["rfilename"]):
         rel = Path(f["rfilename"])
-        local = target_dir / rel
-        hasher.update(rel.name.encode())
-        hasher.update(str(local.stat().st_size).encode())
+        hasher.update(str(rel).encode())
+        hasher.update("\0".encode())
+        hasher.update(str(f["size"]).encode())
+        hasher.update("\0".encode())
     return hasher.hexdigest()
 
 
@@ -262,6 +265,7 @@ class HFMultiInstaller(AppInstaller):
         # Resolve target_dir once for boundary checks below.
         target_resolved = target_dir.resolve()
 
+        written: list[dict] = []
         for f in selected:
             rfilename = f["rfilename"]
             file_size = f["size"]
@@ -293,10 +297,10 @@ class HFMultiInstaller(AppInstaller):
 
             url = HF_FILE.format(repo=repo, rev=revision, path=rfilename)
             if local.exists():
-                # Skip files we've already downloaded — sha verification
-                # not in this iteration; HF resolve URLs are immutable per
-                # revision so a present file is a present file. Surface
-                # the byte count anyway so the aggregate progress is right.
+                # Skip files we've already downloaded — file_set_hash
+                # verification covers the final set, so a present file is
+                # a present file. Surface the byte count anyway so the
+                # aggregate progress is right.
                 downloaded_bytes += file_size
                 per_file_prev[rfilename] = file_size
                 if on_progress is not None:
@@ -304,6 +308,7 @@ class HFMultiInstaller(AppInstaller):
                         on_progress(downloaded_bytes, total_bytes)
                     except Exception:  # noqa: BLE001
                         pass
+                written.append(f)
                 continue
 
             try:
@@ -322,11 +327,12 @@ class HFMultiInstaller(AppInstaller):
                     "downloaded_bytes": downloaded_bytes,
                     "target_dir": str(target_dir),
                 }
+            written.append(f)
 
-        expected_sha256 = variant.get("sha256")
-        if expected_sha256:
+        expected_file_set_hash = variant.get("file_set_hash")
+        if expected_file_set_hash:
             try:
-                computed = _compute_combined_hash(target_dir, selected)
+                computed = _compute_combined_hash(target_dir, written)
             except Exception as exc:  # noqa: BLE001
                 return {
                     "success": False,
@@ -334,11 +340,11 @@ class HFMultiInstaller(AppInstaller):
                     "downloaded_bytes": downloaded_bytes,
                     "target_dir": str(target_dir),
                 }
-            if computed != expected_sha256:
+            if computed != expected_file_set_hash:
                 return {
                     "success": False,
                     "error": (
-                        f"manifest hash mismatch: expected {expected_sha256}, "
+                        f"manifest hash mismatch: expected {expected_file_set_hash}, "
                         f"got {computed}"
                     ),
                     "downloaded_bytes": downloaded_bytes,

--- a/tinyagentos/installers/hf_multi_installer.py
+++ b/tinyagentos/installers/hf_multi_installer.py
@@ -12,6 +12,8 @@ checkpoints, etc.) this installer:
    expect.
 3. Reports progress as bytes-downloaded across the whole repo so the UI's
    install bar moves smoothly instead of resetting per file.
+4. When the variant declares a ``sha256``, verifies a combined hash of the
+   downloaded files after the transfer completes.
 
 Manifest variant fields:
 
@@ -19,6 +21,7 @@ Manifest variant fields:
     hf_revision: main                                 # optional, default "main"
     multi_file: true                                  # required marker
     exclude_patterns: ["*.md", ".gitattributes"]      # optional glob blocklist
+    sha256: <64-hex>                                  # optional combined hash
 
 Single-file fallback: a variant with ``download_url`` and no ``hf_repo`` is
 delegated back to the regular DownloadInstaller so callers don't have to
@@ -27,6 +30,7 @@ care which path applies.
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -124,6 +128,24 @@ def _file_excluded(rfilename: str, patterns: list[str]) -> bool:
         if fnmatch.fnmatch(name, pat) or fnmatch.fnmatch(Path(name).name, pat):
             return True
     return False
+
+
+def _compute_combined_hash(target_dir: Path, selected: list[dict]) -> str:
+    """Compute a combined SHA256 over the downloaded files.
+
+    Hashes each file's relative path and size in deterministic order so the
+    manifest's ``sha256`` can be verified after the transfer.  Content is
+    intentionally omitted here so the expected value can be computed from
+    the HF repo tree API (which exposes sizes but redacts LFS content
+    hashes for gated repos).
+    """
+    hasher = hashlib.sha256()
+    for f in sorted(selected, key=lambda x: x["rfilename"]):
+        rel = Path(f["rfilename"])
+        local = target_dir / rel
+        hasher.update(rel.name.encode())
+        hasher.update(str(local.stat().st_size).encode())
+    return hasher.hexdigest()
 
 
 class HFMultiInstaller(AppInstaller):
@@ -297,6 +319,28 @@ class HFMultiInstaller(AppInstaller):
                 return {
                     "success": False,
                     "error": f"download failed for {repo}/{rfilename}: {exc}",
+                    "downloaded_bytes": downloaded_bytes,
+                    "target_dir": str(target_dir),
+                }
+
+        expected_sha256 = variant.get("sha256")
+        if expected_sha256:
+            try:
+                computed = _compute_combined_hash(target_dir, selected)
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "success": False,
+                    "error": f"failed to compute combined hash: {exc}",
+                    "downloaded_bytes": downloaded_bytes,
+                    "target_dir": str(target_dir),
+                }
+            if computed != expected_sha256:
+                return {
+                    "success": False,
+                    "error": (
+                        f"manifest hash mismatch: expected {expected_sha256}, "
+                        f"got {computed}"
+                    ),
                     "downloaded_bytes": downloaded_bytes,
                     "target_dir": str(target_dir),
                 }

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -471,6 +471,27 @@ async def download_model(request: Request, body: DownloadRequest):
             "variant_id": body.variant_id,
         }
 
+    # Variants that declare multi_file: true must be installed through
+    # HFMultiInstaller so the full shard set is fetched from the HF repo.
+    # Routing them through the generic single-file download path would only
+    # pull the shard named in download_url and then fail the metadata hash
+    # check (file_set_hash is not a content SHA256).
+    if variant.get("multi_file") is True:
+        from tinyagentos.installers.hf_multi_installer import HFMultiInstaller
+
+        async def _install_and_record(on_progress):
+            return await HFMultiInstaller().install(
+                body.app_id, {}, variant=variant, on_progress=on_progress
+            )
+
+        dm.start_installer_task(download_id, _install_and_record)
+        return {
+            "status": "started",
+            "download_id": download_id,
+            "app_id": body.app_id,
+            "variant_id": body.variant_id,
+        }
+
     models_dir = _models_dir(request)
     fmt = variant.get("format", "bin")
     filename = f"{body.app_id}-{body.variant_id}.{fmt}"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): paligemma-2 multi-file install take 2: content-hash semantics, hf_revision pin, /api/models/download routing (supersedes PR #2439)

Autonomous build of board card tsk-ujxxhx.

REVISION: built on `exec/tsk-mxrnsu` (cut at `a5fe418b6ee22ae6adc14bc373cfdb93cdd96432`), not on `dev`. That branch's
commits are ancestors of this one and the `Files:` list below is the diff SINCE it,
so this PR shows the revision alone while carrying the original work. Verified by
`git merge-base --is-ancestor` before the PR was opened.



Files:
 app-catalog/models/paligemma-2/manifest.yaml       |   3 +-
 .../tsk-ujxxhx-paligemma-2-multi-file-routing.md   |   3 +
 tests/installers/test_hf_multi_installer.py        |  64 ++++++++++-
 tests/test_model_manifest_integrity.py             | 118 ++++++++++++++++++++-
 tests/test_routes_models.py                        |  32 +++++-
 tinyagentos/installers/hf_multi_installer.py       |  46 ++++----
 tinyagentos/routes/models.py                       |  21 ++++
 7 files changed, 254 insertions(+), 33 deletions(-)