### PR TITLE
Ollama/hailo-ollama installs ignore target_remote: remote-node model installs pull onto the controller

### DIFF
--- a/changelog.d/tsk-mlogef-remote-target-ollama.md
+++ b/changelog.d/tsk-mlogef-remote-target-ollama.md
@@ -1,0 +1,2 @@
+### Fixed
+- Ollama and hailo-ollama installs targeted at a remote worker (`target_remote`) now pull models onto that worker's daemon instead of the controller's localhost; `resolve_ollama_url(target_remote, backend_id)` selects the correct host and port (11434 for ollama, 7836 for hailo-ollama via `TAOS_HAILO_OLLAMA_PORT`) following the same convention as `resolve_rkllama_url`.

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -9,6 +9,7 @@ import pytest
 
 from tinyagentos.agent_image import base_image_alias
 from tinyagentos.catalog.resolver import DeviceCapability
+from tinyagentos.installers.ollama_installer import OllamaInstaller, resolve_ollama_url
 
 
 # ---------------------------------------------------------------------------
@@ -968,6 +969,168 @@ class TestInstallV2:
                 "variant_id": "v1",
             })
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /api/store/install-v2 -- ollama / hailo-ollama remote target (#tsk-mlogef)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOllamaUrl:
+    """Unit tests for the resolve_ollama_url helper."""
+
+    @pytest.mark.parametrize("remote", [None, "", "local"])
+    def test_local_ollama_returns_default_host(self, remote, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_ollama_url(remote, "ollama") == "http://localhost:11434"
+
+    @pytest.mark.parametrize("remote", [None, "", "local"])
+    def test_local_hailo_ollama_returns_localhost_7836(self, remote, monkeypatch):
+        monkeypatch.delenv("TAOS_HAILO_OLLAMA_PORT", raising=False)
+        assert resolve_ollama_url(remote, "hailo-ollama") == "http://localhost:7836"
+
+    def test_remote_ollama_uses_worker_hostname(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_ollama_url("worker-x", "ollama") == "http://worker-x:11434"
+
+    def test_remote_hailo_ollama_uses_worker_hostname(self, monkeypatch):
+        monkeypatch.delenv("TAOS_HAILO_OLLAMA_PORT", raising=False)
+        assert resolve_ollama_url("worker-x", "hailo-ollama") == "http://worker-x:7836"
+
+    def test_remote_hailo_ollama_honours_port_override(self, monkeypatch):
+        monkeypatch.setenv("TAOS_HAILO_OLLAMA_PORT", "9000")
+        assert resolve_ollama_url("worker-x", "hailo-ollama") == "http://worker-x:9000"
+
+    def test_local_hailo_ollama_honours_port_override(self, monkeypatch):
+        monkeypatch.setenv("TAOS_HAILO_OLLAMA_PORT", "9000")
+        assert resolve_ollama_url(None, "hailo-ollama") == "http://localhost:9000"
+
+    def test_ollama_host_env_overrides_default_port(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://ollama-box:1234")
+        assert resolve_ollama_url(None, "ollama") == "http://ollama-box:1234"
+
+
+class TestOllamaRemoteTargetInstall:
+    """Regression: install_app must pass target_remote through get_installer
+    to OllamaInstaller so the model lands on the selected worker, not the
+    controller's localhost daemon (tsk-mlogef).
+
+    These tests exercise the REAL get_installer call path -- only
+    OllamaInstaller.install is mocked (to avoid real HTTP), never get_installer
+    itself.
+    """
+
+    def _setup(self, client, manifest):
+        """Wire registry + installed_apps on the test app state."""
+        reg = _make_registry(manifest)
+        reg.mark_installed = MagicMock()
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+        return reg
+
+    @pytest.mark.asyncio
+    async def test_hailo_ollama_remote_target_hits_remote_worker(self, client):
+        """target_remote='worker-x' with hailo-ollama backend must produce an
+        OllamaInstaller whose host is http://worker-x:7836, NOT localhost:7836."""
+        manifest = _make_model_manifest(backend_id="hailo-ollama")
+        self._setup(client, manifest)
+
+        cap = _cpu_cap(installed_backends=("hailo-ollama",))
+        captured: list[str] = []
+
+        async def _spy_install(self, app_id, install_config, **_):
+            captured.append(self.host)
+            return {"success": True, "app_id": app_id}
+
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=cap),
+        ), patch.object(OllamaInstaller, "install", _spy_install):
+            resp = await client.post("/api/store/install-v2", json={
+                "manifest_id": "test-model",
+                "variant_id": "v1",
+                "target_remote": "worker-x",
+            })
+
+        assert resp.status_code == 200
+        assert captured == ["http://worker-x:7836"]
+
+    @pytest.mark.asyncio
+    async def test_plain_ollama_remote_target_hits_remote_worker(self, client):
+        """Same regression for the plain ollama backend -- host must be
+        http://worker-x:11434."""
+        manifest = _make_model_manifest(backend_id="ollama")
+        self._setup(client, manifest)
+
+        cap = _cpu_cap(installed_backends=("ollama",))
+        captured: list[str] = []
+
+        async def _spy_install(self, app_id, install_config, **_):
+            captured.append(self.host)
+            return {"success": True, "app_id": app_id}
+
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=cap),
+        ), patch.object(OllamaInstaller, "install", _spy_install):
+            resp = await client.post("/api/store/install-v2", json={
+                "manifest_id": "test-model",
+                "variant_id": "v1",
+                "target_remote": "worker-x",
+            })
+
+        assert resp.status_code == 200
+        assert captured == ["http://worker-x:11434"]
+
+    @pytest.mark.asyncio
+    async def test_hailo_ollama_local_target_uses_localhost(self, client):
+        """Control: no target_remote means local install, host stays localhost:7836."""
+        manifest = _make_model_manifest(backend_id="hailo-ollama")
+        self._setup(client, manifest)
+
+        cap = _cpu_cap(installed_backends=("hailo-ollama",))
+        captured: list[str] = []
+
+        async def _spy_install(self, app_id, install_config, **_):
+            captured.append(self.host)
+            return {"success": True, "app_id": app_id}
+
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=cap),
+        ), patch.object(OllamaInstaller, "install", _spy_install):
+            resp = await client.post("/api/store/install-v2", json={
+                "manifest_id": "test-model",
+                "variant_id": "v1",
+            })
+
+        assert resp.status_code == 200
+        assert captured == ["http://localhost:7836"]
+
+    @pytest.mark.asyncio
+    async def test_plain_ollama_local_target_uses_localhost(self, client):
+        """Control: no target_remote means local install, host stays localhost:11434."""
+        manifest = _make_model_manifest(backend_id="ollama")
+        self._setup(client, manifest)
+
+        cap = _cpu_cap(installed_backends=("ollama",))
+        captured: list[str] = []
+
+        async def _spy_install(self, app_id, install_config, **_):
+            captured.append(self.host)
+            return {"success": True, "app_id": app_id}
+
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=cap),
+        ), patch.object(OllamaInstaller, "install", _spy_install):
+            resp = await client.post("/api/store/install-v2", json={
+                "manifest_id": "test-model",
+                "variant_id": "v1",
+            })
+
+        assert resp.status_code == 200
+        assert captured == ["http://localhost:11434"]
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/installers/ollama_installer.py
+++ b/tinyagentos/installers/ollama_installer.py
@@ -29,15 +29,56 @@ from tinyagentos.installers.base import AppInstaller
 logger = logging.getLogger(__name__)
 
 
