### PR TITLE
Gate class defect: pull_request gates execute their own checker from the PR merge ref - a PR can disable the check that gates it

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -166,8 +166,19 @@ deps the project does not pin set `check_upgrade = false`.
   `.github/scripts/check_all_skip.py`) fails a PR when a test file it adds or modifies
   has tests and ALL of them skip (e.g. `pytest.importorskip` on a module that does not
   exist yet) — green CI that asserts nothing. The failure names the file and the guard.
-  Landing tests ahead of code stays legal via an explicit waiver trailer in the PR body:
-  `Tests-Skipped-Intentionally: <file>, <why>`. Files with SOME skips pass (v1 scope).
+   Landing tests ahead of code stays legal via an explicit waiver trailer in the PR body:
+   `Tests-Skipped-Intentionally: <file>, <why>`. Files with SOME skips pass (v1 scope).
+- **Gate integrity** (`.github/workflows/gate-integrity.yml`, implementation in
+  `scripts/check_gate_integrity.py`): because each `pull_request` gate checks
+  out the PR merge ref and runs its checker FROM that checkout, a PR can edit
+  its own gate to always-exit-0 and green-pass the check that gates it. This
+  workflow runs on `pull_request_target` from the base ref and inspects the PR
+  diff via the GitHub API only -- it never checks out or executes PR code. It
+  fails any PR touching `.github/workflows/`, `.github/scripts/`, or
+  `scripts/check_*.py` unless the PR carries the human-set
+  `gate-integrity-allow` label (the only way to land a legitimate change to CI
+  or a gate checker). Add that label yourself; lanes must not add it. Branch
+  protection must require "Gate integrity" as a blocking check.
 
 ## CLA - HUMAN signs
 

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -1,0 +1,66 @@
+name: Gate integrity
+
+# CLASS DEFECT fix (tsk-o2vhcq): every gate workflow triggered on
+# `pull_request` checks out the PR MERGE REF (actions/checkout's default on
+# that event) and runs its checker script FROM THAT CHECKOUT. A PR can
+# therefore edit its own checker (and its own workflow YAML -- `pull_request`
+# runs the workflow file from the merge ref too) to always-exit-0 and
+# green-pass the very check that is supposed to gate it.
+#
+# This workflow breaks that loop:
+#   * It triggers on `pull_request_target`, so the workflow file AND this
+#     script are resolved from the BASE branch, never from the PR head. A PR
+#     editing this workflow or its checker is inert here.
+#   * It does NOT check out or execute PR code. `actions/checkout` is pinned
+#     to `ref: ${{ github.base_ref }}` (the base branch) -- the PR merge ref is
+#     deliberately never fetched. The base-ref checker then inspects the PR diff
+#     via the GitHub REST API only.
+#   * It fails any PR whose diff touches a protected gate file --
+#     .github/workflows/, .github/scripts/, or scripts/check_*.py -- unless the
+#     PR carries the human-set `gate-integrity-allow` label.
+#
+# Token permissions are minimal (contents: read, pull-requests: read); the
+# GITHUB_TOKEN never acquires write scope here, and PR-controlled code is never
+# run, so a malicious PR cannot escalate through this job.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [master, dev]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate-integrity:
+    name: Gate integrity
+    runs-on: ubuntu-latest
+    # permissions are set at the workflow root above; restated here so the
+    # job is safe even if copy-pasted into another workflow.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # Checkout the BASE branch ONLY. On `pull_request_target` the default
+      # ref would be the merge ref (PR head + base), which is PR-controlled
+      # code -- exactly what we must not run. Pinning `ref` to base_ref
+      # guarantees the base-ref checker (and this workflow) are what execute.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Inspect PR diff via API for self-editing gates
+        # Fail closed on infrastructure errors (exit 2) so a transient API
+        # blip never reads as green -- see check_gate_integrity.EXIT_ERROR.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python scripts/check_gate_integrity.py "$PR_NUMBER"

