### PR TITLE
Fenced controller must release GPU leases + cancel arbiter tasks (post-#1928, prove via REAL _monitor_loop)

### DIFF
--- a/changelog.d/tsk-krklez-fenced-lease-release.md
+++ b/changelog.d/tsk-krklez-fenced-lease-release.md
@@ -1,0 +1,2 @@
+### Fixed
+- A fenced (superseded) controller now releases GPU leases and cancels in-flight GPU arbiter tasks for its workers, matching the sibling termination branches. Previously it only marked workers offline and skipped the lease release and arbiter cancellation, stranding VRAM leases and allowing arbiter tasks to collide with the winning controller.

--- a/tests/test_cluster_persistence.py
+++ b/tests/test_cluster_persistence.py
@@ -697,6 +697,60 @@ class TestClusterManagerPersistence:
         await mgr.stop()
         await store.close()
 
+    async def test_fenced_controller_releases_leases_of_draining_worker(self, tmp_path):
+        """Fencing must release leases for EVERY non-local worker, including
+        one mid-drain: the fenced branch `continue`s past the normal
+        stale-drain cleanup, so anything it skips here leaks forever."""
+        store = await self._new_store(tmp_path)
+        mgr = ClusterManager(worker_registry_store=store)
+        await mgr.start()
+        assert mgr.generation >= 1
+
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+        mgr.get_worker("gpu-box").status = "draining"
+
+        lease_id = "l_gpu_box_drain_0"
+        mgr._leases[lease_id] = GpuLease(
+            lease_id=lease_id,
+            resource_id="gpu-box:gpu-cuda-0",
+            caller="test-caller",
+            expires_at=time.time() + 3600,
+            required_vram_mb=1024,
+        )
+
+        cancel_mock = AsyncMock()
+        cancel_mock.cancel_running_for_leases.return_value = (1, 0)
+        mgr._gpu_arbiter = cancel_mock
+
+        await store.increment_generation()
+        assert await store.current_generation() > mgr.generation
+
+        mgr._monitor_task.cancel()
+        try:
+            await mgr._monitor_task
+        except asyncio.CancelledError:
+            pass
+
+        task = asyncio.create_task(mgr._monitor_loop())
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Status stays draining (fencing only transitions online/
+        # update-available workers), but the lease must be gone and the
+        # arbiter cancel must have fired.
+        assert mgr.get_worker("gpu-box").status == "draining"
+        assert lease_id not in mgr._leases
+        cancel_mock.cancel_running_for_leases.assert_called_once_with({lease_id})
+
+        await mgr.stop()
+        await store.close()
+
 
 # ── TaskRouter circuit breaker tests (Fix 3) ───────────────────────────
 

--- a/tests/test_cluster_persistence.py
+++ b/tests/test_cluster_persistence.py
@@ -663,12 +663,22 @@ class TestClusterManagerPersistence:
             required_vram_mb=1024,
         )
 
-        cancel_mock = AsyncMock(return_value=(1, 0))
+        cancel_mock = AsyncMock()
+        cancel_mock.cancel_running_for_leases.return_value = (1, 0)
         mgr._gpu_arbiter = cancel_mock
 
         await store.increment_generation()
         durable_gen = await store.current_generation()
         assert durable_gen > mgr.generation
+
+        # start() already spawned a _monitor_loop task; cancel it so only
+        # the loop instance below runs, else both can enter the fenced
+        # branch and double-call the arbiter cancel.
+        mgr._monitor_task.cancel()
+        try:
+            await mgr._monitor_task
+        except asyncio.CancelledError:
+            pass
 
         task = asyncio.create_task(mgr._monitor_loop())
         try:

--- a/tests/test_cluster_persistence.py
+++ b/tests/test_cluster_persistence.py
@@ -15,7 +15,7 @@ import pytest
 from tinyagentos.cluster.failure_tracker import FailureTracker
 from tinyagentos.cluster.manager import ClusterManager, HEARTBEAT_TIMEOUT
 from tinyagentos.cluster.router import TaskRouter
-from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.cluster.worker_protocol import GpuLease, WorkerInfo
 from tinyagentos.cluster.worker_registry_store import WorkerRegistryStore
 
 
@@ -641,6 +641,52 @@ class TestClusterManagerPersistence:
 
         await mgr_a.stop()
         await store.close()
+
+    async def test_fenced_controller_releases_leases_and_cancels_arbiter(self, tmp_path):
+        """A fenced controller must release GPU leases and cancel in-flight
+        arbiter tasks for its workers, mirroring the sibling termination
+        branches. Driven by the REAL monitor loop (not a re-implemented check)."""
+        store = await self._new_store(tmp_path)
+        mgr = ClusterManager(worker_registry_store=store)
+        await mgr.start()
+        assert mgr.generation >= 1
+
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+        assert mgr.get_worker("gpu-box").status == "online"
+
+        lease_id = "l_gpu_box_0"
+        mgr._leases[lease_id] = GpuLease(
+            lease_id=lease_id,
+            resource_id="gpu-box:gpu-cuda-0",
+            caller="test-caller",
+            expires_at=time.time() + 3600,
+            required_vram_mb=1024,
+        )
+
+        cancel_mock = AsyncMock(return_value=(1, 0))
+        mgr._gpu_arbiter = cancel_mock
+
+        await store.increment_generation()
+        durable_gen = await store.current_generation()
+        assert durable_gen > mgr.generation
+
+        task = asyncio.create_task(mgr._monitor_loop())
+        try:
+            await asyncio.sleep(0.05)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert mgr.get_worker("gpu-box").status == "offline"
+        assert lease_id not in mgr._leases
+        cancel_mock.cancel_running_for_leases.assert_called_once_with({lease_id})
+
+        await mgr.stop()
+        await store.close()
+
 
 # ── TaskRouter circuit breaker tests (Fix 3) ───────────────────────────
 

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -1001,33 +1001,38 @@ class ClusterManager:
                 # Fenced controller — release all leases, cancel arbiter tasks,
                 # mark all workers offline and stop routing.
                 for worker in list(self._workers.values()):
-                    if worker.name != "local" and worker.status in ("online", "update-available"):
+                    if worker.name == "local":
+                        continue
+                    if worker.status in ("online", "update-available"):
                         worker.status = "offline"
                         logger.info("Worker '%s' marked offline (controller fenced)", worker.name)
-                        # Release any active leases for this worker's resources.
-                        # Match on the exact worker name (not a resource_id
-                        # prefix) so "gpu-node" and "gpu-node-2" don't collide.
-                        async with self._lease_lock:
-                            offline_lids = [
-                                lid for lid, lease in self._leases.items()
-                                if (parsed := self._parse_resource_id(lease.resource_id))
-                                and parsed[0] == worker.name
-                            ]
-                            for lid in offline_lids:
-                                self._leases.pop(lid, None)
-                                logger.debug("Lease %s released — worker %s fenced", lid, worker.name)
-                        # Cancel any running GPU arbiter tasks for the
-                        # released leases (taOS cross-cutting wiring).
-                        if offline_lids and self._gpu_arbiter is not None:
-                            try:
-                                cancelled, already_done = await self._gpu_arbiter.cancel_running_for_leases(set(offline_lids))
-                                logger.info(
-                                    "Controller fenced: arbiter cancelled %d tasks, %d already done",
-                                    cancelled, already_done)
-                            except Exception:
-                                logger.exception(
-                                    "gpu-arbiter: cancel for fenced controller of '%s' failed",
-                                    worker.name)
+                    # Release any active leases for this worker's resources —
+                    # for every non-local worker regardless of status: a
+                    # draining worker can still hold leases, and the fenced
+                    # branch skips the normal stale-drain cleanup below.
+                    # Match on the exact worker name (not a resource_id
+                    # prefix) so "gpu-node" and "gpu-node-2" don't collide.
+                    async with self._lease_lock:
+                        offline_lids = [
+                            lid for lid, lease in self._leases.items()
+                            if (parsed := self._parse_resource_id(lease.resource_id))
+                            and parsed[0] == worker.name
+                        ]
+                        for lid in offline_lids:
+                            self._leases.pop(lid, None)
+                            logger.debug("Lease %s released — worker %s fenced", lid, worker.name)
+                    # Cancel any running GPU arbiter tasks for the
+                    # released leases (taOS cross-cutting wiring).
+                    if offline_lids and self._gpu_arbiter is not None:
+                        try:
+                            cancelled, already_done = await self._gpu_arbiter.cancel_running_for_leases(set(offline_lids))
+                            logger.info(
+                                "Controller fenced: arbiter cancelled %d tasks, %d already done",
+                                cancelled, already_done)
+                        except Exception:
+                            logger.exception(
+                                "gpu-arbiter: cancel for fenced controller of '%s' failed",
+                                worker.name)
                 await asyncio.sleep(5)
                 continue
             now = time.time()

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -998,11 +998,36 @@ class ClusterManager:
                 except Exception:
                     logger.exception("Failed to check durable generation")
             if self._fenced:
-                # Fenced controller — mark all workers offline and stop routing.
+                # Fenced controller — release all leases, cancel arbiter tasks,
+                # mark all workers offline and stop routing.
                 for worker in list(self._workers.values()):
                     if worker.name != "local" and worker.status in ("online", "update-available"):
                         worker.status = "offline"
                         logger.info("Worker '%s' marked offline (controller fenced)", worker.name)
+                        # Release any active leases for this worker's resources.
+                        # Match on the exact worker name (not a resource_id
+                        # prefix) so "gpu-node" and "gpu-node-2" don't collide.
+                        async with self._lease_lock:
+                            offline_lids = [
+                                lid for lid, lease in self._leases.items()
+                                if (parsed := self._parse_resource_id(lease.resource_id))
+                                and parsed[0] == worker.name
+                            ]
+                            for lid in offline_lids:
+                                self._leases.pop(lid, None)
+                                logger.debug("Lease %s released — worker %s fenced", lid, worker.name)
+                        # Cancel any running GPU arbiter tasks for the
+                        # released leases (taOS cross-cutting wiring).
+                        if offline_lids and self._gpu_arbiter is not None:
+                            try:
+                                cancelled, already_done = await self._gpu_arbiter.cancel_running_for_leases(set(offline_lids))
+                                logger.info(
+                                    "Controller fenced: arbiter cancelled %d tasks, %d already done",
+                                    cancelled, already_done)
+                            except Exception:
+                                logger.exception(
+                                    "gpu-arbiter: cancel for fenced controller of '%s' failed",
+                                    worker.name)
                 await asyncio.sleep(5)
                 continue
             now = time.time()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fenced controller must release GPU leases + cancel arbiter tasks (post-#1928, prove via REAL _monitor_loop)

Autonomous build of board card tsk-krklez.

The fenced branch of _monitor_loop (introduced in #1928) marked workers
offline and continued, but never released VRAM leases under _lease_lock
or called cancel_running_for_leases on the GPU arbiter. A superseded
controller therefore stranded leases and in-flight arbiter tasks that
could collide with the winning controller.

Fix mirrors the exact release+cancel sequence from the sibling
termination branches (offline-timeout, drain-timeout, stuck-updating)
into the fenced branch.

Adds a real-loop test (test_fenced_controller_releases_leases_and_cancels_arbiter)
that drives _monitor_loop via asyncio.create_task and asserts both lease
release and arbiter cancellation. The test fails without the fix and
passes after.

Files:
 changelog.d/tsk-krklez-fenced-lease-release.md |  2 ++
 tests/test_cluster_persistence.py              | 48 +++++++++++++++++++++++++-
 tinyagentos/cluster/manager.py                 | 27 ++++++++++++++-
 3 files changed, 75 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fenced controllers now release GPU leases held by affected workers, including workers in the draining state.
  * In-flight GPU arbitration tasks are canceled to prevent stranded leases and task conflicts.
  * Worker routing is disabled cleanly when a newer durable controller generation is detected.

* **Tests**
  * Added regression coverage for online and draining workers during fencing.

* **Documentation**
  * Updated the changelog with the fencing behavior improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->