+_DEFAULT_OLLAMA_PORT = 11434
+_DEFAULT_HAILO_OLLAMA_PORT = 7836
+
+
 def _default_host() -> str:
     """Resolve daemon URL from OLLAMA_HOST or fallback to localhost:11434."""
     raw = os.environ.get("OLLAMA_HOST", "").strip()
     if not raw:
         return "http://localhost:11434"
-    # OLLAMA_HOST sometimes carries just `host:port` without scheme — normalize.
+    # OLLAMA_HOST sometimes carries just `host:port` without scheme -- normalize.
     if "://" not in raw:
         raw = f"http://{raw}"
     return raw.rstrip("/")
+
+
+def _hailo_ollama_port() -> int:
+    """Return the hailo-ollama port, honouring TAOS_HAILO_OLLAMA_PORT override."""
+    raw = os.environ.get("TAOS_HAILO_OLLAMA_PORT", "").strip()
+    if not raw:
+        return _DEFAULT_HAILO_OLLAMA_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "TAOS_HAILO_OLLAMA_PORT=%r is not an integer; using default %d",
+            raw, _DEFAULT_HAILO_OLLAMA_PORT,
+        )
+        return _DEFAULT_HAILO_OLLAMA_PORT
+
+
+def resolve_ollama_url(target_remote: str | None, backend_id: str = "ollama") -> str:
+    """Resolve which ollama/hailo-ollama instance to talk to.
+
+    - ``None`` / empty / "local" -> the controller's own daemon (localhost).
+    - Anything else -> the remote worker's hostname on the backend's port.
+
+    Ports:
+    - ollama: 11434 (``_default_host`` honours ``OLLAMA_HOST``).
+    - hailo-ollama: 7836, overridable via ``TAOS_HAILO_OLLAMA_PORT``
+      (see docs/design/hailo-llm-backend.md section B).
+    """
+    if backend_id == "hailo-ollama":
+        port = _hailo_ollama_port()
+        if not target_remote or target_remote == "local":
+            return f"http://localhost:{port}"
+        return f"http://{target_remote}:{port}"
+    # Plain ollama backend.
+    if not target_remote or target_remote == "local":
+        return _default_host()
+    return f"http://{target_remote}:{_DEFAULT_OLLAMA_PORT}"
 
 
 class OllamaInstaller(AppInstaller):

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -34,6 +34,7 @@ from tinyagentos.catalog.resolver import (
 from tinyagentos.cluster.capabilities import hardware_to_targets
 from tinyagentos.installers.base import get_installer
 from tinyagentos.installers.lxc_installer import LXCInstaller
+from tinyagentos.installers.ollama_installer import resolve_ollama_url
 from tinyagentos.task_utils import _create_supervised_task
 
 logger = logging.getLogger(__name__)
@@ -1028,7 +1029,7 @@ async def install_app(request: Request):
         )
     model_installer = get_installer(
         install_method,
-        **({"host": "http://localhost:7836"} if result.backend_id == "hailo-ollama" else {}),
+        **({"host": resolve_ollama_url(target_remote, result.backend_id)} if install_method == "ollama" else {}),
     )
     install_config = dict(getattr(manifest, "install", None) or {})
     install_config["backend"] = result.backend_id


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Ollama/hailo-ollama installs ignore target_remote: remote-node model installs pull onto the controller

