### PR TITLE
App tiering S4: viewers/editors become file handlers, out of the launcher (#2143)

### DIFF
--- a/changelog.d/tsk-h72kga-app-tiering-file-handlers.md
+++ b/changelog.d/tsk-h72kga-app-tiering-file-handlers.md
@@ -1,0 +1,3 @@
+### Added
+- Marked Text Editor, Image Viewer, and Media Player as file handlers (tier 4) so they no longer appear in the launcher but remain openable programmatically.
+- Files now routes text files to Text Editor, images to Image Viewer, and audio/video to Media Player on double-click or context menu open.

--- a/desktop/src/apps/FilesApp.handlers.test.ts
+++ b/desktop/src/apps/FilesApp.handlers.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { handlerAppForFile, isText, isImage, isMedia } from "@/apps/FilesApp";
+
+describe("FilesApp file handler routing", () => {
+  describe("isText", () => {
+    it("matches text and code extensions", () => {
+      expect(isText("notes.txt")).toBe(true);
+      expect(isText("README.md")).toBe(true);
+      expect(isText("script.py")).toBe(true);
+      expect(isText("app.tsx")).toBe(true);
+    });
+
+    it("rejects non-text extensions", () => {
+      expect(isText("photo.jpg")).toBe(false);
+      expect(isText("song.mp3")).toBe(false);
+      expect(isText("movie.mp4")).toBe(false);
+    });
+  });
+
+  describe("isImage", () => {
+    it("matches image extensions", () => {
+      expect(isImage("photo.png")).toBe(true);
+      expect(isImage("pic.JPG")).toBe(true);
+      expect(isImage("diagram.svg")).toBe(true);
+    });
+
+    it("rejects non-image extensions", () => {
+      expect(isImage("doc.txt")).toBe(false);
+      expect(isImage("song.mp3")).toBe(false);
+    });
+  });
+
+  describe("isMedia", () => {
+    it("matches audio and video extensions", () => {
+      expect(isMedia("song.mp3")).toBe(true);
+      expect(isMedia("clip.mp4")).toBe(true);
+      expect(isMedia("movie.mkv")).toBe(true);
+      expect(isMedia("audio.wav")).toBe(true);
+    });
+
+    it("rejects non-media extensions", () => {
+      expect(isMedia("doc.txt")).toBe(false);
+      expect(isMedia("photo.png")).toBe(false);
+    });
+  });
+
+  describe("handlerAppForFile", () => {
+    it("routes text files to text-editor", () => {
+      expect(handlerAppForFile("notes.txt")).toBe("text-editor");
+      expect(handlerAppForFile("script.py")).toBe("text-editor");
+      expect(handlerAppForFile("README.md")).toBe("text-editor");
+    });
+
+    it("routes images to image-viewer", () => {
+      expect(handlerAppForFile("photo.png")).toBe("image-viewer");
+      expect(handlerAppForFile("pic.jpg")).toBe("image-viewer");
+      expect(handlerAppForFile("diagram.svg")).toBe("image-viewer");
+    });
+
+    it("routes audio to media-player", () => {
+      expect(handlerAppForFile("song.mp3")).toBe("media-player");
+      expect(handlerAppForFile("audio.wav")).toBe("media-player");
+    });
+
+    it("routes video to media-player", () => {
+      expect(handlerAppForFile("clip.mp4")).toBe("media-player");
+      expect(handlerAppForFile("movie.mkv")).toBe("media-player");
+      expect(handlerAppForFile("video.webm")).toBe("media-player");
+    });
+
+    it("returns null for unhandled file types", () => {
+      expect(handlerAppForFile("archive.zip")).toBeNull();
+      expect(handlerAppForFile("unknown.xyz")).toBeNull();
+    });
+  });
+});

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -142,9 +142,31 @@ const EXT_ICONS: Record<string, typeof File> = {
 
 const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
 
-function isImage(name: string): boolean {
+export function isImage(name: string): boolean {
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   return IMAGE_EXTS.has(ext);
+}
+
+const TEXT_EXTS = new Set(["txt", "md", "markdown", "log", "csv", "json", "yaml", "yml", "toml", "xml", "html", "css", "js", "ts", "tsx", "py", "rs", "go", "c", "cpp", "h", "java", "rb", "sh", "gitignore", "env"]);
+
+export function isText(name: string): boolean {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return TEXT_EXTS.has(ext);
+}
+
+const AUDIO_EXTS = new Set(["mp3", "wav", "ogg", "flac", "aac"]);
+const VIDEO_EXTS = new Set(["mp4", "mkv", "avi", "mov", "webm"]);
+
+export function isMedia(name: string): boolean {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return AUDIO_EXTS.has(ext) || VIDEO_EXTS.has(ext);
+}
+
+export function handlerAppForFile(name: string): string | null {
+  if (isText(name)) return "text-editor";
+  if (isImage(name)) return "image-viewer";
+  if (isMedia(name)) return "media-player";
+  return null;
 }
 
 const AGENT_LOCATION_PREFIX = "agent:";
@@ -1683,7 +1705,16 @@ export function FilesApp({
                   }}
                   onDoubleClick={() => {
                     if (!f.is_dir && isWritable) {
-                      window.open(fileUrl(location, f.path || f.name), "_blank");
+                      const handler = handlerAppForFile(f.name);
+                      if (handler) {
+                        window.dispatchEvent(
+                          new CustomEvent("taos:open-app", {
+                            detail: { app: handler, props: { url: fileUrl(location, f.path || f.name) } },
+                          }),
+                        );
+                      } else {
+                        window.open(fileUrl(location, f.path || f.name), "_blank");
+                      }
                     }
                   }}
                   className="flex flex-col items-center gap-2 p-3 text-center w-full rounded-xl"
@@ -1838,6 +1869,15 @@ export function FilesApp({
     const isMarkdown = lowerName.endsWith(".md") || lowerName.endsWith(".markdown");
     if (isMarkdown && isProjectLocation(location)) {
       setDocViewer({ url: fileUrl(location, f.path || f.name), title: f.name });
+      return;
+    }
+    const handler = handlerAppForFile(f.name);
+    if (handler) {
+      window.dispatchEvent(
+        new CustomEvent("taos:open-app", {
+          detail: { app: handler, props: { url: fileUrl(location, f.path || f.name) } },
+        }),
+      );
       return;
     }
     if (isWritable) {

--- a/desktop/src/apps/ImageViewerApp.tsx
+++ b/desktop/src/apps/ImageViewerApp.tsx
@@ -1,17 +1,24 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { ZoomIn, ZoomOut, RotateCw, Maximize } from "lucide-react";
 
 const ZOOM_STEP = 0.25;
 const MIN_ZOOM = 0.1;
 const MAX_ZOOM = 5;
 
-export function ImageViewerApp({ windowId: _windowId }: { windowId: string }) {
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
+export function ImageViewerApp({ windowId: _windowId, url }: { windowId: string; url?: string }) {
+  const [imageUrl, setImageUrl] = useState<string | null>(url ?? null);
   const [fileName, setFileName] = useState("");
   const [zoom, setZoom] = useState(1);
   const [rotation, setRotation] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (!url) return;
+    setImageUrl(url);
+    const path = url.split("/").pop() ?? "";
+    setFileName(decodeURIComponent(path));
+  }, [url]);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];

--- a/desktop/src/apps/MediaPlayerApp.tsx
+++ b/desktop/src/apps/MediaPlayerApp.tsx
@@ -3,11 +3,18 @@ import Plyr from "plyr";
 import "plyr/dist/plyr.css";
 import { Film, FolderOpen } from "lucide-react";
 
-export function MediaPlayerApp({ windowId: _windowId }: { windowId: string }) {
+export function MediaPlayerApp({ windowId: _windowId, url }: { windowId: string; url?: string }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const playerRef = useRef<Plyr | null>(null);
-  const [mediaUrl, setMediaUrl] = useState<string | null>(null);
+  const [mediaUrl, setMediaUrl] = useState<string | null>(url ?? null);
   const [fileName, setFileName] = useState<string>("");
+
+  useEffect(() => {
+    if (!url) return;
+    setMediaUrl(url);
+    const path = url.split("/").pop() ?? "";
+    setFileName(decodeURIComponent(path));
+  }, [url]);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];

--- a/desktop/src/apps/TextEditorApp.tsx
+++ b/desktop/src/apps/TextEditorApp.tsx
@@ -184,7 +184,7 @@ const MarkdownEditor = React.forwardRef<
 
 /* ── Main App ────────────────────────────────────────────── */
 
-export function TextEditorApp({ windowId: _windowId }: { windowId: string }) {
+export function TextEditorApp({ windowId: _windowId, url }: { windowId: string; url?: string }) {
   const [notes, setNotes] = useState<Note[]>(loadNotes);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -219,6 +219,27 @@ export function TextEditorApp({ windowId: _windowId }: { windowId: string }) {
     setNotes((prev) => prev.filter((n) => n.id !== id));
     if (activeId === id) setActiveId(null);
   }, [activeId]);
+
+  useEffect(() => {
+    if (!url) return;
+    let cancelled = false;
+    fetch(url)
+      .then((r) => (r.ok ? r.text() : Promise.reject(r.status)))
+      .then((text) => {
+        if (cancelled) return;
+        const note: Note = {
+          id: randomId("file-"),
+          content: text,
+          updatedAt: Date.now(),
+        };
+        setNotes((prev) => [note, ...prev]);
+        setActiveId(note.id);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
 
   const handleChange = useCallback(
     (value: string) => {

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -74,3 +74,34 @@ describe("LoRA Studio launcher visibility", () => {
     expect(getApp("lora-studio")?.optional).toBeFalsy();
   });
 });
+
+describe("file handler tiering", () => {
+  const handlerIds = ["text-editor", "image-viewer", "media-player"];
+
+  it("handler apps are absent from launcher listings", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    for (const id of handlerIds) {
+      expect(ids, `handler app "${id}" should not be in launcher`).not.toContain(id);
+    }
+  });
+
+  it("handler apps are still openable programmatically via getApp", () => {
+    for (const id of handlerIds) {
+      expect(getApp(id)?.id).toBe(id);
+    }
+  });
+
+  it("handler apps are still openable programmatically via resolveApp", () => {
+    for (const id of handlerIds) {
+      expect(resolveApp(id)?.id).toBe(id);
+    }
+  });
+
+  it("handler apps have tier 4 and handler:true in the manifest", () => {
+    for (const id of handlerIds) {
+      const app = getApp(id);
+      expect(app?.tier).toBe(4);
+      expect(app?.handler).toBe(true);
+    }
+  });
+});

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -94,9 +94,9 @@ const apps: AppManifest[] = [
   // Single Browser app. The proxy vs real-Neko-streamed engine is a per-tab
   // toggle inside it (BrowserModeToggle / LiveBrowserView), not a separate app.
   { id: "browser", name: "Browser", icon: "globe", category: "os", component: () => import("@/apps/BrowserApp").then((m) => ({ default: m.BrowserApp })), defaultSize: { w: 1024, h: 700 }, minSize: { w: 600, h: 400 }, singleton: false, pinned: false, launchpadOrder: 23 },
-  { id: "media-player", name: "Media Player", icon: "play-circle", category: "os", component: () => import("@/apps/MediaPlayerApp").then((m) => ({ default: m.MediaPlayerApp })), defaultSize: { w: 800, h: 500 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 24 },
-  { id: "text-editor", name: "Text Editor", icon: "file-text", category: "os", component: () => import("@/apps/TextEditorApp").then((m) => ({ default: m.TextEditorApp })), defaultSize: { w: 800, h: 550 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 25 },
-  { id: "image-viewer", name: "Image Viewer", icon: "eye", category: "os", component: () => import("@/apps/ImageViewerApp").then((m) => ({ default: m.ImageViewerApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 26 },
+  { id: "media-player", name: "Media Player", icon: "play-circle", category: "os", component: () => import("@/apps/MediaPlayerApp").then((m) => ({ default: m.MediaPlayerApp })), defaultSize: { w: 800, h: 500 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 24, tier: 4, handler: true },
+  { id: "text-editor", name: "Text Editor", icon: "file-text", category: "os", component: () => import("@/apps/TextEditorApp").then((m) => ({ default: m.TextEditorApp })), defaultSize: { w: 800, h: 550 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 25, tier: 4, handler: true },
+  { id: "image-viewer", name: "Image Viewer", icon: "eye", category: "os", component: () => import("@/apps/ImageViewerApp").then((m) => ({ default: m.ImageViewerApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 300 }, singleton: false, pinned: false, launchpadOrder: 26, tier: 4, handler: true },
   { id: "terminal", name: "Terminal", icon: "terminal", category: "os", component: () => import("@/apps/TerminalApp").then((m) => ({ default: m.TerminalApp })), defaultSize: { w: 800, h: 500 }, minSize: { w: 400, h: 250 }, singleton: false, pinned: false, launchpadOrder: 27 },
 
   // Games
@@ -160,7 +160,9 @@ export function getOptionalApps(): AppManifest[] {
  * installed optional app ids (from /api/apps/optional/installed).
  */
 export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
-  return getAllApps().filter((a) => !a.optional || installedOptional.has(a.id));
+  return getAllApps().filter(
+    (a) => (!a.optional || installedOptional.has(a.id)) && a.tier !== 4 && a.handler !== true,
+  );
 }
 
 const prefetched = new Set<string>();

--- a/desktop/src/stores/mobile-home-store.test.ts
+++ b/desktop/src/stores/mobile-home-store.test.ts
@@ -14,7 +14,7 @@ describe("mobile-home-store", () => {
     );
     // Optional apps (Reddit/YouTube/GitHub/X) ship uninstalled and are added
     // from the Store, so they are intentionally absent from the default grid.
-    const defaultIds = getAllApps().filter((a) => !a.optional).map((a) => a.id);
+    const defaultIds = getAllApps().filter((a) => !a.optional && a.tier !== 4 && a.handler !== true).map((a) => a.id);
     for (const id of defaultIds) {
       expect(allIdsInPages.has(id), `missing app "${id}" in home grid`).toBe(true);
     }

--- a/desktop/src/stores/mobile-home-store.ts
+++ b/desktop/src/stores/mobile-home-store.ts
@@ -24,7 +24,7 @@ const DEFAULT_PAGES: HomePage[] = [
     // Optional apps (Reddit/YouTube/GitHub/X) are excluded from the default
     // home grid; they ship uninstalled and are added from the Store.
     items: getAllApps()
-      .filter((a) => !a.optional)
+      .filter((a) => !a.optional && a.tier !== 4 && a.handler !== true)
       .map((a) => ({ type: "app", appId: a.id }) as AppItem),
   },
 ];


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): App tiering S4: viewers/editors become file handlers, out of the launcher (#2143)

Autonomous build of board card tsk-h72kga.

- Set handler:true and tier:4 on text-editor, image-viewer, media-player
  so they leave the launcher (launchpad, search, mobile home)
- Update getLaunchableApps and mobile-home-store to filter out tier 4 /
  handler apps
- Files now routes text files to Text Editor, images to Image Viewer,
  and audio/video to Media Player via taos:open-app with a url prop
- TextEditorApp, ImageViewerApp, and MediaPlayerApp accept an optional
  url prop so agents and Files can open them with a file path
- Add regression tests: handler apps absent from launcher, still
  resolvable by getApp/resolveApp, file routing covers all handler types

Files:
 desktop/src/apps/ImageViewerApp.tsx                | 13 +++-
 desktop/src/apps/MediaPlayerApp.tsx                | 11 +++-
 desktop/src/apps/TextEditorApp.tsx                 | 23 ++++++-
 desktop/src/registry/app-registry.test.ts          | 31 +++++++++
 desktop/src/registry/app-registry.ts               | 10 +--
 desktop/src/stores/mobile-home-store.test.ts       |  2 +-
 desktop/src/stores/mobile-home-store.ts            |  2 +-
 10 files changed, 201 insertions(+), 14 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Opening text, image, audio, and video files now launches the appropriate dedicated app.
  - Markdown project documents continue opening in the document viewer.
  - Supported files opened from the grid or context menu now load directly into their corresponding apps.
  - File-handler apps remain available when opening compatible files but no longer appear in app launchers or default home grids.

- **Bug Fixes**
  - Unsupported file types retain browser-tab opening behavior.
  - Dedicated apps now correctly load file content and update when a different file is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->