### PR TITLE
Core-dep guard asserts the stale-install cause in its own error text while omitting the versions that would discriminate it

### DIFF
--- a/changelog.d/tsk-us4dyr-harden-core-dep-guard.md
+++ b/changelog.d/tsk-us4dyr-harden-core-dep-guard.md
@@ -1,0 +1,2 @@
+### Fixed
+- The core-dep integrity guard diagnostic in tests/conftest.py now prints `name==version` for each reported module (instead of bare names), plus resolved `__file__` and whether `__spec__.submodule_search_locations` is set -- the two observations that discriminate a stale/partial install from a version-bump API removal. The error text states the observation and names both candidate causes rather than asserting a stale install as fact. Installed-package lines now include versions.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,8 +234,10 @@ def _patch_aiosqlite_daemon_threads():
 # to run (see tsk-2nvear).
 #
 # This guard catches the shape at session start with a single loud error and
-# prints __file__ / __path__ / the resolved package set so the cause is
-# observable, not inferred.
+# prints name==version, __file__ / __path__ / __spec__ /
+# submodule_search_locations / the resolved package set so the cause is
+# observable, not asserted. Both candidate causes (stale install vs. version
+# bump) are named; the version discriminates.
 #
 # Each entry maps a module name to the attributes that MUST be present on it
 # whenever the module is importable.  A module that is genuinely absent
@@ -280,12 +282,23 @@ def _check_core_deps(
     return problems
 
 
+def _module_version(mod_name: str) -> str:
+    """Return the installed distribution version for *mod_name*, or
+    ``"unknown"`` if no matching distribution is found."""
+    import importlib.metadata
+    try:
+        return importlib.metadata.version(mod_name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def _verify_core_deps() -> None:
     """Fail loudly at session start if a core dependency is
     importable-but-attribute-less.
 
-    Prints ``__file__``, ``__path__``, ``__spec__`` and the resolved package
-    set so the cause is observable, not inferred.
+    Prints ``name==version``, ``__file__``, ``__path__``, ``__spec__``,
+    and ``submodule_search_locations`` for each reported module so the
+    cause is observable, not asserted.
     """
     import importlib.metadata
 
@@ -295,25 +308,35 @@ def _verify_core_deps() -> None:
 
     lines = [
         "CORE DEP GUARD: importable-but-attribute-less dependencies detected.",
-        "A package directory is present on sys.path but its public API is",
-        "absent (stale namespace package or incomplete install). This would",
-        "surface as hundreds of opaque AttributeError failures in tests.",
+        "Observation: an importable module lacks an attribute its contract",
+        "requires. Candidate causes: a stale or partial install (empty",
+        "namespace package on sys.path) or a version bump that moved or",
+        "removed the API. The version and import path discriminate between",
+        "them; both are reported below so neither cause is assumed.",
         "",
         "Diagnosis:",
     ]
     for mod_name, missing_attrs, mod in problems:
-        lines.append(f"  module: {mod_name}")
+        version = _module_version(mod_name)
+        spec = getattr(mod, "__spec__", None)
+        search_locs = (
+            getattr(spec, "submodule_search_locations", None) if spec else None
+        )
+        lines.append(f"  module: {mod_name}=={version}")
         lines.append(f"    missing attributes: {', '.join(missing_attrs)}")
         lines.append(f"    __file__ = {getattr(mod, '__file__', None)!r}")
         lines.append(f"    __path__ = {getattr(mod, '__path__', None)!r}")
-        lines.append(f"    __spec__ = {getattr(mod, '__spec__', None)!r}")
+        lines.append(f"    __spec__ = {spec!r}")
+        lines.append(f"    submodule_search_locations = {search_locs!r}")
     dists = sorted(
-        (d.metadata["Name"] or "") for d in importlib.metadata.distributions()
+        (f"{(d.metadata['Name'] or 'unknown')}=={d.version}"
+         for d in importlib.metadata.distributions()),
+        key=lambda s: s.lower(),
     )
     lines.append("")
     lines.append("Installed packages:")
-    for name in dists:
-        lines.append(f"  {name}")
+    for dist in dists:
+        lines.append(f"  {dist}")
     raise RuntimeError("\n".join(lines))
 
 

--- a/tests/test_core_deps.py
+++ b/tests/test_core_deps.py
@@ -137,9 +137,32 @@ class TestCoreDepGuard:
                 assert "some_attribute" in msg
                 assert "__file__" in msg
                 assert "__path__" in msg
+                assert "submodule_search_locations" in msg
                 assert "Installed packages:" in msg
             finally:
                 _CORE_DEP_CONTRACTS.clear()
                 _CORE_DEP_CONTRACTS.update(original)
         finally:
             self._remove_stale_namespace(tmp_path, "another_stale_pkg")
+
+    def test_diagnostic_contains_version_for_reported_module(self):
+        """The diagnostic must print name==version for a module it reports
+        on.  A raise-only assertion cannot catch a missing version -- the
+        guard already raises today, which is why the output itself must be
+        tested."""
+        import importlib.metadata
+
+        original = dict(_CORE_DEP_CONTRACTS)
+        _CORE_DEP_CONTRACTS.clear()
+        _CORE_DEP_CONTRACTS.update({
+            "idna": ("_nonexistent_attr_for_test",),
+        })
+        try:
+            with pytest.raises(RuntimeError) as exc_info:
+                _verify_core_deps()
+            msg = str(exc_info.value)
+            expected_version = importlib.metadata.version("idna")
+            assert f"idna=={expected_version}" in msg
+        finally:
+            _CORE_DEP_CONTRACTS.clear()
+            _CORE_DEP_CONTRACTS.update(original)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Core-dep guard asserts the stale-install cause in its own error text while omitting the versions that would discriminate it

Autonomous build of board card tsk-us4dyr.

The _verify_core_deps guard in tests/conftest.py asserted a stale install
as fact in its error text while printing package names without versions --
the one datum that would discriminate a stale/partial install from a
version-bump API removal. This hardening:

- Prints name==version for each reported module and for the full installed
  package list
- Adds __spec__.submodule_search_locations (the PEP 420 namespace tell)
- Rewrites the error header to state the observation and name both
  candidate causes, rather than asserting a stale install
- Adds test_diagnostic_contains_version_for_reported_module which asserts
  the diagnostic contains name==version for a reported module, and
  extends the existing diagnostic test to check submodule_search_locations

Files:
 changelog.d/tsk-us4dyr-harden-core-dep-guard.md |  2 ++
 tests/conftest.py                               | 47 ++++++++++++++++++-------
 tests/test_core_deps.py                         | 23 ++++++++++++
 3 files changed, 60 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved core dependency error diagnostics with installed package versions, resolved paths, and submodule search-location details.
  - Clarified whether failures may result from stale or incomplete installations versus API changes after a version update.
- **Tests**
  - Added regression coverage to verify package versions appear in dependency validation errors.
- **Documentation**
  - Added a changelog entry describing the improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->