### PR TITLE
Fix-forward: launcher tier filtering — surface installed tier-5 studios + red test (revises PR #2530)

### DIFF
--- a/changelog.d/tsk-t2rrim-fix-launcher-tier-filtering.md
+++ b/changelog.d/tsk-t2rrim-fix-launcher-tier-filtering.md
@@ -1,0 +1,5 @@
+### Fixed
+- Launcher tier filtering in `getLaunchableApps` now includes installed tier-5 optional apps (e.g., "coding-studio", "design-studio") when they are installed via the Store's optional-install flow. Previously these tier-5 apps were unconditionally excluded even when installed.
+- Red-proven test added to verify the fix: tier-5 optional apps now appear in launcher listings when installed, and are excluded when not installed.
+
+The fix ensures that the documented contract in "Re-fetch the installed set so the card flips to Open and the launcher surfaces the studio at once" is properly honored, allowing users who install tier-5 studios from the Store to immediately see them in the launcher.

--- a/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
+++ b/changelog.d/tsk-u2g6bt-launcher-tier-filtering.md
@@ -1,0 +1,3 @@
+### Added
+- Launcher tier filtering in `getLaunchableApps`: tier 1 and tier 2 apps surface in the launcher; tier 3+ and handler apps are excluded.
+- Exported `APP_REDIRECTS` map and `resolvePinnedId` so dock pin-restore can resolve legacy or renamed app ids before treating them as orphaned.

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -4,11 +4,29 @@ import { useSessionPersistence } from "../use-session-persistence";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useAuthReadyStore } from "@/stores/auth-ready-store";
+import { APP_REDIRECTS } from "@/registry/app-registry";
 
