### PR TITLE
doc-gate is CONTENT-BLIND: a doc emptied of its protected sections satisfies every rule forever

### DIFF
--- a/changelog.d/tsk-b5f5wy-doc-content-blind.md
+++ b/changelog.d/tsk-b5f5wy-doc-content-blind.md
@@ -1,0 +1,2 @@
+### Fixed
+- The doc-gate content-blindness defect: a per-doc list of required section headings is now asserted present in the working tree. A `docs/agent-coordination.md` emptied of its protected API-surface sections now fails the `invariants` check instead of passing the gate indefinitely.

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -39,6 +39,21 @@ referenced_paths_scan = [
 # name it without failing the gate forever.
 ignore_tokens = ["docs/STATUS.md"]
 
+[[invariants.required_sections]]
+doc = "docs/agent-coordination.md"
+headings = [
+    "Agent API surface (scoped registry JWT)",
+    "Device bearer self-service (second, narrower passthrough)",
+    "Share destinations (device bearer)",
+    "Requesting more scope for an existing identity (scope requests)",
+    "User resource sharing (share routes)",
+    "Project invite redeem route (link + PIN)",
+    "OS change-event stream (`GET /api/os/events`, session-only)",
+    "LoRA Studio routes (session-only, no agent scope)",
+    "What `GET /api/decisions/agent` returns (grant scoping)",
+    "Agent memory mode (deploy + `PATCH /api/agents/{slug}/memory`, session-only)",
+]
+
 [[rules]]
 name = "apps"
 when_changed = ["desktop/src/apps/*/**"]

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -170,6 +170,20 @@ def _validate_config(config: dict) -> None:
     for j, item in enumerate(ignore):
         if not isinstance(item, str):
             raise ValueError(f"invariants.ignore_tokens[{j}] must be a string")
+    required_sections = invariants.get("required_sections", [])
+    if not isinstance(required_sections, list):
+        raise ValueError("'invariants.required_sections' must be a list")
+    for i, entry in enumerate(required_sections):
+        if not isinstance(entry, dict):
+            raise ValueError(f"invariants.required_sections[{i}] must be a table")
+        if "doc" in entry and not isinstance(entry["doc"], str):
+            raise ValueError(f"invariants.required_sections[{i}].doc must be a string")
+        if "headings" in entry and not isinstance(entry["headings"], list):
+            raise ValueError(f"invariants.required_sections[{i}].headings must be a list")
+        elif "headings" in entry:
+            for j, item in enumerate(entry["headings"]):
+                if not isinstance(item, str):
+                    raise ValueError(f"invariants.required_sections[{i}].headings[{j}] must be a string")
 
 
 def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: dict) -> list[str]:
@@ -178,7 +192,7 @@ def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: di
     does not exist (e.g. a local-only, gitignored doc) is silently skipped
     rather than treated as a failure.
 
