### PR TITLE
App tiering S1 RESIDUE: launcher tier filtering + redirect map (fields landed inert in 3ec0ff3cb)

### DIFF
--- a/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
+++ b/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **App tiering S1 residue (#2143)**: `getLaunchableApps` now correctly excludes all
+  tier 3+ apps from the desktop launcher (launchpad, search, mobile home), not just
+  tier 4. Previously the filter was `a.tier !== 4`, which let tier 3 apps
+  (`providers`, `mcp`, `channels`) leak into the launcher. The filter is now
+  `(a.tier ?? 1) <= 2`, matching the S1 contract: tier 1 and 2 are shown, tier 3+
+  and `handler: true` apps are hidden. Apps without an explicit tier default to
+  tier 1 and remain launchable. Additionally, a `APP_REDIRECTS` map and
+  `resolveAppRedirect` helper were added to app-registry, and dock/launchpad
+  pin-restore now resolves saved pins through the map before dropping orphans
+  silently instead of throwing.
+
+### Added
+
+- `APP_REDIRECTS: Record<string, {appId: string; section?: string}>` export in
+  `desktop/src/registry/app-registry.ts` for mapping renamed app ids during
+  dock/launchpad pin-restore. Seeded empty; later slices add entries.

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -5,9 +5,12 @@ import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
+import { resolveAppRedirect } from "@/registry/app-registry";
+
 vi.mock("@/registry/app-registry", () => ({
   getApp: () => undefined,
   prefetchApp: () => {},
+  resolveAppRedirect: vi.fn((id: string) => id),
 }));
 
 vi.mock("@/lib/browser-windows-api", () => ({
@@ -38,6 +41,7 @@ beforeEach(() => {
   // which exercise restore-on-mount in isolation. The auth-gating tests
   // further down explicitly manipulate this.
   useAuthReadyStore.setState({ ready: true });
+  vi.mocked(resolveAppRedirect).mockImplementation((id: string) => id);
 });
 
 afterEach(() => {
@@ -86,6 +90,44 @@ describe("useSessionPersistence — dock settings restore (#1603)", () => {
       expect(useDockStore.getState().position).toBe("left");
     });
     expect(useDockStore.getState().pinned).toEqual(["messages", "files"]);
+  });
+
+  it("drops orphaned dock pins that resolve to nothing during restore", async () => {
+    vi.mocked(resolveAppRedirect).mockImplementation((id: string) =>
+      id === "ghost-app" ? undefined : id,
+    );
+    mockFetchWith({
+      "/api/desktop/dock": {
+        pinned: ["messages", "ghost-app", "files"],
+        iconSize: "medium",
+        position: "bottom",
+      },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useDockStore.getState().pinned).toEqual(["messages", "files"]);
+    });
+  });
+
+  it("restores redirected dock pins to their canonical id", async () => {
+    vi.mocked(resolveAppRedirect).mockImplementation((id: string) =>
+      id === "retired-id" ? "messages" : id,
+    );
+    mockFetchWith({
+      "/api/desktop/dock": {
+        pinned: ["retired-id", "files"],
+        iconSize: "medium",
+        position: "bottom",
+      },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useDockStore.getState().pinned).toEqual(["messages", "files"]);
+    });
   });
 
   it("ignores an invalid persisted icon size or position", async () => {

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -3,7 +3,7 @@ import { useProcessStore, type SnapPosition } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useWidgetStore, type Widget } from "@/stores/widget-store";
-import { getApp } from "@/registry/app-registry";
+import { getApp, resolveAppRedirect } from "@/registry/app-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { loadWindows as loadBrowserWindows, saveWindows as saveBrowserWindows } from "@/lib/browser-windows-api";
 import type { BrowserWindowState } from "@/apps/BrowserApp/types";
@@ -96,7 +96,12 @@ export function useSessionPersistence() {
       .then((r) => r.json())
       .then((data: { pinned?: string[]; iconSize?: string; position?: string }) => {
         if (data.pinned && Array.isArray(data.pinned)) {
-          useDockStore.getState().reorder(data.pinned);
+          // Follow APP_REDIRECTS for renamed pins, then drop orphans that
+          // resolve to nothing, silently and without throwing.
+          const resolved = data.pinned
+            .map((id: string) => resolveAppRedirect(id))
+            .filter((id: string | undefined): id is string => id !== undefined);
+          useDockStore.getState().reorder(resolved);
         }
         if (data.iconSize === "small" || data.iconSize === "medium" || data.iconSize === "large") {
           useDockStore.getState().setIconSize(data.iconSize);

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp } from "./app-registry";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp, addApp, removeApp, APP_REDIRECTS, resolveAppRedirect } from "./app-registry";
+import type { AppManifest } from "./app-registry";
 
 describe("resolveApp (deep-navigation token resolver)", () => {
   it("resolves an exact app id", () => {
@@ -103,5 +104,108 @@ describe("file handler tiering", () => {
       expect(app?.tier).toBe(4);
       expect(app?.handler).toBe(true);
     }
+  });
+});
+
+const S1_FIXTURE_IDS = ["s1-test-tier-3", "s1-test-handler", "s1-test-tier-5"];
+
+function makeFixture(overrides: Partial<AppManifest>): AppManifest {
+  return {
+    id: "fixture-default",
+    name: "Fixture App",
+    icon: "test-tube",
+    category: "platform",
+    component: (() => Promise.resolve({ default: (() => null) as never })) as never,
+    defaultSize: { w: 400, h: 300 },
+    minSize: { w: 300, h: 200 },
+    singleton: false,
+    pinned: false,
+    launchpadOrder: 99,
+    ...overrides,
+  };
+}
+
+describe("launcher tier filtering (S1 contract #2143)", () => {
+  beforeEach(() => {
+    addApp(makeFixture({ id: "s1-test-tier-3", tier: 3 }));
+    addApp(makeFixture({ id: "s1-test-handler", handler: true }));
+    addApp(makeFixture({ id: "s1-test-tier-5", tier: 5, optional: true }));
+  });
+
+  afterEach(() => {
+    for (const id of S1_FIXTURE_IDS) removeApp(id);
+  });
+
+  it("excludes tier 3 apps from the launcher", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids, "tier 3 apps must not appear in the launcher").not.toContain("s1-test-tier-3");
+  });
+
+  it("excludes handler apps from the launcher", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids, "handler apps must not appear in the launcher").not.toContain("s1-test-handler");
+  });
+
+  it("excludes tier 5 (Store-optional) apps even when marked installed", () => {
+    const ids = getLaunchableApps(new Set(["s1-test-tier-5"])).map((a) => a.id);
+    expect(ids).not.toContain("s1-test-tier-5");
+  });
+
+  it("includes tier 1 (default) and tier 2 apps", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).toContain("messages");
+    expect(ids).toContain("models");
+    expect(ids).toContain("cluster");
+  });
+
+  it("apps without an explicit tier default to tier 1 and remain launchable", () => {
+    const app = getApp("messages");
+    expect(app?.tier).toBeUndefined();
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).toContain("messages");
+  });
+
+  it("tier 2 entries carry their group", () => {
+    const launchable = getLaunchableApps(new Set());
+    const tier2 = launchable.find((a) => a.id === "models");
+    expect(tier2).toBeDefined();
+    expect(tier2?.tier).toBe(2);
+    expect(tier2?.group).toBe("System");
+  });
+
+  it("existing tier 3 registry apps are also excluded after the fix", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).not.toContain("providers");
+    expect(ids).not.toContain("mcp");
+    expect(ids).not.toContain("channels");
+  });
+});
+
+describe("APP_REDIRECTS and pin-restore resolution", () => {
+  beforeEach(() => {
+    APP_REDIRECTS["s1-retired-app"] = { appId: "messages" };
+    APP_REDIRECTS["s1-orphan-redirect"] = { appId: "s1-ghost-target" };
+  });
+
+  afterEach(() => {
+    delete APP_REDIRECTS["s1-retired-app"];
+    delete APP_REDIRECTS["s1-orphan-redirect"];
+  });
+
+  it("resolves a redirected pin to the target app id", () => {
+    expect(resolveAppRedirect("s1-retired-app")).toBe("messages");
+  });
+
+  it("keeps a pin for a registered app with no redirect entry", () => {
+    expect(resolveAppRedirect("messages")).toBe("messages");
+    expect(resolveAppRedirect("settings")).toBe("settings");
+  });
+
+  it("drops a pin whose redirect target is unknown without throwing", () => {
+    expect(resolveAppRedirect("s1-orphan-redirect")).toBeUndefined();
+  });
+
+  it("drops a pin that is neither a redirect nor a registered app", () => {
+    expect(resolveAppRedirect("s1-ghost-id")).toBeUndefined();
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -123,7 +123,31 @@ const APP_ALIASES: Record<string, string> = {
 };
 
 /**
- * Resolve a user- or agent-supplied app token to a registered manifest.
+ * Redirect map for dock/launchpad pin-restore (issue #2143).
+ * Maps a renamed or retired app id to its canonical replacement. When
+ * restoring saved pins, the launcher follows each id through this map before
+ * deciding it is orphaned: a pin whose id still matches a registered app is
+ * kept as-is; a pin whose id is in this map is rewritten to the target; a pin
+ * that matches neither is dropped silently.
+ *
+ * Seeded by app renames; later tiering slices add entries as apps move.
+ */
+export const APP_REDIRECTS: Record<string, { appId: string; section?: string }> = {};
+
+/**
+ * Resolve a pinned dock/launchpad id through APP_REDIRECTS.
+ *
+ * Returns the canonical id when the pin can be followed to a registered app
+ * (either directly or via a redirect entry). Returns undefined when the pin is
+ * orphaned, i.e. neither a known app nor a redirect target, so callers can
+ * drop it without throwing.
+ */
+export function resolveAppRedirect(pinnedId: string): string | undefined {
+  const resolved = APP_REDIRECTS[pinnedId]?.appId ?? pinnedId;
+  return getApp(resolved) ? resolved : undefined;
+}
+
+/**
  * Matches in order: exact id, alias, then case-insensitive name. Powers the
  * deep-navigation API (`?app=` and the `taos:open-app` event) so callers can
  * use friendly names ("activity", "Activity", "monitor") instead of ids.
@@ -161,7 +185,7 @@ export function getOptionalApps(): AppManifest[] {
  */
 export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
   return getAllApps().filter(
-    (a) => (!a.optional || installedOptional.has(a.id)) && a.tier !== 4 && a.handler !== true,
+    (a) => (!a.optional || installedOptional.has(a.id)) && (a.tier ?? 1) <= 2 && a.handler !== true,
   );
 }
 
@@ -254,4 +278,15 @@ export function syncUserspaceApps(manifests: AppManifest[]): void {
   for (const m of manifests) {
     if (!present.has(m.id)) apps.push(m);
   }
+}
+
+/** (test-only) Register an additional app manifest into the registry. */
+export function addApp(manifest: AppManifest): void {
+  if (!apps.find((a) => a.id === manifest.id)) apps.push(manifest);
+}
+
+/** (test-only) Remove a manifest from the registry by id. */
+export function removeApp(appId: string): void {
+  const i = apps.findIndex((a) => a.id === appId);
+  if (i >= 0) apps.splice(i, 1);
 }

--- a/desktop/src/stores/mobile-home-store.test.ts
+++ b/desktop/src/stores/mobile-home-store.test.ts
@@ -14,7 +14,7 @@ describe("mobile-home-store", () => {
     );
     // Optional apps (Reddit/YouTube/GitHub/X) ship uninstalled and are added
     // from the Store, so they are intentionally absent from the default grid.
-    const defaultIds = getAllApps().filter((a) => !a.optional && a.tier !== 4 && a.handler !== true).map((a) => a.id);
+    const defaultIds = getAllApps().filter((a) => !a.optional && (a.tier ?? 1) <= 2 && a.handler !== true).map((a) => a.id);
     for (const id of defaultIds) {
       expect(allIdsInPages.has(id), `missing app "${id}" in home grid`).toBe(true);
     }

--- a/desktop/src/stores/mobile-home-store.ts
+++ b/desktop/src/stores/mobile-home-store.ts
@@ -24,7 +24,7 @@ const DEFAULT_PAGES: HomePage[] = [
     // Optional apps (Reddit/YouTube/GitHub/X) are excluded from the default
     // home grid; they ship uninstalled and are added from the Store.
     items: getAllApps()
-      .filter((a) => !a.optional && a.tier !== 4 && a.handler !== true)
+      .filter((a) => !a.optional && (a.tier ?? 1) <= 2 && a.handler !== true)
       .map((a) => ({ type: "app", appId: a.id }) as AppItem),
   },
 ];


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): App tiering S1 RESIDUE: launcher tier filtering + redirect map (fields landed inert in 3ec0ff3cb)

Autonomous build of board card tsk-u2g6bt.

S1 commit 3ec0ff3cb landed the manifest fields (tier/group/handler) and ~10
tier annotations but never the two load-bearing halves: launcher tier filtering
and the redirect map. S4 (1707b6a7a) added partial filtering (a.tier !== 4),
which still let tier 3 apps leak into the launcher.

Changes:
- getLaunchableApps filter: a.tier !== 4 -> (a.tier ?? 1) <= 2
  Tier 1 and 2 now surface in the launcher; tier 3+ and handler:true are
  hidden. Apps without an explicit tier default to tier 1, so no previously
  visible app disappears unless explicitly tier 3+ or a handler.
- APP_REDIRECTS const + resolveAppRedirect() exported from app-registry.
  Dock/launchpad pin-restore resolves saved ids through the map before
  dropping orphans that resolve to nothing, silently and without throwing.
- mobile-home-store: same tier 3+ filter for consistency.
- addApp/removeApp test helpers for fixture registration.

RED proof (filter reverted to a.tier !== 4):
  npx vitest run src/registry/app-registry.test.ts
  Tests  3 failed | 23 passed (26)
  Failing: excludes tier 3 apps from the launcher
           excludes tier 5 (Store-optional) apps even when marked installed
           existing tier 3 registry apps are also excluded after the fix

GREEN proof (filter = (a.tier ?? 1) <= 2):
  npx vitest run src/registry/app-registry.test.ts
           src/hooks/__tests__/use-session-persistence.test.ts
           src/stores/mobile-home-store.test.ts
  Test Files  3 passed (3)
  Tests  39 passed (39)

ID diff (getLaunchableApps before -> after):
  Removed from launcher: providers, channels, mcp (tier 3)
  Added to launcher: none

Typecheck:
  npx tsc -b ; echo "exit $?"
  exit 0

Changelog: changelog.d/tsk-u2g6bt-launcher-tier-filtering.md

Files:
 changelog.d/tsk-u2g6bt-launcher-tier-filtering.md  |  18 ++++
 .../__tests__/use-session-persistence.test.ts      |  42 ++++++++
 desktop/src/hooks/use-session-persistence.ts       |   9 +-
 desktop/src/registry/app-registry.test.ts          | 108 ++++++++++++++++++++-
 desktop/src/registry/app-registry.ts               |  39 +++++++-
 desktop/src/stores/mobile-home-store.test.ts       |   2 +-
 desktop/src/stores/mobile-home-store.ts            |   2 +-
 7 files changed, 212 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Launcher, search, and mobile home views now show only supported tier 1 and 2 apps.
  - Handler and higher-tier apps are excluded from launchable app lists.
  - Saved dock and launchpad pins now follow renamed apps automatically.
  - Obsolete or unavailable pins are removed silently instead of causing restore errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->