### PR TITLE
deleted-symbols-gate is keyed on path:symbol, so it cannot tell a deletion from a symbol that still resolves (12 false positives on #2490)

### DIFF
--- a/changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md
+++ b/changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md
@@ -1,0 +1,2 @@
+### Fixed
+- The deleted-symbols gate now resolves each signal symbol against the merge result before reporting it. Symbols that remain importable at their public path (for example, a module file deleted but shadowed by a same-named package, or a definition moved) are no longer falsely reported as deleted, while genuinely missing symbols and dropped re-exports still fire.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -38,12 +38,15 @@ from __future__ import annotations
 
 import argparse
 import ast
+import importlib.util
 import io
 import os
 import re
 import subprocess
 import sys
 import tarfile
+import tempfile
+import types
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -87,6 +90,13 @@ def _extract_symbols(source: str, file_path: str) -> dict[str, str]:
                 name = f"{prefix}{child.name}" if prefix else child.name
                 symbols[f"{file_path}:{name}"] = "class"
                 visit(child, f"{name}.")
+            elif isinstance(child, ast.ImportFrom):
+                if file_path.endswith("/__init__.py") and child.module:
+                    for alias in child.names:
+                        if alias.name == "*":
+                            continue
+                        public_name = alias.asname or alias.name
+                        symbols[f"{file_path}:{public_name}"] = "import"
             else:
                 visit(child, prefix)
 
@@ -111,6 +121,81 @@ def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]
             source = f.read().decode("utf-8", errors="ignore")
             symbols.update(_extract_symbols(source, member.name))
     return symbols
+
+
+def _file_path_to_module_path(file_path: str) -> str:
+    """Convert a file path like 'pkg/mod.py' or 'pkg/__init__.py' to a module path."""
+    if file_path.endswith("/__init__.py"):
+        file_path = file_path[: -len("/__init__.py")]
+    elif file_path.endswith(".py"):
+        file_path = file_path[: -len(".py")]
+    return file_path.replace("/", ".")
+
+
+def _extract_tree_to_dir(ref: str, dest: Path, repo_root: Path = REPO_ROOT) -> None:
+    """Extract a git tree to a directory."""
+    result = subprocess.run(
+        ["git", "archive", ref],
+        cwd=repo_root, capture_output=True, check=True,
+    )
+    with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+        tar.extractall(dest)
+
+
+def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
+    """Check if a symbol is still importable from the merge result.
+
+    Loads the module directly from the merge result tree using
+    importlib.util, bypassing sys.path and editable-install path hooks
+    that would otherwise route the import back to the working tree.
+    """
+    module_path = _file_path_to_module_path(file_path)
+
+    parts = module_path.split(".")
+    file_rel_path = "/".join(parts)
+    if file_path.endswith("/__init__.py"):
+        file_rel_path += "/__init__.py"
+    else:
+        file_rel_path += ".py"
+
+    abs_file = merge_result_dir / file_rel_path
+
+    # If the original module file was deleted but a same-named package
+    # directory exists in the merge result, the public import path resolves
+    # through the package's __init__.py.
+    if not abs_file.is_file():
+        package_init = merge_result_dir / file_rel_path.replace(".py", "/__init__.py")
+        if package_init.is_file():
+            abs_file = package_init
+        else:
+            return False
+
+    name_parts = name.split(".")
+    attr_name = name_parts[-1]
+
+    try:
+        parent_pkg_name = ".".join(parts[:-1])
+        if parent_pkg_name:
+            parent_pkg_path = str((merge_result_dir / parent_pkg_name.replace(".", "/")).resolve())
+            if parent_pkg_name not in sys.modules:
+                parent_pkg = types.ModuleType(parent_pkg_name)
+                parent_pkg.__path__ = [parent_pkg_path]
+                sys.modules[parent_pkg_name] = parent_pkg
+
+        sys.modules.pop(module_path, None)
+        spec = importlib.util.spec_from_file_location(module_path, str(abs_file))
+        if spec is None or spec.loader is None:
+            return False
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_path] = module
+        spec.loader.exec_module(module)
+
+        obj = module
+        for part in name_parts:
+            obj = getattr(obj, part)
+        return True
+    except Exception:
+        return False
 
 
 def _merge_tree(base_ref: str, pr_head_sha: str, repo_root: Path = REPO_ROOT) -> str | None:
