### PR TITLE
Fix-forward: gate-integrity checker - wire _get_token, protect gate DATA, correct pull_request_target rationale (revises PR #2527)

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -166,8 +166,8 @@ deps the project does not pin set `check_upgrade = false`.
   `.github/scripts/check_all_skip.py`) fails a PR when a test file it adds or modifies
   has tests and ALL of them skip (e.g. `pytest.importorskip` on a module that does not
   exist yet) — green CI that asserts nothing. The failure names the file and the guard.
-   Landing tests ahead of code stays legal via an explicit waiver trailer in the PR body:
-   `Tests-Skipped-Intentionally: <file>, <why>`. Files with SOME skips pass (v1 scope).
+  Landing tests ahead of code stays legal via an explicit waiver trailer in the PR body:
+  `Tests-Skipped-Intentionally: <file>, <why>`. Files with SOME skips pass (v1 scope).
 - **Gate integrity** (`.github/workflows/gate-integrity.yml`, implementation in
   `scripts/check_gate_integrity.py`): because each `pull_request` gate checks
   out the PR merge ref and runs its checker FROM that checkout, a PR can edit

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -12,9 +12,10 @@ name: Gate integrity
 #     script are resolved from the BASE branch, never from the PR head. A PR
 #     editing this workflow or its checker is inert here.
 #   * It does NOT check out or execute PR code. `actions/checkout` is pinned
-#     to `ref: ${{ github.base_ref }}` (the base branch) -- the PR merge ref is
-#     deliberately never fetched. The base-ref checker then inspects the PR diff
-#     via the GitHub REST API only.
+#     to `ref: ${{ github.base_ref }}` (the base branch) -- on
+#     `pull_request_target` the default ref is already the base branch, but the
+#     explicit pin is kept for defense-in-depth. The base-ref checker then
+#     inspects the PR diff via the GitHub REST API only.
 #   * It fails any PR whose diff touches a protected gate file --
 #     .github/workflows/, .github/scripts/, or scripts/check_*.py -- unless the
 #     PR carries the human-set `gate-integrity-allow` label.
@@ -42,10 +43,13 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      # Checkout the BASE branch ONLY. On `pull_request_target` the default
-      # ref would be the merge ref (PR head + base), which is PR-controlled
-      # code -- exactly what we must not run. Pinning `ref` to base_ref
-      # guarantees the base-ref checker (and this workflow) are what execute.
+      # On `pull_request_target`, actions/checkout's default `ref` is the
+      # BASE branch -- GITHUB_REF for this event resolves to the trusted base
+      # branch, not the PR merge ref. The explicit `ref: ${{ github.base_ref }}`
+      # pin is kept for defense-in-depth: the guard never silently trusts an
+      # action default, and the pin makes the trust boundary visible in the
+      # workflow itself. The base-ref checker then inspects the PR diff via
+      # the GitHub REST API only -- no PR code is ever checked out or executed.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.base_ref }}

--- a/changelog.d/tsk-egbllm-gate-integrity-fix.md
+++ b/changelog.d/tsk-egbllm-gate-integrity-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Gate-integrity checker (`scripts/check_gate_integrity.py`) now calls `_get_token()` so the workflow's `GITHUB_TOKEN` env var is forwarded to the GitHub API when no `--token` flag is passed (previously defined but never called, so API calls were silently unauthenticated); the protected set also now covers gate rule data files (`docs/doc-gate.toml`, `pyproject.toml`, `tests/conftest.py`) so a PR cannot disable a gate by corrupting its config; and the `pull_request_target` checkout rationale in the workflow comments is corrected (the default ref is the base branch, not the merge ref).

--- a/scripts/check_gate_integrity.py
+++ b/scripts/check_gate_integrity.py
@@ -68,6 +68,16 @@ DEFAULT_ALLOW_LABEL = "gate-integrity-allow"
 PROTECTED_PREFIXES: tuple[str, ...] = (
     ".github/workflows/",
     ".github/scripts/",
+    # Gate rules are data, not code: a PR corrupting or deleting these config
+    # files could disable a gate without editing a checker. docs/doc-gate.toml
+    # drives the doc-drift gate (test paths are already excluded by the gate).
+    "docs/doc-gate.toml",
+    # pyproject.toml pins the tooling (pytest, ruff, mypy) and test config the
+    # gates rely on; a PR could relax or disable those checks by editing it.
+    "pyproject.toml",
+    # tests/conftest.py holds shared fixtures and live-tree regression guards;
+    # a PR editing it could weaken tests the gates depend on.
+    "tests/conftest.py",
 )
 # Every repo gate checker is named `scripts/check_*.py` by convention; that
 # glob captures all current and future gate scripts in one rule so the guard
