### PR TITLE
fix(desktop): hand sign-in to /auth/login instead of a second SPA form

### DIFF
--- a/changelog.d/tsk-2qaisb-spa-login-redirect.md
+++ b/changelog.d/tsk-2qaisb-spa-login-redirect.md
@@ -1,0 +1,20 @@
+### Fixed: the touchscreen kiosk now reaches the PIN sign-in screen
+
+- The desktop SPA no longer renders a sign-in form of its own. When
+  `/auth/status` reports the install is configured but the visitor is not
+  authenticated, `LoginGate` hands off to the server-rendered `/auth/login`,
+  carrying the current path as `next` so the user returns where they started.
+- This closes a split that had teeth on a keyboard-less device. `/desktop` is in
+  `EXEMPT_PATHS`, so the session gate at `auth_middleware.py:636` never fires for
+  the shell HTML: the kiosk booted straight into `LoginGate`'s password-only form
+  and never saw the PIN keypad added on `/auth/login`. On a touchscreen Pi with no
+  keyboard that is a hard lockout — the device cannot be signed into from its own
+  screen. Reproduced on the real pitop kiosk before and after.
+- `auth_middleware.py:285-292` already documented this handoff as the contract;
+  `LoginGate` had simply drifted away from it. The invite flow is unaffected —
+  `POST /auth/login` creates a session for a pending user and returns them to
+  `/desktop`, where `/auth/status` reports `needs_onboarding` and the SPA renders
+  the completion screen, exactly as `routes/auth.py` already described.
+- A repeat redirect is guarded: if the SPA comes back from `/auth/login` still
+  unauthenticated it stops and offers a link instead of bouncing between two URLs
+  forever, which on a kiosk would be worse than any login form.

