### PR TITLE
deleted-symbols-gate false-positives on re-run after base moves (event-pinned merge ref vs fresh base fetch)

### DIFF
--- a/.github/workflows/deleted-symbols-gate.yml
+++ b/.github/workflows/deleted-symbols-gate.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
     env:
       BASE_REF: ${{ github.base_ref }}
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -41,4 +42,4 @@ jobs:
       - name: Check for silently deleted symbols
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: python scripts/check_deleted_symbols.py --base "origin/$BASE_REF"
+        run: python scripts/check_deleted_symbols.py --base "origin/$BASE_REF" --pr-head "$PR_HEAD"

--- a/changelog.d/tsk-n2g5qw-stale-merge-false-positive.md
+++ b/changelog.d/tsk-n2g5qw-stale-merge-false-positive.md
@@ -1,0 +1,2 @@
+### Fixed
+- deleted-symbols CI gate no longer reports false positives on `pull_request` re-runs after the base advances: the merge result is recomputed in-script via `git merge-tree --write-tree <base> <pr-head>` (`scripts/check_deleted_symbols.py`) instead of comparing the event-time test-merge commit checked out as HEAD

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -9,9 +9,12 @@ because the PR branch simply wins on files dev touched after the branch point.
 
 Algorithm:
   1. Extract all Python def/class symbols at two points: the target branch
-     head and HEAD (the merge ref / PR head).
+     head and the PR merge result. The merge result is computed in-script via
+     `git merge-tree --write-tree <base> <pr-head>` when --pr-head is given,
+     so a stale checkout HEAD on a re-run cannot invent false deletions; when
+     omitted, the checkout HEAD is used directly.
   2. A symbol is "deleted by the PR" if it exists at the target head but not
-     at HEAD. The signal is that set.
+     at the merge result. The signal is that set.
   3. Fail with an explicit list of the deleted symbols and the commits that
      added them.
   4. A "Removes-Intentionally: <symbol>, ..." trailer in the PR body waives
@@ -21,9 +24,15 @@ Narrow by design: Python def/class names only (test functions are defs).
 No semantic analysis -- name-level matching catches every instance hit so far.
 
 Usage:
-    python scripts/check_deleted_symbols.py --base origin/dev
-    python scripts/check_deleted_symbols.py --base origin/dev --pr-body "..."
-    python scripts/check_deleted_symbols.py --base origin/dev --waived "path/file.py:func"
+    python scripts/check_deleted_symbols.py --base origin/dev --pr-head <sha>
+    python scripts/check_deleted_symbols.py --base origin/dev --pr-head <sha> --pr-body "..."
+    python scripts/check_deleted_symbols.py --base origin/dev --pr-head <sha> --waived "path/file.py:func"
+
+--pr-head passes github.event.pull_request.head.sha so the merge result is
+recomputed in-script with `git merge-tree --write-tree` instead of trusting
+checkout HEAD. On pull_request events HEAD is GitHub's event-time test-merge
+commit, which goes stale on a re-run after the base advances and falsely
+reports base-added symbols as deleted. When omitted, HEAD is used directly.
 """
 from __future__ import annotations
 
@@ -103,6 +112,25 @@ def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]
     return symbols
 
 
+def _merge_tree(base_ref: str, pr_head_sha: str, repo_root: Path = REPO_ROOT) -> str | None:
+    """Compute the merge result tree of base_ref and pr_head_sha.
+
+    Uses `git merge-tree --write-tree` so the merge is computed in-script
+    without trusting the checkout's HEAD, which on pull_request events is the
+    event-time test-merge commit and goes stale on a re-run after the base
+    branch advances. Returns the result tree SHA on a clean merge, or None
+    when the merge reports conflicts (mergeability is gated elsewhere, and a
+    conflicted PR cannot silently delete symbols by merging cleanly).
+    """
+    result = subprocess.run(
+        ["git", "merge-tree", "--write-tree", base_ref, pr_head_sha],
+        cwd=repo_root, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
 def _find_adding_commit(
     file_path: str,
     name: str,
@@ -165,15 +193,25 @@ def check_deleted_symbols(
     repo_root: Path = REPO_ROOT,
     pr_body: str | None = None,
     waived: set[str] | None = None,
-) -> tuple[list[Violation], set[str]]:
+    pr_head_sha: str | None = None,
+) -> tuple[list[Violation], set[str], bool]:
     """Main check function.
 