@@ -233,6 +243,7 @@ def check_gate_integrity(
     API cannot be reached or returns an error, so a cannot-see state never
     reads as a clean pass.
     """
+    token = token or _get_token()
     files = collect_pr_files(owner, repo, pr_number, token)
     if files is None:
         return EXIT_ERROR, (

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -75,6 +75,11 @@ class TestIsProtected:
             ".github/workflows/deleted-symbols-gate.yml",
             ".github/workflows/gate-integrity.yml",
             ".github/scripts/check_all_skip.py",
+            # Gate rules are data, not code: config files that control gate
+            # behaviour must be protected from self-editing PRs.
+            "docs/doc-gate.toml",
+            "pyproject.toml",
+            "tests/conftest.py",
         ],
     )
     def test_gate_files_are_protected(self, path: str) -> None:
@@ -114,7 +119,11 @@ class TestIsProtected:
             ".github/FUNDING.yml",
             ".coderabbit.yaml",
             "docs/something.md",
+            "docs/agent-coordination.md",
             "changelog.d/foo.md",
+            # protected data files must not over-match neighbours
+            "tests/test_foo.py",
+            "tests/fixtures/bar.py",
             # a check_*.py nested in a subdir is NOT matched by the single
             # scripts/check_*.py convention the guard enforces
             "scripts/platform/check_foo.py",
@@ -263,6 +272,98 @@ class TestCheckGateIntegrity:
 
 
 # ---------------------------------------------------------------------------
+# main() -- the workflow's entry point (zero tests exercised it before)
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntry:
+    """main() is the workflow's entry point -- it is invoked directly from
+    .github/workflows/gate-integrity.yml via `python scripts/check_gate_integrity.py
+    "$PR_NUMBER"`.
+
+    These tests prove the workflow's GITHUB_TOKEN env var actually reaches
+    _api_get so the Authorization header is built. Pre-fix, _get_token() was
+    defined but NEVER CALLED: main() passed args.token (None, since the
+    workflow does not pass --token) straight to _api_get, so the token was
+    silently dropped and GitHub API calls went unauthenticated."""
+
+    def _fake_urlopen(self, captured: list) -> MagicMock:
+        """Return a side-effect that captures the outgoing Request and serves
+        an empty response so _api_get completes without network access. Must
+        mirror _api_get's response expectations: a JSON-decodable body and a
+        headers mapping with a blank Link (no pagination)."""
+
+        def _fake(req, *args, **kwargs):
+            captured.append(req)
+            resp = MagicMock()
+            resp.read.return_value = b"[]"
+            resp.headers = {"Link": ""}
+            resp.__enter__.return_value = resp
+            resp.__exit__.return_value = False
+            return resp
+
+        return _fake
+
+    def test_main_forwards_env_github_token_to_api_get(self, monkeypatch) -> None:
+        """RED proof through main(): with GITHUB_TOKEN set and _api_get
+        observed (urlopen mocked so _api_get's real header logic runs), the
+        Authorization header must be present on the outgoing Request.
+
+        Pre-fix this fails: _get_token() is never called, token stays None,
+        _api_get omits the Authorization header, and the assertion trips."""
+        monkeypatch.setenv("GITHUB_TOKEN", "proof-token")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        captured: list = []
+        with patch(
+            "urllib.request.urlopen", side_effect=self._fake_urlopen(captured)
+        ):
+            code = cgi.main(["42", "--owner", "jaylfc", "--repo", "taOS"])
+
+        assert captured, "no outgoing API request observed from main()"
+        # _api_get sets headers["Authorization"] = f"Bearer {token}" when token
+        # is truthy; get_header does the case-insensitive lookup.
+        assert captured[0].get_header("Authorization") == "Bearer proof-token"
+        assert code == cgi.EXIT_OK
+
+    def test_main_no_token_means_no_auth_header(self, monkeypatch) -> None:
+        """Negative control: when neither GITHUB_TOKEN nor GH_TOKEN is set,
+        _api_get still runs cleanly (token=None -> no Authorization header),
+        so the guard degrades to unauthenticated calls rather than crashing."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        captured: list = []
+        with patch(
+            "urllib.request.urlopen", side_effect=self._fake_urlopen(captured)
+        ):
+            code = cgi.main(["42", "--owner", "jaylfc", "--repo", "taOS"])
+
+        assert captured, "no outgoing API request observed from main()"
+        assert captured[0].get_header("Authorization") is None
+        assert code == cgi.EXIT_OK
+
+    def test_main_explicit_token_arg_wins_over_env(self, monkeypatch) -> None:
+        """An explicit --token flag must take precedence over the env vars,
+        mirroring check_bot_review.py's `token = token or _get_token()`
+        contract."""
+        monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        captured: list = []
+        with patch(
+            "urllib.request.urlopen", side_effect=self._fake_urlopen(captured)
+        ):
+            code = cgi.main(
+                ["42", "--owner", "jaylfc", "--repo", "taOS", "--token", "flag-token"]
+            )
+
+        assert captured
+        assert captured[0].get_header("Authorization") == "Bearer flag-token"
+        assert code == cgi.EXIT_OK
+
+
+# ---------------------------------------------------------------------------
 # Live regression guards: the committed tree must not outrun the protected set
 # ---------------------------------------------------------------------------
 
@@ -297,6 +398,19 @@ class TestCoversRealGates:
         for path in sorted(gh_scripts.glob("**/*.py")):
             rel = path.relative_to(REPO_ROOT).as_posix()
             assert cgi.is_protected(rel), f".github gate script not protected: {rel}"
+
+    def test_protected_data_files_are_covered(self) -> None:
+        """Gate rules and their config/drivers are data, not code: a PR
+        deleting or corrupting them must trip the guard. These files must
+        stay in the protected set so the guard never goes blind to a gate
+        config edit."""
+        data_files = [
+            "docs/doc-gate.toml",
+            "pyproject.toml",
+            "tests/conftest.py",
+        ]
+        for rel in data_files:
+            assert cgi.is_protected(rel), f"protected data file missing: {rel}"
 
     def test_real_repo_passes_integrity(self) -> None:
         # The committed tree must be itself green: no gate script should be


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward: gate-integrity checker - wire _get_token, protect gate DATA, correct pull_request_target rationale (revises PR #2527)

Autonomous build of board card tsk-egbllm.

REVISION: built on `exec/tsk-o2vhcq` (cut at `ceb9062e9f4fc35e7b669c1a7c2fa65415cb2227`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Fix-forward on PR #2527 (tsk-egbllm). Surgical corrections:

1. _get_token() was defined but never called in check_gate_integrity.py.
   Added 'token = token or _get_token()' in check_gate_integrity(), mirroring
   check_bot_review.py:174, so the workflow's GITHUB_TOKEN env var is forwarded
   to the GitHub API. Pre-fix the token was silently dropped and API calls went
   unauthenticated.

   RED PROOF (through main(), which no test exercised before): with
   GITHUB_TOKEN=proof-token set and urllib.request.urlopen mocked so _api_get's
   real header-building runs, the outgoing Request's Authorization header must
   equal 'Bearer proof-token'. Pre-fix _get_token() is never called, token stays
   None, _api_get omits the Authorization header, and the assertion fails:
     assert None == 'Bearer proof-token'
   Post-fix: 59 passed in tests/test_check_gate_integrity.py.

2. Added docs/doc-gate.toml, pyproject.toml, tests/conftest.py to
   PROTECTED_PREFIXES -- gate rules are data, and corrupting these config files
   could disable a gate without editing a checker.

3. Corrected the pull_request_target rationale in
   .github/workflows/gate-integrity.yml comments: checkout's default ref on
   pull_request_target is the BASE branch (GITHUB_REF resolves to the trusted
   base, not the PR merge ref), not the merge ref as the comments stated. The
   explicit ref: ${{ github.base_ref }} pin is kept for defense-in-depth.

4. Reverted a whitespace-only re-indent (3-space to 2-space) of the two
   Tests-Skipped-Intentionally lines in SKILL.md.

Run: uv run pytest tests/test_check_gate_integrity.py -q (59 passed)

Files:
 .claude/skills/taos-development-skill/SKILL.md |   4 +-
 .github/workflows/gate-integrity.yml           |  18 ++--
 changelog.d/tsk-egbllm-gate-integrity-fix.md   |   3 +
 scripts/check_gate_integrity.py                |  11 +++
 tests/test_check_gate_integrity.py             | 116 ++++++++++++++++++++++++-
 5 files changed, 142 insertions(+), 10 deletions(-)


---

_CI note: `Gate integrity` never ran on this PR. The workflow only registered once it reached the default branch (`master`, 2026-08-27T02:50Z), so every PR opened before then carries no gate context at all — which would leave it pending forever once the check becomes required. This body edit fires the `edited` trigger to create the missing context. No code change. Tracked by `tsk-diza64`._