### PR TITLE
validate target_remote at the install API boundary: hostile strings flow into backend daemon URLs across ALL resolve_*_url helpers

### DIFF
--- a/changelog.d/tsk-3rontv-validate-target-remote.md
+++ b/changelog.d/tsk-3rontv-validate-target-remote.md
@@ -1,0 +1,2 @@
+### Fixed
+- `POST /api/store/install-v2` now validates `target_remote` at the API boundary before it is interpolated into backend daemon URLs (`resolve_rkllama_url`, LXC remote addressing). Hostile strings containing `:`, `/`, `?`, `#`, or `@` are rejected with HTTP 400 and a named `invalid_target_remote` reason, preventing SSRF-shaped installs or silent mis-routing to unregistered workers.

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -667,8 +667,8 @@ class TestTargetRemoteValidation:
         mock_get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_target_remote_with_port_and_path_rejected(self, client, fake_registry):
-        """Any target_remote carrying ':' or '/' is rejected at the boundary."""
+    async def test_target_remote_with_port_and_at_sign_rejected(self, client, fake_registry):
+        """Any target_remote carrying ':' or '@' is rejected at the boundary."""
         client._transport.app.state.registry = fake_registry
         with patch(
             "tinyagentos.routes.store_install.get_installer"
@@ -677,6 +677,22 @@ class TestTargetRemoteValidation:
                 "manifest_id": "qwen2.5-3b",
                 "variant_id": "q4_k_m",
                 "target_remote": "10.0.0.1:443@attacker.com",
+            })
+        assert r.status_code == 400
+        assert r.json()["reason"] == "invalid_target_remote"
+        mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nonstring_target_remote_rejected_cleanly(self, client, fake_registry):
+        """A non-string target_remote (e.g. JSON 123) must 400, not crash 500."""
+        client._transport.app.state.registry = fake_registry
+        with patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": 123,
             })
         assert r.status_code == 400
         assert r.json()["reason"] == "invalid_target_remote"

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -635,3 +635,126 @@ class TestHailoDaemonHost:
             f"expected a get_installer call with method='ollama' and "
             f"host='http://localhost:7836', got {mock_get.call_args_list!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# target_remote boundary validation (hostile string hardening)
