### PR TITLE
Execution-policy gate: close the fail-open on absent store + real None-path test (supersedes tsk-ij7te4 / PR #2529)

### DIFF
--- a/changelog.d/tsk-ykeaqh-fail-closed-execution-policies.md
+++ b/changelog.d/tsk-ykeaqh-fail-closed-execution-policies.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- The delegation and skill-exec governance gates now deny (403) when `app.state.execution_policies` is absent instead of silently allowing every request. An absent store indicates a misconfigured app because the startup wiring in `app.py` sets `app.state.execution_policies` unconditionally.
+- The delegation and skill-exec governance gates now deny (403) when `app.state.execution_policies` is absent instead of silently allowing the call. This covers governed calls only: an admin human session and an unclassified skill each return before the store is consulted, unchanged by this fix. An absent store indicates a misconfigured app because the startup wiring in `app.py` sets `app.state.execution_policies` unconditionally.

--- a/changelog.d/tsk-ykeaqh-fail-closed-execution-policies.md
+++ b/changelog.d/tsk-ykeaqh-fail-closed-execution-policies.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The delegation and skill-exec governance gates now deny (403) when `app.state.execution_policies` is absent instead of silently allowing every request. An absent store indicates a misconfigured app because the startup wiring in `app.py` sets `app.state.execution_policies` unconditionally.

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -51,6 +51,35 @@ def _seed_agents(app):
 
 
 @pytest.mark.asyncio
+class TestDelegationGateFailClosed:
+    async def test_absent_execution_policies_denies_with_403(self, client, app):
+        """When app.state.execution_policies is absent, the delegation gate
+        must deny rather than silently allow. This proves the None path is
+        fail-closed, not fail-open."""
+        original = getattr(app.state, "execution_policies", None)
+        app.state.execution_policies = None
+        try:
+            _project, task = await _make_project_and_task(app)
+
+            agent_client = _local_token_client(app)
+            try:
+                resp = await agent_client.post(
+                    "/api/agents/from-agent/delegate",
+                    json={"to_agent": "to-agent", "task_id": task["id"]},
+                )
+            finally:
+                await agent_client.aclose()
+
+            assert resp.status_code == 403
+            assert resp.json()["error"] == "execution_policies not configured"
+
+            unchanged = await app.state.project_task_store.get_task(task["id"])
+            assert unchanged["assignee_id"] is None
+        finally:
+            app.state.execution_policies = original
+
+
+@pytest.mark.asyncio
 class TestDelegationGateDeny:
     async def test_deny_policy_returns_403_and_does_not_assign(self, client, app):
         await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")
@@ -512,3 +541,15 @@ class TestDelegationValidation:
         finally:
             await member_client.aclose()
         assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestWiringCoupling:
+    async def test_execution_policies_is_wired_at_startup(self, app):
+        """The startup wiring in app.py must set app.state.execution_policies.
+        If the wiring is removed, this test fails."""
+        from tinyagentos.governance.policy_store import ExecutionPolicyStore
+
+        assert hasattr(app.state, "execution_policies")
+        assert app.state.execution_policies is not None
+        assert isinstance(app.state.execution_policies, ExecutionPolicyStore)

--- a/tests/test_skill_exec_governance.py
+++ b/tests/test_skill_exec_governance.py
@@ -219,6 +219,32 @@ class TestAllowedActionClass:
 
 
 @pytest.mark.asyncio
+class TestFailClosedOnAbsentStore:
+    async def test_absent_execution_policies_denies_with_403(self, client, app):
+        """When app.state.execution_policies is absent, the skill-exec gate
+        must deny rather than silently allow. This proves the None path is
+        fail-closed, not fail-open."""
+        await _ensure_skills_seeded(app)
+        original = getattr(app.state, "execution_policies", None)
+        app.state.execution_policies = None
+        try:
+            agent_client = _local_token_client(app)
+            try:
+                with patch("subprocess.run") as mock_run:
+                    resp = await agent_client.post(
+                        "/api/skill-exec/code_exec/call",
+                        json={"args": {"code": "print('no')"}, "agent_name": "agent-a"},
+                    )
+            finally:
+                await agent_client.aclose()
+            assert resp.status_code == 403
+            assert resp.json()["error"] == "execution_policies not configured"
+            mock_run.assert_not_called()
+        finally:
+            app.state.execution_policies = original
+
+
+@pytest.mark.asyncio
 class TestAdminSessionBypass:
     """Governance applies only to agent (local-token) callers. An admin HUMAN
     session is the user driving the OS directly and is never gated -- the same

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -134,9 +134,13 @@ async def _check_delegation_policy(
 
     policies = getattr(request.app.state, "execution_policies", None)
     if policies is None:
-        # Not wired in this deployment; fail open rather than break
-        # delegation over an additive, not-yet-present store.
-        return None
+        # The startup wiring in app.py sets app.state.execution_policies
+        # unconditionally, so an absent store here signals a misconfigured
+        # app. Deny rather than silently allow.
+        return JSONResponse(
+            {"error": "execution_policies not configured"},
+            status_code=403,
+        )
 
     effect = await policies.effective_effect(from_agent, ACTION_CLASS)
     if effect == "allow":

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -613,9 +613,13 @@ async def _check_execution_policy(
 
     policies = getattr(request.app.state, "execution_policies", None)
     if policies is None:
-        # Not wired in this deployment; fail open rather than break every
-        # skill call over an additive, not-yet-present store.
-        return None
+        # The startup wiring in app.py sets app.state.execution_policies
+        # unconditionally, so an absent store here signals a misconfigured
+        # app. Deny rather than silently allow.
+        return JSONResponse(
+            {"error": "execution_policies not configured"},
+            status_code=403,
+        )
 
     effect = await policies.effective_effect(agent_name, action_class)
     if effect == "allow":


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Execution-policy gate: close the fail-open on absent store + real None-path test (supersedes tsk-ij7te4 / PR #2529)

Autonomous build of board card tsk-ykeaqh.

Both _check_delegation_policy and _check_execution_policy now return 403
instead of None when app.state.execution_policies is missing. The startup
wiring in app.py sets app.state.execution_policies unconditionally, so an
absent store signals a misconfigured app, not a supported deployment.

Added red-proven tests for both endpoints that force the store to None and
assert the request is denied with 403. Added a wiring-coupling guard test
that fails if app.py stops wiring execution_policies at startup.

Docs-Reviewed: no user-facing documentation change needed, this is an
internal security hardening (fail-closed on misconfigured app)

Files:
 .../tsk-ykeaqh-fail-closed-execution-policies.md   |  3 ++
 tests/test_routes_delegation.py                    | 41 ++++++++++++++++++++++
 tests/test_skill_exec_governance.py                | 26 ++++++++++++++
 tinyagentos/routes/delegation.py                   | 10 ++++--
 tinyagentos/routes/skill_exec.py                   | 10 ++++--
 5 files changed, 84 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegation requests are now denied with a 403 error when execution policies are unavailable.
  * Skill execution is blocked with a 403 error when execution policies are not configured.
  * Prevented task assignment and subprocess execution when governance settings are missing.
  * Added startup validation to ensure execution policy settings are initialized correctly.

* **Documentation**
  * Added changelog notes describing the fail-closed execution policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->