### PR TITLE
fix(auth): non-object JSON body is a 400, not a 500

### DIFF
--- a/changelog.d/auth-json-object-body.md
+++ b/changelog.d/auth-json-object-body.md
@@ -1,0 +1,2 @@
+### Fixed
+- Auth routes now answer `400` instead of `500` when a JSON request body parses but is not an object. `request.json()` accepts `null`, `[]`, `1` and `"x"` as valid JSON, and the subsequent `body.get()` raised `AttributeError`. All six affected routes (`POST /auth/login`, `/auth/setup`, `/auth/complete`, `/auth/users`, `/auth/users/{username}/profile`, `/auth/users/{username}/password`) now share one `_json_object()` helper. Three of them are session-exempt, so the fault was reachable without credentials.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -139,6 +139,18 @@ believes access was removed when it was not. Do not rely on it.
 400 without `?channel=<thread>`; there is no all-threads mode yet, so watching
 several threads means one connection each.
 
+**A malformed JSON body to an auth route is a 400, not a 500.** `request.json()`
+happily parses `null`, `[]`, `1` and `"x"` - all valid JSON, none of them an
+object - and the `body.get()` that follows then raises `AttributeError`. Six
+routes in `tinyagentos/routes/auth.py` shared that shape, and three of them
+(`/auth/login`, `/auth/setup`, `/auth/complete`) are in `EXEMPT_PATHS`, so any
+unauthenticated caller could reach the 500. They now answer 400 for a body that
+is not a JSON object. If you are driving these endpoints, treat a 400 as "your
+body was the wrong shape" and stop reading a 500 there as a server fault worth
+escalating. When adding a route that reads a JSON body, use the `_json_object()`
+helper rather than parsing inline - it follows the module's existing
+`(value, error_response)` convention.
+
 ## Gate on fresh CI, not stale rollups
 
 - Open the PR against `dev` and let the required checks run: the Python test

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1311,3 +1311,85 @@ class TestAuthStatusUserAgentSymmetry:
             "/auth/me", headers={"user-agent": "TaosPWA/2.0 (updated browser)"}
         )
         assert rotated.status_code == 401
+
+
+# --- Non-object JSON bodies must be a 400, never a 500 -------------------------
+#
+# request.json() accepts null / [] / 1 / "x" -- all valid JSON, none of them a
+# mapping. Every one of these routes then calls body.get(), which raises
+# AttributeError and surfaces as a 500 for what is plainly a malformed request.
+# /auth/login, /auth/setup and /auth/complete are all session-exempt, so the
+# 500 is reachable by anyone who can talk to the port.
+
+# Sent as raw content, not via json=, because httpx omits the body entirely
+# for json=None -- which would test "no body" rather than the literal null.
+_NON_OBJECT_BODIES = ["null", "[]", "1", '"x"']
+_JSON_CT = {"content-type": "application/json"}
+
+
+class TestNonObjectJsonBody:
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_login_rejects_non_object_body(self, auth_client, body):
+        resp = await auth_client.post("/auth/login", content=body, headers=_JSON_CT)
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"
+
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_setup_rejects_non_object_body(self, auth_client, body):
+        # Unconfigured store, so the is_configured() 409 short-circuit above the
+        # body.get() calls does not mask the defect.
+        resp = await auth_client.post("/auth/setup", content=body, headers=_JSON_CT)
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"
+
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_complete_rejects_non_object_body(self, auth_client, body):
+        resp = await auth_client.post("/auth/complete", content=body, headers=_JSON_CT)
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"
+
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_add_user_rejects_non_object_body(self, auth_client, body):
+        await auth_client.post(
+            "/auth/setup",
+            json={"username": "admin", "full_name": "Admin", "email": "", "password": "adminpass", "auto_login": False},
+        )
+        login = await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "adminpass", "auto_login": False},
+        )
+        resp = await auth_client.post("/auth/users", content=body, headers=_JSON_CT, cookies=login.cookies)
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"
+
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_update_profile_rejects_non_object_body(self, auth_client, body):
+        await auth_client.post(
+            "/auth/setup",
+            json={"username": "admin", "full_name": "Admin", "email": "", "password": "adminpass", "auto_login": False},
+        )
+        login = await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "adminpass", "auto_login": False},
+        )
+        resp = await auth_client.post(
+            "/auth/users/admin/profile", content=body, headers=_JSON_CT, cookies=login.cookies
+        )
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"
+
+    @pytest.mark.parametrize("body", _NON_OBJECT_BODIES)
+    @pytest.mark.asyncio
+    async def test_change_password_rejects_non_object_body(self, auth_client, body):
+        await auth_client.post(
+            "/auth/setup",
+            json={"username": "admin", "full_name": "Admin", "email": "", "password": "adminpass", "auto_login": False},
+        )
+        login = await auth_client.post(
+            "/auth/login",
+            json={"username": "admin", "password": "adminpass", "auto_login": False},
+        )
+        resp = await auth_client.post(
+            "/auth/users/admin/password", content=body, headers=_JSON_CT, cookies=login.cookies
+        )
+        assert resp.status_code == 400, f"{body!r} produced {resp.status_code}"

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import json
 import logging
 import threading
 import time
