### PR TITLE
Agent-as-a-Model: forward multi-turn context, not just the last user message

### DIFF
--- a/changelog.d/tsk-qb3f23-forward-multiturn-history.md
+++ b/changelog.d/tsk-qb3f23-forward-multiturn-history.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Agent-as-a-Model multi-turn context**: `POST /v1/chat/completions` now forwards the full conversation history (not just the last user message) to the agent turn driver, so multi-turn conversations are no longer silently dropped on each request (qodo bug 2).

--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -247,6 +247,86 @@ async def test_chat_missing_model_is_openai_shaped_400(client):
     assert resp.json()["error"]["type"] == "invalid_request_error"
 
 
+@pytest.mark.asyncio
+async def test_chat_multi_turn_forwards_full_history(client, monkeypatch):
+    """Two-turn conversation where turn 2 references turn 1 content: the full
+    history must reach drive_turn so the agent-visible prompt contains turn 1
+    (regression for the bug that forwarded only the last user message)."""
+    import tinyagentos.routes.agent_model_api as api
+
+    class _FakeServer:
+        base_url = "http://127.0.0.1:4188"
+
+    async def _fake_ensure(app_state, agent_id):
+        return _FakeServer()
+
+    captured: list[str] = []
+
+    async def _fake_drive_turn(text, trace_id, sink, *, base_url, model_id,
+                               model_provider_id="litellm", server_password=None,
+                               adapter_factory=None, turn_timeout=300.0):
+        captured.append(text)
+        sink({"kind": "final", "content": f"reply about {text}"})
+
+    monkeypatch.setattr(api, "ensure_taos_opencode_server", _fake_ensure)
+    monkeypatch.setattr(api, "drive_turn", _fake_drive_turn)
+
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "agent-a",
+            "messages": [
+                {"role": "user", "content": "turn 1: remember the word banana"},
+                {"role": "assistant", "content": "I will remember banana."},
+                {"role": "user", "content": "what fruit did I just tell you?"},
+            ],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(captured) == 1
+    # Turn 1 content must be present in the agent-visible prompt.
+    assert "banana" in captured[0]
+    assert "what fruit did I just tell you?" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_chat_single_message_forwards_only_content(client, monkeypatch):
+    """Fresh-session path (no prior history): a single user message forwards
+    just the message text to drive_turn -- no context prefix, no history
+    wrapping -- preserving the single-turn behaviour."""
+    import tinyagentos.routes.agent_model_api as api
+
+    class _FakeServer:
+        base_url = "http://127.0.0.1:4188"
+
+    async def _fake_ensure(app_state, agent_id):
+        return _FakeServer()
+
+    captured: list[str] = []
+
+    async def _fake_drive_turn(text, trace_id, sink, *, base_url, model_id,
+                               model_provider_id="litellm", server_password=None,
+                               adapter_factory=None, turn_timeout=300.0):
+        captured.append(text)
+        sink({"kind": "final", "content": text})
+
+    monkeypatch.setattr(api, "ensure_taos_opencode_server", _fake_ensure)
+    monkeypatch.setattr(api, "drive_turn", _fake_drive_turn)
+
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"model": "agent-a", "messages": [{"role": "user", "content": "hello"}]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured == ["hello"]
+
+
 # ---------------------------------------------------------------------------
 # Middleware passthrough (tsk-hfs6zv): an EXTERNAL client (no session cookie)
 # must reach the /v1 handlers, whose consent-key check is the credential.

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -191,35 +191,58 @@ async def _run_agent_turn(app_state, agent_id: str, messages: list) -> str:
     The two runtime calls are referenced via module-level names so tests can
     monkeypatch them (no opencode binary required in CI).
     """
-    # The last user message is the prompt; system/earlier messages are context
-    # the agent harness already carries per-turn, so we pass the latest user text.
+    # Build the prompt text from the full OpenAI conversation, not just the
+    # last user message. The opencode session is fresh per drive_turn call
+    # (a new adapter + session is built each turn), so prior messages must be
+    # included in the prompt for the agent to see the same multi-turn history
+    # an OpenAI-compatible client sent. An earlier version forwarded only the
+    # last user message, silently dropping conversation context (qodo bug 2).
+    #
     # Validate content type before forwarding to drive_turn (Kilo finding: a
     # non-str / non-list content must not reach the adapter as a string).
+    prior_segments: list[str] = []
     user_text: str | None = None
-    for m in reversed(messages):
-        if isinstance(m, dict) and m.get("role") == "user":
-            content = m.get("content", "")
-            if isinstance(content, str):
-                user_text = content
-            elif isinstance(content, list):  # content parts -> flatten to text
-                parts = []
-                for p in content:
-                    if isinstance(p, dict):
-                        if isinstance(p.get("text"), str):
-                            parts.append(p["text"])
-                        elif isinstance(p.get("text"), list):
-                            parts.append(" ".join(str(x) for x in p["text"]))
-                    elif isinstance(p, str):
-                        parts.append(p)
-                user_text = " ".join(parts)
-            else:
-                # content is int/null/object — malformed request.
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        content = m.get("content", "")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):  # content parts -> flatten to text
+            parts = []
+            for p in content:
+                if isinstance(p, dict):
+                    if isinstance(p.get("text"), str):
+                        parts.append(p["text"])
+                    elif isinstance(p.get("text"), list):
+                        parts.append(" ".join(str(x) for x in p["text"]))
+                elif isinstance(p, str):
+                    parts.append(p)
+            text = " ".join(parts)
+        else:
+            if role == "user":
                 raise _BadRequest("message content must be a string or list of parts")
-            break
+            continue  # non-user messages with non-str content are skipped
+        if role == "user":
+            if user_text is not None:
+                # Earlier user messages become conversation context.
+                prior_segments.append(user_text)
+            user_text = text
+        elif role in ("system", "assistant"):
+            if text:
+                prior_segments.append(text)
+
     if not user_text:
         # Absent/empty user role is a client validation failure -> 400,
         # not a transport error (Kilo finding: was mapped to 502).
         raise _BadRequest("no user message found in request")
+
+    # Prepend prior conversation turns so the agent sees the full history.
+    # When no prior messages exist, the text is just the last user message
+    # (fresh-session path unchanged).
+    if prior_segments:
+        user_text = "\n\n".join(prior_segments) + "\n\n" + user_text
 
     server = await ensure_taos_opencode_server(app_state, agent_id)
     collected: dict = {"final": None}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent-as-a-Model: forward multi-turn context, not just the last user message

Autonomous build of board card tsk-qb3f23.

_run_agent_turn extracted only the last user message and passed it to
drive_turn. Since drive_turn builds a fresh opencode adapter and session
per call, prior messages (system, earlier user turns, assistant replies)
were silently dropped from the agent-visible prompt, giving the agent
amnesia on every multi-turn request from OpenAI-compatible clients.

Build the prompt text from the full OpenAI conversation instead,
prepending prior messages as context. The single-user-message path is
unchanged (no context prefix when history is absent). The misleading
comment claiming the harness already carries the context is replaced.

Tests: a two-turn conversation asserts prior content reaches drive_turn;
a single-message case asserts the text is forwarded unchanged.

Docs-Reviewed: docs/agent-coordination.md documents only the consent-key
surface and model scoping for /v1/chat/completions (plus the stale 501
stub note), not the internal prompt-building behaviour; this change
does not alter the documented API contract.

Files:
 .../tsk-qb3f23-forward-multiturn-history.md        |  3 +
 tests/test_routes_agent_model_api.py               | 80 ++++++++++++++++++++++
 tinyagentos/routes/agent_model_api.py              | 65 ++++++++++++------
 3 files changed, 127 insertions(+), 21 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Chat completions now preserve full conversation history for multi-turn interactions, including system, user, and assistant messages.
  * Single-message requests continue to work as before.

* **Bug Fixes**
  * Improved validation for malformed or empty user messages.
  * Invalid user content now returns a clear request error, while malformed non-user messages are safely skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->