@@ -218,15 +303,28 @@ def check_deleted_symbols(
     """
     base_symbols = _get_symbols_at_ref(base_ref, repo_root)
 
+    merge_result_dir: Path
     if pr_head_sha:
         merge_tree = _merge_tree(base_ref, pr_head_sha, repo_root)
         if merge_tree is None:
             return [], set(), True
         head_symbols = _get_symbols_at_ref(merge_tree, repo_root)
+        merge_result_dir = Path(tempfile.mkdtemp())
+        _extract_tree_to_dir(merge_tree, merge_result_dir, repo_root)
     else:
         head_symbols = _get_symbols_at_ref("HEAD", repo_root)
+        merge_result_dir = repo_root
 
     signal = find_signal_symbols(base_symbols, head_symbols)
+
+    # Resolve each signal symbol against the merge result. A symbol that is
+    # still importable at its public path is not a genuine deletion.
+    resolved_signal: dict[str, str] = {}
+    for symbol, kind in sorted(signal.items()):
+        file_path, name = symbol.rsplit(":", 1)
+        if _resolve_symbol(merge_result_dir, file_path, name):
+            continue
+        resolved_signal[symbol] = kind
 
     waived_set: set[str] = set()
     if waived:
@@ -235,7 +333,7 @@ def check_deleted_symbols(
 
     violations: list[Violation] = []
     waived_in_signal: set[str] = set()
-    for symbol, kind in sorted(signal.items()):
+    for symbol, kind in sorted(resolved_signal.items()):
         if symbol in waived_set:
             waived_in_signal.add(symbol)
             continue

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -442,6 +442,66 @@ class TestCheckDeletedSymbols:
         assert "function_c" in violations[0].symbol
         assert "tinyagentos/foo.py:function_b" in waived
 
+    def test_module_shadowed_by_package_is_silent(self, tmp_path: Path):
+        """A module file deleted but shadowed by a same-named package is
+        SILENT: the public import path still resolves through the package."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tinyagentos/containers/__init__.py",
+            "class ContainerInfo:\n    pass\n",
+            "init: add containers package",
+        )
+        _commit_file(
+            repo, "tinyagentos/containers.py",
+            "class ContainerInfo:\n    pass\n",
+            "init: add containers module (shadowed by package)",
+        )
+        base_tip = _get_head(repo)
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _delete_file(repo, "tinyagentos/containers.py")
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr-branch", "--no-edit")
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert violations == []
+        assert waived == set()
+
+    def test_reexport_dropped_from_init_fires(self, tmp_path: Path):
+        """A re-export dropped from __init__.py while the def survives FIREs:
+        the public name in the package namespace is gone."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    pass\n\ndef function_b():\n    pass\n",
+            "init: add function_a and function_b",
+        )
+        _commit_file(
+            repo, "tinyagentos/__init__.py",
+            "from .foo import function_b\n",
+            "init: re-export function_b",
+        )
+        base_tip = _get_head(repo)
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _commit_file(
+            repo, "tinyagentos/__init__.py",
+            "",
+            "refactor: drop re-export",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr-branch", "--no-edit")
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert len(violations) == 1
+        assert "function_b" in violations[0].symbol
+        assert "tinyagentos/__init__.py" in violations[0].symbol
+        assert violations[0].added_by != "unknown"
+
 
 # ---------------------------------------------------------------------------
 # --pr-head (merge-tree recomputation) path


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deleted-symbols-gate is keyed on path:symbol, so it cannot tell a deletion from a symbol that still resolves (12 false positives on #2490)

Autonomous build of board card tsk-tdwpwz.

tsk-tdwpwz: the gate compared path:symbol pairs between base and merge
result, so a module file deleted but shadowed by a same-named package
was scored identically to a genuinely missing symbol. #2490 produced
12 false positives when containers.py was removed while the
containers/ package remained.

Fix: before reporting a signal symbol, load its module directly from the
merge result tree via importlib.util and check whether the attribute is
still reachable. If the original module file was deleted but a same-named
package directory exists, the check falls back to the package __init__.py.
Genuinely missing symbols and dropped re-exports from __init__.py still
fire; symbols that still resolve are silenced.

Added _file_path_to_module_path, _extract_tree_to_dir, and _resolve_symbol.
_extract_symbols now also records ImportFrom re-exports in __init__.py so
that a dropped re-export is included in the signal set.

Files:
 changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md |   2 +
 scripts/check_deleted_symbols.py                  | 100 +++++++++++++++++++++-
 tests/test_check_deleted_symbols.py               |  60 +++++++++++++
 3 files changed, 161 insertions(+), 1 deletion(-)


---

_CI note: `Gate integrity` never ran on this PR. The workflow only registered once it reached the default branch (`master`, 2026-08-27T02:50Z), so every PR opened before then carries no gate context at all — which would leave it pending forever once the check becomes required. This body edit fires the `edited` trigger to create the missing context. No code change. Tracked by `tsk-diza64`._