### PR TITLE
Viewer/media apps show full nested path as fileName (basename after decode)

### DIFF
--- a/changelog.d/tsk-dldkma-viewer-filename-basename.md
+++ b/changelog.d/tsk-dldkma-viewer-filename-basename.md
@@ -1,0 +1,2 @@
+### Fixed
+- Image Viewer and Media Player now display the basename of a routed file URL in their title bar: the final URL segment is decoded before the directory path is stripped, so a nested route like `nested/photo.png` no longer leaks into the displayed file name.

--- a/desktop/src/apps/ImageViewerApp.test.tsx
+++ b/desktop/src/apps/ImageViewerApp.test.tsx
@@ -50,6 +50,14 @@ describe("ImageViewerApp", () => {
     expect(screen.getByText(/open image/i)).toBeInTheDocument();
   });
 
+  it("shows the basename of a decoded routed url, not the full nested path", async () => {
+    const url = `http://localhost/api/files/${encodeURIComponent("nested/photo.png")}`;
+    render(<ImageViewerApp windowId="win-1" url={url} />);
+    await flush();
+    expect(screen.getByText("photo.png")).toBeInTheDocument();
+    expect(screen.queryByText("nested/photo.png")).not.toBeInTheDocument();
+  });
+
   it("loads a selected file, shows its name, and reveals the toolbar", () => {
     const { container } = render(<ImageViewerApp windowId="win-1" />);
     const input = container.querySelector(

--- a/desktop/src/apps/ImageViewerApp.tsx
+++ b/desktop/src/apps/ImageViewerApp.tsx
@@ -16,8 +16,8 @@ export function ImageViewerApp({ windowId: _windowId, url }: { windowId: string;
   useEffect(() => {
     if (!url) return;
     setImageUrl(url);
-    const path = url.split("/").pop() ?? "";
-    setFileName(decodeURIComponent(path));
+    const path = decodeURIComponent(url.split("/").pop() ?? "");
+    setFileName(path.split("/").pop() ?? "");
   }, [url]);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {

--- a/desktop/src/apps/MediaPlayerApp.test.tsx
+++ b/desktop/src/apps/MediaPlayerApp.test.tsx
@@ -74,6 +74,14 @@ describe("MediaPlayerApp", () => {
     );
   });
 
+  it("shows the basename of a decoded routed url, not the full nested path", async () => {
+    const url = `http://localhost/api/files/${encodeURIComponent("nested/intro.mp4")}`;
+    render(<MediaPlayerApp windowId="win-1" url={url} />);
+    await flush();
+    expect(screen.getByText("intro.mp4")).toBeInTheDocument();
+    expect(screen.queryByText("nested/intro.mp4")).not.toBeInTheDocument();
+  });
+
   it("loads a selected file, shows its name, and mounts the video element", () => {
     const { container } = render(<MediaPlayerApp windowId="win-1" />);
     fireEvent.change(getFileInput(container), {

--- a/desktop/src/apps/MediaPlayerApp.tsx
+++ b/desktop/src/apps/MediaPlayerApp.tsx
@@ -12,8 +12,8 @@ export function MediaPlayerApp({ windowId: _windowId, url }: { windowId: string;
   useEffect(() => {
     if (!url) return;
     setMediaUrl(url);
-    const path = url.split("/").pop() ?? "";
-    setFileName(decodeURIComponent(path));
+    const path = decodeURIComponent(url.split("/").pop() ?? "");
+    setFileName(path.split("/").pop() ?? "");
   }, [url]);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Viewer/media apps show full nested path as fileName (basename after decode)

Autonomous build of board card tsk-dldkma.

Decode the final URL segment before taking the basename so a nested
routed path like nested/photo.png renders as photo.png rather than the
full encoded path. Adds a red vitest case per app proving the nested
path leaked into the displayed name before the fix.

Files:
 changelog.d/tsk-dldkma-viewer-filename-basename.md | 2 ++
 desktop/src/apps/ImageViewerApp.test.tsx           | 8 ++++++++
 desktop/src/apps/ImageViewerApp.tsx                | 4 ++--
 desktop/src/apps/MediaPlayerApp.test.tsx           | 8 ++++++++
 desktop/src/apps/MediaPlayerApp.tsx                | 4 ++--
 5 files changed, 22 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image Viewer and Media Player title bars now show decoded filenames when opened from routed URLs.
  * Nested paths are excluded, so only the file’s basename is displayed.
  * Encoded characters in filenames are correctly decoded.

* **Tests**
  * Added regression coverage for encoded filenames and nested routed paths.

* **Documentation**
  * Updated the changelog to reflect these filename display improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->