-vi.mock("@/registry/app-registry", () => ({
-  getApp: () => undefined,
-  prefetchApp: () => {},
-}));
+vi.mock("@/registry/app-registry", () => {
+  const apps = new Map<string, { id: string }>([
+    ["messages", { id: "messages" }],
+    ["files", { id: "files" }],
+    ["agents", { id: "agents" }],
+    ["store", { id: "store" }],
+    ["settings", { id: "settings" }],
+  ]);
+  const redirects: Record<string, { appId: string; section?: string }> = {};
+
+  return {
+    getApp: (id: string) => apps.get(id),
+    prefetchApp: () => {},
+    resolvePinnedId: (id: string) => {
+      const redirect = redirects[id];
+      const targetId = redirect?.appId ?? id;
+      return apps.has(targetId) ? targetId : undefined;
+    },
+    APP_REDIRECTS: redirects,
+  };
+});
 
 vi.mock("@/lib/browser-windows-api", () => ({
   loadWindows: async () => [],
@@ -99,6 +117,30 @@ describe("useSessionPersistence — dock settings restore (#1603)", () => {
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(useDockStore.getState().iconSize).toBe("medium");
     expect(useDockStore.getState().position).toBe("bottom");
+  });
+
+  it("resolves pinned ids through APP_REDIRECTS and drops unresolvable ids", async () => {
+    APP_REDIRECTS["legacy-pin"] = { appId: "agents" };
+
+    mockFetchWith({
+      "/api/desktop/dock": {
+        pinned: ["legacy-pin", "nonexistent-app", "messages"],
+        iconSize: "medium",
+        position: "bottom",
+      },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      const pinned = useDockStore.getState().pinned;
+      expect(pinned).toContain("agents");
+      expect(pinned).toContain("messages");
+      expect(pinned).not.toContain("nonexistent-app");
+      expect(pinned).not.toContain("legacy-pin");
+    });
+
+    delete APP_REDIRECTS["legacy-pin"];
   });
 });
 

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -3,7 +3,7 @@ import { useProcessStore, type SnapPosition } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
 import { useWidgetStore, type Widget } from "@/stores/widget-store";
-import { getApp } from "@/registry/app-registry";
+import { getApp, resolvePinnedId } from "@/registry/app-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { loadWindows as loadBrowserWindows, saveWindows as saveBrowserWindows } from "@/lib/browser-windows-api";
 import type { BrowserWindowState } from "@/apps/BrowserApp/types";
@@ -96,7 +96,10 @@ export function useSessionPersistence() {
       .then((r) => r.json())
       .then((data: { pinned?: string[]; iconSize?: string; position?: string }) => {
         if (data.pinned && Array.isArray(data.pinned)) {
-          useDockStore.getState().reorder(data.pinned);
+          const resolved = data.pinned
+            .map((id) => resolvePinnedId(id))
+            .filter((id): id is string => id !== undefined);
+          useDockStore.getState().reorder(resolved);
         }
         if (data.iconSize === "small" || data.iconSize === "medium" || data.iconSize === "large") {
           useDockStore.getState().setIconSize(data.iconSize);

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -208,6 +208,22 @@ describe("getLaunchableApps tier filtering (S1 contract)", () => {
   });
 });
 
+describe("getLaunchableApps tier-5 optional app filtering", () => {
+  it("includes installed tier-5 optional apps", () => {
+    const installed = new Set(["coding-studio", "design-studio"]);
+    const ids = getLaunchableApps(installed).map((a) => a.id);
+    expect(ids).toContain("coding-studio");
+    expect(ids).toContain("design-studio");
+  });
+
+  it("excludes non-installed tier-5 optional apps", () => {
+    const installed = new Set();
+    const ids = getLaunchableApps(installed).map((a) => a.id);
+    expect(ids).not.toContain("coding-studio");
+    expect(ids).not.toContain("design-studio");
+  });
+});
+
 describe("APP_REDIRECTS", () => {
   it("is exported as a Record", () => {
     expect(APP_REDIRECTS).toBeDefined();

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp } from "./app-registry";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AppManifest } from "./app-registry";
+import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp, apps, APP_REDIRECTS, resolvePinnedId } from "./app-registry";
 
 describe("resolveApp (deep-navigation token resolver)", () => {
   it("resolves an exact app id", () => {
@@ -103,5 +104,135 @@ describe("file handler tiering", () => {
       expect(app?.tier).toBe(4);
       expect(app?.handler).toBe(true);
     }
+  });
+});
+
+describe("getLaunchableApps tier filtering (S1 contract)", () => {
+  const TIER3_ID = "test-tier3-app";
+  const HANDLER_ID = "test-handler-app";
+  const TIER2_ID = "test-tier2-app";
+  const TIER1_ID = "test-tier1-app";
+
+  function addFixture(app: AppManifest) {
+    apps.push(app);
+  }
+
+  function removeFixture(id: string) {
+    const idx = apps.findIndex((a) => a.id === id);
+    if (idx !== -1) apps.splice(idx, 1);
+  }
+
+  beforeEach(() => {
+    addFixture({
+      id: TIER3_ID,
+      name: "Tier 3",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      tier: 3,
+    });
+    addFixture({
+      id: HANDLER_ID,
+      name: "Handler",
+      icon: "box",
+      category: "os",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      handler: true,
+    });
+    addFixture({
+      id: TIER2_ID,
+      name: "Tier 2",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+      tier: 2,
+      group: "TestGroup",
+    });
+    addFixture({
+      id: TIER1_ID,
+      name: "Tier 1",
+      icon: "box",
+      category: "platform",
+      component: () => Promise.resolve({ default: () => null }),
+      defaultSize: { w: 100, h: 100 },
+      minSize: { w: 50, h: 50 },
+      singleton: true,
+      pinned: false,
+      launchpadOrder: 999,
+    });
+  });
+
+  afterEach(() => {
+    removeFixture(TIER3_ID);
+    removeFixture(HANDLER_ID);
+    removeFixture(TIER2_ID);
+    removeFixture(TIER1_ID);
+  });
+
+  it("excludes tier 3 apps", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).not.toContain(TIER3_ID);
+  });
+
+  it("excludes handler apps", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).not.toContain(HANDLER_ID);
+  });
+
+  it("includes tier 1 apps (apps without explicit tier)", () => {
+    const ids = getLaunchableApps(new Set()).map((a) => a.id);
+    expect(ids).toContain(TIER1_ID);
+  });
+
+  it("includes tier 2 apps and preserves their group", () => {
+    const appsList = getLaunchableApps(new Set());
+    const tier2 = appsList.find((a) => a.id === TIER2_ID);
+    expect(tier2).toBeDefined();
+    expect(tier2?.tier).toBe(2);
+    expect(tier2?.group).toBe("TestGroup");
+  });
+});
+
+describe("APP_REDIRECTS", () => {
+  it("is exported as a Record", () => {
+    expect(APP_REDIRECTS).toBeDefined();
+    expect(typeof APP_REDIRECTS).toBe("object");
+  });
+});
+
+describe("resolvePinnedId", () => {
+  it("returns the id for a valid app", () => {
+    expect(resolvePinnedId("messages")).toBe("messages");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(resolvePinnedId("does-not-exist")).toBeUndefined();
+  });
+
+  it("resolves a redirect to the target app id", () => {
+    APP_REDIRECTS["legacy-id"] = { appId: "agents" };
+    expect(resolvePinnedId("legacy-id")).toBe("agents");
+    delete APP_REDIRECTS["legacy-id"];
+  });
+
+  it("returns undefined for a redirect to a non-existent app", () => {
+    APP_REDIRECTS["legacy-id"] = { appId: "does-not-exist" };
+    expect(resolvePinnedId("legacy-id")).toBeUndefined();
+    delete APP_REDIRECTS["legacy-id"];
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -41,7 +41,7 @@ export interface AppManifest {
   handler?: boolean;
 }
 
-const apps: AppManifest[] = [
+export const apps: AppManifest[] = [
   // Platform apps
   { id: "messages", name: "Messages", icon: "message-circle", category: "platform", component: () => import("@/apps/MessagesApp").then((m) => ({ default: m.MessagesApp })), defaultSize: { w: 900, h: 600 }, minSize: { w: 400, h: 300 }, singleton: true, pinned: true, launchpadOrder: 1, pwa: true },
   { id: "mail", name: "Mail", icon: "mail", category: "platform", component: () => import("@/apps/MailApp").then((m) => ({ default: m.MailApp })), defaultSize: { w: 1200, h: 800 }, minSize: { w: 720, h: 480 }, singleton: true, pinned: true, launchpadOrder: 1.25 },
@@ -159,10 +159,21 @@ export function getOptionalApps(): AppManifest[] {
  * optional apps the user has installed. `installedOptional` is the set of
  * installed optional app ids (from /api/apps/optional/installed).
  */
+export const APP_REDIRECTS: Record<string, { appId: string; section?: string }> = {};
+
 export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
   return getAllApps().filter(
-    (a) => (!a.optional || installedOptional.has(a.id)) && a.tier !== 4 && a.handler !== true,
+    (a) =>
+      (!a.optional || installedOptional.has(a.id)) &&
+      a.handler !== true &&
+      (a.tier === undefined || a.tier <= 2),
   );
+}
+
+export function resolvePinnedId(id: string): string | undefined {
+  const redirect = APP_REDIRECTS[id];
+  const targetId = redirect?.appId ?? id;
+  return getApp(targetId) ? targetId : undefined;
 }
 
 const prefetched = new Set<string>();

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -166,7 +166,7 @@ export function getLaunchableApps(installedOptional: Set<string>): AppManifest[]
     (a) =>
       (!a.optional || installedOptional.has(a.id)) &&
       a.handler !== true &&
-      (a.tier === undefined || a.tier <= 2),
+      (a.tier === undefined || a.tier <= 2 || (a.tier === 5 && installedOptional.has(a.id))),
   );
 }
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward: launcher tier filtering — surface installed tier-5 studios + red test (revises PR #2530)

Autonomous build of board card tsk-t2rrim.

REVISION: built on `exec/tsk-u2g6bt` (cut at `bfc40c1e60fe4e901aa4147f2ca3d44712d7926d`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Previously, tier-5 optional apps (coding-studio, design-studio) were unconditionally excluded from getLaunchableApps even when installed via the Store's optional-install flow. This broke the documented contract in StudiosView: 'Re-fetch the installed set so the card flips to Open and the launcher surfaces the studio at once'.

The fix adds tier-5 optional apps to launcher when they're installed by extending the tier filter: (a.tier === undefined || a.tier <= 2 || (a.tier === 5 && installedOptional.has(a.id))).

Red-proven test added to verify the fix:
- Tier-5 optional apps appear in launcher listings when installed
- Tier-5 optional apps are excluded when not installed
- Positive half fails on current exec/tsk-u2g6bt head as required

Changelog: Fixed launcher tier filtering to honor installed optional tier-5 studios.

Files:
 .../tsk-t2rrim-fix-launcher-tier-filtering.md      |   5 +
 changelog.d/tsk-u2g6bt-launcher-tier-filtering.md  |   3 +
 .../__tests__/use-session-persistence.test.ts      |  52 ++++++-
 desktop/src/hooks/use-session-persistence.ts       |   7 +-
 desktop/src/registry/app-registry.test.ts          | 151 ++++++++++++++++++++-
 desktop/src/registry/app-registry.ts               |  15 +-
 6 files changed, 222 insertions(+), 11 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installed optional apps now appear in launcher listings, while uninstalled apps remain hidden.
  * Launcher visibility updates immediately after installing an app from the Store.
  * Restored dock pins now resolve updated app links and remove unknown or invalid entries.

* **Bug Fixes**
  * Improved launcher filtering to exclude non-launchable handlers and correctly handle app tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->