### PR TITLE
notifications: validate `level` on POST /api/notifications (bot finding #2320/F11)

### DIFF
--- a/changelog.d/tsk-rwnjqs-notification-level-validation.md
+++ b/changelog.d/tsk-rwnjqs-notification-level-validation.md
@@ -1,0 +1,2 @@
+### Fixed
+- `POST /api/notifications` now rejects unknown `level` values with a 400 error, matching the allowed set `{"info", "warning", "error"}`.

--- a/changelog.d/tsk-rwnjqs-notification-level-validation.md
+++ b/changelog.d/tsk-rwnjqs-notification-level-validation.md
@@ -1,2 +1,2 @@
 ### Fixed
-- `POST /api/notifications` now rejects unknown `level` values with a 400 error, matching the allowed set `{"info", "warning", "error"}`.
+- `POST /api/notifications` now rejects unknown `level` values with a 400 error, matching the canonical level set `{"info", "success", "warning", "error"}` (single source of truth: `VALID_LEVELS` in `tinyagentos/notifications.py`, shared with the `notify_user` tool).

--- a/tests/test_routes_notifications.py
+++ b/tests/test_routes_notifications.py
@@ -121,3 +121,15 @@ class TestNotificationCreateRoutes:
         assert created["source"] == "review-request"
         assert created["data"] == {"pr": 42}
         assert created["read"] is False
+
+    async def test_admin_create_rejects_invalid_level(self, client):
+        """POST /api/notifications with an unknown level is rejected with 400."""
+        resp = await client.post(
+            "/api/notifications",
+            json={
+                "title": "bad level",
+                "message": "should not be stored",
+                "level": "bogus",
+            },
+        )
+        assert resp.status_code == 400

--- a/tests/test_routes_notifications.py
+++ b/tests/test_routes_notifications.py
@@ -133,3 +133,19 @@ class TestNotificationCreateRoutes:
             },
         )
         assert resp.status_code == 400
+        listing = await client.get("/api/notifications")
+        assert all(n["title"] != "bad level" for n in listing.json())
+
+    async def test_admin_create_accepts_success_level(self, client):
+        """'success' is part of the canonical level set (see VALID_LEVELS in
+        tinyagentos/notifications.py; notify_user tool schema and the toast UI
+        both support it) and must not be rejected at the route boundary."""
+        resp = await client.post(
+            "/api/notifications",
+            json={
+                "title": "success level",
+                "message": "stored fine",
+                "level": "success",
+            },
+        )
+        assert resp.status_code == 200

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 from tinyagentos.base_store import BaseStore
 
+# Canonical notification level vocabulary — single source of truth.
+# The notify_user tool schema, the POST /api/notifications route, and the
+# desktop toast/archive renderers all consume this set.
+VALID_LEVELS = frozenset({"info", "success", "warning", "error"})
+
 logger = logging.getLogger(__name__)
 
 NOTIF_SCHEMA = """

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -4,7 +4,7 @@ import json
 import time
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, field_validator
 
@@ -12,6 +12,8 @@ from tinyagentos.auth import get_current_user
 from tinyagentos.routes.auth import _require_admin
 
 router = APIRouter()
+
+_VALID_LEVELS = frozenset({"info", "warning", "error"})
 
 
 def _format_ts(ts: int) -> str:
@@ -66,6 +68,11 @@ async def create_notification(request: Request, body: CreateNotificationRequest)
     ok, err = _require_admin(request)
     if not ok:
         return err
+    if body.level not in _VALID_LEVELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"level must be one of {sorted(_VALID_LEVELS)}",
+        )
     store = request.app.state.notifications
     await store.add(
         title=body.title,

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -8,12 +8,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, field_validator
 
+from tinyagentos.notifications import VALID_LEVELS
+
 from tinyagentos.auth import get_current_user
 from tinyagentos.routes.auth import _require_admin
 
 router = APIRouter()
-
-_VALID_LEVELS = frozenset({"info", "warning", "error"})
 
 
 def _format_ts(ts: int) -> str:
@@ -68,10 +68,10 @@ async def create_notification(request: Request, body: CreateNotificationRequest)
     ok, err = _require_admin(request)
     if not ok:
         return err
-    if body.level not in _VALID_LEVELS:
+    if body.level not in VALID_LEVELS:
         raise HTTPException(
             status_code=400,
-            detail=f"level must be one of {sorted(_VALID_LEVELS)}",
+            detail=f"level must be one of {sorted(VALID_LEVELS)}",
         )
     store = request.app.state.notifications
     await store.add(

--- a/tinyagentos/tools/notify_tools.py
+++ b/tinyagentos/tools/notify_tools.py
@@ -13,7 +13,7 @@ from fastapi import Request
 
 # The bell renders these severities; anything else falls back to "info" so a
 # stray level can never break rendering.
-VALID_LEVELS = frozenset({"info", "success", "warning", "error"})
+from tinyagentos.notifications import VALID_LEVELS
 
 NOTIFY_USER_TOOL = {
     "name": "notify_user",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): notifications: validate `level` on POST /api/notifications (bot finding #2320/F11)

Autonomous build of board card tsk-rwnjqs.

Docs-Reviewed: notifications route is not documented in agent-coordination.md, no doc change needed

Files:
 changelog.d/tsk-rwnjqs-notification-level-validation.md |  2 ++
 tests/test_routes_notifications.py                      | 12 ++++++++++++
 tinyagentos/routes/notifications.py                     |  9 ++++++++-
 3 files changed, 22 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification creation now rejects unsupported notification levels with a clear HTTP 400 error.
  * Accepted levels are limited to `info`, `warning`, and `error`.

* **Documentation**
  * Added a changelog entry describing the notification level validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->