### PR TITLE
tasks API: create accepts a partial object silently — unknown fields dropped, empty body dispatches, success reported

### DIFF
--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -842,21 +842,46 @@ async def test_create_with_unknown_key_tags_warns(client, caplog):
 
 
 @pytest.mark.asyncio
-async def test_create_with_description_instead_of_body_returns_422(client, caplog):
+async def test_create_with_description_instead_of_body_returns_422(client):
     """POST with 'description' instead of 'body' must be rejected with 422.
 
     This catches the defect where sending "description" (a field that silently
     vanishes) resulted in a card with an empty body - the only channel that
-    reaches a lane. Now it is rejected early.
+    reaches a lane. The rejection here comes from ``extra="forbid"`` (unknown
+    key), before any model validator runs.
     """
     pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
 
-    with caplog.at_level(logging.WARNING, logger=_LOGGER):
-        resp = await client.post(
-            f"/api/projects/{pid}/tasks",
-            json={"title": "T", "description": "do the thing", "labels": ["claimable"]},
-        )
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "T", "description": "do the thing", "labels": ["claimable"]},
+    )
     assert resp.status_code == 422
     body = resp.json()
-    assert "body" in str(body).lower() or "description" in str(body).lower() or "extra" in str(body).lower()
+    assert "description" in str(body).lower() or "extra" in str(body).lower()
+
+
+@pytest.mark.asyncio
+async def test_create_claimable_with_empty_body_returns_422(client):
+    """A claimable card with no body must be rejected by the model validator.
+
+    The payload contains ONLY declared fields, so ``extra="forbid"`` cannot
+    reject it first — this exercises ``_assert_body_for_claimable`` itself
+    (deleting that validator makes this test fail).
+    """
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    for payload in (
+        {"title": "T", "labels": ["claimable"]},
+        {"title": "T", "labels": ["Claimable "], "body": "   "},
+    ):
+        resp = await client.post(f"/api/projects/{pid}/tasks", json=payload)
+        assert resp.status_code == 422, payload
+        assert "claimable" in str(resp.json()).lower()
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "T", "labels": ["claimable"], "body": "do the thing"},
+    )
+    assert resp.status_code == 200
 

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -836,10 +836,27 @@ async def test_create_with_unknown_key_tags_warns(client, caplog):
             f"/api/projects/{pid}/tasks",
             json={"title": "T", "tags": ["bug"]},
         )
-    assert resp.status_code == 200
-    warns = [r for r in caplog.records if "unknown keys" in r.message]
-    assert warns, "expected a warning for unknown key tags"
-    msg = warns[0].message
-    assert "CreateTaskIn" in msg
-    assert "tags" in msg
+    assert resp.status_code == 422
+    err = resp.json()
+    assert "extra" in str(err).lower() or "validation" in str(err).lower() or "unknown" in str(err).lower()
+
+
+@pytest.mark.asyncio
+async def test_create_with_description_instead_of_body_returns_422(client, caplog):
+    """POST with 'description' instead of 'body' must be rejected with 422.
+
+    This catches the defect where sending "description" (a field that silently
+    vanishes) resulted in a card with an empty body - the only channel that
+    reaches a lane. Now it is rejected early.
+    """
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = await client.post(
+            f"/api/projects/{pid}/tasks",
+            json={"title": "T", "description": "do the thing", "labels": ["claimable"]},
+        )
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "body" in str(body).lower() or "description" in str(body).lower() or "extra" in str(body).lower()
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -469,6 +469,8 @@ class _TaskRequestModelMixin:
 
 
 class CreateTaskIn(_TaskRequestModelMixin, BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     title: str
     body: str = ""
     priority: int = 0
@@ -476,6 +478,16 @@ class CreateTaskIn(_TaskRequestModelMixin, BaseModel):
     assignee_id: str | None = None
     parent_task_id: str | None = None
     element_id: str | None = None
+
+    @model_validator(mode="after")
+    def _assert_body_for_claimable(self) -> self:
+        labels = self.labels or []
+        has_claimable = any(l.strip().lower() == "claimable" for l in labels)
+        if has_claimable and not self.body.strip():
+            raise ValueError(
+                "Claimable cards must have a non-empty body"
+            )
+        return self
 
 
 class UpdateTaskIn(_TaskRequestModelMixin, BaseModel):

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -480,8 +480,8 @@ class CreateTaskIn(_TaskRequestModelMixin, BaseModel):
     element_id: str | None = None
 
     @model_validator(mode="after")
-    def _assert_body_for_claimable(self) -> self:
-        labels = self.labels or []
+    def _assert_body_for_claimable(self) -> CreateTaskIn:
+        labels = self.labels
         has_claimable = any(l.strip().lower() == "claimable" for l in labels)
         if has_claimable and not self.body.strip():
             raise ValueError(


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tasks API: create accepts a partial object silently — unknown fields dropped, empty body dispatches, success reported

Autonomous build of board card tsk-fhgiik.

1. CreateTaskIn now uses extra='forbid' so unknown keys like 'description'
   trigger 422 instead of being silently dropped.
2. Added _assert_body_for_claimable validator: claimable cards require
   non-empty body, 422 otherwise.
3. Updated test_create_with_unknown_key_tags_warns to expect 422.
4. Added test_create_with_description_instead_of_body_returns_422 as RED PROOF.

Docs-Reviewed: validation changes to CreateTaskIn model do not require doc updates

Files:
 tests/test_routes_projects.py  | 29 +++++++++++++++++++++++------
 tinyagentos/routes/projects.py | 12 ++++++++++++
 2 files changed, 35 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task creation now rejects unknown fields with a validation error instead of silently accepting them.
  * Requests using `description` instead of `body` are rejected.
  * Claimable tasks must include non-blank body content.
  * Valid claimable task requests continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->