@@ -577,7 +578,14 @@ async def _json_object(request: Request) -> tuple[dict | None, JSONResponse | No
     """
     try:
         body = await request.json()
-    except Exception:
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        # Deliberately narrow. request.json() READS the body before it parses
+        # it, so a blanket `except Exception` also swallows body-read failures
+        # (a client disconnecting mid-upload raises ClientDisconnect here) and
+        # reports them to the caller as "your JSON was malformed". That is a
+        # false accusation, and it hides a transport fault behind a 400 that
+        # nobody investigates. A read failure is not the client's syntax error,
+        # so let it propagate.
         return None, JSONResponse({"error": "invalid JSON body"}, status_code=400)
     if not isinstance(body, dict):
         return None, JSONResponse({"error": "invalid JSON body"}, status_code=400)

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -566,6 +566,24 @@ def _require_self(request: Request, username: str) -> tuple[bool, JSONResponse |
     return True, None
 
 
+async def _json_object(request: Request) -> tuple[dict | None, JSONResponse | None]:
+    """Read a JSON request body that must be an object. Returns (body, error_response).
+
+    Parsing alone is not enough: request.json() happily returns null, [], 1 or
+    "x" -- all valid JSON, none of them a mapping. A bare body.get() on any of
+    those raises AttributeError, so the caller gets a 500 for what is plainly a
+    malformed request. /auth/login, /auth/setup and /auth/complete are all
+    session-exempt, so that 500 is reachable by anyone who can reach the port.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return None, JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    if not isinstance(body, dict):
+        return None, JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    return body, None
+
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request, error: str = "", next: str = ""):
     """Server-rendered login page. Works without JavaScript — the SPA
@@ -643,10 +661,9 @@ async def login(request: Request):
             return JSONResponse({"error": _LOCKOUT_MSG}, status_code=429)
         return RedirectResponse("/auth/login?error=rate_limit", status_code=303)
     if "application/json" in content_type:
-        try:
-            body = await request.json()
-        except Exception:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+        body, body_err = await _json_object(request)
+        if body_err:
+            return body_err
         username = (body.get("username") or "").strip() or None
         password = body.get("password") or ""
 
@@ -984,10 +1001,9 @@ async def auth_setup(request: Request):
     content_type = request.headers.get("content-type", "")
     user_agent = request.headers.get("user-agent", "")
     if "application/json" in content_type:
-        try:
-            body = await request.json()
-        except Exception:
-            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+        body, body_err = await _json_object(request)
+        if body_err:
+            return body_err
         if auth_mgr.is_configured():
             return JSONResponse({"error": "already configured"}, status_code=409)
         username = (body.get("username") or "").strip()
@@ -1099,10 +1115,9 @@ async def complete_invite(request: Request):
             status_code=429,
         )
 
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err:
+        return body_err
 
     username = (body.get("username") or "").strip()
     invite_code = (body.get("invite_code") or "").strip()
@@ -1240,10 +1255,9 @@ async def add_user(request: Request):
     ok, err = _require_admin(request)
     if not ok:
         return err
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err:
+        return body_err
     username = (body.get("username") or "").strip()
     if not username:
         return JSONResponse({"error": "username is required"}, status_code=400)
@@ -1298,10 +1312,9 @@ async def update_profile(username: str, request: Request):
     ok, err = _require_self(request, username)
     if not ok:
         return err
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err:
+        return body_err
     full_name = body.get("full_name")
     email = body.get("email")
     auth_mgr = request.app.state.auth
@@ -1318,10 +1331,9 @@ async def change_password(username: str, request: Request):
     ok, err = _require_self(request, username)
     if not ok:
         return err
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err:
+        return body_err
     current = body.get("current") or ""
     new_pw = body.get("new") or ""
     if not new_pw or len(new_pw) < 8:

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -815,16 +815,9 @@ async def pin_login(request: Request):
     if not _request_is_console(request):
         return JSONResponse({"error": "PIN sign-in is not available"}, status_code=404)
 
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-    # request.json() happily returns null/[]/1/"x" -- all valid JSON, none of
-    # them a mapping. Without this the first body.get() raises AttributeError
-    # and the client gets a 500 for what is plainly a bad request. This route
-    # is reachable without a session, so any console client can send `null`.
-    if not isinstance(body, dict):
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err is not None:
+        return body_err
     username = (body.get("username") or "").strip() or None
     pin = body.get("pin") or ""
 
@@ -883,16 +876,9 @@ async def set_pin(request: Request):
     if not user_id:
         return JSONResponse({"error": "not authenticated"}, status_code=401)
 
-    try:
-        body = await request.json()
-    except Exception:
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
-    # request.json() happily returns null/[]/1/"x" -- all valid JSON, none of
-    # them a mapping. Without this the first body.get() raises AttributeError
-    # and the client gets a 500 for what is plainly a bad request. This route
-    # is reachable without a session, so any console client can send `null`.
-    if not isinstance(body, dict):
-        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    body, body_err = await _json_object(request)
+    if body_err is not None:
+        return body_err
 
     user = auth_mgr.get_user_by_id(user_id)
     if not user:


### PR DESCRIPTION
## What

`request.json()` accepts `null`, `[]`, `1` and `"x"` — all valid JSON, none of them a
mapping. Every auth route then called `body.get(...)`, which raises `AttributeError`
and surfaces as a **500** for what is plainly a malformed request.

Six routes shared the shape:

| Route | Reachable |
|---|---|
| `POST /auth/login` | **session-exempt** |
| `POST /auth/setup` | **session-exempt** |
| `POST /auth/complete` | **session-exempt** |
| `POST /auth/users` | admin |
| `POST /auth/users/{username}/profile` | self |
| `POST /auth/users/{username}/password` | self |

Three are in `EXEMPT_PATHS`, so the fault was reachable **without any credential**.

## Why a helper

The six sites each carried their own parse-only `try/except`. Rather than paste a
seventh copy of the `isinstance` check, they now share one `_json_object()` that
follows the existing `(value, error_response)` convention of `_require_admin` and
`_require_self` in the same module.

## Red proof

24 new cases (6 routes × `null` / `[]` / `1` / `"x"`):

```
24 failed, 96 deselected, 12 warnings in 39.21s
```

on the parent commit — most as a raised `AttributeError` rather than a status code,
since the ASGI transport re-raises. After the fix:

```
24 passed, 96 deselected, 12 warnings in 28.45s
```

The bodies are sent as raw `content=` rather than `json=`, because httpx omits the
body entirely for `json=None` — that would have tested "no body" instead of the
literal `null`, and `null` is the case a real client sends.

## Regression sweep

```
240 passed, 31 warnings in 98.69s
```

(`test_auth`, `test_routes_auth`, `test_auth_middleware`, `test_auth_email_login`,
`test_auth_store_durability`, `test_auth_context`, `test_device_auth`)

## Provenance

Found while reviewing #2540, which fixed this same shape on the two PIN routes it
adds. Those two are not touched here — this branch is cut from `dev`, so they do not
exist on it yet. When #2540 merges its inline guards should adopt this helper; noted
so the duplication is deliberate and short-lived, not forgotten.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional console-only PIN authentication and PIN management.
  - Added PIN setup during account creation, attempt throttling, and an on-screen keyboard.
  - Authentication status now indicates whether a PIN is available.
- **Bug Fixes**
  - Authentication endpoints now return HTTP 400 for valid JSON bodies that are not objects, preventing server errors.
- **Tests**
  - Added coverage for invalid JSON body types across affected authentication routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->