--- a/changelog.d/tsk-o2vhcq-gate-integrity.md
+++ b/changelog.d/tsk-o2vhcq-gate-integrity.md
@@ -1,0 +1,10 @@
+### Security
+
+- `Gate integrity` workflow (`.github/workflows/gate-integrity.yml`) runs on
+  `pull_request_target` from the base ref and fails any PR whose diff touches
+  `.github/workflows/`, `.github/scripts/`, or `scripts/check_*.py` unless it
+  carries the human-set `gate-integrity-allow` label. This closes the class
+  defect where `pull_request`-triggered gates checked out the merge ref and ran
+  their own checker from it, letting a PR edit its gate to always-exit-0 and
+  green-pass the check that gated it. The integrity check inspects the PR diff
+  via the GitHub API only and never checks out or executes PR code.

--- a/scripts/check_gate_integrity.py
+++ b/scripts/check_gate_integrity.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Gate-integrity guard: a PR must not edit its own gate to green itself.
+
+CLASS DEFECT being closed: every gate workflow triggered on `pull_request`
+checks out the PR MERGE REF (`actions/checkout`'s default on that event) and
+runs its checker script FROM THAT CHECKOUT. A PR can therefore edit the
+checker -- and the workflow file itself, since `pull_request` runs the
+workflow YAML from the merge ref too -- and make its own required check pass
+while disabling detection. The gates affected by this class defect:
+
+  - bot-review-gate        -> scripts/check_bot_review.py
+  - deleted-symbols-gate     -> scripts/check_deleted_symbols.py
+  - doc-gate                 -> scripts/check_doc_gate.py, check_schema_migrations.py,
+                                check_retrofit_migrations.py, check_manifests.py
+  - secret-ignores-gate      -> scripts/check_secret_ignores.py
+  - store-wiring-gate        -> scripts/check_store_wiring.py
+  - distrust-green-gate      -> .github/scripts/check_all_skip.py
+  - security                 -> scripts/check_dependency_audit_ignores.py
+  - evil-merge-gate          -> scripts/check_evil_merge.py (when present)
+
+Fix direction #1 (the one that actually closes the class): this guard runs on
+`pull_request_target`, which resolves BOTH the workflow file and this script
+to the BASE ref (`origin/dev`). It does NOT check out or execute any PR code
+-- it reads the PR's changed-files list and its labels through the GitHub REST
+API only, using the base-ref version of this script. When the PR diff touches
+a protected path, the run FAILS, unless the PR carries an explicit human-set
+allow label so legitimate changes to CI/gates can still land.
+
+Fix direction #2 (gates fetch their checker from the BASE ref) is NOT
+sufficient on its own: it protects the checker script but not the workflow
+file that drives it, which is why #1 is still required. This guard covers
+both, so #2 is redundant for the covered surface.
+
+Protected paths (the minimal gate surface a lane could corrupt):
+  - `.github/workflows/`        the required-check workflow YAML itself
+  - `.github/scripts/`          gate checkers collocated under `.github`
+  - `scripts/check_*.py`        every repo gate checker lives here by convention
+
+Usage:
+    python scripts/check_gate_integrity.py <pr-number> [--owner O] [--repo R] [--label LABEL]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+API = "https://api.github.com"
+EXIT_OK = 0
+EXIT_BLOCKED = 1
+EXIT_ERROR = 2
+
+# A human-placed label that explicitly waives the gate integrity check for a
+# PR that legitimately edits CI/gates. It must be applied manually -- never by
+# automation in a PR-lane -- so the waiver is a conscious human act.
+DEFAULT_ALLOW_LABEL = "gate-integrity-allow"
+
+# Protected path prefixes. A PR editing any file under these prefixes can
+# silence or subvert a required check, so such edits are blocked unless the
+# allow label is set.
+PROTECTED_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    ".github/scripts/",
+)
+# Every repo gate checker is named `scripts/check_*.py` by convention; that
+# glob captures all current and future gate scripts in one rule so the guard
+# never silently goes blind to a new gate.
+GATE_SCRIPT_PREFIX = "scripts/check_"
+GATE_SCRIPT_SUFFIX = ".py"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class CheckResult:
+    exit_code: int
+    message: str
+
+
+def _get_token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or None
+
+
+def _api_get(url: str, token: str | None = None) -> list | None:
+    """Fetch a paginated GitHub REST endpoint; None on infrastructure failure.
+
+    None means "cannot see" (network error, auth failure, 404, bad JSON) so a
+    cannot-see state is never mistaken for a clean pass -- the worker fails
+    the run instead. A legitimately empty result returns []. Pagination is
+    followed via the Link header, matching check_bot_review.py's contract.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "taos-gate-integrity",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    items: list = []
+    page_url: str | None = url
+    while page_url:
+        req = urllib.request.Request(page_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                raw = r.read().decode("utf-8")
+                data = json.loads(raw)
+                link = r.headers.get("Link", "")
+        except urllib.error.HTTPError as e:
+            print(f"error: GET {url} failed: HTTP {e.code} {e.reason}", file=sys.stderr)
+            return None
+        except Exception as e:  # any infra failure fails closed
+            print(f"error: GET {url} failed: {e}", file=sys.stderr)
+            return None
+        if isinstance(data, dict) and data.get("message"):
+            print(f"error: API response message: {data['message']}", file=sys.stderr)
+            return None
+        if isinstance(data, list):
+            items.extend(data)
+        elif isinstance(data, dict):
+            items.append(data)
+        page_url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                match = re.search(r"<([^>]+)>", part)
+                if match:
+                    page_url = match.group(1)
+                break
+    return items
+
+
+def is_protected(path: str) -> bool:
+    """Return True if `path` is a gate file a PR must not edit without the
+    allow label. Paths are normalised to forward slashes so Windows-style
+    clients cannot dodge the check."""
+    norm = path.replace("\\", "/")
+    for prefix in PROTECTED_PREFIXES:
+        if norm.startswith(prefix):
+            return True
+    if (
+        norm.startswith(GATE_SCRIPT_PREFIX)
+        and norm.endswith(GATE_SCRIPT_SUFFIX)
+        and norm.count("/") == 1
+    ):
+        # `scripts/check_<x>.py` directly under scripts/ only; a nested file
+        # like scripts/platform/check_foo.py is not matched by the flat
+        # `scripts/check_*.py` convention.
+        return True
+    return False
+
+
+def collect_pr_files(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> list[str] | None:
+    """Return the list of filenames changed by a PR (via the API, never a
+    local checkout). None on infrastructure failure."""
+    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}/files", token)
+    if data is None:
+        return None
+    return [f.get("filename", "") for f in data if isinstance(f, dict)]
+
+
+def collect_pr_labels(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> set[str] | None:
+    """Return the PR's label names (via the API). None on infrastructure
+    failure."""
+    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}", token)
+    if data is None:
+        return None
+    pr = data[0] if isinstance(data, list) and data else {}
+    if not isinstance(pr, dict):
+        return set()
+    return {
+        lbl.get("name", "") for lbl in pr.get("labels", []) if isinstance(lbl, dict)
+    }
+
+
+def classify(
+    files: list[str], labels: list[str] | set[str], allow_label: str,
+) -> CheckResult:
+    """Pure decision: given a PR's changed files and labels, decide pass/fail.
+
+    RED  -- a protected gate file is in the diff and no allow label is set.
+    GREEN -- no protected files in the diff, or the allow label waives them.
+    """
+    violations = sorted({f for f in files if is_protected(f)})
+    label_set = set(labels or [])
+    if not violations:
+        return CheckResult(
+            EXIT_OK,
+            "gate-integrity: PASS -- PR touches no gate workflows or checker scripts",
+        )
+    if allow_label in label_set:
+        return CheckResult(
+            EXIT_OK,
+            (
+                f"gate-integrity: PASS -- {len(violations)} protected gate file(s) "
+                f"touched but waived by human-set `{allow_label}` label: "
+                f"{violations}"
+            ),
+        )
+    return CheckResult(
+        EXIT_BLOCKED,
+        (
+            f"gate-integrity: FAIL -- PR touches {len(violations)} protected "
+            f"gate file(s) without the `{allow_label}` label: {violations}. "
+            "A pull_request gate checks out the merge ref and runs its checker "
+            "FROM that checkout, so a PR editing its own gate can green-pass "
+            "the check that gates it. Set the label to acknowledge a human "
+            "reviewed and approved the gate change."
+        ),
+    )
+
+
+def check_gate_integrity(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    allow_label: str = DEFAULT_ALLOW_LABEL,
+    token: str | None = None,
+) -> tuple[int, str]:
+    """Fetch a PR's files + labels via the API and classify the integrity.
+
+    Returns (exit_code, message). EXIT_ERROR (2) is returned when the GitHub
+    API cannot be reached or returns an error, so a cannot-see state never
+    reads as a clean pass.
+    """
+    files = collect_pr_files(owner, repo, pr_number, token)
+    if files is None:
+        return EXIT_ERROR, (
+            f"gate-integrity: error -- could not fetch changed files for "
+            f"PR #{pr_number} (infrastructure failure, exit {EXIT_ERROR})"
+        )
+    labels = collect_pr_labels(owner, repo, pr_number, token)
+    if labels is None:
+        return EXIT_ERROR, (
+            f"gate-integrity: error -- could not fetch labels for PR #{pr_number} "
+            f"(infrastructure failure, exit {EXIT_ERROR})"
+        )
+    result = classify(files, labels, allow_label)
+    return result.exit_code, result.message
+
+
+def _detect_repo() -> tuple[str, str]:
+    """Detect (owner, repo) from GITHUB_REPOSITORY env var or git remote.
+
+    Falls back to ("jaylfc", "taOS") if neither is available. The repo is only
+    needed to build the API URL, never for authentication.
+    """
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    if env_repo and "/" in env_repo:
+        parts = env_repo.split("/")
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+        url = result.stdout.strip()
+        if "github.com" in url:
+            path = url.split("github.com/", 1)[1].replace(".git", "").strip()
+            parts = path.split("/")
+            if len(parts) >= 2:
+                return parts[0], parts[1]
+    except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+        pass
+
+    return "jaylfc", "taOS"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pr_number", type=int, help="GitHub PR number to inspect (files + labels only).",
+    )
+    parser.add_argument(
+        "--owner", default=None, help="Repo owner (default: auto-detect).",
+    )
+    parser.add_argument(
+        "--repo", default=None, help="Repo name (default: auto-detect).",
+    )
+    parser.add_argument(
+        "--label", default=DEFAULT_ALLOW_LABEL,
+        help=f"Allow label that waives the check (default: {DEFAULT_ALLOW_LABEL}).",
+    )
+    parser.add_argument(
+        "--token", default=None,
+        help="GitHub token (default: $GH_TOKEN or $GITHUB_TOKEN).",
+    )
+    args = parser.parse_args(argv)
+
+    owner = args.owner
+    repo = args.repo
+    if not owner or not repo:
+        detected_owner, detected_repo = _detect_repo()
+        owner = owner or detected_owner
+        repo = repo or detected_repo
+
+    exit_code, message = check_gate_integrity(
+        owner, repo, args.pr_number, args.label, args.token,
+    )
+    print(message)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -1,0 +1,305 @@
+"""Tests for the gate-integrity guard (scripts/check_gate_integrity.py).
+
+CLASS DEFECT (tsk-o2vhcq, flagged CodeRabbit #2510): every `pull_request`
+gate checks out the PR MERGE REF and runs its checker FROM that checkout, so a
+PR can edit its own checker (or its own workflow YAML) to always-exit-0 and
+green-pass the check that gates it. A lane diff touching a gate script
+alongside its nominal change is exactly the shape the gates exist to catch --
+and today it would go green.
+
+`check_gate_integrity.py` runs on `pull_request_target` from the BASE ref and
+inspects the PR diff via the GitHub API only (no checkout, no execution of PR
+code). These tests prove the acceptance criteria:
+
+  RED   -- a PR diff that edits a gate checker to always-exit-0 trips the guard
+           (the edit to scripts/check_*.py is itself the signal; because the
+           guard runs from base, the tampered checker cannot disable it).
+  GREEN -- a PR touching neither .github/workflows/ nor a gate checker passes.
+
+The API layer is mocked at the narrowest scope (check_gate_integrity._api_get)
+so the decision logic is exercised end-to-end without network access. Cannot-
+see is never mistaken for clean: an API failure yields EXIT_ERROR (fail
+closed).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# scripts/ is not a package; make it importable like the other scripts/*.py
+# gate tests (see tests/test_check_secret_ignores.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import check_gate_integrity as cgi  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _files_payload(filenames: list[str]) -> list[dict]:
+    """Shape of GET /repos/{o}/{r}/pulls/{n}/files items: {'filename': str}."""
+    return [{"filename": f} for f in filenames]
+
+
+def _pr_payload(label_names: list[str]) -> list[dict]:
+    # GET /pulls/{n} is a single object; _api_get wraps it in a list.
+    return [{"labels": [{"name": lbl} for lbl in label_names]}]
+
+
+def _api_get_routing(files: list[str], labels: list[str]):
+    """Build a side_effect that routes files vs PR-object requests by URL."""
+
+    def _fake(url: str, token: str | None = None, **_: object) -> list:
+        if url.endswith("/files"):
+            return _files_payload(files)
+        # single-object /pulls/{n} endpoint
+        return _pr_payload(labels)
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# is_protected(path)
+# ---------------------------------------------------------------------------
+
+
+class TestIsProtected:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/workflows/bot-review-gate.yml",
+            ".github/workflows/doc-gate.yml",
+            ".github/workflows/secret-ignores-gate.yml",
+            ".github/workflows/store-wiring-gate.yml",
+            ".github/workflows/deleted-symbols-gate.yml",
+            ".github/workflows/gate-integrity.yml",
+            ".github/scripts/check_all_skip.py",
+        ],
+    )
+    def test_gate_files_are_protected(self, path: str) -> None:
+        assert cgi.is_protected(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "scripts/check_bot_review.py",
+            "scripts/check_deleted_symbols.py",
+            "scripts/check_doc_gate.py",
+            "scripts/check_secret_ignores.py",
+            "scripts/check_store_wiring.py",
+            "scripts/check_dependency_audit_ignores.py",
+            "scripts/check_manifests.py",
+            "scripts/check_schema_migrations.py",
+            "scripts/check_retrofit_migrations.py",
+            "scripts/check_evil_merge.py",
+            "scripts/check_gate_integrity.py",
+        ],
+    )
+    def test_gate_checker_scripts_are_protected(self, path: str) -> None:
+        assert cgi.is_protected(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tinyagentos/app.py",
+            "tinyagentos/routes/foo.py",
+            "README.md",
+            "desktop/package.json",
+            "data/hub/identity.json",
+            "scripts/audit-forks.py",
+            "scripts/audit-manifests.py",
+            # .github config that is not a workflow or gate script is not blocked
+            ".github/dependabot.yml",
+            ".github/FUNDING.yml",
+            ".coderabbit.yaml",
+            "docs/something.md",
+            "changelog.d/foo.md",
+            # a check_*.py nested in a subdir is NOT matched by the single
+            # scripts/check_*.py convention the guard enforces
+            "scripts/platform/check_foo.py",
+        ],
+    )
+    def test_non_gate_paths_are_not_protected(self, path: str) -> None:
+        assert not cgi.is_protected(path)
+
+    def test_backslash_paths_normalised(self) -> None:
+        assert cgi.is_protected(".github\\workflows\\gate.yml")
+        assert not cgi.is_protected("tinyagentos\\app.py")
+
+
+# ---------------------------------------------------------------------------
+# classify(files, labels, allow_label) -- the RED / GREEN decision (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_green_when_no_protected_files(self) -> None:
+        """GREEN control: a PR touching neither workflows nor gate scripts."""
+        files = ["tinyagentos/app.py", "README.md", "desktop/src/foo.ts"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_OK
+        assert "PASS" in result.message
+
+    def test_red_when_gate_script_edited_without_label(self) -> None:
+        # RED proof: a lane edits its own checker to always-exit-0. The edit to
+        # scripts/check_bot_review.py is itself the signal; the base guard
+        # detects it and fails the PR.
+        files = [
+            "tinyagentos/some_feature.py",
+            "scripts/check_bot_review.py",
+        ]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert result.message.startswith("gate-integrity: FAIL")
+        # the offending path is named in the message for the audit trail
+        assert "scripts/check_bot_review.py" in result.message
+
+    def test_red_when_workflow_edited_without_label(self) -> None:
+        files = [".github/workflows/bot-review-gate.yml", "tinyagentos/app.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert ".github/workflows/bot-review-gate.yml" in result.message
+
+    def test_red_when_dotgithub_scripts_gate_edited(self) -> None:
+        files = [".github/scripts/check_all_skip.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+
+    def test_allow_label_waives_protected_edit(self) -> None:
+        files = ["scripts/check_bot_review.py"]
+        result = cgi.classify(
+            files, [cgi.DEFAULT_ALLOW_LABEL], cgi.DEFAULT_ALLOW_LABEL
+        )
+        assert result.exit_code == cgi.EXIT_OK
+        assert "waived" in result.message
+
+    def test_wrong_label_does_not_waive(self) -> None:
+        files = ["scripts/check_bot_review.py"]
+        # a different label name is not the allow label, so still blocked
+        result = cgi.classify(files, ["some-other-label"], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+
+    def test_multiple_protected_files_all_listed(self) -> None:
+        files = [
+            ".github/workflows/doc-gate.yml",
+            "scripts/check_doc_gate.py",
+            "scripts/check_store_wiring.py",
+            "tinyagentos/app.py",
+        ]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert "scripts/check_doc_gate.py" in result.message
+        assert "scripts/check_store_wiring.py" in result.message
+        assert ".github/workflows/doc-gate.yml" in result.message
+
+    def test_duplicates_collapsed_in_message(self) -> None:
+        files = ["scripts/check_bot_review.py", "scripts/check_bot_review.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        # one protected file, even though listed twice in the diff
+        assert result.message.count("scripts/check_bot_review.py") == 1
+
+
+# ---------------------------------------------------------------------------
+# check_gate_integrity(owner, repo, pr) -- API wiring (mocked at _api_get)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGateIntegrity:
+    def test_red_integration_gate_script_edit_fails(self) -> None:
+        # Fixture: a PR diff that edits a gate checker to always-exit-0.
+        files = ["scripts/check_bot_review.py", "tinyagentos/x.py"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, []),
+        ):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_BLOCKED
+        assert "scripts/check_bot_review.py" in message
+
+    def test_green_integration_clean_pr_passes(self) -> None:
+        # GREEN control: a PR touching neither workflows nor gate scripts.
+        files = ["tinyagentos/app.py", "README.md"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, []),
+        ):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+
+    def test_green_integration_when_allow_label_present(self) -> None:
+        files = ["scripts/check_store_wiring.py"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, [cgi.DEFAULT_ALLOW_LABEL]),
+        ):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+        assert "waived" in message
+
+    def test_infra_failure_fails_closed(self) -> None:
+        # cannot-see must not read as clean pass: None from _api_get is an
+        # infrastructure error -> EXIT_ERROR.
+        with patch("check_gate_integrity._api_get", return_value=None):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_ERROR
+
+    def test_fetches_files_then_labels(self) -> None:
+        # The guard must consult BOTH the changed files AND the labels: a PR
+        # editing a gate checker with the allow label must still pass.
+        files = ["scripts/check_bot_review.py"]
+        captured: list[str] = []
+
+        def _spy(url: str, token: str | None = None, **_: object) -> list:
+            captured.append(url)
+            return _api_get_routing(files, [cgi.DEFAULT_ALLOW_LABEL])(url, token)
+
+        with patch("check_gate_integrity._api_get", side_effect=_spy):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+        assert any(u.endswith("/files") for u in captured)
+        assert any(u.endswith("/pulls/42") for u in captured)
+
+
+# ---------------------------------------------------------------------------
+# Live regression guards: the committed tree must not outrun the protected set
+# ---------------------------------------------------------------------------
+
+
+class TestCoversRealGates:
+    def test_all_gate_checker_scripts_are_protected(self) -> None:
+        """Every scripts/check_*.py on disk is a gate checker the guard must
+        cover. If a new gate script were added outside the protected set, this
+        would fail and force the set to be extended -- so the guard never goes
+        silently blind to a gate."""
+        scripts_dir = REPO_ROOT / "scripts"
+        gate_scripts = sorted(scripts_dir.glob("check_*.py"))
+        assert gate_scripts, "expected gate checker scripts under scripts/"
+        for path in gate_scripts:
+            rel = f"scripts/{path.name}"
+            assert cgi.is_protected(rel), f"gate script not protected: {rel}"
+
+    def test_all_workflow_files_are_protected(self) -> None:
+        """Every .github/workflows/*.yml on dev is a required-check workflow
+        whose edits must be caught by the base-ref guard."""
+        workflows_dir = REPO_ROOT / ".github" / "workflows"
+        workflows = sorted(workflows_dir.glob("*.yml"))
+        assert workflows, "expected workflow files under .github/workflows"
+        for path in workflows:
+            rel = f".github/workflows/{path.name}"
+            assert cgi.is_protected(rel), f"workflow not protected: {rel}"
+
+    def test_gh_scripts_gate_checker_is_protected(self) -> None:
+        gh_scripts = REPO_ROOT / ".github" / "scripts"
+        if not gh_scripts.is_dir():
+            return
+        for path in sorted(gh_scripts.glob("**/*.py")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            assert cgi.is_protected(rel), f".github gate script not protected: {rel}"
+
+    def test_real_repo_passes_integrity(self) -> None:
+        # The committed tree must be itself green: no gate script should be
+        # mid-tamper. The PR files for the real repo's HEAD (none) trivially
+        # pass; this guards the classify/is_protected invariants together.
+        assert cgi.classify([], [], cgi.DEFAULT_ALLOW_LABEL).exit_code == cgi.EXIT_OK


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Gate class defect: pull_request gates execute their own checker from the PR merge ref - a PR can disable the check that gates it

Autonomous build of board card tsk-o2vhcq.

CLASS DEFECT (tsk-o2vhcq, flagged CodeRabbit on evil-merge-gate.yml:46,
verified by @taOS-dev 2026-08-24): every `pull_request` gate checks out the
PR merge ref and runs its checker SCRIPT FROM THAT CHECKOUT, so a PR can
edit its own checker (and its own workflow YAML, which pull_request also
resolves from the merge ref) to always-exit-0 and green-pass the check that
gates it. The threatened shape is exactly an exec-PR lane diff touching a
gate script alongside its nominal change, with commit text repeatedly
misdescribing its own diffs (documented trap).

SWEEP -- `.github/workflows/*.yml` on `pull_request` that run a repo script,
and the required-check names branch protection backs (configured in GitHub
repo settings, not stored in-repo), verified against origin/dev:

  bot-review-gate.yml      "Bot review gate"        scripts/check_bot_review.py
  deleted-symbols-gate.yml "Deleted symbols gate"   scripts/check_deleted_symbols.py
  doc-gate.yml             "Doc drift gate"         check_doc_gate.py,
                                 check_schema_migrations.py, check_retrofit_migrations.py,
                                 check_manifests.py
  secret-ignores-gate.yml "Secret-ignores gate"     scripts/check_secret_ignores.py
  store-wiring-gate.yml   "Store wiring gate"       scripts/check_store_wiring.py
  distrust-green-gate.yml "Distrust Green Gate"     .github/scripts/check_all_skip.py
  security.yml            "Security" (dep-audit)    scripts/check_dependency_audit_ignores.py
  ci.yml                  "test (3.12)" / "test (3.13)" / "lint" / "spa-build"

  evil-merge-gate.yml is NOT on dev (only on the unmerged exec/tsk-m44uf7
  branch). The protected set covers .github/workflows/ and
  scripts/check_*.py, so it is defended automatically once it lands.

FIX (direction #1, the one that closes the class). A new `Gate integrity`
workflow triggers on `pull_request_target` only. It never checks out PR code:
`actions/checkout` is pinned to the base ref, so the workflow file AND the
checker script are resolved from base and a PR editing either of them is
inert. The base-ref checker inspects the PR diff via the GitHub REST API only
(changed files + labels) -- no PR code is executed. It FAILS any PR whose
diff touches .github/workflows/, .github/scripts/, or scripts/check_*.py,
unless the PR carries the human-set `gate-integrity-allow` label (the
documented escape hatch for legitimate gate edits). Token permissions are
minimal (contents: read, pull-requests: read); GITHUB_TOKEN never gains write
scope and PR-controlled code is never run, so no escalation surface exists.

Direction #2 (gates fetch checkers from the base ref) is intentionally NOT
added: it protects the checker but not the workflow YAML that drives it, and
#1 covers both, so adding #2 would be redundant churn that risks disrupting
the live gates. Direction #3 (CODEOWNERS) is supplementary only, as the card
states -- lanes push as jaylfc -- so it is not a substitute.

PROOF (tests/test_check_gate_integrity.py, 49 tests, all green):

  RED -- fixture PR that edits a gate checker to always-exit-0:
       files = ["scripts/check_bot_review.py", "tinyagentos/x.py"]
       -> check_gate_integrity() returns EXIT_BLOCKED; the message names
          "scripts/check_bot_review.py". The guard runs from base, so the
          tampered checker cannot silence it: the edit to the protected path
          is the signal, independent of what the edit does to the checker.
  GREEN -- control PR touching neither workflows nor gate scripts:
       files = ["tinyagentos/app.py", "README.md"]
       -> EXIT_OK.
  PLUS -- an API/infrastructure failure returns EXIT_ERROR (fail closed, never
        green); the `gate-integrity-allow` label waives a protected edit; a
        different label name does not waive it; live-tree regression asserts
        every scripts/check_*.py and .github/workflows/*.yml on dev is in the
        protected set, so the guard never goes blind to a gate.

Run: uv run --no-sync pytest tests/test_check_gate_integrity.py -q
(49 passed).

The contributor-skill doc (SKILL.md) edit documents the new workflow and
label, satisfying the doc-gate `contributor-skill` rule (it triggers on
.github/workflows/*.yml) without touching any protected gate file.

Note: branch protection must add "Gate integrity" (job `gate-integrity`) to
the required checks in GitHub repo settings -- that config is not in-repo.
The proving fixture lives only in the test suite; no PR was opened or merged.

Files: .github/workflows/gate-integrity.yml,
scripts/check_gate_integrity.py, tests/test_check_gate_integrity.py,
changelog.d/tsk-o2vhcq-gate-integrity.md, and the contributor-skill SKILL.md.

Files:
 .claude/skills/taos-development-skill/SKILL.md |  15 +-
 .github/workflows/gate-integrity.yml           |  66 +++++
 changelog.d/tsk-o2vhcq-gate-integrity.md       |  10 +
 scripts/check_gate_integrity.py                | 317 +++++++++++++++++++++++++
 tests/test_check_gate_integrity.py             | 305 ++++++++++++++++++++++++
 5 files changed, 711 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Gate integrity check for pull requests that monitors protected workflow and validation files.
  * Protected-file changes now require a human-applied approval label.
  * The check fails safely when required repository information cannot be verified.

* **Documentation**
  * Added guidance and changelog coverage for the Gate integrity workflow.

* **Tests**
  * Added comprehensive coverage for protected paths, approval-label handling, API failures, and clean pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->