### PR TITLE
check_all_skip: zero-collected violations invisible in the final ::error summary (says "0 file(s)")

### DIFF
--- a/.github/scripts/check_all_skip.py
+++ b/.github/scripts/check_all_skip.py
@@ -310,9 +310,17 @@ def main() -> int:
     all_skip_files = sum(
         1 for info in results.values() if info["total"] > 0 and info["skipped"] == info["total"]
     )
+    zero_collected_files = sum(
+        1 for info in results.values() if info["total"] == 0 and info["defined_tests"] > 0
+    )
 
     if any_fail:
-        print(f"\n::error:: {all_skip_files} file(s) have all tests skipping — see above for details")
+        parts = []
+        if all_skip_files > 0:
+            parts.append(f"{all_skip_files} file(s) have all tests skipping")
+        if zero_collected_files > 0:
+            parts.append(f"{zero_collected_files} file(s) yielded no collected tests")
+        print(f"\n::error:: {', '.join(parts)} — see above for details")
         return 1
 
     print(f"\nOK: {total_changed} test file(s) checked, no all-skip violations")

--- a/.github/scripts/check_all_skip.py
+++ b/.github/scripts/check_all_skip.py
@@ -313,11 +313,20 @@ def main() -> int:
     zero_collected_files = sum(
         1 for info in results.values() if info["total"] == 0 and info["defined_tests"] > 0
     )
+    # The error line must mirror exactly the conditions that set any_fail:
+    # a WAIVED all-skip file did not fail, so it must not be counted here
+    # (all_skip_files keeps including waived files for the OK-branch note).
+    unwaived_all_skip = sum(
+        1 for filepath, info in results.items()
+        if info["total"] > 0
+        and info["skipped"] == info["total"]
+        and not has_escape_hatch(pr_body, filepath)
+    )
 
     if any_fail:
         parts = []
-        if all_skip_files > 0:
-            parts.append(f"{all_skip_files} file(s) have all tests skipping")
+        if unwaived_all_skip > 0:
+            parts.append(f"{unwaived_all_skip} file(s) have all tests skipping")
         if zero_collected_files > 0:
             parts.append(f"{zero_collected_files} file(s) yielded no collected tests")
         print(f"\n::error:: {', '.join(parts)} — see above for details")

--- a/changelog.d/tsk-syhpdp-skip-validation-error-summary.md
+++ b/changelog.d/tsk-syhpdp-skip-validation-error-summary.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `check_all_skip.py` now reports zero-collected violations in the final `::error` annotation alongside all-skip violations, instead of incorrectly claiming "0 file(s) have all tests skipping" when only zero-collected files are present.

--- a/tests/scripts/test_check_all_skip.py
+++ b/tests/scripts/test_check_all_skip.py
@@ -172,6 +172,38 @@ class TestMainZeroCollectedWithDefinedTests:
         assert "collection yielded 0 of 2 defined tests" in captured.out
         assert "yielded no collected tests" in captured.out
 
+    def test_waived_all_skip_not_counted_in_error_line(
+        self, check_mod, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A WAIVED all-skip file did not fail — the ::error line must not count it."""
+        zc_file = tmp_path / "test_zc.py"
+        zc_file.write_text("def test_a():\n    assert True\n")
+        waived_file = tmp_path / "test_waived.py"
+        waived_file.write_text("def test_b():\n    assert True\n")
+        results = {
+            str(zc_file): {
+                "total": 0, "skipped": 0, "passed": 0, "failed": 0,
+                "import_guards": [],
+                "defined_tests": check_mod._count_defined_tests(str(zc_file)),
+            },
+            str(waived_file): {
+                "total": 2, "skipped": 2, "passed": 0, "failed": 0,
+                "import_guards": ["pytest.importorskip"],
+                "defined_tests": 2,
+            },
+        }
+        pr_body = "Tests-Skipped-Intentionally: test_waived.py, landing ahead of code\n"
+        with patch.object(check_mod, "resolve_base_ref", return_value="origin/dev"):
+            with patch.object(check_mod, "get_test_outcomes", return_value=results):
+                with patch.object(check_mod, "find_changed_test_files", return_value=[str(zc_file), str(waived_file)]):
+                    with patch.object(check_mod, "get_pr_body", return_value=pr_body):
+                        with patch.object(check_mod.os, "environ", {"BASE_REF": "origin/dev"}):
+                            rc = check_mod.main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "1 file(s) yielded no collected tests" in captured.out
+        assert "have all tests skipping" not in captured.out
+
 
 class TestMainAllSkipStillFails:
     def test_all_skips_is_violation(self, check_mod, capsys: pytest.CaptureFixture) -> None:

--- a/tests/scripts/test_check_all_skip.py
+++ b/tests/scripts/test_check_all_skip.py
@@ -138,6 +138,41 @@ class TestMainZeroCollectedWithDefinedTests:
         assert "has 0 test outcomes, skipping check" in captured.out
 
 
+    def test_zero_collected_summary_names_violation(
+        self, check_mod, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        test_file = tmp_path / "test_zc.py"
+        test_file.write_text(
+            "class TestSomething:\n"
+            "    def __init__(self):\n"
+            "        pass\n"
+            "    def test_a(self):\n"
+            "        assert True\n"
+            "    def test_b(self):\n"
+            "        assert True\n"
+        )
+        results = {
+            str(test_file): {
+                "total": 0,
+                "skipped": 0,
+                "passed": 0,
+                "failed": 0,
+                "import_guards": [],
+                "defined_tests": check_mod._count_defined_tests(str(test_file)),
+            }
+        }
+        with patch.object(check_mod, "resolve_base_ref", return_value="origin/dev"):
+            with patch.object(check_mod, "get_test_outcomes", return_value=results):
+                with patch.object(check_mod, "find_changed_test_files", return_value=[str(test_file)]):
+                    with patch.object(check_mod, "get_pr_body", return_value=""):
+                        with patch.object(check_mod.os, "environ", {"BASE_REF": "origin/dev"}):
+                            rc = check_mod.main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "collection yielded 0 of 2 defined tests" in captured.out
+        assert "yielded no collected tests" in captured.out
+
+
 class TestMainAllSkipStillFails:
     def test_all_skips_is_violation(self, check_mod, capsys: pytest.CaptureFixture) -> None:
         results = {


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_all_skip: zero-collected violations invisible in the final ::error summary (says "0 file(s)")

Autonomous build of board card tsk-syhpdp.



Files:
 .github/scripts/check_all_skip.py                  | 10 ++++++-
 .../tsk-syhpdp-skip-validation-error-summary.md    |  3 ++
 tests/scripts/test_check_all_skip.py               | 35 ++++++++++++++++++++++
 3 files changed, 47 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test validation reports to distinguish fully skipped files from files where no test results were collected.
  * Excluded approved skipped files from failure counts while continuing to flag zero-result files.
  * Enhanced error messages to clearly identify each applicable validation issue and affected files.

* **Documentation**
  * Added changelog details covering the updated test validation reporting and zero-result violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->