### PR TITLE
Fix-forward #2500 (agent-as-model context): emit history in order + a test that can fail

### DIFF
--- a/changelog.d/tsk-o43fol-fix-history-order.md
+++ b/changelog.d/tsk-o43fol-fix-history-order.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Agent-as-a-Model conversation history ordering**: `_run_agent_turn` in
+  `tinyagentos/routes/agent_model_api.py` emitted prior conversation segments
+  out of source order because user turns were deferred until the next user
+  message arrived, while system/assistant messages were appended immediately.
+  This inverted every user/assistant pair (`[u1, a1, u2]` became `a1, u1, u2`,
+  and the pattern compounded as history grew). The fix appends each message in
+  source order in a single pass and identifies the last user message separately
+  (via index) so it remains the final prompt without reordering the transcript
+  (#2500, fix-forward tsk-o43fol).

--- a/changelog.d/tsk-qb3f23-forward-multiturn-history.md
+++ b/changelog.d/tsk-qb3f23-forward-multiturn-history.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Agent-as-a-Model multi-turn context**: `POST /v1/chat/completions` now forwards the full conversation history (not just the last user message) to the agent turn driver, so multi-turn conversations are no longer silently dropped on each request (qodo bug 2).

--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -293,6 +293,55 @@ async def test_chat_multi_turn_forwards_full_history(client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_chat_multi_turn_forwards_history_in_source_order(client, monkeypatch):
+    """The full conversation history must reach drive_turn in SOURCE order,
+    not scrambled. The lead review found that _run_agent_turn deferred user
+    turns, so an assistant reply was emitted before the user message that
+    produced it ([u1, a1, u2] -> a1, u1, u2). This test asserts on POSITIONS
+    (not containment) so it is RED on the broken behaviour."""
+    import tinyagentos.routes.agent_model_api as api
+
+    class _FakeServer:
+        base_url = "http://127.0.0.1:4188"
+
+    async def _fake_ensure(app_state, agent_id):
+        return _FakeServer()
+
+    captured: list[str] = []
+
+    async def _fake_drive_turn(text, trace_id, sink, *, base_url, model_id,
+                               model_provider_id="litellm", server_password=None,
+                               adapter_factory=None, turn_timeout=300.0):
+        captured.append(text)
+        sink({"kind": "final", "content": "ok"})
+
+    monkeypatch.setattr(api, "ensure_taos_opencode_server", _fake_ensure)
+    monkeypatch.setattr(api, "drive_turn", _fake_drive_turn)
+
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "agent-a",
+            "messages": [
+                {"role": "user", "content": "turn 1: remember the word banana"},
+                {"role": "assistant", "content": "I will remember banana."},
+                {"role": "user", "content": "what fruit did I just tell you?"},
+            ],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(captured) == 1
+    prompt = captured[0]
+    # u1 ("...banana") must come before a1 ("I will remember banana.") which
+    # must come before u2 ("what fruit did I just tell you?").
+    assert prompt.index("banana") < prompt.index("I will remember banana")
+    assert prompt.index("I will remember banana") < prompt.index("what fruit did I just tell you?")
+
+
+@pytest.mark.asyncio
 async def test_chat_single_message_forwards_only_content(client, monkeypatch):
     """Fresh-session path (no prior history): a single user message forwards
     just the message text to drive_turn -- no context prefix, no history

--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -247,6 +247,86 @@ async def test_chat_missing_model_is_openai_shaped_400(client):
     assert resp.json()["error"]["type"] == "invalid_request_error"
 
 
+@pytest.mark.asyncio
+async def test_chat_multi_turn_forwards_full_history(client, monkeypatch):
+    """Two-turn conversation where turn 2 references turn 1 content: the full
+    history must reach drive_turn so the agent-visible prompt contains turn 1
+    (regression for the bug that forwarded only the last user message)."""
+    import tinyagentos.routes.agent_model_api as api
+
+    class _FakeServer:
+        base_url = "http://127.0.0.1:4188"
+
+    async def _fake_ensure(app_state, agent_id):
+        return _FakeServer()
+
+    captured: list[str] = []
+
+    async def _fake_drive_turn(text, trace_id, sink, *, base_url, model_id,
+                               model_provider_id="litellm", server_password=None,
+                               adapter_factory=None, turn_timeout=300.0):
+        captured.append(text)
+        sink({"kind": "final", "content": f"reply about {text}"})
+
+    monkeypatch.setattr(api, "ensure_taos_opencode_server", _fake_ensure)
+    monkeypatch.setattr(api, "drive_turn", _fake_drive_turn)
+
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "agent-a",
+            "messages": [
+                {"role": "user", "content": "turn 1: remember the word banana"},
+                {"role": "assistant", "content": "I will remember banana."},
+                {"role": "user", "content": "what fruit did I just tell you?"},
+            ],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(captured) == 1
+    # Turn 1 content must be present in the agent-visible prompt.
+    assert "banana" in captured[0]
+    assert "what fruit did I just tell you?" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_chat_single_message_forwards_only_content(client, monkeypatch):
+    """Fresh-session path (no prior history): a single user message forwards
+    just the message text to drive_turn -- no context prefix, no history
+    wrapping -- preserving the single-turn behaviour."""
+    import tinyagentos.routes.agent_model_api as api
+
+    class _FakeServer:
+        base_url = "http://127.0.0.1:4188"
+
+    async def _fake_ensure(app_state, agent_id):
+        return _FakeServer()
+
+    captured: list[str] = []
+
+    async def _fake_drive_turn(text, trace_id, sink, *, base_url, model_id,
+                               model_provider_id="litellm", server_password=None,
+                               adapter_factory=None, turn_timeout=300.0):
+        captured.append(text)
+        sink({"kind": "final", "content": text})
+
+    monkeypatch.setattr(api, "ensure_taos_opencode_server", _fake_ensure)
+    monkeypatch.setattr(api, "drive_turn", _fake_drive_turn)
+
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json={"model": "agent-a", "messages": [{"role": "user", "content": "hello"}]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured == ["hello"]
+
+
 # ---------------------------------------------------------------------------
 # Middleware passthrough (tsk-hfs6zv): an EXTERNAL client (no session cookie)
 # must reach the /v1 handlers, whose consent-key check is the credential.

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -191,17 +191,18 @@ async def _run_agent_turn(app_state, agent_id: str, messages: list) -> str:
     The two runtime calls are referenced via module-level names so tests can
     monkeypatch them (no opencode binary required in CI).
     """
-    # Build the prompt text from the full OpenAI conversation, not just the
-    # last user message. The opencode session is fresh per drive_turn call
-    # (a new adapter + session is built each turn), so prior messages must be
-    # included in the prompt for the agent to see the same multi-turn history
-    # an OpenAI-compatible client sent. An earlier version forwarded only the
-    # last user message, silently dropping conversation context (qodo bug 2).
-    #
     # Validate content type before forwarding to drive_turn (Kilo finding: a
     # non-str / non-list content must not reach the adapter as a string).
+    #
+    # Build the prompt text from the full OpenAI conversation in SOURCE order:
+    # one pass, appending each message as encountered. The last user message is
+    # identified separately (last_user_idx) so it remains the final prompt text
+    # while everything else forms the context prefix. This fixes the
+    # out-of-order emission in the prior version, which deferred user turns
+    # and emitted a1 before u1 in [u1, a1, u2].
     prior_segments: list[str] = []
     user_text: str | None = None
+    last_user_idx: int | None = None
     for m in messages:
         if not isinstance(m, dict):
             continue
@@ -224,25 +225,32 @@ async def _run_agent_turn(app_state, agent_id: str, messages: list) -> str:
             if role == "user":
                 raise _BadRequest("message content must be a string or list of parts")
             continue  # non-user messages with non-str content are skipped
+        # Append each message in source order; the last user message is removed
+        # from the context prefix below so it stays the final prompt.
         if role == "user":
-            if user_text is not None:
-                # Earlier user messages become conversation context.
-                prior_segments.append(user_text)
             user_text = text
+            prior_segments.append(text)
+            last_user_idx = len(prior_segments) - 1
         elif role in ("system", "assistant"):
             if text:
                 prior_segments.append(text)
+        # tool and other non-standard roles are scoped out for this slice
+        # (lead review item 4): they remain silently skipped.
 
     if not user_text:
         # Absent/empty user role is a client validation failure -> 400,
         # not a transport error (Kilo finding: was mapped to 502).
         raise _BadRequest("no user message found in request")
 
-    # Prepend prior conversation turns so the agent sees the full history.
-    # When no prior messages exist, the text is just the last user message
-    # (fresh-session path unchanged).
-    if prior_segments:
-        user_text = "\n\n".join(prior_segments) + "\n\n" + user_text
+    # Prepend prior conversation turns so the agent sees the full history in
+    # source order. The last user message is the final prompt; removing it
+    # from the prefix does not reorder the transcript. When no prior messages
+    # exist, the text is just the last user message (fresh-session path
+    # unchanged).
+    if prior_segments and last_user_idx is not None:
+        prior_segments.pop(last_user_idx)
+        if prior_segments:
+            user_text = "\n\n".join(prior_segments) + "\n\n" + user_text
 
     server = await ensure_taos_opencode_server(app_state, agent_id)
     collected: dict = {"final": None}

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -191,35 +191,58 @@ async def _run_agent_turn(app_state, agent_id: str, messages: list) -> str:
     The two runtime calls are referenced via module-level names so tests can
     monkeypatch them (no opencode binary required in CI).
     """
-    # The last user message is the prompt; system/earlier messages are context
-    # the agent harness already carries per-turn, so we pass the latest user text.
+    # Build the prompt text from the full OpenAI conversation, not just the
+    # last user message. The opencode session is fresh per drive_turn call
+    # (a new adapter + session is built each turn), so prior messages must be
+    # included in the prompt for the agent to see the same multi-turn history
+    # an OpenAI-compatible client sent. An earlier version forwarded only the
+    # last user message, silently dropping conversation context (qodo bug 2).
+    #
     # Validate content type before forwarding to drive_turn (Kilo finding: a
     # non-str / non-list content must not reach the adapter as a string).
+    prior_segments: list[str] = []
     user_text: str | None = None
-    for m in reversed(messages):
-        if isinstance(m, dict) and m.get("role") == "user":
-            content = m.get("content", "")
-            if isinstance(content, str):
-                user_text = content
-            elif isinstance(content, list):  # content parts -> flatten to text
-                parts = []
-                for p in content:
-                    if isinstance(p, dict):
-                        if isinstance(p.get("text"), str):
-                            parts.append(p["text"])
-                        elif isinstance(p.get("text"), list):
-                            parts.append(" ".join(str(x) for x in p["text"]))
-                    elif isinstance(p, str):
-                        parts.append(p)
-                user_text = " ".join(parts)
-            else:
-                # content is int/null/object — malformed request.
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        content = m.get("content", "")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):  # content parts -> flatten to text
+            parts = []
+            for p in content:
+                if isinstance(p, dict):
+                    if isinstance(p.get("text"), str):
+                        parts.append(p["text"])
+                    elif isinstance(p.get("text"), list):
+                        parts.append(" ".join(str(x) for x in p["text"]))
+                elif isinstance(p, str):
+                    parts.append(p)
+            text = " ".join(parts)
+        else:
+            if role == "user":
                 raise _BadRequest("message content must be a string or list of parts")
-            break
+            continue  # non-user messages with non-str content are skipped
+        if role == "user":
+            if user_text is not None:
+                # Earlier user messages become conversation context.
+                prior_segments.append(user_text)
+            user_text = text
+        elif role in ("system", "assistant"):
+            if text:
+                prior_segments.append(text)
+
     if not user_text:
         # Absent/empty user role is a client validation failure -> 400,
         # not a transport error (Kilo finding: was mapped to 502).
         raise _BadRequest("no user message found in request")
+
+    # Prepend prior conversation turns so the agent sees the full history.
+    # When no prior messages exist, the text is just the last user message
+    # (fresh-session path unchanged).
+    if prior_segments:
+        user_text = "\n\n".join(prior_segments) + "\n\n" + user_text
 
     server = await ensure_taos_opencode_server(app_state, agent_id)
     collected: dict = {"final": None}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward #2500 (agent-as-model context): emit history in order + a test that can fail

Autonomous build of board card tsk-o43fol.

REVISION: built on `exec/tsk-qb3f23` (cut at `f5dd0ff736927c8da96a29628f8541f5ea2e4b98`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

_run_agent_turn deferred user messages until the next user message arrived,
while system/assistant messages were appended immediately. This inverted
every user/assistant pair ([u1, a1, u2] became a1, u1, u2) and compounded
as history grew ([u1, a1, u2, a2, u3] became a1, u1, a2, u2, u3). The agent
saw its own reply before the question that produced it.

The fix appends each message in source order in a single pass and
identifies the last user message by index so it remains the final prompt
without reordering the transcript. tool and other non-standard roles remain
silently skipped (lead review item 4, scoped out for this slice).

PR #2500's own test asserted containment, not order, so it stayed green on
the bug. A new position-based test
(test_chat_multi_turn_forwards_history_in_source_order) asserts:
  prompt.index('banana') < prompt.index('I will remember banana')
  prompt.index('I will remember banana') < prompt.index('what fruit did I just tell you?')
This was confirmed RED on f5dd0ff73 (prompt was scrambled to
'I will remember banana.\n\nturn 1: remember the word banana\n\nwhat
fruit did I just tell you?') before the fix, and GREEN after. All 25 tests
in test_routes_agent_model_api.py pass.

Role labeling of segments (lead review item 3) is scoped out: segments
remain bare joined. This is a design question for a separate slice, not a
merge blocker for this fix-forward.

Docs-Reviewed: No doc change needed. The fix is internal prompt ordering
within _run_agent_turn in tinyagentos/routes/agent_model_api.py. It does
not alter the /v1/chat/completions API surface (same endpoints, request,
or response shape) documented in docs/agent-coordination.md.

_MERGE_BASE=7334ef9059ff6d34919584954b0e7a69bdcc13fe || _MERGE_BASE=f5dd0ff736927c8da96a29628f8541f5ea2e4b98
Files:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completions now preserve full multi-turn conversation history.
  * Messages are processed in their original order, preventing reversed user and assistant transcripts.
  * System and assistant context is retained when continuing a conversation.
  * Supports both text and multipart message content, with clearer validation for unsupported user content.

* **Tests**
  * Added coverage for multi-turn history forwarding, message ordering, and single-message requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->