### PR TITLE
Docs: AGENTS.md and CLAUDE.md point at a CONTRIBUTING.md section name that does not exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,4 @@ Harness-agnostic entry point: read by any agent harness that loads `AGENTS.md`
 A non-test change under `tinyagentos/` or `desktop/src/` requires a
 `changelog.d/<pr>-<slug>.md` fragment (or a `CHANGELOG.md` line) in the same
 PR. The single-source rule lives in [`docs/changelog-fragments.md`](docs/changelog-fragments.md)
-and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Changelog" section).
+and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Documentation gate" section).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,4 +7,4 @@ Loaded by the Claude CLI / Claude Code agent when present at the repo root.
 A non-test change under `tinyagentos/` or `desktop/src/` requires a
 `changelog.d/<pr>-<slug>.md` fragment (or a `CHANGELOG.md` line) in the same
 PR. The single-source rule lives in [`docs/changelog-fragments.md`](docs/changelog-fragments.md)
-and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Changelog" section).
+and is summarized in [`CONTRIBUTING.md`](CONTRIBUTING.md) (the "Documentation gate" section).


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Docs: AGENTS.md and CLAUDE.md point at a CONTRIBUTING.md section name that does not exist

Autonomous build of board card tsk-q627t6.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

AGENTS.md and CLAUDE.md referenced the "Changelog" section of
CONTRIBUTING.md, but no such heading exists. Point at the actual
"Documentation gate" section where the rule lives.

Fixes tsk-q627t6

Files:
 AGENTS.md | 2 +-
 CLAUDE.md | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)