### PR TITLE
bot-review-gate: CodeRabbit acknowledgement comments read as a real review (fake-green)

### DIFF
--- a/changelog.d/tsk-mk5lit-coderabbit-ack-gate.md
+++ b/changelog.d/tsk-mk5lit-coderabbit-ack-gate.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Bot-review gate fake-green on CodeRabbit acknowledgements**: `scripts/check_bot_review.py` treated CodeRabbit's auto-generated acknowledgement replies (posted when a `@coderabbitai full review` trigger is accepted but no review follows) and the auto-summary comment as real review items, reporting `PASS` on PRs CodeRabbit never reviewed (e.g. #2482 exited 0 on three stub items, zero real reviews). `is_real_item()` now rejects these via the HTML comment markers (`<!-- This is an auto-generated reply by CodeRabbit -->` and `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`), and `classify()` routes acknowledgement/summary-only output to `FAIL` (exit 1). A genuine review alongside acknowledgements still passes (tsk-mk5lit).

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -17,8 +17,12 @@ Three exit cases, all printed with the exit code so they can be read off
 the evidence at the granularity of the audit:
 
     0  PASS  -- a real CodeRabbit review exists, OR CodeRabbit is entirely
-                 absent (dependabot-class PRs; absence is not fake-green).
-    1  FAIL  -- the only CodeRabbit output on the PR is a rate-limit stub.
+               absent (dependabot-class PRs; absence is not fake-green).
+    1  FAIL  -- the only CodeRabbit output on the PR is a stub: a rate-limit
+               stub, or CodeRabbit's own auto-generated scaffolding (the
+               acknowledgement reply posted when a review trigger is accepted
+               but produces no review, or the auto-summary comment). Neither
+               is review content.
     2  ERROR -- infrastructure failure (network, auth, 404, etc.).
 
 Usage:
@@ -58,6 +62,18 @@ RATE_LIMIT_RE = re.compile(
     r"rate\s*limit(?:ed| reached| exhausted| hit| paused)|"
     r"plan\s*quota\s*(?:reached|exhausted)|"
     r"review\s*quota\s*(?:reached|exhausted)",
+    re.IGNORECASE,
+)
+
+# HTML comment markers that CodeRabbit injects into its own auto-generated
+# scaffolding rather than review content: the acknowledgement reply posted
+# when a `@coderabbitai full review` (or similar) trigger is accepted but
+# produces no actual review, and the auto-summary comment posted on
+# merge/close. Both carry no findings and must never read as a review.
+CODERABBIT_SCAFFOLDING_RE = re.compile(
+    r"<!-- This is an auto-generated "
+    r"(?:reply by CodeRabbit|"
+    r"comment: summarize by coderabbit\.ai) -->",
     re.IGNORECASE,
 )
 
@@ -135,16 +151,35 @@ def is_rate_limit_stub(body: str | None) -> bool:
     return bool(RATE_LIMIT_RE.search(body))
 
 
+def is_coderabbit_scaffolding(body: str | None) -> bool:
+    """Return True if a body is CodeRabbit's own auto-generated scaffolding
+    rather than review content.
+
+    Matches the HTML comment markers CodeRabbit appends to (a) the
+    acknowledgement reply posted when a review trigger is accepted but no
+    review follows, and (b) the auto-summary comment posted on merge/close.
+    Neither carries findings; both are machine-identifiable stubs that must
+    not read as a real review, exactly as a rate-limit stub does.
+    """
+    if not body:
+        return False
+    return bool(CODERABBIT_SCAFFOLDING_RE.search(body))
+
+
 def is_real_item(item: CRItem) -> bool:
     """Return True if a CR item represents real review content.
 
-    A rate-limit stub is never real. Review objects with state APPROVED
-    or CHANGES_REQUESTED are always real regardless of body content
-    (the review state itself is the substantive signal). Comments and
-    COMMENTED reviews are real only when they carry non-empty, non-stub
-    body text.
+    A rate-limit stub or CodeRabbit auto-generated scaffolding (acknowledgement
+    reply / auto-summary) is never real -- these are bots posting that a
+    trigger was accepted with no review content following. Review objects
+    with state APPROVED or CHANGES_REQUESTED are always real regardless of
+    body content (the review state itself is the substantive signal).
+    Comments and COMMENTED reviews are real only when they carry non-empty,
+    non-stub body text.
     """
     if is_rate_limit_stub(item.body):
