### PR TITLE
taOStalk S3: sidebar agent presence + grouping

### DIFF
--- a/changelog.d/tsk-z4wn3x-presence-grouping.md
+++ b/changelog.d/tsk-z4wn3x-presence-grouping.md
@@ -1,1 +1,1 @@
-- Chat sidebar regroupes channels into Channels, Agents-DMs, and Direct Messages sections with live presence dots (working/live/idle) and an accent rail on the active channel (#tsk-z4wn3x).
+- Chat sidebar regroups channels into Channels, Agents-DMs, and Direct Messages sections with live presence dots (working/live/idle) and an accent rail on the active channel (#tsk-z4wn3x).

--- a/changelog.d/tsk-z4wn3x-presence-grouping.md
+++ b/changelog.d/tsk-z4wn3x-presence-grouping.md
@@ -1,0 +1,1 @@
+- Chat sidebar regroupes channels into Channels, Agents-DMs, and Direct Messages sections with live presence dots (working/live/idle) and an accent rail on the active channel (#tsk-z4wn3x).

--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   bucketAgentChannels,
+  buildAgentPresence,
   computeAgentPresence,
   type AgentSectionChannel,
   type AgentSectionLiveAgent,
@@ -157,5 +158,54 @@ describe("computeAgentPresence", () => {
 
   it("returns 'working' takes precedence over 'live'", () => {
     expect(computeAgentPresence("running", true)).toBe("working");
+  });
+});
+
+describe("buildAgentPresence", () => {
+  const ch = (id: string, agent?: string) => ({
+    id,
+    settings: agent ? { taostalk_agent: agent } : undefined,
+  });
+  const noDm = { live: [], suspended: [], archived: [] };
+
+  it("marks a live agent DM 'working' while its agent is thinking", () => {
+    const presence = buildAgentPresence(
+      { live: [ch("c1", "hermes")], suspended: [], archived: [] },
+      [],
+      new Set(["hermes"]),
+    );
+    expect(presence).toEqual({ c1: "working" });
+  });
+
+  it("marks a live agent DM 'live' when its agent is not thinking", () => {
+    const presence = buildAgentPresence(
+      { live: [ch("c1", "hermes")], suspended: [], archived: [] },
+      [],
+      new Set(),
+    );
+    expect(presence).toEqual({ c1: "live" });
+  });
+
+  it("marks suspended and archived agent DMs 'idle'", () => {
+    const presence = buildAgentPresence(
+      { live: [], suspended: [ch("c2", "scout")], archived: [ch("c3")] },
+      [],
+      new Set(["scout"]),
+    );
+    expect(presence).toEqual({ c2: "idle", c3: "idle" });
+  });
+
+  it("marks a bound topic/group channel 'working' while its agent is thinking", () => {
+    const presence = buildAgentPresence(noDm, [ch("t1", "hermes")], new Set(["hermes"]));
+    expect(presence).toEqual({ t1: "working" });
+  });
+
+  it("gives bound-but-idle and unbound topic/group channels no entry", () => {
+    const presence = buildAgentPresence(
+      noDm,
+      [ch("t1", "hermes"), ch("t2")],
+      new Set(),
+    );
+    expect(presence).toEqual({});
   });
 });

--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
   bucketAgentChannels,
+  computeAgentPresence,
   type AgentSectionChannel,
   type AgentSectionLiveAgent,
   type AgentSectionArchivedAgent,
+  type AgentPresence,
 } from "./MessagesApp.agentSections";
 
 const dm = (
@@ -126,5 +128,34 @@ describe("bucketAgentChannels", () => {
     expect(result.suspended.map((c) => c.name)).toEqual(["paused-one"]);
     expect(result.archived.map((c) => c.name).sort()).toEqual(["archived-one", "orphan-one"]);
     expect(result.nonAgent.map((c) => c.name)).toEqual(["coord"]);
+  });
+});
+
+describe("computeAgentPresence", () => {
+  it("returns 'working' when the agent is working regardless of status", () => {
+    expect(computeAgentPresence("running", true)).toBe("working");
+    expect(computeAgentPresence("paused", true)).toBe("working");
+    expect(computeAgentPresence("stopped", true)).toBe("working");
+    expect(computeAgentPresence(undefined, true)).toBe("working");
+  });
+
+  it("returns 'live' when the agent is running and not working", () => {
+    expect(computeAgentPresence("running", false)).toBe("live");
+  });
+
+  it("returns 'idle' when the agent is paused and not working", () => {
+    expect(computeAgentPresence("paused", false)).toBe("idle");
+  });
+
+  it("returns 'idle' when the agent is stopped and not working", () => {
+    expect(computeAgentPresence("stopped", false)).toBe("idle");
+  });
+
+  it("returns 'idle' when the agent status is undefined and not working", () => {
+    expect(computeAgentPresence(undefined, false)).toBe("idle");
+  });
+
+  it("returns 'working' takes precedence over 'live'", () => {
+    expect(computeAgentPresence("running", true)).toBe("working");
   });
 });

--- a/desktop/src/apps/MessagesApp.agentSections.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.ts
@@ -67,6 +67,50 @@ export function computeAgentPresence(
   return "idle";
 }
 
+/** Minimal channel shape needed to build the sidebar presence map. */
+export interface PresenceSourceChannel {
+  id: string;
+  settings?: { taostalk_agent?: string };
+}
+
+/**
+ * Build the sidebar presence map from the bucketed agent DM sections plus
+ * the topic/group channels that may carry an agent binding.
+ *
+ * - Live agent DMs: "working" while the bound agent is in `workingSlugs`,
+ *   otherwise "live".
+ * - Suspended/archived agent DMs: "idle".
+ * - Topic/group channels bound via `settings.taostalk_agent`: "working"
+ *   only while the bound agent is in `workingSlugs`; no entry otherwise,
+ *   since absence renders no dot for non-agent channels.
+ *
+ * Pure function -- no side effects -- so it can be unit tested in isolation.
+ */
+export function buildAgentPresence<C extends PresenceSourceChannel>(
+  dm: { live: C[]; suspended: C[]; archived: C[] },
+  boundChannels: C[],
+  workingSlugs: ReadonlySet<string>,
+): Record<string, AgentPresence> {
+  const presence: Record<string, AgentPresence> = {};
+  for (const ch of dm.live) {
+    const bound = ch.settings?.taostalk_agent;
+    presence[ch.id] = computeAgentPresence(
+      "running",
+      !!bound && workingSlugs.has(bound),
+    );
+  }
+  for (const ch of [...dm.suspended, ...dm.archived]) {
+    presence[ch.id] = computeAgentPresence(undefined, false);
+  }
+  for (const ch of boundChannels) {
+    const bound = ch.settings?.taostalk_agent;
+    if (bound && workingSlugs.has(bound)) {
+      presence[ch.id] = computeAgentPresence(undefined, true);
+    }
+  }
+  return presence;
+}
+
 /** The agent identity a DM channel points at: its name or its non-"user" member. */
 function channelAgentKeys<C extends AgentSectionChannel>(ch: C): string[] {
   const keys = [ch.name];

--- a/desktop/src/apps/MessagesApp.agentSections.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.ts
@@ -46,6 +46,27 @@ export interface AgentSections<C> {
   nonAgent: C[];
 }
 
+/**
+ * Agent presence states for sidebar display.
+ * - "working" -- agent is actively thinking / running a tool.
+ * - "live"    -- agent is registered as running and available.
+ * - "idle"    -- agent is paused, stopped, failed, or otherwise unavailable.
+ */
+export type AgentPresence = "live" | "working" | "idle";
+
+/**
+ * Map a registry agent status + working flag to a sidebar presence state.
+ * Pure function -- exported for unit testing.
+ */
+export function computeAgentPresence(
+  status: string | undefined,
+  isWorking: boolean,
+): AgentPresence {
+  if (isWorking) return "working";
+  if (status === "running") return "live";
+  return "idle";
+}
+
 /** The agent identity a DM channel points at: its name or its non-"user" member. */
 function channelAgentKeys<C extends AgentSectionChannel>(ch: C): string[] {
   const keys = [ch.name];

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2071,7 +2071,14 @@ export function MessagesApp({
   const workingSlugs = new Set(typingAgents.map((a) => a.slug));
   const agentPresence = buildAgentPresence(
     dmSections,
-    [...grouped.topic, ...grouped.group],
+    // Bound channels from all three buckets: standalone-mode project
+    // channels are excluded from `grouped`, so include them explicitly or
+    // a working bound project channel renders no dot.
+    [
+      ...grouped.topic,
+      ...grouped.group,
+      ...projectGroups.flatMap((g) => g.channels),
+    ],
     workingSlugs,
   );
 

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -9,9 +9,9 @@ import {
   ChevronRight,
   PanelRight,
   Archive,
-   Bot,
-   CircleDot,
-   AlertTriangle,
+  Bot,
+  CircleDot,
+  AlertTriangle,
   Loader2,
   Check,
   Clock,
@@ -137,9 +137,9 @@ interface ArchivedAgentEntry {
 export type AuthorDisplayState = "active" | "archived" | "removed";
 
 /**
- * Resolve the display state of a message author.
- * Pure function — exported for unit testing.
- */
+* Resolve the display state of a message author.
+* Pure function — exported for unit testing.
+*/
 export function resolveAuthorDisplayState(
   authorId: string,
   authorType: "user" | "agent",
@@ -198,11 +198,11 @@ export interface DecisionContentBlock {
 }
 
 /**
- * Structured message content for taOStalk session turns.
- * Known kinds are handled by dedicated block components (separate cards);
- * any unrecognized kind falls through to the unknown-block fallback in
- * renderContent, which is the slice-2 seam for the renderer registry.
- */
+* Structured message content for taOStalk session turns.
+* Known kinds are handled by dedicated block components (separate cards);
+* any unrecognized kind falls through to the unknown-block fallback in
+* renderContent, which is the slice-2 seam for the renderer registry.
+*/
 export type ContentBlock =
   | TextContentBlock
   | ThinkingContentBlock
@@ -250,10 +250,10 @@ type WsStatus = "connecting" | "connected" | "disconnected";
 /* ------------------------------------------------------------------ */
 
 /**
- * Coerce a server timestamp (number = seconds since epoch, string = ISO
- * or numeric) to milliseconds suitable for `new Date(...)`. The 1e12
- * threshold safely distinguishes seconds (~1.7e9 today) from ms (~1.7e12).
- */
+* Coerce a server timestamp (number = seconds since epoch, string = ISO
+* or numeric) to milliseconds suitable for `new Date(...)`. The 1e12
+* threshold safely distinguishes seconds (~1.7e9 today) from ms (~1.7e12).
+*/
 export function toMs(ts: number | string): number {
   if (typeof ts === "number") return ts < 1e12 ? ts * 1000 : ts;
   if (ts === "" || ts == null) return Date.now();
@@ -273,11 +273,11 @@ export function relativeTime(ts: number | string, nowMs: number = Date.now()): s
 }
 
 /**
- * Dispatch a single content block to its renderer. All four slice-1 kinds now
- * have dedicated components: text and thinking (cards 3+4), tool call and
- * status/question (cards 5+6). Any unrecognised kind still falls through to
- * the unknown-block fallback -- the slice-2 seam for the renderer registry.
- */
+* Dispatch a single content block to its renderer. All four slice-1 kinds now
+* have dedicated components: text and thinking (cards 3+4), tool call and
+* status/question (cards 5+6). Any unrecognised kind still falls through to
+* the unknown-block fallback -- the slice-2 seam for the renderer registry.
+*/
 function renderContentBlock(block: ContentBlock, index: number): React.ReactElement {
   switch (block.kind) {
     case "text": {
@@ -399,22 +399,22 @@ export function renderInline(text: string, keyPrefix: string) {
 /* ------------------------------------------------------------------ */
 
 /**
- * TextBlock -- renders a {kind:"text"} content block by reusing the existing
- * inline markdown renderer (renderInline), so a text block renders
- * identically to a plain message's markdown body.
- */
+* TextBlock -- renders a {kind:"text"} content block by reusing the existing
+* inline markdown renderer (renderInline), so a text block renders
+* identically to a plain message's markdown body.
+*/
 export function TextBlock({ block, index }: { block: TextContentBlock; index: number }): React.ReactElement {
   return <>{renderInline(block.text, `text-block-${index}`)}</>;
 }
 
 /**
- * ThinkingBlock -- renders a {kind:"thinking"} content block as a
- * collapsed-by-default disclosure. The toggle button carries the ARIA
- * disclosure contract (aria-expanded / aria-controls) and a chevron; the
- * panel is dim-styled to de-emphasize the agent's internal reasoning. The
- * container matches the Store/Images card bar (rounded border, shell
- * surface background, dim tertiary text).
- */
+* ThinkingBlock -- renders a {kind:"thinking"} content block as a
+* collapsed-by-default disclosure. The toggle button carries the ARIA
+* disclosure contract (aria-expanded / aria-controls) and a chevron; the
+* panel is dim-styled to de-emphasize the agent's internal reasoning. The
+* container matches the Store/Images card bar (rounded border, shell
+* surface background, dim tertiary text).
+*/
 export function ThinkingBlock({ block, index }: { block: ThinkingContentBlock; index: number }): React.ReactElement {
   const [open, setOpen] = useState(block.collapsed === false);
   const summaryRef = useId();
@@ -489,20 +489,20 @@ function resolveAnswerLabel(d: DecisionData): string | null {
 }
 
 /**
- * DecisionBlock -- inline renderer for a `{kind:"decision", decision_id}`
- * content block. Fetches the decision from the Decisions API and renders the
- * question, options (as click-to-answer buttons when pending), type, and
- * current state (open / answered).
- *
- * Answering posts to the SAME path the Decisions app uses
- * (POST /api/decisions/{id}/answer), so first-answer-wins is enforced server-side
- * and the answer is attributed to the real user identity (session cookie).
- *
- * Live propagation: subscribes to the decision-events store, which the global
- * SSE handler (useEventStream) updates on every `decision.answered` broadcast.
- * When another surface (e.g. the Decisions app) answers this decision, the
- * block re-fetches and resolves in place without a refresh.
- */
+* DecisionBlock -- inline renderer for a `{kind:"decision", decision_id}`
+* content block. Fetches the decision from the Decisions API and renders the
+* question, options (as click-to-answer buttons when pending), type, and
+* current state (open / answered).
+*
+* Answering posts to the SAME path the Decisions app uses
+* (POST /api/decisions/{id}/answer), so first-answer-wins is enforced server-side
+* and the answer is attributed to the real user identity (session cookie).
+*
+* Live propagation: subscribes to the decision-events store, which the global
+* SSE handler (useEventStream) updates on every `decision.answered` broadcast.
+* When another surface (e.g. the Decisions app) answers this decision, the
+* block re-fetches and resolves in place without a refresh.
+*/
 export function DecisionBlock({ block }: { block: DecisionContentBlock }): React.ReactElement {
   const [decision, setDecision] = useState<DecisionData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -1205,15 +1205,15 @@ export function MessagesApp({
             setMessages((prev) =>
               prev.map((m) =>
                 m.id === data.message_id
-               ? {
-                       ...m,
-                       ...(data.content !== undefined && { content: data.content }),
-                       ...(data.edited_at !== undefined && { edited_at: data.edited_at }),
-                       ...(data.metadata !== undefined && { metadata: data.metadata }),
-                       ...(data.content_blocks !== undefined && {
-                         content_blocks: data.content_blocks as ContentBlock[],
-                       }),
-                     }
+              ? {
+                      ...m,
+                      ...(data.content !== undefined && { content: data.content }),
+                      ...(data.edited_at !== undefined && { edited_at: data.edited_at }),
+                      ...(data.metadata !== undefined && { metadata: data.metadata }),
+                      ...(data.content_blocks !== undefined && {
+                        content_blocks: data.content_blocks as ContentBlock[],
+                      }),
+                    }
                   : m,
               ),
             );
@@ -1289,16 +1289,16 @@ export function MessagesApp({
   useRefreshOnFocus(fetchChannels);
 
   /* ---- keep unreadRef in sync with the unread state without re-running
-   * the channel-selection effect (which would re-capture the pending count). ---- */
+  * the channel-selection effect (which would re-capture the pending count). ---- */
   useEffect(() => {
     unreadRef.current = unread;
   }, [unread]);
 
   /* ---- default-select A2A channel on first project visit ----
-   * Also runs when the project switches: if the previously selected channel
-   * is not in the new project's channel list, it's stale — fall back to
-   * the remembered/A2A channel for the new project, or clear the selection.
-   */
+  * Also runs when the project switches: if the previously selected channel
+  * is not in the new project's channel list, it's stale — fall back to
+  * the remembered/A2A channel for the new project, or clear the selection.
+  */
   useEffect(() => {
     if (!scope?.projectId) return;
     if (channels.length === 0) return;
@@ -1315,10 +1315,10 @@ export function MessagesApp({
   }, [scope?.projectId, channels, selectedChannel]);
 
   /* ---- persist last-selected channel per project ----
-   * Split from the channel-join effect so we only write when we know the
-   * current selection actually belongs to the current project — prevents
-   * cross-project leakage when the user switches projects mid-flight.
-   */
+  * Split from the channel-join effect so we only write when we know the
+  * current selection actually belongs to the current project — prevents
+  * cross-project leakage when the user switches projects mid-flight.
+  */
   useEffect(() => {
     if (!scope?.projectId) return;
     if (!selectedChannel) return;
@@ -1327,11 +1327,11 @@ export function MessagesApp({
   }, [scope?.projectId, selectedChannel, channels]);
 
   /* ---- bus / project-channel selection are mutually exclusive ----
-   * Modeled as render precedence: while busSelected is set the bus viewer
-   * wins, otherwise the project channel shows. Picking a project channel
-   * clears busSelected (project view takes over); picking a bus channel keeps
-   * selectedChannel intact so returning from the bus restores it.
-   */
+  * Modeled as render precedence: while busSelected is set the bus viewer
+  * wins, otherwise the project channel shows. Picking a project channel
+  * clears busSelected (project view takes over); picking a bus channel keeps
+  * selectedChannel intact so returning from the bus restores it.
+  */
   useEffect(() => {
     if (selectedChannel) setBusSelected(null);
   }, [selectedChannel]);
@@ -2227,14 +2227,14 @@ export function MessagesApp({
               slow or has gone quiet, so a stalled generation no longer looks
               like a frozen window. */}
 {stallInfo && (
-             <div
-               role="status"
-               className={`mx-4 mb-2 px-3 py-2 rounded-lg border text-[12px] flex items-center gap-2 shrink-0 ${
-                 stallInfo.stalled
-                   ? "bg-amber-500/10 border-amber-500/25 text-amber-300/90"
-                   : "bg-shell-surface border-shell-border text-shell-text-secondary"
-               }`}
-             >
+            <div
+              role="status"
+              className={`mx-4 mb-2 px-3 py-2 rounded-lg border text-[12px] flex items-center gap-2 shrink-0 ${
+                stallInfo.stalled
+                  ? "bg-amber-500/10 border-amber-500/25 text-amber-300/90"
+                  : "bg-shell-surface border-shell-border text-shell-text-secondary"
+              }`}
+            >
               {stallInfo.stalled ? (
                 <AlertTriangle size={13} aria-hidden="true" className="shrink-0" />
               ) : (
@@ -2289,7 +2289,7 @@ export function MessagesApp({
                   setInput("");
                 }}
 className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-colors"
-                 aria-label="Dismiss prefill"
+                aria-label="Dismiss prefill"
               >
                 <X size={12} aria-hidden="true" />
               </button>

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef, useCallback, useId } from "react";
 import {
   MessageCircle,
   Hash,
-  Users,
   Plus,
   X,
   AtSign,
@@ -10,9 +9,9 @@ import {
   ChevronRight,
   PanelRight,
   Archive,
-  CircleDot,
-  PauseCircle,
-  AlertTriangle,
+   Bot,
+   CircleDot,
+   AlertTriangle,
   Loader2,
   Check,
   Clock,
@@ -59,7 +58,7 @@ import {
   readLastChannel,
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
-import { bucketAgentChannels } from "./MessagesApp.agentSections";
+import { bucketAgentChannels, computeAgentPresence, type AgentPresence } from "./MessagesApp.agentSections";
 import {
   pickWatchAgent,
   computeStallInfo,
@@ -1957,9 +1956,11 @@ export function MessagesApp({
     group: channels.filter((c) => c.type === "group" && inSidebarSection(c)),
   };
 
-  // Split DM channels into agent lifecycle buckets (Live / Suspended /
-  // Archived) so deleted-agent DMs no longer mix in with live ones. Plain
-  // user DMs and a2a channels stay under nonAgent (their original placement).
+  // DM channels are bucketed by agent lifecycle (live/suspended/archived)
+  // so we can compute per-channel presence. In the sidebar they are
+  // consolidated into one "Agents-DMs" group with a presence dot, rather
+  // than split across separate lifecycle sections. Plain user DMs and a2a
+  // channels stay under nonAgent ("Direct Messages").
   const dmSections = bucketAgentChannels(grouped.dm, liveAgents, archivedAgents);
 
   const allChannels = [...channels, ...archivedChannels];
@@ -2045,18 +2046,17 @@ export function MessagesApp({
   /*  Sections definition (shared between mobile + desktop lists)     */
   /* ---------------------------------------------------------------- */
 
-  // Agent DMs are grouped by lifecycle so live, suspended, and
-  // archived/deleted agents are visually separated. Empty buckets are
-  // omitted so the list stays compact. Plain user DMs and a2a channels
-  // (nonAgent) keep their original "Direct Messages" placement.
+  // Agent DMs are consolidated into a single "Agents-DMs" group; their
+  // live/working/idle state is conveyed by a per-channel presence dot
+  // (computed above from registry status + thinking events) rather than
+  // by splitting them across separate lifecycle sections. Plain user DMs
+  // and a2a channels stay under nonAgent ("Direct Messages"). Topic and
+  // group channels are merged into one "Channels" group.
   const SECTIONS = [
-    { label: "Live", icon: <CircleDot size={13} />, items: dmSections.live },
-    { label: "Suspended", icon: <PauseCircle size={13} />, items: dmSections.suspended },
-    { label: "Archived Agents", icon: <Archive size={13} />, items: dmSections.archived },
+    { label: "Channels", icon: <Hash size={13} />, items: [...grouped.topic, ...grouped.group] },
+    { label: "Agents-DMs", icon: <Bot size={13} />, items: [...dmSections.live, ...dmSections.suspended, ...dmSections.archived] },
     { label: "Direct Messages", icon: <AtSign size={13} />, items: dmSections.nonAgent },
-    { label: "Topics", icon: <Hash size={13} />, items: grouped.topic },
-    { label: "Groups", icon: <Users size={13} />, items: grouped.group },
-  ].filter((s) => s.items.length > 0 || s.label === "Topics" || s.label === "Groups");
+  ].filter((s) => s.items.length > 0 || s.label === "Channels");
 
   const allEmpty =
     channelsLoaded &&
@@ -2064,12 +2064,21 @@ export function MessagesApp({
     archivedChannels.length === 0 &&
     projectGroups.length === 0;
 
-  const thinkingChannelIds: string[] = channels
-    .filter((ch) => {
-      const bound = (ch.settings as { taostalk_agent?: string } | undefined)?.taostalk_agent;
-      return bound && typingAgents.some((a) => a.slug === bound);
-    })
-    .map((ch) => ch.id);
+  /* ------------------------------------------------------------------ */
+  /*  Agent presence map for sidebar dots (live/working/idle)           */
+  /* ------------------------------------------------------------------ */
+  // Working slugs come from live WS thinking events on bound channels.
+  const workingSlugs = new Set(typingAgents.map((a) => a.slug));
+  const agentPresence: Record<string, AgentPresence> = {};
+  for (const ch of dmSections.live) {
+    const bound = (ch.settings as { taostalk_agent?: string } | undefined)?.taostalk_agent;
+    agentPresence[ch.id] = (bound && workingSlugs.has(bound))
+      ? computeAgentPresence("running", true)
+      : computeAgentPresence("running", false);
+  }
+  for (const ch of [...dmSections.suspended, ...dmSections.archived]) {
+    agentPresence[ch.id] = computeAgentPresence(undefined, false);
+  }
 
   /* ---------------------------------------------------------------- */
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
@@ -2108,8 +2117,8 @@ export function MessagesApp({
       busSelected={busSelected}
       onSelectBusChannel={selectBusChannel}
       formatRelativeTime={relativeTime}
-      thinkingChannelIds={thinkingChannelIds}
-    />
+       agentPresence={agentPresence}
+     />
   );
 
   /* ---------------------------------------------------------------- */

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -58,7 +58,7 @@ import {
   readLastChannel,
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
-import { bucketAgentChannels, computeAgentPresence, type AgentPresence } from "./MessagesApp.agentSections";
+import { bucketAgentChannels, buildAgentPresence } from "./MessagesApp.agentSections";
 import {
   pickWatchAgent,
   computeStallInfo,
@@ -2069,16 +2069,11 @@ export function MessagesApp({
   /* ------------------------------------------------------------------ */
   // Working slugs come from live WS thinking events on bound channels.
   const workingSlugs = new Set(typingAgents.map((a) => a.slug));
-  const agentPresence: Record<string, AgentPresence> = {};
-  for (const ch of dmSections.live) {
-    const bound = (ch.settings as { taostalk_agent?: string } | undefined)?.taostalk_agent;
-    agentPresence[ch.id] = (bound && workingSlugs.has(bound))
-      ? computeAgentPresence("running", true)
-      : computeAgentPresence("running", false);
-  }
-  for (const ch of [...dmSections.suspended, ...dmSections.archived]) {
-    agentPresence[ch.id] = computeAgentPresence(undefined, false);
-  }
+  const agentPresence = buildAgentPresence(
+    dmSections,
+    [...grouped.topic, ...grouped.group],
+    workingSlugs,
+  );
 
   /* ---------------------------------------------------------------- */
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
@@ -2117,8 +2112,8 @@ export function MessagesApp({
       busSelected={busSelected}
       onSelectBusChannel={selectBusChannel}
       formatRelativeTime={relativeTime}
-       agentPresence={agentPresence}
-     />
+      agentPresence={agentPresence}
+    />
   );
 
   /* ---------------------------------------------------------------- */

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui";
 import { MessageAvatar } from "./MessageAvatar";
 import { A2aBusSection, type BusChannel } from "./A2aBusPanel";
-import type { Channel, LiveAgent, ArchivedAgentEntry, ProjectGroup, WsStatus } from "./types";
+import type { Channel, LiveAgent, ArchivedAgentEntry, ProjectGroup, WsStatus, AgentPresence } from "./types";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -61,8 +61,8 @@ export interface ChannelSidebarProps {
   onSelectBusChannel: (channel: string) => void;
   /** Relative time formatter. */
   formatRelativeTime: (ts: number | string, nowMs: number) => string;
-  /** Channel ids whose bound taostalk_agent is currently thinking (live badge). */
-  thinkingChannelIds: string[];
+   /** Per-channel agent presence: "live" | "working" | "idle", keyed by channel id. */
+   agentPresence: Record<string, AgentPresence>;
 }
 
 /* ------------------------------------------------------------------ */
@@ -97,9 +97,9 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
     bus,
     busSelected,
     onSelectBusChannel,
-    formatRelativeTime,
-    thinkingChannelIds,
-  } = props;
+     formatRelativeTime,
+     agentPresence,
+   } = props;
 
   if (isMobile) {
     return (
@@ -184,25 +184,28 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                               ? "Agent coordination — mention @<slug> to hand off."
                               : undefined
                           }
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 12,
-                            width: "100%",
-                            padding: "11px 14px",
-                            background:
-                              selectedChannel === ch.id
-                                ? "var(--color-shell-surface-active)"
-                                : "none",
-                            border: "none",
-                            borderBottom:
-                              idx === arr.length - 1
-                                ? "none"
-                                : "1px solid var(--color-shell-border)",
-                            cursor: "pointer",
-                            color: "inherit",
-                            textAlign: "left" as const,
-                          }}
+                           style={{
+                             display: "flex",
+                             alignItems: "center",
+                             gap: 12,
+                             width: "100%",
+                             padding: "11px 14px",
+                             background:
+                               selectedChannel === ch.id
+                                 ? "var(--color-shell-surface-active)"
+                                 : "none",
+                             border: "none",
+                             borderLeft: selectedChannel === ch.id
+                               ? "3px solid var(--color-accent-line)"
+                               : "none",
+                             borderBottom:
+                               idx === arr.length - 1
+                                 ? "none"
+                                 : "1px solid var(--color-shell-border)",
+                             cursor: "pointer",
+                             color: "inherit",
+                             textAlign: "left" as const,
+                           }}
                         >
                           {agentMember ? (
                             <MessageAvatar
@@ -271,16 +274,10 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                                >
                                  {ch.name}
                                </span>
-                               {thinkingChannelIds.includes(ch.id) && (
-                                 <span
-                                   className="relative inline-flex h-1.5 w-1.5 shrink-0"
-                                   role="img"
-                                   aria-label="Agent is thinking"
-                                 >
-                                   <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
-                                   <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
-                                 </span>
-                               )}
+                                 {(() => {
+                                   const presence = agentPresence[ch.id];
+                                   return presence ? <PresenceDot presence={presence} /> : null;
+                                 })()}
                                {ch.last_message_at && (
                                 <span
                                   style={{
@@ -452,62 +449,56 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                       : undefined;
                   const count = unread[ch.id] ?? 0;
                   return (
-                    <button
-                      key={ch.id}
-                      type="button"
-                      onClick={() => onSelectChannel(ch.id)}
-                      aria-pressed={selectedChannel === ch.id}
-                      className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
-                        selectedChannel === ch.id
-                          ? "bg-shell-surface-active"
-                          : "hover:bg-shell-surface-hover"
-                      }`}
-                      aria-label={`Channel ${ch.name}`}
-                      title={
-                        isA2A
-                          ? "Agent coordination — mention @<slug> to hand off."
-                          : undefined
-                      }
-                    >
-                      {agentMember ? (
-                        <MessageAvatar
-                          size={30}
-                          authorId={agentMember}
-                          displayName={agentMember}
-                          kind="agent"
-                        />
-                      ) : isA2A ? (
-                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
-                          <Bot size={15} aria-hidden />
-                        </span>
-                      ) : (
-                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
-                          {ch.type === "group" ? (
-                            <Users size={15} aria-hidden />
-                          ) : (
-                            <Hash size={15} aria-hidden />
-                          )}
-                        </span>
-                      )}
-                       <span
-                         className={`truncate flex-1 text-[14px] tracking-tight ${
-                           count > 0
-                             ? "font-bold text-shell-text"
-                             : "font-semibold text-shell-text"
-                         }`}
-                       >
-                         {ch.name}
-                       </span>
-                       {thinkingChannelIds.includes(ch.id) && (
-                         <span
-                           className="relative inline-flex h-1.5 w-1.5 shrink-0"
-                           role="img"
-                           aria-label="Agent is thinking"
-                         >
-                           <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
-                           <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
+                     <button
+                       key={ch.id}
+                       type="button"
+                       onClick={() => onSelectChannel(ch.id)}
+                       aria-pressed={selectedChannel === ch.id}
+                       className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
+                         selectedChannel === ch.id
+                           ? "bg-shell-surface-active border-l-2 border-accent-line"
+                           : "hover:bg-shell-surface-hover"
+                       }`}
+                       aria-label={`Channel ${ch.name}`}
+                       title={
+                         isA2A
+                           ? "Agent coordination — mention @<slug> to hand off."
+                           : undefined
+                       }
+                     >
+                       {agentMember ? (
+                         <MessageAvatar
+                           size={30}
+                           authorId={agentMember}
+                           displayName={agentMember}
+                           kind="agent"
+                         />
+                       ) : isA2A ? (
+                         <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+                           <Bot size={15} aria-hidden />
+                         </span>
+                       ) : (
+                         <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
+                           {ch.type === "group" ? (
+                             <Users size={15} aria-hidden />
+                           ) : (
+                             <Hash size={15} aria-hidden />
+                           )}
                          </span>
                        )}
+                        <span
+                          className={`truncate flex-1 text-[14px] tracking-tight ${
+                            count > 0
+                              ? "font-bold text-shell-text"
+                              : "font-semibold text-shell-text"
+                          }`}
+                        >
+                          {ch.name}
+                        </span>
+                         {(() => {
+                           const presence = agentPresence[ch.id];
+                           return presence ? <PresenceDot presence={presence} /> : null;
+                         })()}
                        {count > 0 && (
                         <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
                           {count}
@@ -597,7 +588,41 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Internal sub-components                                            */
+/*  Presence dot                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Small status dot shown next to agent DM channel names in the sidebar.
+ * - working: amber with a pulse animation (agent is actively generating).
+ * - live:   emerald solid (agent is running and available).
+ * - idle:   muted gray (agent is paused, stopped, or otherwise unavailable).
+ */
+function PresenceDot({ presence }: { presence: AgentPresence }) {
+  const is = (presence === "live") ? (
+    <span
+      className="relative inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400"
+      role="img"
+      aria-label="Agent is live"
+    />
+  ) : presence === "working" ? (
+    <span
+      className="relative inline-flex h-1.5 w-1.5 shrink-0"
+      role="img"
+      aria-label="Agent is working"
+    >
+      <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
+      <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
+    </span>
+  ) : (
+    <span
+      className="relative inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-shell-text-tertiary"
+      role="img"
+      aria-label="Agent is idle"
+    />
+  );
+  return is;
+}
+
 /* ------------------------------------------------------------------ */
 
 function ConnectionStatus({ wsStatus }: { wsStatus: WsStatus }) {

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -538,7 +538,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                       }
                       className={`w-full text-left text-xs py-1 px-2 rounded flex items-center gap-1.5 ${
                         selectedChannel === ch.id
-                          ? "bg-white/10"
+                          ? "bg-white/10 border-l-2 border-accent-line"
                           : "hover:bg-white/5"
                       }`}
                     >
@@ -843,6 +843,10 @@ function ProjectsSectionMobile({
                             ? "var(--color-shell-surface-active)"
                             : "none",
                         border: "none",
+                        borderLeft:
+                          selectedChannel === ch.id
+                            ? "3px solid var(--color-accent-line)"
+                            : "none",
                         borderBottom:
                           idx === arr.length - 1
                             ? "none"
@@ -1019,6 +1023,10 @@ function ArchivedSection({
                           ? "var(--color-shell-surface-active)"
                           : "none",
                       border: "none",
+                      borderLeft:
+                        selectedChannel === ch.id
+                          ? "3px solid var(--color-accent-line)"
+                          : "none",
                       cursor: "pointer",
                       color: "inherit",
                       textAlign: "left" as const,
@@ -1135,7 +1143,9 @@ function ArchivedSection({
                   selectedChannel === ch.id ? "secondary" : "ghost"
                 }
                 onClick={() => onSelectChannel(ch.id)}
-                className="flex-1 justify-start h-auto py-1.5 pl-3 pr-1 text-[13px] rounded-none font-normal min-w-0"
+                className={`flex-1 justify-start h-auto py-1.5 pl-3 pr-1 text-[13px] rounded-none font-normal min-w-0 ${
+                  selectedChannel === ch.id ? "border-l-2 border-accent-line" : ""
+                }`}
                 aria-label={`Archived channel ${ch.name}`}
               >
                 <Archive

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -61,8 +61,8 @@ export interface ChannelSidebarProps {
   onSelectBusChannel: (channel: string) => void;
   /** Relative time formatter. */
   formatRelativeTime: (ts: number | string, nowMs: number) => string;
-   /** Per-channel agent presence: "live" | "working" | "idle", keyed by channel id. */
-   agentPresence: Record<string, AgentPresence>;
+  /** Per-channel agent presence: "live" | "working" | "idle", keyed by channel id. */
+  agentPresence: Record<string, AgentPresence>;
 }
 
 /* ------------------------------------------------------------------ */
@@ -97,9 +97,9 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
     bus,
     busSelected,
     onSelectBusChannel,
-     formatRelativeTime,
-     agentPresence,
-   } = props;
+    formatRelativeTime,
+    agentPresence,
+  } = props;
 
   if (isMobile) {
     return (
@@ -184,28 +184,28 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                               ? "Agent coordination — mention @<slug> to hand off."
                               : undefined
                           }
-                           style={{
-                             display: "flex",
-                             alignItems: "center",
-                             gap: 12,
-                             width: "100%",
-                             padding: "11px 14px",
-                             background:
-                               selectedChannel === ch.id
-                                 ? "var(--color-shell-surface-active)"
-                                 : "none",
-                             border: "none",
-                             borderLeft: selectedChannel === ch.id
-                               ? "3px solid var(--color-accent-line)"
-                               : "none",
-                             borderBottom:
-                               idx === arr.length - 1
-                                 ? "none"
-                                 : "1px solid var(--color-shell-border)",
-                             cursor: "pointer",
-                             color: "inherit",
-                             textAlign: "left" as const,
-                           }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 12,
+                            width: "100%",
+                            padding: "11px 14px",
+                            background:
+                              selectedChannel === ch.id
+                                ? "var(--color-shell-surface-active)"
+                                : "none",
+                            border: "none",
+                            borderLeft: selectedChannel === ch.id
+                              ? "3px solid var(--color-accent-line)"
+                              : "none",
+                            borderBottom:
+                              idx === arr.length - 1
+                                ? "none"
+                                : "1px solid var(--color-shell-border)",
+                            cursor: "pointer",
+                            color: "inherit",
+                            textAlign: "left" as const,
+                          }}
                         >
                           {agentMember ? (
                             <MessageAvatar
@@ -261,24 +261,24 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                                 gap: 8,
                               }}
                             >
-                               <span
-                                 style={{
-                                   flex: 1,
-                                   fontSize: 15,
-                                   fontWeight: count > 0 ? 700 : 600,
-                                   color: "var(--color-shell-text)",
-                                   overflow: "hidden",
-                                   textOverflow: "ellipsis",
-                                   whiteSpace: "nowrap",
-                                 }}
-                               >
-                                 {ch.name}
-                               </span>
-                                 {(() => {
-                                   const presence = agentPresence[ch.id];
-                                   return presence ? <PresenceDot presence={presence} /> : null;
-                                 })()}
-                               {ch.last_message_at && (
+                              <span
+                                style={{
+                                  flex: 1,
+                                  fontSize: 15,
+                                  fontWeight: count > 0 ? 700 : 600,
+                                  color: "var(--color-shell-text)",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {ch.name}
+                              </span>
+                                {(() => {
+                                  const presence = agentPresence[ch.id];
+                                  return presence ? <PresenceDot presence={presence} /> : null;
+                                })()}
+                              {ch.last_message_at && (
                                 <span
                                   style={{
                                     fontSize: 11,
@@ -449,43 +449,43 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                       : undefined;
                   const count = unread[ch.id] ?? 0;
                   return (
-                     <button
-                       key={ch.id}
-                       type="button"
-                       onClick={() => onSelectChannel(ch.id)}
-                       aria-pressed={selectedChannel === ch.id}
-                       className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
-                         selectedChannel === ch.id
-                           ? "bg-shell-surface-active border-l-2 border-accent-line"
-                           : "hover:bg-shell-surface-hover"
-                       }`}
-                       aria-label={`Channel ${ch.name}`}
-                       title={
-                         isA2A
-                           ? "Agent coordination — mention @<slug> to hand off."
-                           : undefined
-                       }
-                     >
-                       {agentMember ? (
-                         <MessageAvatar
-                           size={30}
-                           authorId={agentMember}
-                           displayName={agentMember}
-                           kind="agent"
-                         />
-                       ) : isA2A ? (
-                         <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
-                           <Bot size={15} aria-hidden />
-                         </span>
-                       ) : (
-                         <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
-                           {ch.type === "group" ? (
-                             <Users size={15} aria-hidden />
-                           ) : (
-                             <Hash size={15} aria-hidden />
-                           )}
-                         </span>
-                       )}
+                    <button
+                      key={ch.id}
+                      type="button"
+                      onClick={() => onSelectChannel(ch.id)}
+                      aria-pressed={selectedChannel === ch.id}
+                      className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
+                        selectedChannel === ch.id
+                          ? "bg-shell-surface-active border-l-2 border-accent-line"
+                          : "hover:bg-shell-surface-hover"
+                      }`}
+                      aria-label={`Channel ${ch.name}`}
+                      title={
+                        isA2A
+                          ? "Agent coordination — mention @<slug> to hand off."
+                          : undefined
+                      }
+                    >
+                      {agentMember ? (
+                        <MessageAvatar
+                          size={30}
+                          authorId={agentMember}
+                          displayName={agentMember}
+                          kind="agent"
+                        />
+                      ) : isA2A ? (
+                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+                          <Bot size={15} aria-hidden />
+                        </span>
+                      ) : (
+                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
+                          {ch.type === "group" ? (
+                            <Users size={15} aria-hidden />
+                          ) : (
+                            <Hash size={15} aria-hidden />
+                          )}
+                        </span>
+                      )}
                         <span
                           className={`truncate flex-1 text-[14px] tracking-tight ${
                             count > 0
@@ -495,11 +495,11 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                         >
                           {ch.name}
                         </span>
-                         {(() => {
-                           const presence = agentPresence[ch.id];
-                           return presence ? <PresenceDot presence={presence} /> : null;
-                         })()}
-                       {count > 0 && (
+                        {(() => {
+                          const presence = agentPresence[ch.id];
+                          return presence ? <PresenceDot presence={presence} /> : null;
+                        })()}
+                      {count > 0 && (
                         <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
                           {count}
                         </span>
@@ -592,11 +592,11 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
 /* ------------------------------------------------------------------ */
 
 /**
- * Small status dot shown next to agent DM channel names in the sidebar.
- * - working: amber with a pulse animation (agent is actively generating).
- * - live:   emerald solid (agent is running and available).
- * - idle:   muted gray (agent is paused, stopped, or otherwise unavailable).
- */
+* Small status dot shown next to agent DM channel names in the sidebar.
+* - working: amber with a pulse animation (agent is actively generating).
+* - live:   emerald solid (agent is running and available).
+* - idle:   muted gray (agent is paused, stopped, or otherwise unavailable).
+*/
 function PresenceDot({ presence }: { presence: AgentPresence }) {
   const is = (presence === "live") ? (
     <span

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -346,6 +346,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
           onSelectChannel={onSelectChannel}
           unread={unread}
           scope={scope}
+          agentPresence={agentPresence}
         />
 
         {/* Archived channels — mobile */}
@@ -552,7 +553,11 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                           }}
                         />
                       )}
-                      {ch.name}
+                      <span className="truncate flex-1">{ch.name}</span>
+                      {(() => {
+                        const presence = agentPresence[ch.id];
+                        return presence ? <PresenceDot presence={presence} /> : null;
+                      })()}
                     </button>
                   ))}
                 </div>
@@ -723,6 +728,7 @@ function ProjectsSectionMobile({
   onSelectChannel,
   unread,
   scope,
+  agentPresence,
 }: {
   projectGroups: ProjectGroup[];
   projectsExpanded: boolean;
@@ -733,6 +739,7 @@ function ProjectsSectionMobile({
   onSelectChannel: (id: string) => void;
   unread: Record<string, number>;
   scope?: { projectId?: string };
+  agentPresence: Record<string, AgentPresence>;
 }) {
   if (scope?.projectId || projectGroups.length === 0) return null;
 
@@ -879,6 +886,10 @@ function ProjectsSectionMobile({
                       >
                         {ch.name}
                       </span>
+                      {(() => {
+                        const presence = agentPresence[ch.id];
+                        return presence ? <PresenceDot presence={presence} /> : null;
+                      })()}
                       {(unread[ch.id] ?? 0) > 0 && (
                         <span
                           style={{

--- a/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
+++ b/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
@@ -80,9 +80,9 @@ function buildProps(overrides: Partial<ChannelSidebarProps> = {}): ChannelSideba
     bus: { channels: [], available: false, loaded: false },
     busSelected: null,
     onSelectBusChannel: vi.fn(),
-    formatRelativeTime: (ts) => String(ts),
-    thinkingChannelIds: [],
-    ...overrides,
+     formatRelativeTime: (ts) => String(ts),
+     agentPresence: {},
+     ...overrides,
   };
 }
 
@@ -714,16 +714,16 @@ describe("ChannelSidebar — edge cases", () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  Live thinking badge                                                 */
+/*  Agent presence dots                                                 */
 /* ------------------------------------------------------------------ */
 
-describe("ChannelSidebar — thinking badge", () => {
-  it("shows a pulsing amber dot on a thinking channel (desktop)", () => {
+describe("ChannelSidebar — presence dots", () => {
+  it("shows a pulsing amber 'working' dot on a working agent channel (desktop)", () => {
     const ch = makeChannel({ id: "ch-1", name: "session-alice" });
-    const sections = [makeSection("Live", [ch])];
+    const sections = [makeSection("Agents-DMs", [ch])];
     const { container } = render(
       <ChannelSidebar
-        {...buildProps({ sections, thinkingChannelIds: ["ch-1"] })}
+        {...buildProps({ sections, agentPresence: { "ch-1": "working" } })}
       />,
     );
     const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
@@ -732,24 +732,53 @@ describe("ChannelSidebar — thinking badge", () => {
     expect(dot).toHaveClass("bg-amber-400");
   });
 
-  it("does not show thinking dot on non-thinking channels (desktop)", () => {
-    const ch = makeChannel({ id: "ch-1", name: "general" });
-    const sections = [makeSection("Topics", [ch])];
+  it("shows a solid green 'live' dot on a live agent channel (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-alice" });
+    const sections = [makeSection("Agents-DMs", [ch])];
     render(
       <ChannelSidebar
-        {...buildProps({ sections, thinkingChannelIds: [] })}
+        {...buildProps({ sections, agentPresence: { "ch-1": "live" } })}
       />,
     );
     const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
     expect(btn.querySelector(".taos-status-pulse")).toBeNull();
+    const dot = btn.querySelector('[aria-label="Agent is live"]');
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-emerald-400");
   });
 
-  it("shows thinking dot on mobile when channel is thinking", () => {
-    const ch = makeChannel({ id: "ch-1", name: "session-bob" });
-    const sections = [makeSection("Live", [ch])];
-    const { container } = render(
+  it("shows a muted gray 'idle' dot on an idle agent channel (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-alice" });
+    const sections = [makeSection("Agents-DMs", [ch])];
+    render(
       <ChannelSidebar
-        {...buildProps({ isMobile: true, sections, thinkingChannelIds: ["ch-1"] })}
+        {...buildProps({ sections, agentPresence: { "ch-1": "idle" } })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.querySelector(".taos-status-pulse")).toBeNull();
+    const dot = btn.querySelector('[aria-label="Agent is idle"]');
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-shell-text-tertiary");
+  });
+
+  it("does not show a presence dot when channel has no presence entry", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Topics", [ch])];
+    render(
+      <ChannelSidebar {...buildProps({ sections, agentPresence: {} })} />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.querySelector(".taos-status-pulse")).toBeNull();
+    expect(btn.querySelector('[aria-label^="Agent is"]')).toBeNull();
+  });
+
+  it("shows working dot on mobile", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-bob" });
+    const sections = [makeSection("Agents-DMs", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ isMobile: true, sections, agentPresence: { "ch-1": "working" } })}
       />,
     );
     const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
@@ -758,12 +787,12 @@ describe("ChannelSidebar — thinking badge", () => {
     expect(dot).toHaveClass("bg-amber-400");
   });
 
-  it("clears thinking dot when channel leaves thinkingChannelIds", () => {
+  it("clears presence dot when channel leaves the presence map", () => {
     const ch = makeChannel({ id: "ch-1", name: "session-carol" });
-    const sections = [makeSection("Live", [ch])];
+    const sections = [makeSection("Agents-DMs", [ch])];
     const { rerender } = render(
       <ChannelSidebar
-        {...buildProps({ sections, thinkingChannelIds: ["ch-1"] })}
+        {...buildProps({ sections, agentPresence: { "ch-1": "working" } })}
       />,
     );
     let btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
@@ -771,10 +800,80 @@ describe("ChannelSidebar — thinking badge", () => {
 
     rerender(
       <ChannelSidebar
-        {...buildProps({ sections, thinkingChannelIds: [] })}
+        {...buildProps({ sections, agentPresence: {} })}
       />,
     );
     btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
     expect(btn.querySelector(".taos-status-pulse")).toBeNull();
+  });
+
+  it("shows live dot on mobile when channel is live", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-dave" });
+    const sections = [makeSection("Agents-DMs", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ isMobile: true, sections, agentPresence: { "ch-1": "live" } })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    const dot = btn.querySelector('[aria-label="Agent is live"]');
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-emerald-400");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Active-channel accent rail                                          */
+/* ------------------------------------------------------------------ */
+
+describe("ChannelSidebar — accent rail", () => {
+  it("applies accent-left border to the selected channel (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Channels", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ sections, selectedChannel: "ch-1" })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.className).toContain("border-l-2");
+    expect(btn.className).toContain("border-accent-line");
+  });
+
+  it("does not apply accent-left border to unselected channel (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Channels", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ sections, selectedChannel: null })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.className).not.toContain("border-l-2");
+    expect(btn.className).not.toContain("border-accent-line");
+  });
+
+  it("applies accent-left border to the selected channel (mobile)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Channels", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ isMobile: true, sections, selectedChannel: "ch-1" })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.style.borderLeft).toContain("var(--color-accent-line)");
+  });
+
+  it("does not apply accent-left border to unselected channel (mobile)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Channels", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ isMobile: true, sections, selectedChannel: null })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.style.borderLeft).not.toContain("accent-line");
   });
 });

--- a/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
+++ b/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
@@ -572,6 +572,38 @@ describe("ChannelSidebar — projects", () => {
     expect(screen.getByText(/Projects/)).toBeInTheDocument();
   });
 
+  it("shows a working dot on a working bound project channel (desktop)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({
+          projectGroups: [projectGroup],
+          agentPresence: { "pc-1": "working" },
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Channel proj-general" });
+    const dot = btn.querySelector(".taos-status-pulse");
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-amber-400");
+  });
+
+  it("shows a working dot on a working bound project channel (mobile)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({
+          isMobile: true,
+          projectGroups: [projectGroup],
+          projectsExpanded: true,
+          agentPresence: { "pc-1": "working" },
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Channel proj-general" });
+    const dot = btn.querySelector(".taos-status-pulse");
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-amber-400");
+  });
+
   it("calls onToggleProjects on mobile Projects header click", () => {
     const onToggleProjects = vi.fn();
     render(

--- a/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
+++ b/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
@@ -877,3 +877,74 @@ describe("ChannelSidebar — accent rail", () => {
     expect(btn.style.borderLeft).not.toContain("accent-line");
   });
 });
+
+/* ------------------------------------------------------------------ */
+/*  Selected-channel accent rail                                       */
+/* ------------------------------------------------------------------ */
+
+describe("ChannelSidebar — selected accent rail", () => {
+  const projectGroup = {
+    id: "proj-1",
+    name: "My Project",
+    channels: [makeChannel({ id: "pc-1", name: "proj-general" })],
+  };
+
+  it("shows the accent rail on the selected project channel (desktop)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({ projectGroups: [projectGroup], selectedChannel: "pc-1" })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Channel proj-general" });
+    expect(btn).toHaveClass("border-l-2", "border-accent-line");
+  });
+
+  it("shows the accent rail on the selected project channel (mobile)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({
+          isMobile: true,
+          projectGroups: [projectGroup],
+          projectsExpanded: true,
+          projectChannelExpanded: { "proj-1": true },
+          selectedChannel: "pc-1",
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Channel proj-general" });
+    expect(btn.getAttribute("style")).toContain(
+      "border-left: 3px solid var(--color-accent-line)",
+    );
+  });
+
+  it("shows the accent rail on the selected archived channel (desktop)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({
+          archivedChannels: [makeChannel({ id: "arc-1", name: "old-chan" })],
+          archivedExpanded: true,
+          selectedChannel: "arc-1",
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Archived channel old-chan" });
+    expect(btn).toHaveClass("border-l-2", "border-accent-line");
+  });
+
+  it("shows the accent rail on the selected archived channel (mobile)", () => {
+    render(
+      <ChannelSidebar
+        {...buildProps({
+          isMobile: true,
+          archivedChannels: [makeChannel({ id: "arc-1", name: "old-chan" })],
+          archivedExpanded: true,
+          selectedChannel: "arc-1",
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Archived channel old-chan" });
+    expect(btn.getAttribute("style")).toContain(
+      "border-left: 3px solid var(--color-accent-line)",
+    );
+  });
+});

--- a/desktop/src/apps/chat/types.ts
+++ b/desktop/src/apps/chat/types.ts
@@ -45,4 +45,13 @@ export interface ProjectGroup {
   channels: Channel[];
 }
 
+/**
+ * Sidebar presence state for an agent DM channel, derived from the agent's
+ * registry status plus real-time "thinking" events.
+ * - "working" -- agent is actively generating (thinking / running a tool).
+ * - "live"    -- agent is registered as running and available.
+ * - "idle"    -- agent is paused, stopped, failed, or otherwise unavailable.
+ */
+export type AgentPresence = "live" | "working" | "idle";
+
 export type WsStatus = "connecting" | "connected" | "disconnected";


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOStalk S3: sidebar agent presence + grouping

Autonomous build of board card tsk-z4wn3x.

Replace thinkingChannelIds with agentPresence map (working/live/idle),
regroup sidebar into Channels/Agents-DMMs/Direct Messages, add accent
rail on active channel.

Files:
 changelog.d/tsk-z4wn3x-presence-grouping.md        |   1 +
 desktop/src/apps/MessagesApp.agentSections.test.ts |  31 ++++
 desktop/src/apps/MessagesApp.agentSections.ts      |  21 +++
 desktop/src/apps/MessagesApp.tsx                   |  61 +++---
 desktop/src/apps/chat/ChannelSidebar.tsx           | 205 ++++++++++++---------
 .../apps/chat/__tests__/ChannelSidebar.test.tsx    | 139 ++++++++++++--
 desktop/src/apps/chat/types.ts                     |   9 +
 7 files changed, 331 insertions(+), 136 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat sidebar channels are now grouped into Channels, Agents-DMs, and Direct Messages.
  * Agent direct messages show live, working, or idle presence indicators.
  * The selected channel is highlighted with an accent-colored rail on desktop and mobile.

* **Tests**
  * Added coverage for agent presence states, grouping behavior, and selected-channel styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->