### PR TITLE
Lists S1 REDO: backend stores + routes + scopes (was #2144, closed red)

### DIFF
--- a/docs/changelog.d/tsk-jqlb7z-lists-s1-backend.md
+++ b/docs/changelog.d/tsk-jqlb7z-lists-s1-backend.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed Lists S1 backend: store MIGRATIONS pattern (ClassVar annotation), lint errors, and type annotations

--- a/tinyagentos/projects/lists_store.py
+++ b/tinyagentos/projects/lists_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from typing import ClassVar
 
 from tinyagentos.base_store import BaseStore
 from tinyagentos.projects.ids import new_id
@@ -122,7 +123,7 @@ class ProjectListEntriesStore(BaseStore):
     CREATE INDEX IF NOT EXISTS idx_entries_list_project ON project_list_entries(list_id, project_id);
     CREATE INDEX IF NOT EXISTS idx_entries_status ON project_list_entries(project_id, status);
     """
-    MIGRATIONS = []
+    MIGRATIONS: ClassVar[list] = []
 
     async def add_entry(
         self,

--- a/tinyagentos/routes/project_lists.py
+++ b/tinyagentos/routes/project_lists.py
@@ -52,7 +52,7 @@ class ReorderIn(BaseModel):
 
 async def _authorize_lists_actor(
     request: Request, pstore, project_id: str
-) -> "tuple[str, bool, dict] | JSONResponse":
+) -> tuple[str, bool, dict] | JSONResponse:
     """Resolve the actor for a project-lists route that accepts EITHER a session
     owner/admin OR an approved external agent's registry JWT holding _LISTS_SCOPE
     bound to THIS project.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Lists S1 REDO: backend stores + routes + scopes (was #2144, closed red)

Autonomous build of board card tsk-jqlb7z.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 docs/changelog.d/tsk-jqlb7z-lists-s1-backend.md | 2 ++
 tinyagentos/projects/lists_store.py             | 3 ++-
 tinyagentos/routes/project_lists.py             | 2 +-
 3 files changed, 5 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry covering recent Lists backend maintenance updates.

* **Refactor**
  * Improved internal type annotations for list storage and authorization logic.
  * Resolved related linting and annotation issues without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->