### PR TITLE
App tiering S1 RESIDUE: launcher tier filtering + redirect map (fields landed inert in 3ec0ff3cb)

### DIFF
--- a/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
+++ b/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
@@ -1,0 +1,3 @@
+### Added
+- Launcher tier filtering in `getLaunchableApps`: tier 1 and tier 2 apps surface in the launcher; tier 3+ and handler apps are excluded.
+- Exported `APP_REDIRECTS` map and `resolvePinnedId` so dock pin-restore can resolve legacy or renamed app ids before treating them as orphaned.

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -4,11 +4,29 @@ import { useSessionPersistence } from "../use-session-persistence";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useAuthReadyStore } from "@/stores/auth-ready-store";
+import { APP_REDIRECTS } from "@/registry/app-registry";
 
-vi.mock("@/registry/app-registry", () => ({
-  getApp: () => undefined,
-  prefetchApp: () => {},
-}));
+vi.mock("@/registry/app-registry", () => {
+  const apps = new Map<string, { id: string }>([
+    ["messages", { id: "messages" }],
+    ["files", { id: "files" }],
+    ["agents", { id: "agents" }],
+    ["store", { id: "store" }],
+    ["settings", { id: "settings" }],
+  ]);
+  const redirects: Record<string, { appId: string; section?: string }> = {};
+
+  return {
+    getApp: (id: string) => apps.get(id),
+    prefetchApp: () => {},
+    resolvePinnedId: (id: string) => {
+      const redirect = redirects[id];
+      const targetId = redirect?.appId ?? id;
+      return apps.has(targetId) ? targetId : undefined;
+    },
+    APP_REDIRECTS: redirects,
+  };
+});
 
 vi.mock("@/lib/browser-windows-api", () => ({
   loadWindows: async () => [],
@@ -99,6 +117,30 @@ describe("useSessionPersistence — dock settings restore (#1603)", () => {
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(useDockStore.getState().iconSize).toBe("medium");
     expect(useDockStore.getState().position).toBe("bottom");
+  });
+
+  it("resolves pinned ids through APP_REDIRECTS and drops unresolvable ids", async () => {
+    APP_REDIRECTS["legacy-pin"] = { appId: "agents" };
+
+    mockFetchWith({
+      "/api/desktop/dock": {
+        pinned: ["legacy-pin", "nonexistent-app", "messages"],
+        iconSize: "medium",
+        position: "bottom",
+      },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      const pinned = useDockStore.getState().pinned;
+      expect(pinned).toContain("agents");
+      expect(pinned).toContain("messages");
+      expect(pinned).not.toContain("nonexistent-app");
+      expect(pinned).not.toContain("legacy-pin");
+    });
+
+    delete APP_REDIRECTS["legacy-pin"];
   });
 });
 

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -3,7 +3,7 @@ import { useProcessStore, type SnapPosition } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useWidgetStore, type Widget } from "@/stores/widget-store";
-import { getApp } from "@/registry/app-registry";
+import { getApp, resolvePinnedId } from "@/registry/app-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { loadWindows as loadBrowserWindows, saveWindows as saveBrowserWindows } from "@/lib/browser-windows-api";
 import type { BrowserWindowState } from "@/apps/BrowserApp/types";