-    Scan entries may be globs (``docs/agent-manual/*.md``) — expanded against
+    Scan entries may be globs (``docs/agent-manual/*.md``) -- expanded against
     the working tree, so a newly added manual page or skill is scanned without
     a config edit. ``invariants.ignore_tokens`` lists tokens that are
     deliberate tombstones (docs that EXPLAIN a file was removed must be able
@@ -204,6 +218,37 @@ def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: di
                 continue
             if not (repo_root / token).exists():
                 failures.append(f"{rel} references '{token}' which does not exist in the repo")
+    return failures
+
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$")
+
+
+def check_required_sections(repo_root: Path, config: dict) -> list[str]:
+    """Layer A: every doc listed in ``invariants.required_sections`` must
+    contain each of its required headings in the working tree.
+
+    A scan-target file that itself does not exist (e.g. a local-only,
+    gitignored doc) is silently skipped rather than treated as a failure.
+    """
+    failures: list[str] = []
+    for entry in config.get("invariants", {}).get("required_sections", []):
+        doc_rel = entry.get("doc", "")
+        required_headings = entry.get("headings", [])
+        doc_path = repo_root / doc_rel
+        if not doc_path.is_file():
+            continue
+        text = doc_path.read_text(encoding="utf-8", errors="ignore")
+        found_headings: set[str] = set()
+        for line in text.splitlines():
+            m = _HEADING_RE.match(line)
+            if m:
+                found_headings.add(m.group(2).strip())
+        for heading in required_headings:
+            if heading not in found_headings:
+                failures.append(
+                    f"{doc_rel} is missing required section: '{heading}'"
+                )
     return failures
 
 
@@ -432,6 +477,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "invariants":
         files_to_scan = config.get("invariants", {}).get("referenced_paths_scan", [])
         failures = check_referenced_paths(REPO_ROOT, files_to_scan, config)
+        failures.extend(check_required_sections(REPO_ROOT, config))
         return _report(failures)
 
     if args.command == "print-trailer":

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -527,6 +528,106 @@ class TestBroadChangelogRequired:
         changed = [("M", "tinyagentos/README.md")]
         failures = dg.evaluate_rules(changed, [], BROAD_CHANGELOG_CONFIG)
         assert len(failures) == 1
+
+
+class TestRequiredSections:
+    """RED 1 and RED 2: content assertion for Layer A.
+
+    Before this check the gate was path-only: a doc emptied of its protected
+    sections satisfied every rule as long as the file was touched. These tests
+    pin the new content-aware behaviour.
+    """
+
+    def _cfg(self, headings):
+        return {
+            "invariants": {
+                "required_sections": [
+                    {
+                        "doc": "docs/agent-coordination.md",
+                        "headings": headings,
+                    }
+                ]
+            }
+        }
+
+    def test_all_required_sections_present_passes(self, tmp_path: Path):
+        """RED 2: with all required sections present, the gate is GREEN."""
+        doc = tmp_path / "docs" / "agent-coordination.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "# Working the repo\n\n"
+            "## Agent API surface (scoped registry JWT)\n\n"
+            "## Device bearer self-service (second, narrower passthrough)\n\n"
+            "## OS change-event stream (`GET /api/os/events`, session-only)\n"
+        )
+        failures = dg.check_required_sections(
+            tmp_path,
+            self._cfg([
+                "Agent API surface (scoped registry JWT)",
+                "Device bearer self-service (second, narrower passthrough)",
+                "OS change-event stream (`GET /api/os/events`, session-only)",
+            ]),
+        )
+        assert failures == []
+
+    def test_missing_required_section_fails(self, tmp_path: Path):
+        """RED 1: deleting a required section while the file is present and
+        touched causes the gate to FAIL."""
+        doc = tmp_path / "docs" / "agent-coordination.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "# Working the repo\n\n"
+            "## Device bearer self-service (second, narrower passthrough)\n\n"
+            "## OS change-event stream (`GET /api/os/events`, session-only)\n"
+        )
+        failures = dg.check_required_sections(
+            tmp_path,
+            self._cfg([
+                "Agent API surface (scoped registry JWT)",
+                "Device bearer self-service (second, narrower passthrough)",
+                "OS change-event stream (`GET /api/os/events`, session-only)",
+            ]),
+        )
+        assert len(failures) == 1
+        assert "Agent API surface (scoped registry JWT)" in failures[0]
+        assert "docs/agent-coordination.md" in failures[0]
+
+    def test_missing_scan_target_is_skipped(self, tmp_path: Path):
+        """A required doc that does not exist on disk is skipped, not failed."""
+        failures = dg.check_required_sections(
+            tmp_path,
+            self._cfg(["Agent API surface (scoped registry JWT)"]),
+        )
+        assert failures == []
+
+    def test_empty_required_sections_list_passes(self, tmp_path: Path):
+        """No required_sections configured -> clean."""
+        assert dg.check_required_sections(tmp_path, {"invariants": {}}) == []
+
+    def test_invariants_command_reports_required_section_failure(self, tmp_path):
+        """The invariants command function must report missing required sections."""
+        doc = tmp_path / "docs" / "agent-coordination.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "# Working the repo\n\n"
+            "## Device bearer self-service (second, narrower passthrough)\n"
+        )
+        cfg = {
+            "gate": {"trailer": "Docs-Reviewed:"},
+            "invariants": {
+                "required_sections": [
+                    {
+                        "doc": "docs/agent-coordination.md",
+                        "headings": [
+                            "Agent API surface (scoped registry JWT)",
+                        ],
+                    }
+                ]
+            }
+        }
+        failures = dg.check_required_sections(tmp_path, cfg)
+        assert len(failures) == 1
+        assert "Agent API surface (scoped registry JWT)" in failures[0]
 
 
 class TestTrailerLogged:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): doc-gate is CONTENT-BLIND: a doc emptied of its protected sections satisfies every rule forever

Autonomous build of board card tsk-b5f5wy.

docs/agent-coordination.md is no longer path-only: a per-doc list of
required section headings in docs/doc-gate.toml is now asserted present
in the working tree by check_required_sections(). A doc emptied of its
protected API-surface sections now fails the invariants check instead
of satisfying every rule indefinitely.

Fixes the content-blindness defect where #2383's 19-line stub passed the
gate for three days because doc_edited was true despite the content being
absent. Added 10 required headings for docs/agent-coordination.md covering
the agent-facing API-surface sections.

Acceptance:
- RED 1: deleting a required section from a present, touched doc fails
- RED 2: all sections present passes

Closes tsk-b5f5wy

Files:
 changelog.d/tsk-b5f5wy-doc-content-blind.md |   2 +
 docs/doc-gate.toml                          |  15 +++++
 scripts/check_doc_gate.py                   |  48 ++++++++++++-
 tests/test_doc_gate.py                      | 101 ++++++++++++++++++++++++++++
 4 files changed, 165 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation checks now detect when required API and behavior sections are missing from specified documents.
  * Invariant validation reports missing sections clearly while skipping documents that are not present.
* **Tests**
  * Added coverage for complete, incomplete, empty, and missing-document scenarios.
* **Documentation**
  * Added configuration requiring key sections in the agent coordination documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->