Autonomous build of board card tsk-mlogef.

The ollama installer never received target_remote from install_app, so
remote-worker installs pulled models onto the controller's localhost daemon.
Add resolve_ollama_url(target_remote, backend_id) following the
resolve_rkllama_url convention: local targets use the existing defaults
(_default_host() for ollama, localhost:7836 for hailo-ollama with
TAOS_HAILO_OLLAMA_PORT override), remote targets build
http://<target_remote>:<port> (11434 for ollama, 7836 for hailo-ollama).
Pass the resolved host through get_installer instead of the previous
hardcoded localhost:7836.  Includes red-then-green regression tests through
the real get_installer path and a changelog fragment.

Files:
 changelog.d/tsk-mlogef-remote-target-ollama.md |   2 +
 tests/test_routes_store_install.py             | 163 +++++++++++++++++++++++++
 tinyagentos/installers/ollama_installer.py     |  43 ++++++-
 tinyagentos/routes/store_install.py            |   3 +-
 4 files changed, 209 insertions(+), 2 deletions(-)

## Red proof (measured by the lead on the branch, 2026-08-17)
Behavioral red at the wiring layer — dev's `store_install.py` + this PR's tests:
```
FAILED tests/test_routes_store_install.py::TestOllamaRemoteTargetInstall::test_hailo_ollama_remote_target_hits_remote_worker
FAILED tests/test_routes_store_install.py::TestOllamaRemoteTargetInstall::test_plain_ollama_remote_target_hits_remote_worker
2 failed, 2 passed, 57 deselected
```
(the 2 passes are the local-target controls — no behavior change locally). Green: 61/61 on the branch.

Docs-Reviewed: routes/installer changes route installs to the node the UI already lets the user select; no end-user doc describes daemon-URL selection. docs/design/hailo-llm-backend.md §B stays accurate — TAOS_HAILO_OLLAMA_PORT is pre-existing (install-hailo.sh:74) and this PR makes the client honour what §B already promises. README install docs are backend-agnostic and unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Remote Ollama and Hailo-Ollama installations now pull models onto the selected remote worker.
  - Added automatic endpoint handling for local and remote installations.
  - Added configurable Hailo-Ollama ports, with safe fallback to the default when invalid values are provided.

- **Bug Fixes**
  - Improved handling of Ollama hosts without URL schemes.
  - Preserved local installation defaults while correctly routing remote installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->