+# ---------------------------------------------------------------------------
+
+class TestTargetRemoteValidation:
+    """Reject hostile target_remote at the install API boundary.
+
+    An authenticated caller must not be able to inject an arbitrary
+    host/path/port into backend daemon URLs (SSRF-shaped) or silently route
+    an install to a typo'd host via a degenerate stub capability.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hostile_target_remote_returns_400_no_installer(self, client, fake_registry):
+        """target_remote='attacker.example.com:9999/x' must 400 with no installer."""
+        client._transport.app.state.registry = fake_registry
+        with patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": "attacker.example.com:9999/x",
+            })
+        assert r.status_code == 400
+        body = r.json()
+        assert body["reason"] == "invalid_target_remote"
+        mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_target_remote_with_port_and_path_rejected(self, client, fake_registry):
+        """Any target_remote carrying ':' or '/' is rejected at the boundary."""
+        client._transport.app.state.registry = fake_registry
+        with patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": "10.0.0.1:443@attacker.com",
+            })
+        assert r.status_code == 400
+        assert r.json()["reason"] == "invalid_target_remote"
+        mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_local_target_remote_not_rejected(self, client, fake_registry, pi_capability):
+        """'local' / None / empty bypass the host validation entirely."""
+        client._transport.app.state.registry = fake_registry
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=pi_capability),
+        ), patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            backend_inst = MagicMock()
+            backend_inst.install = AsyncMock(return_value={"success": True, "method": "script"})
+            model_inst = MagicMock()
+            model_inst.install = AsyncMock(return_value={"success": True})
+            mock_get.side_effect = [backend_inst, model_inst]
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": "local",
+            })
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_registered_worker_target_remote_passes_validation(self, client, fake_registry, pi_capability):
+        """A target_remote that matches a registered cluster worker is accepted."""
+        from tinyagentos.cluster.worker_protocol import WorkerInfo
+
+        worker = WorkerInfo(
+            name="edge-gpu-01",
+            url="http://10.0.0.50:6969",
+            hardware={"ram_mb": 16384, "gpu": {"type": "nvidia", "vram_mb": 24576}, "disk": {"total_gb": 100, "free_gb": 50}},
+            backends=[{"name": "rkllama"}],
+        )
+        cluster = client._transport.app.state.cluster_manager
+        cluster._workers["edge-gpu-01"] = worker
+        client._transport.app.state.registry = fake_registry
+
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=pi_capability),
+        ), patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            backend_inst = MagicMock()
+            backend_inst.install = AsyncMock(return_value={"success": True, "method": "script"})
+            model_inst = MagicMock()
+            model_inst.install = AsyncMock(return_value={"success": True})
+            mock_get.side_effect = [backend_inst, model_inst]
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": "edge-gpu-01",
+            })
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_bare_hostname_passes_validation(self, client, fake_registry, pi_capability):
+        """A bare hostname (no port/path) is accepted as a registry-less install."""
+        client._transport.app.state.registry = fake_registry
+        with patch(
+            "tinyagentos.routes.store_install.get_device_capability",
+            new=AsyncMock(return_value=pi_capability),
+        ), patch(
+            "tinyagentos.routes.store_install.get_installer"
+        ) as mock_get:
+            backend_inst = MagicMock()
+            backend_inst.install = AsyncMock(return_value={"success": True, "method": "script"})
+            model_inst = MagicMock()
+            model_inst.install = AsyncMock(return_value={"success": True})
+            mock_get.side_effect = [backend_inst, model_inst]
+            r = await client.post("/api/store/install-v2", json={
+                "manifest_id": "qwen2.5-3b",
+                "variant_id": "q4_k_m",
+                "target_remote": "edge-host.pi",
+            })
+        assert r.status_code == 200

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -743,7 +743,21 @@ async def install_app(request: Request):
     body = await request.json()
     manifest_id = body.get("manifest_id") or body.get("app_id")
     variant_id = body.get("variant_id", "auto")
-    target_remote = body.get("target_remote") or None
+    raw_target_remote = body.get("target_remote")
+    if raw_target_remote is not None and not isinstance(raw_target_remote, str):
+        # JSON allows any type here; a truthy non-string (123, true, [...])
+        # would crash the regex below with TypeError → 500. Reject cleanly.
+        return JSONResponse(
+            {
+                "error": (
+                    "target_remote must be a string, 'local', or omitted; "
+                    f"got {type(raw_target_remote).__name__}"
+                ),
+                "reason": "invalid_target_remote",
+            },
+            status_code=400,
+        )
+    target_remote = raw_target_remote or None
     force = bool(body.get("force", False))
 
     # Boundary validation — reject hostile target_remote before it is

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import asdict
 from pathlib import Path
 from urllib.parse import urlparse
@@ -45,6 +46,13 @@ _KNOWN_BACKENDS = {
     "mlx", "vllm", "comfyui", "transformers",
     "hailo-ollama",
 }
+
+# Strict hostname charset for target_remote fallback. Rejects host/path/port
+# injection (":", "/", "?", "#", "@") so an authenticated caller cannot steer
+# a pull at an arbitrary daemon URL (SSRF-shaped) or route an install to a
+# typo'd host silently. A bare hostname still passes so registry-less
+# installs (e.g. ad-hoc worker hostnames) keep working.
+_HOSTNAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 # Backend ID → install method known to get_installer().
 # rkllama has a purpose-built installer (calls /api/pull, manages symlinks,
@@ -737,6 +745,32 @@ async def install_app(request: Request):
     variant_id = body.get("variant_id", "auto")
     target_remote = body.get("target_remote") or None
     force = bool(body.get("force", False))
+
+    # Boundary validation — reject hostile target_remote before it is
+    # interpolated into any backend daemon URL by resolve_rkllama_url or the
+    # lxc <target_remote>:<name> addressing. An authenticated caller must not
+    # be able to inject an arbitrary host/path/port (SSRF-shaped) or silently
+    # route an install to an unregistered worker via a degenerate stub
+    # capability. Accepted values:
+    #   * None / empty / "local"  -> local install
+    #   * a registered cluster worker id (cluster.get_worker() non-None)
+    #   * a bare hostname matching _HOSTNAME_RE (registry-less installs)
+    if target_remote and target_remote != "local":
+        cluster = getattr(request.app.state, "cluster_manager", None)
+        is_known_worker = False
+        if cluster is not None and hasattr(cluster, "get_worker"):
+            is_known_worker = cluster.get_worker(target_remote) is not None
+        if not is_known_worker and not _HOSTNAME_RE.match(target_remote):
+            return JSONResponse(
+                {
+                    "error": (
+                        "target_remote must be 'local' or a registered worker id; "
+                        f"got {target_remote!r}"
+                    ),
+                    "reason": "invalid_target_remote",
+                },
+                status_code=400,
+            )
 
     # Progress store — opened up here so both legacy and v2 paths can
     # tag work-in-flight that the frontend polls for. Importing here


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): validate target_remote at the install API boundary: hostile strings flow into backend daemon URLs across ALL resolve_*_url helpers

Autonomous build of board card tsk-3rontv.

An authenticated caller could pass a hostile target_remote (e.g.
'attacker.example.com:9999/x') that flowed unchecked into resolve_rkllama_url
and LXC <target_remote>:<name> addressing, enabling SSRF-shaped daemon URL
injection or silent mis-routing to unregistered workers via a degenerate stub
capability.

Add a single boundary check in install_app before any capability resolution
or installer construction: target_remote must be None/empty/"local", a
registered cluster worker id, or a bare hostname matching ^[A-Za-z0-9._-]+$.
Anything else returns HTTP 400 with reason "invalid_target_remote".

Docs-Reviewed: agent-coordination.md documents parallel workflow discipline, not
API input validation; no doc change needed for this security hardening.

Files:
 changelog.d/tsk-3rontv-validate-target-remote.md |   2 +
 tests/routes/test_store_install_v2.py            | 123 +++++++++++++++++++++++
 tinyagentos/routes/store_install.py              |  34 +++++++
 3 files changed, 159 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for installation targets.
  - Invalid, malformed, or non-string targets now return HTTP 400 errors.
  - Prevented malformed targets from reaching backend routing or triggering installations.
  - Valid local targets, registered workers, and bare hostnames continue to work as expected.

- **Tests**
  - Added coverage for accepted and rejected installation target values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->