### PR TITLE
bot-review-gate: CodeRabbit acknowledgement comments read as a real review (fake-green)

### DIFF
--- a/changelog.d/tsk-mk5lit-bot-review-gate.md
+++ b/changelog.d/tsk-mk5lit-bot-review-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- CodeRabbit auto-generated acknowledgement and summary scaffolding is now detected as non-review content, preventing fake-green gate outcomes when CodeRabbit only posts trigger acknowledgements and summaries without actual review body text

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -61,6 +61,18 @@ RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# CodeRabbit auto-generated scaffolding markers. These appear in bodies
+# of acknowledgement replies (when @coderabbitai full review is accepted)
+# and auto-summary comments. They are not review content and must not be
+# treated as real review items, mirroring the rate-limit stub guard.
+CODERABBIT_AUTO_GEN_RE = re.compile(
+    r"<!-- This is an auto-generated (?:reply|comment) (?:by|: )(?:CodeRabbit|coderabbit\.ai) -->|"
+    r"CodeRabbit review command invocation:|"
+    r"Actions performed / Full review triggered\.?|"
+    r"<!-- This is an auto-generated comment: summarize by coderabbit\.ai -->",
+    re.IGNORECASE,
+)
+
 EXIT_OK = 0
 EXIT_STUB = 1
 EXIT_ERROR = 2
@@ -143,6 +155,10 @@ def is_real_item(item: CRItem) -> bool:
     (the review state itself is the substantive signal). Comments and
     COMMENTED reviews are real only when they carry non-empty, non-stub
     body text.
+
+    CodeRabbit's auto-generated acknowledgement and summary scaffolding
+    is not review content; items whose bodies match the auto-generated
+    marker pattern are treated the same way as rate-limit stubs.
     """
     if is_rate_limit_stub(item.body):
         return False
@@ -150,6 +166,8 @@ def is_real_item(item: CRItem) -> bool:
         state = (item.review_state or "").upper()
         if state in ("APPROVED", "CHANGES_REQUESTED"):
             return True
+    if CODERABBIT_AUTO_GEN_RE.search(item.body or ""):
+        return False
     return bool(item.body and item.body.strip())
 
 
@@ -249,6 +267,17 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
     if any(is_rate_limit_stub(i.body) for i in items):
         return EXIT_STUB, (
             f"FAIL: only CodeRabbit output is a rate-limit stub (exit {EXIT_STUB})"
+        )
+
+    # If there are items but no real review threads and no rate-limit stub,
+    # check whether the output is CodeRabbit auto-generated scaffolding
+    # (acknowledgement + summary without a real review). This is the same
+    # fake-green condition: a trigger was accepted but only stub scaffolding
+    # came back, which the merge gate must catch.
+    if any(CODERABBIT_AUTO_GEN_RE.search(i.body or "") for i in items):
+        return EXIT_STUB, (
+            f"FAIL: only CodeRabbit auto-generated scaffolding exists "
+            f"(exit {EXIT_STUB})"
         )
 
     # CR output exists but no real review threads and no recognizable stub.

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -169,36 +169,77 @@ class TestClassify:
         assert exit_code == 1
         assert "FAIL" in message
 
-    def test_collect_coderabbit_items_with_coderabbitai_bot(self, check_mod) -> None:
-        """Test that collect_coderabbit_items correctly identifies
-        coderabbitai[bot] login from raw API-shaped JSON, with only
-        _api_get mocked (the narrow filter scope)."""
-        call_count = 0
+    def test_acknowledgement_only_fails(self, check_mod) -> None:
+        """Acknowledgement-only items (auto-generated scaffolding) must not
+        read as real review items -- this is the fake-green condition from
+        PR #2482."""
+        items = [
+            check_mod.CRItem(
+                id=1,
+                body="<!-- This is an auto-generated reply by CodeRabbit --> "
+                       "CodeRabbit review command invocation: abc123 "
+                       "Actions performed / Full review triggered.",
+                is_review=False,
+            ),
+            check_mod.CRItem(
+                id=2,
+                body="<!-- This is an auto-generated reply by CodeRabbit --> "
+                       "CodeRabbit review command invocation: def456 "
+                       "Actions performed / Full review triggered.",
+                is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
 
-        def _api_get_side_effect(url, token=None):
-            nonlocal call_count
-            call_count += 1
-            # Return API-shaped JSON with coderabbitai[bot] login
-            # for the first call only; subsequent calls return empty
-            # to avoid duplicate collection from three endpoints.
-            if call_count == 1:
-                return [
-                    {
-                        "id": 1,
-                        "user": {"login": "coderabbitai[bot]"},
-                        "body": "Some review comment",
-                        "state": "COMMENTED",
-                        "created_at": "2024-01-01T00:00:00Z",
-                    }
-                ]
-            return []
+    def test_summary_plus_acknowledgements_fails(self, check_mod) -> None:
+        """The #2482 set: one auto-summary + two acknowledgement replies
+        must fail (exit 1), not pass as absent."""
+        items = [
+            check_mod.CRItem(
+                id=1,
+                body="<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+                is_review=False,
+            ),
+            check_mod.CRItem(
+                id=2,
+                body="<!-- This is an auto-generated reply by CodeRabbit --> "
+                       "CodeRabbit review command invocation: abc123 "
+                       "Actions performed / Full review triggered.",
+                is_review=False,
+            ),
+            check_mod.CRItem(
+                id=3,
+                body="<!-- This is an auto-generated reply by CodeRabbit --> "
+                       "CodeRabbit review command invocation: def456 "
+                       "Actions performed / Full review triggered.",
+                is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
 
-        with patch.object(check_mod, "_api_get", side_effect=_api_get_side_effect):
-            items = check_mod.collect_coderabbit_items("jaylfc", "taOS", 2412)
-        assert len(items) == 1
-        assert items[0].id == 1
-        assert items[0].body == "Some review comment"
-        assert items[0].is_review is True
+    def test_mixed_genuine_review_and_acknowledgement_stays_green(self, check_mod) -> None:
+        """A genuine review plus acknowledgement items must still pass
+        (the real review is what counts, not the stub scaffolding)."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\n### Found a bug on line 42.", is_review=True,
+                review_state="COMMENTED",
+            ),
+            check_mod.CRItem(
+                id=2,
+                body="<!-- This is an auto-generated reply by CodeRabbit --> "
+                       "CodeRabbit review command invocation: abc123 "
+                       "Actions performed / Full review triggered.",
+                is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
 
     def test_message_echoes_exit_code(self, check_mod) -> None:
         items = [


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): bot-review-gate: CodeRabbit acknowledgement comments read as a real review (fake-green)

Autonomous build of board card tsk-mk5lit.

- items matching CODERABBIT_AUTO_GEN_RE treated same as rate-limit stubs (exit 1)
- genuine review plus acknowledgements still passes (real review counts)
- empty item list remains PASS (absent, not stubbed) for dependabot-class PRs

Files:
 changelog.d/tsk-mk5lit-bot-review-gate.md |   2 +
 scripts/check_bot_review.py               |  29 +++++++++
 tests/scripts/test_check_bot_review.py    | 101 +++++++++++++++++++++---------
 3 files changed, 102 insertions(+), 30 deletions(-)