### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 > **A heads-up on the catalogs:** with 100+ apps, 16 frameworks, and a large model catalog, plenty of install manifests have not been exercised on real hardware yet, so some apps, frameworks, and models will fail to install. If one does, [open an issue](https://github.com/jaylfc/taOS/issues) with the name and the error you saw and I will fix the manifest as soon as I can. These reports are genuinely useful, most manifest fixes ship same-day.
 
 <p align="center">
-<a href="https://www.star-history.com/?repos=jaylfc%2FtaOS&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#jaylfc/taOS&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&legend=top-left" />
-   <img alt="Star History Chart" width="600" src="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jaylfc/taOS&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jaylfc/taOS&type=date&legend=top-left" />
+   <img alt="Star History Chart" width="600" src="https://star-history.dera.page/svg?repos=jaylfc/taOS&type=date&legend=top-left" />
  </picture>
 </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken: the data source it pointed at stopped working, so the chart no longer renders for visitors. This switches the chart to a working replacement that needs no API token and serves the SVG directly. No other changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History chart links and image sources to use the current chart provider domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->