### PR TITLE
NotificationsPanel load error is rendered but never announced (no role=alert)

### DIFF
--- a/changelog.d/tsk-s2eusr-notifications-alert-role.md
+++ b/changelog.d/tsk-s2eusr-notifications-alert-role.md
@@ -1,0 +1,2 @@
+### Fixed
+- Notification prefs load and toggle-save errors are now announced to screen-reader users via `role="alert"` live regions.

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NotificationsPanel } from "./NotificationsPanel";
 
 function jsonResponse(obj: unknown) {
@@ -12,21 +12,25 @@ function jsonResponse(obj: unknown) {
 describe("NotificationsPanel", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("shows an error when the prefs request fails (non-ok)", async () => {
+  it("announces the prefs-load error via role=alert", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(null, { status: 500 }),
     );
     render(<NotificationsPanel />);
-    expect(await screen.findByText("Could not load notification preferences.")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not load notification preferences.",
+    );
   });
 
-  it("shows an error when the prefs request rejects", async () => {
+  it("announces the prefs-load rejection via role=alert", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
     render(<NotificationsPanel />);
-    expect(await screen.findByText("Could not reach backend.")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not reach backend.",
+    );
   });
 
-  it("renders the toggle list on successful fetch", async () => {
+  it("renders the toggle list on successful fetch with no alert present", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse([
         { event_type: "worker.join", muted: false },
@@ -37,8 +41,24 @@ describe("NotificationsPanel", () => {
     expect(await screen.findByText("Notifications")).toBeInTheDocument();
     expect(screen.getByText("Worker joined")).toBeInTheDocument();
     expect(screen.getByText("Backend up")).toBeInTheDocument();
-    expect(screen.queryByText("Could not reach backend.")).not.toBeInTheDocument();
-    expect(screen.queryByText("Could not load notification preferences.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("announces a toggle-save failure via role=alert", async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.resolve(jsonResponse([{ event_type: "worker.join", muted: false }]));
+      }
+      return Promise.resolve(new Response(null, { status: 500 }));
+    });
+    render(<NotificationsPanel />);
+    expect(await screen.findByText("Worker joined")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Worker joined notifications"));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to save (500)",
+    );
   });
 
   it("shows loading state while genuinely pending", async () => {

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
@@ -83,7 +83,7 @@ export function NotificationsPanel() {
         </p>
 
         {error && (
-          <p className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+          <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
             {error}
           </p>
         )}
@@ -100,7 +100,7 @@ export function NotificationsPanel() {
       </p>
 
       {error && (
-        <p className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+        <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
           {error}
         </p>
       )}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): NotificationsPanel load error is rendered but never announced (no role=alert)

Autonomous build of board card tsk-s2eusr.



Files:
 changelog.d/tsk-s2eusr-notifications-alert-role.md |  2 ++
 .../apps/SettingsApp/NotificationsPanel.test.tsx   | 38 +++++++++++++++++-----
 .../src/apps/SettingsApp/NotificationsPanel.tsx    |  4 +--
 3 files changed, 33 insertions(+), 11 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Notification preference loading and saving errors are now announced automatically to screen-reader users.
- **Bug Fixes**
  - Improved error visibility when notification settings fail to load or save.
- **Tests**
  - Added coverage for error alerts and confirmed successful loads display no alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->