### PR TITLE
NotificationsPanel shows Loading forever when the prefs fetch fails (error state unreachable)

### DIFF
--- a/changelog.d/tsk-eyeebv-notifications-panel-fix.md
+++ b/changelog.d/tsk-eyeebv-notifications-panel-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- NotificationsPanel now correctly shows error messages when the prefs fetch fails instead of displaying a permanent loading state. Added a `loaded` flag to track when the initial fetch has settled, distinguishing between genuine loading and error states.

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NotificationsPanel } from "./NotificationsPanel";
+
+function jsonResponse(obj: unknown) {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("NotificationsPanel", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shows an error when the prefs request fails (non-ok)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+    render(<NotificationsPanel />);
+    expect(await screen.findByText("Could not load notification preferences.")).toBeInTheDocument();
+  });
+
+  it("shows an error when the prefs request rejects", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    render(<NotificationsPanel />);
+    expect(await screen.findByText("Could not reach backend.")).toBeInTheDocument();
+  });
+
+  it("renders the toggle list on successful fetch", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse([
+        { event_type: "worker.join", muted: false },
+        { event_type: "backend.up", muted: true },
+      ]),
+    );
+    render(<NotificationsPanel />);
+    expect(await screen.findByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Worker joined")).toBeInTheDocument();
+    expect(screen.getByText("Backend up")).toBeInTheDocument();
+    expect(screen.queryByText("Could not reach backend.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Could not load notification preferences.")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state while genuinely pending", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      return new Promise(() => {}); // never resolves
+    });
+    render(<NotificationsPanel />);
+    expect(await screen.findByText("Loading...")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
@@ -25,6 +25,7 @@ export function NotificationsPanel() {
   const [prefs, setPrefs] = useState<NotifPref[] | null>(null);
   const [saving, setSaving] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     fetch("/api/notifications/prefs")
@@ -33,7 +34,8 @@ export function NotificationsPanel() {
         if (data && Array.isArray(data)) setPrefs(data);
         else setError("Could not load notification preferences.");
       })
-      .catch(() => setError("Could not reach backend."));
+      .catch(() => setError("Could not reach backend."))
+      .finally(() => setLoaded(true));
   }, []);
 
   const toggle = async (eventType: string, muted: boolean) => {
@@ -62,11 +64,29 @@ export function NotificationsPanel() {
     }
   };
 
-  if (!prefs) {
+  if (!loaded) {
     return (
       <section aria-label="Notification settings">
         <h2 className="text-lg font-semibold mb-5">Notifications</h2>
         <p className="text-sm text-shell-text-tertiary">Loading...</p>
+      </section>
+    );
+  }
+
+  if (!prefs) {
+    return (
+      <section aria-label="Notification settings">
+        <h2 className="text-lg font-semibold mb-2">Notifications</h2>
+        <p className="text-sm text-shell-text-tertiary mb-5">
+          Choose which notification types to receive. Disabled types are suppressed
+          everywhere -- no in-app notification, no web push.
+        </p>
+
+        {error && (
+          <p className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+            {error}
+          </p>
+        )}
       </section>
     );
   }


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): NotificationsPanel shows Loading forever when the prefs fetch fails (error state unreachable)

Autonomous build of board card tsk-eyeebv.



Files:
 changelog.d/tsk-eyeebv-notifications-panel-fix.md  |  3 ++
 .../apps/SettingsApp/NotificationsPanel.test.tsx   | 51 ++++++++++++++++++++++
 .../src/apps/SettingsApp/NotificationsPanel.tsx    | 24 +++++++++-
 3 files changed, 76 insertions(+), 2 deletions(-)