+        return False
+    if is_coderabbit_scaffolding(item.body):
         return False
     if item.is_review:
         state = (item.review_state or "").upper()
@@ -230,7 +265,10 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
     Returns (exit_code, message):
     - (0, "PASS ...")            -- a real CodeRabbit review exists.
     - (0, "PASS (absent, ...)")  -- CodeRabbit is entirely absent.
-    - (1, "FAIL ...")            -- only rate-limit stubs exist.
+    - (1, "FAIL ...")            -- only stubs exist, i.e. rate-limit stubs
+                                  or CodeRabbit auto-generated scaffolding
+                                  (acknowledgement / auto-summary), neither
+                                  of which is review content.
     - (0, "PASS ...")            -- CR output exists but is neither a stub
                                   nor substantive (edge case, not fake-green).
     """
@@ -244,11 +282,20 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
             f"(exit {EXIT_OK})"
         )
 
-    # No real review threads. Check whether ANY CR output is a rate-limit
-    # stub -- that is the fake-green condition.
+    # No real review threads. A trigger was accepted but produced no review
+    # content: that is the fake-green condition. This covers both the
+    # rate-limit stub and CodeRabbit's own auto-generated scaffolding
+    # (acknowledgement reply / auto-summary), which the gate must treat
+    # the same way -- it must not land on the absent/PASS path above.
     if any(is_rate_limit_stub(i.body) for i in items):
         return EXIT_STUB, (
             f"FAIL: only CodeRabbit output is a rate-limit stub (exit {EXIT_STUB})"
+        )
+
+    if any(is_coderabbit_scaffolding(i.body) for i in items):
+        return EXIT_STUB, (
+            f"FAIL: only CodeRabbit output is auto-generated scaffolding "
+            f"(no real review, exit {EXIT_STUB})"
         )
 
     # CR output exists but no real review threads and no recognizable stub.

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -24,6 +24,14 @@ def check_mod():
     return _load_module()
 
 
+ACK_BODY = (
+    "<!-- This is an auto-generated reply by CodeRabbit -->\n\n"
+    "CodeRabbit review command invocation: 12345678-0000-0000-0000-000000000000\n\n"
+    "Actions performed / Full review triggered."
+)
+SUMMARY_BODY = "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"
+
+
 class TestIsRateLimitStub:
     def test_review_limit_reached_matches(self, check_mod) -> None:
         assert check_mod.is_rate_limit_stub("review limit reached")
@@ -93,6 +101,39 @@ class TestIsRealItem:
     def test_rate_limit_stub_comment_is_not_real(self, check_mod) -> None:
         item = check_mod.CRItem(
             id=1, body="review limit reached", is_review=False,
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_coderabbit_acknowledgement_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body=ACK_BODY, is_review=False,
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_coderabbit_summary_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body=SUMMARY_BODY, is_review=False,
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_coderabbit_acknowledgement_review_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body=ACK_BODY, is_review=True, review_state="COMMENTED",
+        )
+        assert not check_mod.is_real_item(item)
+
+    def test_genuine_review_control_is_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1,
+            body="## Review\n\n### Findings\n\nLine 42 needs null-checking.",
+            is_review=True,
+            review_state="COMMENTED",
+        )
+        assert check_mod.is_real_item(item)
+
+    def test_rate_limit_stub_control_is_not_real(self, check_mod) -> None:
+        item = check_mod.CRItem(
+            id=1, body="Review rate limited. Please try again later.", is_review=False,
         )
         assert not check_mod.is_real_item(item)
 
@@ -208,6 +249,89 @@ class TestClassify:
         ]
         exit_code, message = check_mod.classify(items)
         assert f"(exit {exit_code})" in message
+
+    def _pr2482_items(self, check_mod):
+        """Build the exact #2482 item set: one auto-summary + two
+        acknowledgement replies, all is_review=False (the live instance
+        verified 2026-08-17 where GET /reviews returned zero reviews yet
+        the gate went green on three stub items)."""
+        return [
+            check_mod.CRItem(id=1, body=SUMMARY_BODY, is_review=False),
+            check_mod.CRItem(id=2, body=ACK_BODY, is_review=False),
+            check_mod.CRItem(id=3, body=ACK_BODY, is_review=False),
+        ]
+
+    def test_acknowledgement_only_fails(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(id=1, body=ACK_BODY, is_review=False),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
+
+    def test_summary_plus_acknowledgements_fails(self, check_mod) -> None:
+        """The #2482 set: summary + two acknowledgements. Must exit non-zero
+        -- a trigger was accepted and nothing came back."""
+        items = self._pr2482_items(check_mod)
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
+        assert "scaffolding" in message
+
+    def test_genuine_review_control_passes(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1,
+                body="## Review\n\n### Findings\n\nLine 42 needs null-checking.",
+                is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
+
+    def test_rate_limit_stub_control_fails(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited. Please try again later.",
+                is_review=False,
+            ),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
+        assert "rate-limit stub" in message
+
+    def test_mixed_genuine_review_and_acknowledgement_passes(self, check_mod) -> None:
+        """A genuine review plus an acknowledgement must stay green -- the
+        real review is what counts."""
+        items = [
+            check_mod.CRItem(
+                id=1,
+                body="## Review\n\n### Findings\n\nLine 42 needs null-checking.",
+                is_review=True,
+                review_state="COMMENTED",
+            ),
+            check_mod.CRItem(id=2, body=ACK_BODY, is_review=False),
+            check_mod.CRItem(id=3, body=SUMMARY_BODY, is_review=False),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "real CodeRabbit review" in message
+
+    def test_mixed_rate_limit_stub_and_acknowledgement_fails(self, check_mod) -> None:
+        """Both kinds of stub present, no real review -> FAIL."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="Review rate limited. Please try again later.",
+                is_review=False,
+            ),
+            check_mod.CRItem(id=2, body=ACK_BODY, is_review=False),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 1
+        assert "FAIL" in message
 
 
 class TestCheckBotReview:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): bot-review-gate: CodeRabbit acknowledgement comments read as a real review (fake-green)

