### PR TITLE
Execution-policy gate fails OPEN on an absent store, and its safety rests on an unenforced coupling to app.py

### DIFF
--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -51,6 +51,37 @@ def _seed_agents(app):
 
 
 @pytest.mark.asyncio
+class TestExecutionPoliciesWired:
+    async def test_execution_policies_is_not_none_when_app_builds(self, app):
+        """Assert that create_app wires execution_policies unconditionally.
+        This must FAIL if app.py:1708 (`app.state.execution_policies = execution_policy_store`)
+        is removed — the assertion becomes False and the test fails."""
+        assert app.state.execution_policies is not None
+
+
+@pytest.mark.asyncio
+class TestDelegationGateControl:
+    async def test_with_store_present_and_deny_policy_gate_still_denies(self, client, app):
+        """Control: with the store present and a deny policy in place, the gate
+        must still deny. This discriminates against a guard that passes with the
+        gate permanently open (because the store is absent)."""
+        await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "forbidden_by_policy"
+
+
+@pytest.mark.asyncio
 class TestDelegationGateDeny:
     async def test_deny_policy_returns_403_and_does_not_assign(self, client, app):
         await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")

--- a/tests/test_skill_exec_governance.py
+++ b/tests/test_skill_exec_governance.py
@@ -62,6 +62,34 @@ def _fake_subprocess_result() -> MagicMock:
 
 
 @pytest.mark.asyncio
+class TestSkillExecGateControl:
+    async def test_with_store_present_and_deny_policy_gate_still_denies(self, app):
+        """Control: with the store present and a deny policy in place, the gate
+        must still deny. This discriminates against a guard that passes with the
+        gate permanently open (because the store is absent)."""
+        execution_policies = app.state.execution_policies
+        if execution_policies._db is not None:
+            await execution_policies.close()
+        await execution_policies.init()
+        await app.state.execution_policies.set_policy("code-exec", "deny")
+        await _ensure_skills_seeded(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            with patch("subprocess.run") as mock_run:
+                resp = await agent_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('no')"}, "agent_name": "agent-a"},
+                )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "forbidden_by_policy"
+        mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
 class TestConservativeDefaultRequiresApproval:
     async def test_code_exec_pending_approval_and_no_run(self, client, app):
         """code-exec is a seeded conservative default: an agent (local-token)

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -134,8 +134,9 @@ async def _check_delegation_policy(
 
     policies = getattr(request.app.state, "execution_policies", None)
     if policies is None:
-        # Not wired in this deployment; fail open rather than break
-        # delegation over an additive, not-yet-present store.
+        # Not wired in this deployment; fail open rather than break delegation.
+        # Absence means not-wired BECAUSE app.py wires execution_policies unconditionally
+        # at startup (app.py:1708).
         return None
 
     effect = await policies.effective_effect(from_agent, ACTION_CLASS)

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -613,8 +613,9 @@ async def _check_execution_policy(
 
     policies = getattr(request.app.state, "execution_policies", None)
     if policies is None:
-        # Not wired in this deployment; fail open rather than break every
-        # skill call over an additive, not-yet-present store.
+        # Not wired in this deployment; fail open rather than break every skill call.
+        # Absence means not-wired BECAUSE app.py wires execution_policies unconditionally
+        # at startup (app.py:1708).
         return None
 
     effect = await policies.effective_effect(agent_name, action_class)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Execution-policy gate fails OPEN on an absent store, and its safety rests on an unenforced coupling to app.py

Autonomous build of board card tsk-ij7te4.

- update comments in delegation.py and skill_exec.py to name the assumption:
  absence means not-wired BECAUSE app.py wires execution_policies unconditionally
  at startup (app.py:1708)
- add TestExecutionPoliciesWired test asserting app.state.execution_policies is not None
  when app builds; must FAIL if app.py:1708 assignment is removed
- add TestDelegationGateControl control test: with store present + deny policy,
  gate must still deny (discards permanently-open guard)
- add TestSkillExecGateControl control test: same discrimination for skill_exec gate
- cover both call sites: delegation and skill_exec gates both tested

Docs-Reviewed: comment updates only, no doc change needed

Files:
 tests/test_routes_delegation.py     | 31 +++++++++++++++++++++++++++++++
 tests/test_skill_exec_governance.py | 28 ++++++++++++++++++++++++++++
 tinyagentos/routes/delegation.py    |  5 +++--
 tinyagentos/routes/skill_exec.py    |  5 +++--
 4 files changed, 65 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards ensuring configured execution-deny policies consistently block agent delegation and skill execution.
  * Blocked operations now return a clear `403 forbidden_by_policy` response and prevent subprocess invocation.

* **Tests**
  * Added regression coverage for policy enforcement during application startup and local-token requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->