-    Returns (violations, waived_symbols) where violations is a list of
-    Violation objects for non-waived signal symbols, and waived_symbols is
-    the set of signal symbols that were waived.
+    Returns (violations, waived_symbols, conflicted) where violations is a
+    list of Violation objects for non-waived signal symbols, waived_symbols is
+    the set of signal symbols that were waived, and conflicted is True when the
+    in-script merge-tree reported conflicts (the merge result was not clean and
+    the check is skipped with an exit code of 0).
     """
     base_symbols = _get_symbols_at_ref(base_ref, repo_root)
-    head_symbols = _get_symbols_at_ref("HEAD", repo_root)
+
+    if pr_head_sha:
+        merge_tree = _merge_tree(base_ref, pr_head_sha, repo_root)
+        if merge_tree is None:
+            return [], set(), True
+        head_symbols = _get_symbols_at_ref(merge_tree, repo_root)
+    else:
+        head_symbols = _get_symbols_at_ref("HEAD", repo_root)
 
     signal = find_signal_symbols(base_symbols, head_symbols)
 
@@ -192,12 +230,19 @@ def check_deleted_symbols(
         added_by = _find_adding_commit(file_path, name, kind, base_ref, repo_root)
         violations.append(Violation(symbol=symbol, added_by=added_by))
 
-    return violations, waived_in_signal
+    return violations, waived_in_signal, False
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", required=True, help="Target branch ref (e.g. origin/dev)")
+    parser.add_argument(
+        "--pr-head",
+        default=None,
+        help="PR head commit SHA (github.event.pull_request.head.sha). When set, "
+        "the merge result is recomputed in-script via git merge-tree --write-tree "
+        "instead of trusting checkout HEAD.",
+    )
     parser.add_argument("--pr-body", default=None, help="PR body text (for Removes-Intentionally trailer)")
     parser.add_argument("--waived", default=None, help="Comma-separated list of waived symbols")
     args = parser.parse_args(argv)
@@ -206,6 +251,8 @@ def main(argv: list[str] | None = None) -> int:
     if pr_body is None:
         pr_body = os.environ.get("PR_BODY")
 
+    pr_head_sha = args.pr_head or os.environ.get("PR_HEAD") or None
+
     waived: set[str] = set()
     if args.waived:
         for sym in args.waived.split(","):
@@ -213,7 +260,17 @@ def main(argv: list[str] | None = None) -> int:
             if sym:
                 waived.add(sym)
 
-    violations, waived_symbols = check_deleted_symbols(args.base, REPO_ROOT, pr_body, waived)
+    violations, waived_symbols, conflicted = check_deleted_symbols(
+        args.base, REPO_ROOT, pr_body, waived, pr_head_sha
+    )
+
+    if conflicted:
+        print(
+            f"deleted-symbols-guard: merge-tree reported conflicts for "
+            f"{args.base}..{pr_head_sha or 'HEAD'}; not evaluating "
+            f"(mergeability is gated elsewhere)"
+        )
+        return 0
 
     if waived_symbols:
         for sym in sorted(waived_symbols):

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -40,6 +40,7 @@ import argparse
 import ast
 import io
 import os
+import re
 import subprocess
 import sys
 import tarfile
@@ -126,9 +127,21 @@ def _merge_tree(base_ref: str, pr_head_sha: str, repo_root: Path = REPO_ROOT) ->
         ["git", "merge-tree", "--write-tree", base_ref, pr_head_sha],
         cwd=repo_root, capture_output=True, text=True,
     )
-    if result.returncode != 0:
+    first_line = result.stdout.splitlines()[0].strip() if result.stdout else ""
+    oid_on_stdout = bool(re.fullmatch(r"[0-9a-f]{40,64}", first_line))
+    if result.returncode == 0 and oid_on_stdout:
+        return first_line
+    if result.returncode == 1 and oid_on_stdout:
+        # A genuine conflict still prints the merge-tree OID first; a bad ref
+        # ("not something we can merge") exits 1 with EMPTY stdout, so rc alone
+        # cannot distinguish them.
         return None
-    return result.stdout.strip()
+    # Anything else is a tooling failure (invalid ref, missing object, usage
+    # error). The gate must fail loudly here, not skip as "conflicted".
+    raise RuntimeError(
+        f"git merge-tree --write-tree {base_ref} {pr_head_sha} failed "
+        f"(rc={result.returncode}): {result.stderr.strip()}"
+    )
 
 
 def _find_adding_commit(

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -176,7 +176,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         v = violations[0]
@@ -213,7 +213,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert violations == []
         assert waived == set()
@@ -240,7 +240,7 @@ class TestCheckDeletedSymbols:
         _git(repo, "merge", "pr-branch", "--no-edit")
 
         pr_body = "Removes-Intentionally: tinyagentos/foo.py:function_b"
-        violations, waived = cds.check_deleted_symbols(base_tip, repo, pr_body=pr_body)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo, pr_body=pr_body)
 
         assert violations == []
         assert "tinyagentos/foo.py:function_b" in waived
@@ -265,7 +265,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "NewClass" in violations[0].symbol
@@ -297,7 +297,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "Foo.new_method" in violations[0].symbol
@@ -322,7 +322,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "test_new" in violations[0].symbol
@@ -351,7 +351,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "test_old_case" in violations[0].symbol
@@ -383,7 +383,7 @@ class TestCheckDeletedSymbols:
         _checkout(repo, "main")
         _git(repo, "merge", "pr-branch", "--no-edit")
 
-        violations, waived = cds.check_deleted_symbols(base_tip, repo)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "function_b" in violations[0].symbol
@@ -409,7 +409,7 @@ class TestCheckDeletedSymbols:
         _git(repo, "merge", "pr-branch", "--no-edit")
 
         waived_arg = {"tinyagentos/foo.py:function_b"}
-        violations, waived = cds.check_deleted_symbols(base_tip, repo, waived=waived_arg)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo, waived=waived_arg)
 
         assert violations == []
         assert "tinyagentos/foo.py:function_b" in waived
@@ -436,8 +436,194 @@ class TestCheckDeletedSymbols:
         _git(repo, "merge", "pr-branch", "--no-edit")
 
         pr_body = "Removes-Intentionally: tinyagentos/foo.py:function_b"
-        violations, waived = cds.check_deleted_symbols(base_tip, repo, pr_body=pr_body)
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo, pr_body=pr_body)
 
         assert len(violations) == 1
         assert "function_c" in violations[0].symbol
         assert "tinyagentos/foo.py:function_b" in waived
+
+
+# ---------------------------------------------------------------------------
+# --pr-head (merge-tree recomputation) path
+#
+# On pull_request events GitHub pins checkout HEAD to the event-time
+# test-merge commit. A re-run (no new push) after the base advances compares
+# the *current* base against that *stale* merge result, so symbols added to
+# base after the pin are falsely reported as deleted. Passing the PR head SHA
+# via --pr-head recomputes the merge result in-script against the fresh base.
+# ---------------------------------------------------------------------------
+
+
+def _build_stale_re_run_repo(repo: Path) -> tuple[str, str]:
+    """Reproduce the stale re-run false positive.
+
+    Produces a merge commit M (PR merged at event time), advances the base
+    branch with a brand-new symbol in a file the PR never touches, then checks
+    HEAD out at the stale merge commit M. Returns (base_ref, pr_head_sha) where
+    base_ref resolves to the advanced base carrying the new symbol.
+    """
+    _commit_file(
+        repo,
+        "tinyagentos/foo.py",
+        "def function_a():\n    pass\n",
+        "init: add function_a",
+    )
+    _branch(repo, "pr-branch")
+    _checkout(repo, "pr-branch")
+    _commit_file(
+        repo,
+        "tinyagentos/foo.py",
+        "def function_a():\n    pass\n\ndef function_pr():\n    pass\n",
+        "pr: add function_pr",
+    )
+    pr_head = _get_head(repo)
+    _checkout(repo, "main")
+    _git(repo, "merge", "pr-branch", "--no-edit")
+    stale_merge = _get_head(repo)
+    # The base advances after the event-time merge: a new symbol lands on main
+    # in a file the PR branch never touches.
+    _commit_file(
+        repo,
+        "tests/test_stale.py",
+        "def TestNewSymbol():\n    pass\n",
+        "base: add TestNewSymbol after event-time merge",
+    )
+    # Pin HEAD at the stale merge commit, mirroring a re-run with a fresh base.
+    _checkout(repo, stale_merge)
+    return "main", pr_head
+
+
+class TestStaleReRunFalsePositive:
+    def test_head_based_lookup_on_stale_checkout_is_red(self, tmp_path: Path):
+        """RED (pre-fix bug): without --pr-head the check trusts HEAD -- the
+        event-time merge commit -- so a symbol added to base after the pin is
+        falsely reported as deleted. This documents the exact false positive
+        the --pr-head fix addresses."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        base_ref, _pr_head = _build_stale_re_run_repo(repo)
+
+        violations, waived, conflicted = cds.check_deleted_symbols(base_ref, repo)
+
+        assert not conflicted
+        assert len(violations) == 1
+        assert "TestNewSymbol" in violations[0].symbol
+        assert "test_stale.py" in violations[0].symbol
+
+    def test_pr_head_merge_tree_is_green(self, tmp_path: Path):
+        """GREEN: with --pr-head the merge result is recomputed against the
+        fresh base, so the post-pin symbol survives the merge and the check
+        passes with exit code 0."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        base_ref, pr_head = _build_stale_re_run_repo(repo)
+
+        violations, waived, conflicted = cds.check_deleted_symbols(
+            base_ref, repo, pr_head_sha=pr_head
+        )
+
+        assert not conflicted
+        assert violations == []
+        assert waived == set()
+
+    def test_pr_body_waiver_still_applies_with_pr_head(self, tmp_path: Path):
+        """The Removes-Intentionally trailer still waives a named signal symbol
+        when the merge result is recomputed via merge-tree."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n\ndef function_b():\n    pass\n",
+            "init: add function_a and function_b",
+        )
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "refactor: remove function_b",
+        )
+        pr_head = _get_head(repo)
+        _checkout(repo, "main")
+
+        pr_body = "Removes-Intentionally: tinyagentos/foo.py:function_b"
+        violations, waived, conflicted = cds.check_deleted_symbols(
+            "main", repo, pr_body=pr_body, pr_head_sha=pr_head
+        )
+
+        assert not conflicted
+        assert violations == []
+        assert "tinyagentos/foo.py:function_b" in waived
+
+
+class TestPrHeadControlAndConflicts:
+    def test_genuine_deletion_with_pr_head_still_fails(self, tmp_path: Path):
+        """CONTROL: a PR that genuinely deletes a base-added symbol is still
+        caught when the merge result is recomputed via merge-tree -- the gate's
+        original red case stays red on the new code path."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n\ndef function_b():\n    pass\n",
+            "init: add function_a and function_b",
+        )
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "refactor: remove function_b",
+        )
+        pr_head = _get_head(repo)
+        _checkout(repo, "main")
+
+        violations, waived, conflicted = cds.check_deleted_symbols(
+            "main", repo, pr_head_sha=pr_head
+        )
+
+        assert not conflicted
+        assert len(violations) == 1
+        assert "function_b" in violations[0].symbol
+        assert violations[0].added_by != "unknown"
+
+    def test_conflicting_merge_tree_skips_check(self, tmp_path: Path):
+        """When the recomputed merge reports conflicts the gate exits 0 with a
+        note instead of failing: mergeability is gated elsewhere and a
+        conflicted PR cannot silently delete symbols by merging cleanly."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "init: add function_a",
+        )
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    THEIR_CHANGE\n\ndef function_pr():\n    pass\n",
+            "pr: conflicting edit",
+        )
+        pr_head = _get_head(repo)
+        _checkout(repo, "main")
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    BASE_CHANGE\n",
+            "base: conflicting edit",
+        )
+
+        violations, waived, conflicted = cds.check_deleted_symbols(
+            "main", repo, pr_head_sha=pr_head
+        )
+
+        assert conflicted
+        assert violations == []
+        assert waived == set()

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -627,3 +627,21 @@ class TestPrHeadControlAndConflicts:
         assert conflicted
         assert violations == []
         assert waived == set()
