### PR TITLE
download_file's proxy/trust_env invariant lives in a docstring sentence, not in the code

### DIFF
--- a/changelog.d/tsk-ay6za5-proxy-trust-env-derivation.md
+++ b/changelog.d/tsk-ay6za5-proxy-trust-env-derivation.md
@@ -1,0 +1,8 @@
+### Fixed
+- `download_file` in `tinyagentos/installers/download_installer.py` now pairs
+  `proxy` and `trust_env` structurally instead of relying on callers remembering
+  to pass `trust_env=False`: `trust_env` defaults to `None` and resolves to
+  `False` when an explicit `proxy` is given (so an ambient `HTTPS_PROXY` env
+  var cannot silently override the caller's explicit choice), while remaining
+  `True` for the no-proxy path used by `hf_multi_installer`. An explicit
+  `trust_env` always wins (#tsk-ay6za5).

--- a/tests/installers/test_download_installer.py
+++ b/tests/installers/test_download_installer.py
@@ -302,7 +302,7 @@ class TestDownloadFileSsrf:
         """Exceeding max redirects must raise ValueError."""
         dest = tmp_path / "out.bin"
         redirect = _FakeResponse(302, body=b"",
-                                  headers={"location": "https://safe.example/loop"})
+                                   headers={"location": "https://safe.example/loop"})
 
         mock_client, mock_send = _mock_async_client(redirect)
 
@@ -310,3 +310,71 @@ class TestDownloadFileSsrf:
             with patch("httpx.AsyncClient", return_value=mock_client):
                 with pytest.raises(ValueError, match="Too many redirects"):
                     await download_file("https://safe.example/model.bin", dest)
+
+
+# ── proxy / trust_env pairing ────────────────────────────────────────
+
+class TestDownloadFileProxyTrustEnv:
+    @pytest.mark.asyncio
+    async def test_proxy_implies_trust_env_false(self, tmp_path):
+        """An explicit proxy must imply trust_env=False, even though the caller
+        does not pass trust_env. This prevents an ambient HTTPS_PROXY env var
+        from silently overriding the caller's explicit proxy choice on the
+        download path that installs models and apps.
+        """
+        dest = tmp_path / "out.bin"
+        fake = _FakeResponse(200, body=b"ok", headers={"content-length": "2"})
+        mock_client, _mock_send = _mock_async_client(fake)
+
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            with patch("httpx.AsyncClient", return_value=mock_client) as patched_client:
+                await download_file(
+                    "https://example.com/model.bin",
+                    dest,
+                    proxy="socks5://geo.example:1080",
+                )
+
+        kwargs = patched_client.call_args.kwargs
+        assert kwargs["proxy"] == "socks5://geo.example:1080"
+        assert kwargs["trust_env"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_proxy_resolves_trust_env_true(self, tmp_path):
+        """Control: with no proxy (proxy=None), trust_env must resolve to True
+        so ambient env vars (proxies, certs) still apply for the no-proxy path
+        used by callers such as hf_multi_installer.
+        """
+        dest = tmp_path / "out.bin"
+        fake = _FakeResponse(200, body=b"ok", headers={"content-length": "2"})
+        mock_client, _mock_send = _mock_async_client(fake)
+
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            with patch("httpx.AsyncClient", return_value=mock_client) as patched_client:
+                await download_file(
+                    "https://example.com/model.bin",
+                    dest,
+                )
+
+        kwargs = patched_client.call_args.kwargs
+        assert kwargs["proxy"] is None
+        assert kwargs["trust_env"] is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_trust_env_wins_over_proxy(self, tmp_path):
+        """A caller that genuinely wants ambient env together with a proxy must
+        be able to pass trust_env=True explicitly and have it honored."""
+        dest = tmp_path / "out.bin"
+        fake = _FakeResponse(200, body=b"ok", headers={"content-length": "2"})
+        mock_client, _mock_send = _mock_async_client(fake)
+
+        with patch("socket.getaddrinfo", return_value=_gai("93.184.216.34")):
+            with patch("httpx.AsyncClient", return_value=mock_client) as patched_client:
+                await download_file(
+                    "https://example.com/model.bin",
+                    dest,
+                    proxy="socks5://geo.example:1080",
+                    trust_env=True,
+                )
+
+        kwargs = patched_client.call_args.kwargs
+        assert kwargs["trust_env"] is True

--- a/tinyagentos/installers/download_installer.py
+++ b/tinyagentos/installers/download_installer.py
@@ -64,7 +64,7 @@ async def download_file(
     *,
     on_progress: ProgressCallback | None = None,
     proxy: str | None = None,
-    trust_env: bool = True,
+    trust_env: bool | None = None,
 ) -> Path:
     """Download a file with optional SHA256 verification.
 
@@ -80,12 +80,22 @@ async def download_file(
     ``proxy`` routes this download through an explicit HTTP/SOCKS proxy
     (LoRA Studio's Civitai ingest uses this for its geo-blocked fetches).
     Every other caller leaves it ``None`` and egress is unaffected.
-    ``trust_env`` defaults to True (httpx's own default, preserving existing
-    behaviour); callers that pass an explicit ``proxy`` should pass
-    ``trust_env=False`` so an unrelated HTTPS_PROXY env var cannot silently
-    override the caller's explicit choice.
+
+    ``trust_env`` is derived from the proxy/trust_env pairing: when neither is
+    given it resolves to ``True`` (httpx's own default, preserving existing
+    behaviour so ambient env vars such as HTTPS_PROXY still apply for callers
+    that pass no proxy). When an explicit ``proxy`` is given without an explicit
+    ``trust_env``, ``trust_env`` resolves to ``False`` so an unrelated HTTPS_PROXY
+    env var cannot silently override the caller's explicit choice. An explicit
+    ``trust_env`` always wins, letting a caller that genuinely wants ambient env
+    with a proxy opt in by passing ``trust_env=True`` together with ``proxy``.
     """
     from urllib.parse import urljoin, urlparse
+
+    # Pair proxy/trust_env structurally rather than by convention: an explicit
+    # proxy implies trust_env=False unless the caller overrides trust_env.
+    if trust_env is None:
+        trust_env = proxy is None
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     import time as _time


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): download_file's proxy/trust_env invariant lives in a docstring sentence, not in the code

Autonomous build of board card tsk-ay6za5.

Previously the proxy/trust_env invariant lived only in a docstring
sentence: callers passing an explicit proxy were instructed to also pass
trust_env=False, but nothing enforced it. The next caller that forgot
would silently route the install/app download path through an ambient
HTTPS_PROXY, succeeding visibly but through a proxy nobody chose.

Change the default to `trust_env: bool | None = None` and resolve it as
`trust_env if trust_env is not None else (proxy is None)`. An explicit
proxy now implies trust_env=False by construction; an explicit trust_env
always wins; and the no-proxy path (hf_multi_installer) still resolves
True -- i.e. unchanged httpx default behaviour. Docstring updated to
describe the derivation instead of instructing callers to remember it.

Tests (tests/installers/test_download_installer.py):
- test_proxy_implies_trust_env_false: asserts the AsyncClient is built
  with trust_env=False when an explicit proxy is given WITHOUT the call
  site passing trust_env. Granularity: it observes the trust_env kwarg
  handed to httpx.AsyncClient, not the download outcome, so it cannot
  pass when the defect is present.
- test_no_proxy_resolves_trust_env_true: control -- proxy=None still
  resolves trust_env=True, distinguishing this change from flipping the
  default to False for everyone (which would break hf_multi_installer).
- test_explicit_trust_env_wins_over_proxy: an explicit trust_env=True
  with a proxy is honored.

Red proof: reverting only the derivation (trust_env: bool = True) makes
test_proxy_implies_trust_env_false fail for the right reason:

    >       assert kwargs["trust_env"] is False
    E       assert True is False
    tests/installers/test_download_installer.py::TestDownloadFileProxyTrustEnv::test_proxy_implies_trust_env_false
    =============== 1 failed, 2 passed ===============

The control test_no_proxy_resolves_trust_env_true stays GREEN in the
same run. With the fix restored, all 24 tests in the file pass, and the
call-site suites (hf_multi_installer, lora_studio) pass (78 passed).

changelog.d/tsk-ay6za5-proxy-trust-env-derivation.md added per the doc
gate.

Docs-Reviewed: no routes/ file changes; only installers/download_installer.py,
its tests, and a changelog fragment were modified.

Files:
 .../tsk-ay6za5-proxy-trust-env-derivation.md       |  8 +++
 tests/installers/test_download_installer.py        | 70 +++++++++++++++++++++-
 tinyagentos/installers/download_installer.py       | 20 +++++--
 3 files changed, 92 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved download behavior when using proxies: environment-based proxy settings are disabled by default for explicit proxies and remain enabled when no proxy is specified.
  - Explicit environment-setting preferences continue to take precedence.

- **Documentation**
  - Added documentation describing proxy and environment-setting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->