@@ -96,7 +96,10 @@ export function useSessionPersistence() {
       .then((r) => r.json())
       .then((data: { pinned?: string[]; iconSize?: string; position?: string }) => {
         if (data.pinned && Array.isArray(data.pinned)) {
-          useDockStore.getState().reorder(data.pinned);
+          const resolved = data.pinned
+            .map((id) => resolvePinnedId(id))
+            .filter((id): id is string => id !== undefined);
+          useDockStore.getState().reorder(resolved);
         }
         if (data.iconSize === "small" || data.iconSize === "medium" || data.iconSize === "large") {
           useDockStore.getState().setIconSize(data.iconSize);

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp } from "./app-registry";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AppManifest } from "./app-registry";
+import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp, apps, APP_REDIRECTS, resolvePinnedId } from "./app-registry";
 
 describe("resolveApp (deep-navigation token resolver)", () => {
   it("resolves an exact app id", () => {
@@ -103,5 +104,135 @@ describe("file handler tiering", () => {
       expect(app?.tier).toBe(4);
       expect(app?.handler).toBe(true);
     }
+  });
+});
+
+describe("getLaunchableApps tier filtering (S1 contract)", () => {
+  const TIER3_ID = "test-tier3-app";
+  const HANDLER_ID = "test-handler-app";
+  const TIER2_ID = "test-tier2-app";
+  const TIER1_ID = "test-tier1-app";
+
+  function addFixture(app: AppManifest) {
+    apps.push(app);
+  }
+
+  function removeFixture(id: string) {
+    const idx = apps.findIndex((a) => a.id === id);
+    if (idx !== -1) apps.splice(idx, 1);
+  }
+
+  beforeEach(() => {
+    addFixture({
+      id: TIER3_ID,
+      name: "Tier 3",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      tier: 3,
+    });
+    addFixture({
+      id: HANDLER_ID,
+      name: "Handler",
+      icon: "box",
+      category: "os",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      handler: true,
+    });
+    addFixture({
+      id: TIER2_ID,
+      name: "Tier 2",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      tier: 2,
+      group: "TestGroup",
+    });
+    addFixture({
+      id: TIER1_ID,
+      name: "Tier 1",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+    });
+  });
+
+  afterEach(() => {
+    removeFixture(TIER3_ID);
+    removeFixture(HANDLER_ID);
+    removeFixture(TIER2_ID);
+    removeFixture(TIER1_ID);
+  });
+
+  it("excludes tier 3 apps", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).not.toContain(TIER3_ID);
+  });
+
+  it("excludes handler apps", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).not.toContain(HANDLER_ID);
+  });
+
+  it("includes tier 1 apps (apps without explicit tier)", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).toContain(TIER1_ID);
+  });
+
+  it("includes tier 2 apps and preserves their group", () => {
+    const appsList = getLaunchableApps(new Set());
+    const tier2 = appsList.find((a) => a.id === TIER2_ID);
+    expect(tier2).toBeDefined();
+    expect(tier2?.tier).toBe(2);
+    expect(tier2?.group).toBe("TestGroup");
+  });
+});
+
+describe("APP_REDIRECTS", () => {
+  it("is exported as a Record", () => {
+    expect(APP_REDIRECTS).toBeDefined();
+    expect(typeof APP_REDIRECTS).toBe("object");
+  });
+});
+
+describe("resolvePinnedId", () => {
+  it("returns the id for a valid app", () => {
+    expect(resolvePinnedId("messages")).toBe("messages");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(resolvePinnedId("does-not-exist")).toBeUndefined();
+  });
+
+  it("resolves a redirect to the target app id", () => {
+    APP_REDIRECTS["legacy-id"] = { appId: "agents" };
+    expect(resolvePinnedId("legacy-id")).toBe("agents");
+    delete APP_REDIRECTS["legacy-id"];
+  });
+
+  it("returns undefined for a redirect to a non-existent app", () => {
+    APP_REDIRECTS["legacy-id"] = { appId: "does-not-exist" };
+    expect(resolvePinnedId("legacy-id")).toBeUndefined();
+    delete APP_REDIRECTS["legacy-id"];
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -41,7 +41,7 @@ export interface AppManifest {
   handler?: boolean;
 }
 
-const apps: AppManifest[] = [
+export const apps: AppManifest[] = [
   // Platform apps
   { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1, pwa: true },
   { id: "mail", name: "Mail", icon: "mail", category: "platform", component: () => import("@/apps/MailApp").then((m) => ({ default: m.MailApp })), defaultSize: { w: 1200, h: 800 }, minSize: { w: 720, h: 480 }, singleton: true, pinned: true, launchpadOrder: 1.25 },
@@ -159,10 +159,21 @@ export function getOptionalApps(): AppManifest[] {
  * optional apps the user has installed. `installedOptional` is the set of
  * installed optional app ids (from /api/apps/optional/installed).
  */
+export const APP_REDIRECTS: Record<string, { appId: string; section?: string }> = {};
+
 export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
   return getAllApps().filter(
-    (a) => (!a.optional || installedOptional.has(a.id)) && a.tier !== 4 && a.handler !== true,
+    (a) =>
+      (!a.optional || installedOptional.has(a.id)) &&
+      a.handler !== true &&
+      (a.tier === undefined || a.tier <= 2),
   );
+}
+
+export function resolvePinnedId(id: string): string | undefined {
+  const redirect = APP_REDIRECTS[id];
+  const targetId = redirect?.appId ?? id;
+  return getApp(targetId) ? targetId : undefined;
 }
 
 const prefetched = new Set<string>();


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): App tiering S1 RESIDUE: launcher tier filtering + redirect map (fields landed inert in 3ec0ff3cb)

Autonomous build of board card tsk-u2g6bt.

Proof: red run had 6 failing tests (tier-3 apps still present, APP_REDIRECTS missing,
resolvePinnedId undefined). Green run: 34 tests pass in affected files, tsc -b clean,
vite build clean.

Apps newly excluded from launcher: providers, mcp, channels (tier 3),
coding-studio, design-studio (tier 5). Handler apps were already excluded.

Files:
 changelog.d/tsk-u2g6bt-launcher-tier-filtering.md  |   3 +
 .../__tests__/use-session-persistence.test.ts      |  52 +++++++-
 desktop/src/hooks/use-session-persistence.ts       |   7 +-
 desktop/src/registry/app-registry.test.ts          | 135 ++++++++++++++++++++-
 desktop/src/registry/app-registry.ts               |  15 ++-
 5 files changed, 201 insertions(+), 11 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launcher listings now show only apps eligible for launch, improving visibility of supported options.
  * Dock pins automatically follow updated app identifiers when apps are renamed or redirected.

* **Bug Fixes**
  * Restored dock layouts no longer retain unknown or outdated app pins.
  * Improved reliability when loading saved dock arrangements after app changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->