+
+    def test_merge_tree_tool_error_is_loud_not_skipped(self, tmp_path: Path):
+        """rc>1 from merge-tree (invalid ref, missing object) is a tooling
+        failure, not a conflict: the gate must raise, never report
+        conflicted=True and exit 0."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo,
+            "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "init: add function_a",
+        )
+
+        with pytest.raises(RuntimeError, match="merge-tree"):
+            cds.check_deleted_symbols(
+                "main", repo, pr_head_sha="0000000000000000000000000000000000000000"
+            )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deleted-symbols-gate false-positives on re-run after base moves (event-pinned merge ref vs fresh base fetch)

Autonomous build of board card tsk-n2g5qw.

The deleted-symbols gate compared freshly-fetched origin/<base> against
checkout HEAD. On pull_request events HEAD is the event-time test-merge
commit, so a re-run (no new push) after the base advanced compared the
current base against a stale merge result and falsely reported every
base-added symbol as deleted by the PR.

Pass github.event.pull_request.head.sha to the gate as --pr-head and
recompute the merge result in-script with
`git merge-tree --write-tree <base> <pr-head>`, extracting symbols from
that tree. That result is the true outcome of merging the PR head into the
current base, so symbols added to base after the event pin are preserved.
When --pr-head is omitted the script falls back to HEAD, keeping the
existing manual-run behavior. Conflicting merges exit 0 with a note:
mergeability is gated elsewhere, and a conflicted PR cannot silently
delete symbols by merging cleanly.

- scripts/check_deleted_symbols.py: merge-tree recomputation plus --pr-head
- .github/workflows/deleted-symbols-gate.yml: pass github.event.pull_request.head.sha
- tests/test_check_deleted_symbols.py: RED, GREEN, CONTROL and conflict coverage

Docs-Reviewed: workflow file modified only to forward the PR head SHA to the gate; reviewed .claude/skills/taos-development-skill/SKILL.md whose only git merge-tree caution (line 545) covers mergeable_state inference, which is unrelated to this gate's in-script merge recompute, so no doc update is required

Files:
 .github/workflows/deleted-symbols-gate.yml         |   3 +-
 .../tsk-n2g5qw-stale-merge-false-positive.md       |   2 +
 scripts/check_deleted_symbols.py                   |  81 ++++++--
 tests/test_check_deleted_symbols.py                | 206 ++++++++++++++++++++-
 4 files changed, 269 insertions(+), 23 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deleted-symbol checks to evaluate the latest base and pull request changes, preventing false positives when the base branch advances.
  * Conflicted merges are now safely skipped instead of producing misleading results.
  * Added clearer handling for invalid references and merge-tool failures.

* **Tests**
  * Expanded coverage for updated merge scenarios, waivers, genuine deletions, conflicts, and stale checkouts.

* **Documentation**
  * Added a changelog entry describing the corrected CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->