### PR TITLE
gpu_arbiter: no discover/bulk-cancel of QUEUED ops by resource_id (blocks fence handling in tsk-krklez)

### DIFF
--- a/changelog.d/tsk-5aiafr-queued-fence-cancel.md
+++ b/changelog.d/tsk-5aiafr-queued-fence-cancel.md
@@ -1,0 +1,2 @@
+### Added
+- `GpuArbiter.queue_snapshot()` now includes `resource_id` per entry, and a new `cancel_queued_for_resource(resource_id)` cancels every queued GPU op targeting a fenced resource through the same race-safe `_cancelled_ids` path as `cancel_op`. Fence handlers can now proactively cancel queued ops instead of waiting for `claim_lease` to reject them on admission (#tsk-5aiafr).

--- a/tests/test_gpu_arbiter_queue_ops.py
+++ b/tests/test_gpu_arbiter_queue_ops.py
@@ -110,3 +110,62 @@ async def test_cancel_running_op_delegates_to_evict():
     await asyncio.sleep(0.05)
     assert mgr.reserved_vram_mb == 0          # reservation released
     f.cancel()
+
+
+@pytest.mark.asyncio
+async def test_queue_snapshot_exposes_resource_id():
+    """queue_snapshot() must surface resource_id so fence handlers can discover
+    which queued ops target a fenced node without touching private state."""
+    arbiter = GpuArbiter(vram_reservation=_mgr(0))   # everything queues
+    t1 = _task(submitter="pull:x")
+    f = asyncio.ensure_future(arbiter.submit_gpu(
+        t1, required_vram_mb=1024, op="load", model="qwen",
+        backend_name="b1", resource_id="gpu-node-1:gpu-0"))
+    await asyncio.sleep(0.05)      # let it enqueue
+    snap = arbiter.queue_snapshot()
+    assert len(snap) == 1
+    assert snap[0]["resource_id"] == "gpu-node-1:gpu-0"
+    assert "resource_id" in snap[0]
+    f.cancel()
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_for_resource_cancels_matching():
+    """cancel_queued_for_resource cancels every queued op for a resource_id,
+    surfacing resource_id in the snapshot and removing entries from the
+    queue. Bulk + selective: only the targeted resource is cancelled."""
+    arbiter = GpuArbiter(vram_reservation=_mgr(0))   # everything queues
+    t_a1 = _task(submitter="a1")
+    t_a2 = _task(submitter="a2")
+    t_b = _task(submitter="b")
+    f_a1 = asyncio.ensure_future(arbiter.submit_gpu(
+        t_a1, required_vram_mb=1024, op="load", model="m1",
+        backend_name="b1", resource_id="gpu-node-1:gpu-0"))
+    f_a2 = asyncio.ensure_future(arbiter.submit_gpu(
+        t_a2, required_vram_mb=1024, op="load", model="m2",
+        backend_name="b1", resource_id="gpu-node-1:gpu-0"))
+    f_b = asyncio.ensure_future(arbiter.submit_gpu(
+        t_b, required_vram_mb=1024, op="load", model="m3",
+        backend_name="b1", resource_id="gpu-node-2:gpu-0"))
+    await asyncio.sleep(0.05)      # let all three enqueue
+    assert len(arbiter.queue_snapshot()) == 3
+
+    cancelled = await arbiter.cancel_queued_for_resource("gpu-node-1:gpu-0")
+    assert cancelled == 2                          # bulk: both gpu-node-1 ops
+
+    # Targeted ops must have their futures cancelled (arbiter cancel semantics
+    # identical to cancel_op).
+    with pytest.raises(asyncio.CancelledError):
+        await f_a1
+    with pytest.raises(asyncio.CancelledError):
+        await f_a2
+
+    # Entries removed from the queue; the non-matching op survives.
+    assert t_a1.id not in arbiter._queued_entries
+    assert t_a2.id not in arbiter._queued_entries
+    assert t_b.id in arbiter._queued_entries
+    snap = arbiter.queue_snapshot()
+    assert [e["task_id"] for e in snap] == [t_b.id]
+    assert snap[0]["resource_id"] == "gpu-node-2:gpu-0"
+
+    f_b.cancel()

--- a/tinyagentos/scheduler/gpu_arbiter.py
+++ b/tinyagentos/scheduler/gpu_arbiter.py
@@ -869,11 +869,45 @@ class GpuArbiter:
             return bool(await self._evict_task(task_id))
         return False
 
+    async def cancel_queued_for_resource(self, resource_id: str | None) -> int:
+        """Cancel every queued GPU task targeting *resource_id*.
+
+        Fence-handler companion to ``cancel_running_for_leases``: when a worker
+        is fenced the arbiter must proactively cancel queued ops destined for it
+        rather than let them sit until ``claim_lease`` rejects them on
+        admission (a delayed error rather than a proactive cancel).
+
+        Reuses ``cancel_op``'s race-safe ``_cancelled_ids`` path so the
+        cooperative re-checks in ``_drain_queue`` (at dequeue, post-admit, and
+        post-re-queue) stay consistent, with no second cancellation mechanism
+        invented. If a victim was promoted to ``_running`` during the await
+        window, ``cancel_op`` falls through to eviction of the running task.
+
+        Returns the number of queued entries cancelled.
+        """
+        if resource_id is None:
+            return 0
+        victims = [
+            e.task.id for e in self._queued_entries.values()
+            if e.resource_id == resource_id
+        ]
+        cancelled = 0
+        for task_id in victims:
+            if await self.cancel_op(task_id):
+                cancelled += 1
+        if cancelled:
+            logger.info(
+                "gpu-arbiter: cancelled %d queued op(s) for fenced "
+                "resource %s", cancelled, resource_id,
+            )
+        return cancelled
+
     def queue_snapshot(self) -> list[dict]:
         now = time.time()
         return [
             {"task_id": e.task.id, "capability": e.task.capability.value,
              "op": e.op, "model": e.model, "backend_name": e.backend_name,
+             "resource_id": e.resource_id,
              "submitter": e.task.submitter, "priority": e.priority,
              "vram_mb": e.required_vram_mb,
              "queued_seconds": now - e.queued_at,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): gpu_arbiter: no discover/bulk-cancel of QUEUED ops by resource_id (blocks fence handling in tsk-krklez)

Autonomous build of board card tsk-5aiafr.

Fence handlers (tsk-krklez) could cancel RUNNING tasks via
cancel_running_for_leases but had no way to discover or cancel QUEUED ops
targeting a fenced node. queue_snapshot() did not surface resource_id, so fence
handlers could not discover which queued task_ids target a fenced node without
reaching into private state; a queued op for a fenced node would just sit until
admission failed on claim_lease -- a delayed error, not a proactive cancel.

- queue_snapshot() now includes resource_id per entry.
- New cancel_queued_for_resource(resource_id) cancels every queued op for a
  resource via cancel_op's race-safe _cancelled_ids mechanism, so the
  cooperative re-checks in _drain_queue (dequeue, post-admit, post-re-queue)
  stay consistent -- no second cancellation path is introduced.

(#tsk-5aiafr)

Files:
 changelog.d/tsk-5aiafr-queued-fence-cancel.md |  2 +
 tests/test_gpu_arbiter_queue_ops.py           | 59 +++++++++++++++++++++++++++
 tinyagentos/scheduler/gpu_arbiter.py          | 34 +++++++++++++++
 3 files changed, 95 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into which resource each queued GPU operation targets.
  * Added the ability to cancel all queued GPU operations associated with a specific resource.
* **Bug Fixes**
  * Improved cancellation handling for queued operations, including operations affected by resource fencing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->