Autonomous build of board card tsk-mk5lit.

scripts/check_bot_review.py is_real_item() returned True for any CodeRabbit
comment/review whose body was non-empty and did not match RATE_LIMIT_RE.
CodeRabbit's own auto-generated scaffolding qualifies: the acknowledgement
reply posted when a @coderabbitai full review trigger is accepted (body
carries <!-- This is an auto-generated reply by CodeRabbit --> plus
invocation UUID and 'Actions performed / Full review triggered.'), and the
auto-summary comment <!-- This is an auto-generated comment: summarize by
coderabbit.ai -->.

Neither is review content. classify() reported PASS on PRs CodeRabbit never
reviewed. Verified at source for live PR #2482 (head 50d5d0bfb): GET
/repos/jaylfc/taOS/pulls/2482/reviews returned ZERO reviews yet the gate
exited 0 with 'PASS: 3 real CodeRabbit review item(s)' -- the summary plus
two acknowledgements.

Add CODERABBIT_SCAFFOLDING_RE + is_coderabbit_scaffolding(); gate both stubs
in is_real_item(); add a scaffolding-only FAIL branch in classify() so the
#2482 set lands on FAIL (exit 1), not the absent/PASS path. Existing exit
contract preserved: 0 PASS (real review or absent), 1 FAIL (stub-only),
2 ERROR (infrastructure).

Reproduction before fix: #2482 item set exits 0 (green, wrong). After fix:
exits 1 (red, correct). Genuine-review control and rate-limit-stub control
both unchanged in the same run. Mixed genuine-review + acknowledgement stays
green.

Tests: extend tests/scripts/test_check_bot_review.py with acknowledgement-only,
summary-plus-acknowledgements (#2482 set), genuine-review control, rate-limit
stub control, mixed (genuine + ack) green, mixed stub+ack red. 44 tests pass.

Proof: 44 passed in tests/scripts/test_check_bot_review.py

Files:
 changelog.d/tsk-mk5lit-coderabbit-ack-gate.md |   3 +
 scripts/check_bot_review.py                   |  67 +++++++++++---
 tests/scripts/test_check_bot_review.py        | 124 ++++++++++++++++++++++++++
 3 files changed, 184 insertions(+), 10 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review validation to distinguish genuine CodeRabbit reviews from automated acknowledgement, summary, and rate-limit messages.
  - Review checks now fail when only automated messages are present, preventing incomplete reviews from being accepted.
  - Genuine review comments continue to pass validation, including cases where they appear alongside automated messages.

- **Documentation**
  - Added release documentation describing the updated review-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->