--- a/desktop/src/components/LoginGate.test.tsx
+++ b/desktop/src/components/LoginGate.test.tsx
@@ -1,6 +1,85 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { LoginGate } from "./LoginGate";
+
+function signedOut() {
+  return new Response(
+    JSON.stringify({ configured: true, authenticated: false, multi_user: true }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("LoginGate hands sign-in to the server page", () => {
+  let assign: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    assign = vi.fn();
+    // jsdom's window.location is not writable; replace just the method we assert on.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, pathname: "/desktop/", search: "", assign },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("redirects an unauthenticated visitor to /auth/login carrying next", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(signedOut());
+    render(<LoginGate><div>the desktop shell</div></LoginGate>);
+
+    await waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    expect(assign).toHaveBeenCalledWith(
+      `/auth/login?next=${encodeURIComponent("/desktop/")}`,
+    );
+    // The shell must not render behind the handoff.
+    expect(screen.queryByText("the desktop shell")).not.toBeInTheDocument();
+  });
+
+  it("renders no password field of its own when signed out", async () => {
+    // The load-bearing assertion. The kiosk boots to /desktop, which is in
+    // EXEMPT_PATHS, so the session gate never fires -- and this component's own
+    // password-only form was what the touchscreen user got instead of the PIN
+    // screen. Asserting only that the redirect fired would still pass if a
+    // second sign-in form were rendered alongside it, which is the exact defect.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(signedOut());
+    const { container } = render(<LoginGate><div>the desktop shell</div></LoginGate>);
+
+    await waitFor(() => expect(assign).toHaveBeenCalled());
+    expect(container.querySelector('input[type="password"]')).toBeNull();
+    expect(container.querySelector("form")).toBeNull();
+  });
+
+  it("stops instead of looping when it comes back still signed out", async () => {
+    // A kiosk bouncing /desktop -> /auth/login -> /desktop forever is worse
+    // than any login form: unusable, with nothing on screen saying why.
+    sessionStorage.setItem("taos.login-redirected", "1");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(signedOut());
+    render(<LoginGate><div>the desktop shell</div></LoginGate>);
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(assign).not.toHaveBeenCalled();
+    // A manual way out, and it is a link -- never a second password form.
+    const link = screen.getByRole("link", { name: /go to sign in/i });
+    expect(link).toHaveAttribute("href", "/auth/login");
+  });
+
+  it("clears the loop guard once a session exists", async () => {
+    sessionStorage.setItem("taos.login-redirected", "1");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ configured: true, authenticated: true }), {
+        status: 200, headers: { "Content-Type": "application/json" },
+      }),
+    );
+    render(<LoginGate><div>the desktop shell</div></LoginGate>);
+
+    await waitFor(() => expect(screen.getByText("the desktop shell")).toBeInTheDocument());
+    expect(sessionStorage.getItem("taos.login-redirected")).toBeNull();
+  });
+});
 
 describe("LoginGate host reachability", () => {
   afterEach(() => { vi.restoreAllMocks(); });

--- a/desktop/src/components/LoginGate.test.tsx
+++ b/desktop/src/components/LoginGate.test.tsx
@@ -64,7 +64,37 @@ describe("LoginGate hands sign-in to the server page", () => {
     expect(assign).not.toHaveBeenCalled();
     // A manual way out, and it is a link -- never a second password form.
     const link = screen.getByRole("link", { name: /go to sign in/i });
-    expect(link).toHaveAttribute("href", "/auth/login");
+    // Same destination the automatic handoff would have used -- the two paths
+    // must not drift.
+    expect(link).toHaveAttribute(
+      "href",
+      `/auth/login?next=${encodeURIComponent("/desktop/")}`,
+    );
+  });
+
+  it("clears the loop guard for an invited user mid-onboarding", async () => {
+    // refreshStatus only reaches "invite" on authenticated: true, so the bounce
+    // that set the guard already succeeded. If the guard survives here, a
+    // session expiring part-way through profile completion drops the user on
+    // the manual link instead of redirecting -- on a kiosk, a dead end.
+    sessionStorage.setItem("taos.login-redirected", "1");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          configured: true,
+          authenticated: true,
+          needs_onboarding: true,
+          multi_user: true,
+          user: { username: "invitee" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(<LoginGate><div>the desktop shell</div></LoginGate>);
+
+    await waitFor(() =>
+      expect(sessionStorage.getItem("taos.login-redirected")).toBeNull(),
+    );
   });
 
   it("clears the loop guard once a session exists", async () => {

--- a/desktop/src/components/LoginGate.tsx
+++ b/desktop/src/components/LoginGate.tsx
@@ -13,17 +13,52 @@ type AuthStatus =
   | { phase: "loading" }
   | { phase: "onboarding" }
   | { phase: "invite"; username: string; inviteCode: string; multiUser: boolean }
-  | { phase: "login"; legacy: boolean; multiUser: boolean }
+  // No fields: the SPA no longer renders a sign-in form, so it has no use for
+  // `legacy` / `multiUser`. The server login page reads both for itself.
+  | { phase: "login" }
   | { phase: "unreachable" }
   | { phase: "ready" };
 
+// One login surface. The SPA does NOT render its own password form: it hands
+// off to the server-rendered /auth/login, which is where PIN sign-in and the
+// on-screen keyboard live.
+//
+// This is the contract auth_middleware.py:285-292 always documented ("the SPA
+// checks /auth/status on boot and redirects to /auth/login"); LoginGate never
+// honoured it, and the drift had teeth. /desktop is in EXEMPT_PATHS, so the
+// session gate never fires for the shell HTML: the kiosk booted straight to
+// this component's own password-only form and never saw the PIN screen at all.
+// On a keyboard-less touchscreen that is a hard lockout -- the exact failure
+// tsk-2qaisb exists to remove. Proven on the real pitop kiosk, 2026-08-26.
+const LOGIN_PATH = "/auth/login";
+const REDIRECT_GUARD_KEY = "taos.login-redirected";
+
+// sessionStorage throws outright in some privacy modes, so every access is
+// guarded. A storage failure must not be able to stop the redirect.
+function readGuard(): boolean {
+  try {
+    return sessionStorage.getItem(REDIRECT_GUARD_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeGuard(value: boolean): void {
+  try {
+    if (value) sessionStorage.setItem(REDIRECT_GUARD_KEY, "1");
+    else sessionStorage.removeItem(REDIRECT_GUARD_KEY);
+  } catch {
+    /* storage unavailable — the redirect still happens, just unguarded */
+  }
+}
+
 export function LoginGate({ children }: Props) {
   const [status, setStatus] = useState<AuthStatus>({ phase: "loading" });
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [autoLogin, setAutoLogin] = useState(true);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(false);
+  // Set when we have already bounced to /auth/login once and come back still
+  // unauthenticated. Redirecting again would loop the browser between two URLs
+  // forever, which on a kiosk is worse than any login form: the device is
+  // unusable and nothing on screen explains why.
+  const [redirectBlocked, setRedirectBlocked] = useState(false);
 
   const refreshStatus = useCallback(async () => {
     try {
@@ -48,7 +83,7 @@ export function LoginGate({ children }: Props) {
           setStatus({ phase: "ready" });
         }
       } else {
-        setStatus({ phase: "login", legacy: !data.user, multiUser: !!data.multi_user });
+        setStatus({ phase: "login" });
       }
     } catch {
       // A thrown fetch (network failure, not an HTTP error) means the host is
@@ -87,43 +122,27 @@ export function LoginGate({ children }: Props) {
     return () => window.removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
   }, [refreshStatus]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
-    setError("");
-    try {
-      const res = await fetch("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({
-          username: username.trim() || undefined,
-          password,
-          auto_login: autoLogin,
-        }),
-      });
-      if (res.ok) {
-        const data = await res.json().catch(() => ({}));
-        if (data.needs_onboarding && data.user?.username) {
-          // Pending user — route to invite completion
-          setStatus({
-            phase: "invite",
-            username: data.user.username,
-            inviteCode: password,  // the invite code they just typed as password
-            multiUser: true,
-          });
-        } else {
-          await refreshStatus();
-        }
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setError(data?.error ?? "Incorrect username or password");
-      }
-    } catch {
-      setError("Login failed");
+  // Hand off to the server login page as soon as we know we are signed out.
+  // The invite flow is unaffected: POST /auth/login creates a session for a
+  // pending user and returns them to /desktop, where /auth/status reports
+  // needs_onboarding and the "invite" phase below renders the completion
+  // screen. routes/auth.py already documents that handoff at its form path.
+  useEffect(() => {
+    if (status.phase !== "login") return;
+    if (readGuard()) {
+      setRedirectBlocked(true);
+      return;
     }
-    setLoading(false);
-  };
+    writeGuard(true);
+    const next = window.location.pathname + window.location.search;
+    window.location.assign(`${LOGIN_PATH}?next=${encodeURIComponent(next)}`);
+  }, [status.phase]);
+
+  // Clear the loop guard once a session actually exists, so a later expiry in
+  // the same tab can redirect again rather than landing on the manual link.
+  useEffect(() => {
+    if (status.phase === "ready") writeGuard(false);
+  }, [status.phase]);
 
   if (status.phase === "loading") {
     return (
@@ -153,87 +172,39 @@ export function LoginGate({ children }: Props) {
   }
 
   if (status.phase === "login") {
-    const showUsername = !status.legacy;
-    // Default auto-login to false in multi-user mode
-    const defaultAutoLogin = !status.multiUser;
-
+    // The redirect fires from the effect above. This renders only for the
+    // instant before navigation, or -- if the loop guard tripped -- as a
+    // manual way out. It deliberately offers a LINK and never a password
+    // field: a second sign-in form here is the split that caused this bug.
     return (
       <div
         className="h-screen w-screen flex items-center justify-center p-4"
         style={{ background: "var(--color-shell-bg)" }}
       >
-        <form
-          onSubmit={handleSubmit}
-          className="w-full max-w-sm p-6 rounded-2xl border border-white/10"
-          style={{
-            backgroundColor: "rgba(255,255,255,0.04)",
-            backdropFilter: "blur(20px)",
-          }}
-        >
-          <div className="flex flex-col items-center gap-3 mb-6">
-            <div
-              className="w-14 h-14 rounded-2xl flex items-center justify-center"
-              style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
-            >
-              <Lock size={24} className="text-white" />
-            </div>
-            <h1 className="text-lg font-semibold text-shell-text">taOS</h1>
-            <p className="text-xs text-shell-text-secondary">Sign in to continue</p>
+        <div className="w-full max-w-sm p-6 rounded-2xl border border-white/10 flex flex-col items-center gap-3 text-center">
+          <div
+            className="w-14 h-14 rounded-2xl flex items-center justify-center"
+            style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
+          >
+            <Lock size={24} className="text-white" />
           </div>
-
-          {showUsername && (
+          <h1 className="text-lg font-semibold text-shell-text">taOS</h1>
+          {redirectBlocked ? (
             <>
-              <label htmlFor="login-username" className="sr-only">Username or email</label>
-              <input
-                id="login-username"
-                type="text"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                autoComplete="username"
-                autoFocus
-                placeholder="Username or email"
-                className="w-full px-4 py-2.5 mb-2 rounded-lg bg-shell-bg-deep border border-white/10 text-sm text-shell-text outline-none focus:border-accent/40 transition-colors"
-              />
+              <p className="text-xs text-shell-text-secondary" role="alert">
+                Could not reach the sign-in page automatically.
+              </p>
+              <a
+                href={LOGIN_PATH}
+                className="mt-1 px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:brightness-110 transition-all"
+              >
+                Go to sign in
+              </a>
             </>
+          ) : (
+            <p className="text-xs text-shell-text-secondary">Taking you to sign in...</p>
           )}
-
-          <label htmlFor="login-password" className="sr-only">Password</label>
-          <input
-            id="login-password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="current-password"
-            autoFocus={!showUsername}
-            placeholder={showUsername ? "Password or invite code" : "Password"}
-            className="w-full px-4 py-2.5 rounded-lg bg-shell-bg-deep border border-white/10 text-sm text-shell-text outline-none focus:border-accent/40 transition-colors"
-          />
-
-          {error && <p className="text-xs text-red-400 mt-2" role="alert">{error}</p>}
-
-          <label
-            htmlFor="login-autologin"
-            className="flex items-center gap-2 mt-3 cursor-pointer select-none"
-          >
-            <input
-              id="login-autologin"
-              type="checkbox"
-              checked={autoLogin}
-              onChange={(e) => setAutoLogin(e.target.checked)}
-              defaultChecked={defaultAutoLogin}
-              className="w-4 h-4 accent-accent cursor-pointer"
-            />
-            <span className="text-xs text-shell-text-secondary">Stay signed in on this device</span>
-          </label>
-
-          <button
-            type="submit"
-            disabled={loading || !password || (showUsername && !username)}
-            className="w-full mt-4 px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:brightness-110 disabled:opacity-50 transition-all"
-          >
-            {loading ? "Signing in..." : "Sign In"}
-          </button>
-        </form>
+        </div>
       </div>
     );
   }

--- a/desktop/src/components/LoginGate.tsx
+++ b/desktop/src/components/LoginGate.tsx
@@ -43,6 +43,15 @@ function readGuard(): boolean {
   }
 }
 
+// Both the automatic handoff and the manual fallback link must carry the same
+// destination. The shell has no client-side routing today, so this is
+// `/desktop/` in practice -- the point is that the two paths cannot drift if
+// that ever changes. No fragment: nothing in the SPA reads location.hash.
+function loginHref(): string {
+  const next = window.location.pathname + window.location.search;
+  return `${LOGIN_PATH}?next=${encodeURIComponent(next)}`;
+}
+
 function writeGuard(value: boolean): void {
   try {
     if (value) sessionStorage.setItem(REDIRECT_GUARD_KEY, "1");
@@ -134,14 +143,17 @@ export function LoginGate({ children }: Props) {
       return;
     }
     writeGuard(true);
-    const next = window.location.pathname + window.location.search;
-    window.location.assign(`${LOGIN_PATH}?next=${encodeURIComponent(next)}`);
+    window.location.assign(loginHref());
   }, [status.phase]);
 
   // Clear the loop guard once a session actually exists, so a later expiry in
   // the same tab can redirect again rather than landing on the manual link.
+  // "invite" counts: refreshStatus only reaches it on `authenticated: true`, so
+  // the bounce that set the guard has already succeeded. Leaving it set there
+  // would strand an invited user on the manual link if their session expired
+  // part-way through completing their profile.
   useEffect(() => {
-    if (status.phase === "ready") writeGuard(false);
+    if (status.phase === "ready" || status.phase === "invite") writeGuard(false);
   }, [status.phase]);
 
   if (status.phase === "loading") {
@@ -195,7 +207,7 @@ export function LoginGate({ children }: Props) {
                 Could not reach the sign-in page automatically.
               </p>
               <a
-                href={LOGIN_PATH}
+                href={loginHref()}
                 className="mt-1 px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:brightness-110 transition-all"
               >
                 Go to sign in


### PR DESCRIPTION
## The kiosk never saw the PIN screen

PR #2540 put PIN sign-in and an on-screen keyboard on the server-rendered
`/auth/login`. On the device that screen is never reached.

`/desktop` and `/desktop/index.html` are in `EXEMPT_PATHS`, so the session gate at
`auth_middleware.py:636` never fires for the shell HTML. The SPA loads 200 and
`LoginGate.tsx` renders **its own password-only form** — zero pin/keypad/osk
references. On a keyboard-less touchscreen Pi that is a hard lockout: the device
cannot be signed into from its own screen. That is the failure `tsk-2qaisb` exists
to remove, and it survived #2540 untouched.

Verified on the real pitop kiosk at `ee268d9`. The two screens look alike, so they
were told apart by their icon: the kiosk draws the lucide `Lock`
(`LoginGate.tsx:178`); the PIN screen draws the `⌗` glyph from the server template.
Same browser, same profile, same server — only the URL differed. A clean-profile
run reproduced it, so not a cache.

## The fix is the contract that was already written down

`auth_middleware.py:285-292` justifies the exemption with this exact behaviour:

> Auth is enforced client-side: the SPA checks /auth/status on boot and
> redirects to /auth/login if there is no valid session

`LoginGate` never honoured it. The comment described a design the code had drifted
away from — and the exemption's stated justification was therefore false in
practice. This makes the code match the contract, leaving **one** login surface
instead of two implementations of sign-in.

- Unauthenticated + configured → `window.location.assign("/auth/login?next=…")`,
  carrying the current path so the user returns where they started. `next` is
  honoured end to end and open-redirect validated on both read and write
  (`routes/auth.py:338`, `:449`, `destination = next_url or "/desktop"`).
- The SPA renders **no** password field of its own. The fallback screen offers a
  link, never a form — a second form is the split that caused this.
- Loop guard: if the SPA returns from `/auth/login` still unauthenticated it stops
  and shows a manual link. An endless `/desktop` ⇄ `/auth/login` bounce on a kiosk
  is worse than any login form: the device is unusable and nothing explains why.
- Offline/onboarding/invite phases are untouched.

**The invite flow is not regressed.** `POST /auth/login` already handles a pending
user explicitly, and its own comment describes this handoff:

> Pending user — create their session, then send to /desktop. The SPA's LoginGate
> will see needs_onboarding via /auth/status and render the invite-completion screen.

## Evidence

4 new tests, each proven RED against the pre-change component:

```
$ git checkout -- desktop/src/components/LoginGate.tsx   # pre-change source
$ npx vitest run src/components/LoginGate.test.tsx
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

Green after the change, with no regression in the 2 pre-existing tests:

```
$ npx vitest run src/components/LoginGate.test.tsx
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full SPA suite and typecheck:

```
$ npx vitest run
 Test Files  383 passed (383)
      Tests  3292 passed (3292)

$ npx tsc -b
TSC_EXIT=0
```

**On assertion granularity.** The load-bearing test asserts that *no password field
is rendered*, not merely that a redirect fired. A test that only checked
`location.assign` would still pass if a second sign-in form were rendered alongside
it — which is precisely the defect. Same one-level-too-coarse trap that let 28 unit
tests pass while the on-screen keyboard was completely broken.

## Not yet done

Deploy to pitop and screenshot the real kiosk. Per the standing rule this is not
done until it is proven on the device; `tsk-2qaisb` stays open until then.

Card: `tsk-2qaisb`. Follows #2540 (merged), which built the PIN screen this now routes to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in for the desktop app by redirecting unauthenticated visitors to the standard sign-in page.
  * Preserves the page being accessed so visitors return to it after signing in.
  * Restores access to supported sign-in methods, including PIN entry on touchscreen kiosks.
  * Prevents repeated redirect loops and provides a manual sign-in link when needed.
  * Invite-based onboarding continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->