### PR TITLE
cluster register route replies 200 registered when the manager rejected the worker (fenced or stale generation)

### DIFF
--- a/changelog.d/tsk-yl23ua-register-fenced-stale-generation.md
+++ b/changelog.d/tsk-yl23ua-register-fenced-stale-generation.md
@@ -1,0 +1,2 @@
+### Fixed
+- `POST /api/cluster/workers` now returns `409 Conflict` when the controller is fenced or the worker echoes a stale generation, instead of incorrectly replying `200 registered` while leaving the worker absent from the registry. This stops superseded controllers from misleading workers into heartbeating against a controller that has no record of them (#tsk-yl23ua).

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -930,6 +930,54 @@ async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_register_returns_409_when_controller_fenced(client, app):
+    """A fenced controller must refuse registration with 409, not claim success."""
+    import json as _json
+    key = await pair_worker(client, app, "fenced-worker", "http://10.0.0.1:9000")
+    app.state.cluster_manager._fenced = True
+    reg_body = _json.dumps({
+        "name": "fenced-worker",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["chat"],
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "fenced-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 409, resp.text
+    assert "fenced" in resp.json().get("error", "").lower()
+    workers = (await client.get("/api/cluster/workers")).json()
+    assert not any(w["name"] == "fenced-worker" for w in workers)
+    app.state.cluster_manager._fenced = False
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_register_returns_409_when_generation_mismatch(client, app):
+    """A worker echoing a stale generation must be refused with 409."""
+    import json as _json
+    key = await pair_worker(client, app, "stale-gen-worker", "http://10.0.0.2:9000")
+    app.state.cluster_manager._generation = 999
+    reg_body = _json.dumps({
+        "name": "stale-gen-worker",
+        "url": "http://10.0.0.2:9000",
+        "capabilities": ["chat"],
+        "generation": 1,
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "stale-gen-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 409, resp.text
+    assert "generation" in resp.json().get("error", "").lower()
+    workers = (await client.get("/api/cluster/workers")).json()
+    assert not any(w["name"] == "stale-gen-worker" for w in workers)
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
 async def test_update_all_workers_admin_gate_rejected(app, tmp_data_dir):
     """Unauthenticated callers are rejected with 401/403."""
     from httpx import ASGITransport, AsyncClient

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -91,8 +91,16 @@ class ClusterManager:
 
     async def register_worker(
         self, info: WorkerInfo, generation: int | None = None
-    ) -> None:
-        # Snapshot capabilities before adding worker
+    ) -> tuple[bool, str]:
+        """Register a worker, returning (ok, reason).
+
+        On success ``ok`` is True and ``reason`` is the empty string.
+        On refusal ``ok`` is False and ``reason`` is one of:
+
+        - ``"fenced"`` -- this controller instance has been superseded.
+        - ``"stale_generation"`` -- the worker echoed a generation that does
+          not match the controller's current generation.
+        """
         caps_before = set()
         if self._capabilities:
             caps_before = {k for k, v in self._capabilities.get_all_capabilities().items() if v["available"]}
@@ -103,7 +111,7 @@ class ClusterManager:
         # taOS #640: controller fence — if this instance has been superseded
         # by another controller, reject all registrations (CodeRabbit PR #1928).
         if self._fenced:
-            return
+            return (False, "fenced")
         # taOS #640: split-brain protection — reject registration from a
         # worker that echoes a different generation (another active controller).
         # Legacy workers that don't send generation get a pass (None).
@@ -112,7 +120,7 @@ class ClusterManager:
                 "Registration from '%s' rejected: generation %s != controller %s",
                 info.name, generation, self._generation,
             )
-            return
+            return (False, "stale_generation")
 
         prev_status = self._workers[info.name].status if info.name in self._workers else None
 
@@ -189,6 +197,7 @@ class ClusterManager:
         task = asyncio.create_task(_promote_bg())
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+        return (True, "")
 
     def kv_quant_union(self) -> list[str]:
         """Return the set-union of KV cache quant types across all online workers.

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -398,7 +398,9 @@ async def register_worker(request: Request, body: WorkerRegister):
         worker_lxc_image_version=body.worker_lxc_image_version,
         signing_key=signing_key,
     )
-    await cluster.register_worker(info, generation=body.generation)
+    ok, reason = await cluster.register_worker(info, generation=body.generation)
+    if not ok:
+        return JSONResponse({"error": reason}, status_code=409)
     await _record_worker_capability(request.app, body.name, body.host_lan_ip, body.hardware)
     if body.pending_storage_backup:
         await _surface_storage_backup(request.app, body.name, body.pending_storage_backup)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): cluster register route replies 200 registered when the manager rejected the worker (fenced or stale generation)

Autonomous build of board card tsk-yl23ua.

register_worker now returns (ok, reason) so the route can distinguish a
successful registration from the two refusal cases -- fenced controller
and stale generation echoed by the worker. The route maps each refusal to
409 Conflict with the reason in the error body, so the worker side sees
a non-2xx, logs Failed to register, returns False, and the run loop
retries instead of incorrectly setting _registered = True.

Tests cover both refusal paths through the real route, asserting the
status code and the worker's absence from the registry.

Docs-Reviewed: agent-coordination.md does not document worker registration response codes, so no doc change was needed.

Files:
 .../tsk-yl23ua-register-fenced-stale-generation.md |  2 +
 tests/test_routes_cluster.py                       | 48 ++++++++++++++++++++++
 tinyagentos/cluster/manager.py                     | 17 ++++++--
 tinyagentos/routes/cluster.py                      |  4 +-
 4 files changed, 66 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worker registration now returns `409 Conflict` when the controller is fenced or the worker reports a stale generation.
  * Rejected workers are no longer recorded as successfully registered.
  * Successful registrations continue to return the expected success response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->