### PR TITLE
ci: promote gate-integrity workflow + checker to master

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -168,6 +168,18 @@ deps the project does not pin set `check_upgrade = false`.
   exist yet) — green CI that asserts nothing. The failure names the file and the guard.
   Landing tests ahead of code stays legal via an explicit waiver trailer in the PR body:
   `Tests-Skipped-Intentionally: <file>, <why>`. Files with SOME skips pass (v1 scope).
+- **Gate integrity** (`.github/workflows/gate-integrity.yml`, implementation in
+  `scripts/check_gate_integrity.py`): because each `pull_request` gate checks
+  out the PR merge ref and runs its checker FROM that checkout, a PR can edit
+  its own gate to always-exit-0 and green-pass the check that gates it. This
+  workflow runs on `pull_request_target` from the base ref and inspects the PR
+  diff via the GitHub API only -- it never checks out or executes PR code. It
+  fails any PR touching `.github/workflows/`, `.github/scripts/`,
+  `scripts/check_*.py`, `docs/doc-gate.toml`, `pyproject.toml`, or
+  `tests/conftest.py` unless the PR carries the human-set
+  `gate-integrity-allow` label (the only way to land a legitimate change to CI
+  or a gate checker). Add that label yourself; lanes must not add it. Branch
+  protection must require "Gate integrity" as a blocking check.
 
 ## CLA - HUMAN signs
 

--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -180,6 +180,12 @@ deps the project does not pin set `check_upgrade = false`.
   `gate-integrity-allow` label (the only way to land a legitimate change to CI
   or a gate checker). Add that label yourself; lanes must not add it. Branch
   protection must require "Gate integrity" as a blocking check.
+  **Retargeting a PR re-runs this gate, and it can newly fail.** The verdict is
+  a function of the base..head diff, so a PR that passed against one base can
+  touch protected files against another; the workflow subscribes to the
+  `edited` activity type (which is what a base change fires) so the new diff is
+  actually inspected. If you change a PR's base and this gate goes red, that is
+  the new diff being judged, not a flake -- re-read what the failure names.
 
 ## CLA - HUMAN signs
 

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -1,0 +1,68 @@
+name: Gate integrity
+
+# CLASS DEFECT fix (tsk-o2vhcq): every gate workflow triggered on
+# `pull_request` checks out the PR MERGE REF (actions/checkout's default on
+# that event) and runs its checker script FROM THAT CHECKOUT. A PR can
+# therefore edit its own checker (and its own workflow YAML -- `pull_request`
+# runs the workflow file from the merge ref too) to always-exit-0 and
+# green-pass the very check that is supposed to gate it.
+#
+# This workflow breaks that loop:
+#   * It triggers on `pull_request_target`, so the workflow file AND this
+#     script are resolved from the BASE branch, never from the PR head. A PR
+#     editing this workflow or its checker is inert here.
+#   * It does NOT check out or execute PR code. `actions/checkout` is pinned
+#     to `ref: ${{ github.base_ref }}` (the base branch) -- the PR merge ref is
+#     deliberately never fetched. The base-ref checker then inspects the PR diff
+#     via the GitHub REST API only.
+#   * It fails any PR whose diff touches a protected gate file -- the
+#     PROTECTED_PREFIXES set in scripts/check_gate_integrity.py (workflows,
+#     gate checkers, gate data and test config) -- unless the PR carries the
+#     human-set `gate-integrity-allow` label. The checker is the single
+#     source of truth for the protected set; this comment deliberately does
+#     not enumerate it.
+#
+# Token permissions are minimal (contents: read, pull-requests: read); the
+# GITHUB_TOKEN never acquires write scope here, and PR-controlled code is never
+# run, so a malicious PR cannot escalate through this job.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [master, dev]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate-integrity:
+    name: Gate integrity
+    runs-on: ubuntu-latest
+    # permissions are set at the workflow root above; restated here so the
+    # job is safe even if copy-pasted into another workflow.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # On `pull_request_target` checkout defaults to the base branch,
+      # not the merge ref. Pinning `ref` to base_ref guarantees
+      # the base-ref checker (and this workflow) execute from base.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Inspect PR diff via API for self-editing gates
+        # Fail closed on infrastructure errors (exit 2) so a transient API
+        # blip never reads as green -- see check_gate_integrity.EXIT_ERROR.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          python scripts/check_gate_integrity.py "$PR_NUMBER"

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -26,9 +26,17 @@ name: Gate integrity
 # GITHUB_TOKEN never acquires write scope here, and PR-controlled code is never
 # run, so a malicious PR cannot escalate through this job.
 
+# `edited` is not cosmetic here. Retargeting a PR's base branch fires `edited`
+# (carrying `changes.base`) and no other activity type, so without it this gate
+# never re-inspects the new base..head file list. `dev` runs loose branch
+# protection (`strict: false`), so the head SHA does not move on a retarget and
+# nothing else forces a re-run -- a PASS earned against one base would keep
+# satisfying the required check against another whose diff touches protected
+# gate files. `edited` also fires on title/body edits; re-running is cheap and
+# read-only, so the gate takes the extra runs rather than the bypass.
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [master, dev]
 
 permissions:

--- a/scripts/check_gate_integrity.py
+++ b/scripts/check_gate_integrity.py
@@ -310,11 +310,20 @@ def _detect_repo() -> tuple[str, str]:
         if "github.com" in url:
             # Handles both https://github.com/owner/repo(.git) and
             # SCP-style git@github.com:owner/repo(.git) remotes.
-            path = url.split("github.com", 1)[1].lstrip(":/").replace(".git", "").strip()
+            # `.git` is stripped as a SUFFIX only. `.replace(".git", "")` was
+            # global and also ate the marker out of the middle of a repository
+            # name, so `acme/widgets.git.archive.git` resolved to
+            # `acme/widgets.archive` -- a repo that does not exist.
+            path = url.split("github.com", 1)[1].lstrip(":/").strip().removesuffix(".git")
             parts = path.split("/")
             if len(parts) >= 2:
                 return parts[0], parts[1]
-    except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+    # subprocess.TimeoutExpired descends from SubprocessError, NOT from
+    # CalledProcessError, so the 5s timeout above escaped this handler and
+    # killed the script on an uncaught traceback. That exits 1 -- and
+    # EXIT_BLOCKED is also 1, so a merely slow `git` was indistinguishable from
+    # "this PR edits a protected gate file" and blocked an innocent PR.
+    except (subprocess.SubprocessError, FileNotFoundError, IndexError):
         pass
 
     return "jaylfc", "taOS"

--- a/scripts/check_gate_integrity.py
+++ b/scripts/check_gate_integrity.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Gate-integrity guard: a PR must not edit its own gate to green itself.
+
+CLASS DEFECT being closed: every gate workflow triggered on `pull_request`
+checks out the PR MERGE REF (`actions/checkout`'s default on that event) and
+runs its checker script FROM THAT CHECKOUT. A PR can therefore edit the
+checker -- and the workflow file itself, since `pull_request` runs the
+workflow YAML from the merge ref too -- and make its own required check pass
+while disabling detection. The gates affected by this class defect:
+
+  - bot-review-gate        -> scripts/check_bot_review.py
+  - deleted-symbols-gate     -> scripts/check_deleted_symbols.py
+  - doc-gate                 -> scripts/check_doc_gate.py, check_schema_migrations.py,
+                                check_retrofit_migrations.py, check_manifests.py
+  - secret-ignores-gate      -> scripts/check_secret_ignores.py
+  - store-wiring-gate        -> scripts/check_store_wiring.py
+  - distrust-green-gate      -> .github/scripts/check_all_skip.py
+  - security                 -> scripts/check_dependency_audit_ignores.py
+  - evil-merge-gate          -> scripts/check_evil_merge.py (when present)
+
+Fix direction #1 (the one that actually closes the class): this guard runs on
+`pull_request_target`, which resolves BOTH the workflow file and this script
+to the BASE ref (`origin/dev`). It does NOT check out or execute any PR code
+-- it reads the PR's changed-files list and its labels through the GitHub REST
+API only, using the base-ref version of this script. When the PR diff touches
+a protected path, the run FAILS, unless the PR carries an explicit human-set
+allow label so legitimate changes to CI/gates can still land.
+
+Fix direction #2 (gates fetch their checker from the BASE ref) is NOT
+sufficient on its own: it protects the checker script but not the workflow
+file that drives it, which is why #1 is still required. This guard covers
+both, so #2 is redundant for the covered surface.
+
+Protected paths (the minimal gate surface a lane could corrupt):
+  - `.github/workflows/`        the required-check workflow YAML itself
+  - `.github/scripts/`          gate checkers collocated under `.github`
+  - `scripts/check_*.py`        every repo gate checker lives here by convention
+  - `docs/doc-gate.toml`        the doc-gate's rule DATA (a gate input, not code)
+  - `pyproject.toml`            tool/test configuration the gates execute under
+  - `tests/conftest.py`         fixture root every gate-adjacent test imports
+
+Usage:
+    python scripts/check_gate_integrity.py <pr-number> [--owner O] [--repo R] [--label LABEL]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+API = "https://api.github.com"
+EXIT_OK = 0
+EXIT_BLOCKED = 1
+EXIT_ERROR = 2
+
+# A human-placed label that explicitly waives the gate integrity check for a
+# PR that legitimately edits CI/gates. It must be applied manually -- never by
+# automation in a PR-lane -- so the waiver is a conscious human act.
+DEFAULT_ALLOW_LABEL = "gate-integrity-allow"
+
+# Protected path prefixes. A PR editing any file under these prefixes can
+# silence or subvert a required check, so such edits are blocked unless the
+# allow label is set.
+PROTECTED_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/",
+    ".github/scripts/",
+    "docs/doc-gate.toml",
+    "pyproject.toml",
+    "tests/conftest.py",
+)
+# Every repo gate checker is named `scripts/check_*.py` by convention; that
+# glob captures all current and future gate scripts in one rule so the guard
+# never silently goes blind to a new gate.
+GATE_SCRIPT_PREFIX = "scripts/check_"
+GATE_SCRIPT_SUFFIX = ".py"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class CheckResult:
+    exit_code: int
+    message: str
+
+
+def _get_token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or None
+
+
+def _api_get(url: str, token: str | None = None) -> list | None:
+    """Fetch a paginated GitHub REST endpoint; None on infrastructure failure.
+
+    None means "cannot see" (network error, auth failure, 404, bad JSON) so a
+    cannot-see state is never mistaken for a clean pass -- the worker fails
+    the run instead. A legitimately empty result returns []. Pagination is
+    followed via the Link header, matching check_bot_review.py's contract.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "taos-gate-integrity",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    items: list = []
+    page_url: str | None = url
+    while page_url:
+        req = urllib.request.Request(page_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                raw = r.read().decode("utf-8")
+                data = json.loads(raw)
+                link = r.headers.get("Link", "")
+        except urllib.error.HTTPError as e:
+            print(f"error: GET {page_url} failed: HTTP {e.code} {e.reason}", file=sys.stderr)
+            return None
+        except Exception as e:  # any infra failure fails closed
+            print(f"error: GET {page_url} failed: {e}", file=sys.stderr)
+            return None
+        if isinstance(data, dict) and data.get("message"):
+            print(f"error: API response message: {data['message']}", file=sys.stderr)
+            return None
+        if isinstance(data, list):
+            items.extend(data)
+        elif isinstance(data, dict):
+            items.append(data)
+        page_url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                match = re.search(r"<([^>]+)>", part)
+                if match:
+                    page_url = match.group(1)
+                break
+    return items
+
+
+def is_protected(path: str) -> bool:
+    """Return True if `path` is a gate file a PR must not edit without the
+    allow label. Paths are normalised to forward slashes so Windows-style
+    clients cannot dodge the check."""
+    norm = path.replace("\\", "/")
+    for prefix in PROTECTED_PREFIXES:
+        if norm.startswith(prefix):
+            return True
+    if (
+        norm.startswith(GATE_SCRIPT_PREFIX)
+        and norm.endswith(GATE_SCRIPT_SUFFIX)
+        and norm.count("/") == 1
+    ):
+        # `scripts/check_<x>.py` directly under scripts/ only; a nested file
+        # like scripts/platform/check_foo.py is not matched by the flat
+        # `scripts/check_*.py` convention.
+        return True
+    return False
+
+
+def collect_pr_files(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> tuple[list[str], int] | None:
+    """Return (changed paths, API record count) for a PR (via the API, never
+    a local checkout). A rename edits BOTH paths -- renaming a workflow out
+    of .github/workflows/ disables it -- so `previous_filename` is included
+    alongside `filename`. The record count is returned separately: the
+    truncation check must compare records against `changed_files`, or every
+    rename would read as a truncated listing. None on infrastructure
+    failure."""
+    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}/files", token)
+    if data is None:
+        return None
+    records = [f for f in data if isinstance(f, dict)]
+    paths: list[str] = []
+    for f in records:
+        paths.append(f.get("filename", ""))
+        prev = f.get("previous_filename")
+        if isinstance(prev, str) and prev:
+            paths.append(prev)
+    return paths, len(records)
+
+
+def collect_pr_meta(
+    owner: str, repo: str, pr_number: int, token: str | None = None,
+) -> tuple[set[str], int] | None:
+    """Return (label names, changed_files count) for the PR (via the API).
+
+    None on infrastructure failure, and also when the payload carries no
+    usable `changed_files` count: without it a truncated /files listing is
+    undetectable, and cannot-see must never read as a clean pass."""
+    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}", token)
+    if data is None:
+        return None
+    pr = data[0] if isinstance(data, list) and data else {}
+    if not isinstance(pr, dict):
+        return None
+    changed = pr.get("changed_files")
+    if not isinstance(changed, int) or isinstance(changed, bool):
+        return None
+    labels = {
+        lbl.get("name", "") for lbl in pr.get("labels", []) if isinstance(lbl, dict)
+    }
+    return labels, changed
+
+
+def classify(
+    files: list[str], labels: list[str] | set[str], allow_label: str,
+) -> CheckResult:
+    """Pure decision: given a PR's changed files and labels, decide pass/fail.
+
+    RED  -- a protected gate file is in the diff and no allow label is set.
+    GREEN -- no protected files in the diff, or the allow label waives them.
+    """
+    violations = sorted({f for f in files if is_protected(f)})
+    label_set = set(labels or [])
+    if not violations:
+        return CheckResult(
+            EXIT_OK,
+            "gate-integrity: PASS -- PR touches no protected gate paths "
+            f"({', '.join(PROTECTED_PREFIXES)} or {GATE_SCRIPT_PREFIX}*{GATE_SCRIPT_SUFFIX})",
+        )
+    if allow_label in label_set:
+        return CheckResult(
+            EXIT_OK,
+            (
+                f"gate-integrity: PASS -- {len(violations)} protected gate file(s) "
+                f"touched but waived by human-set `{allow_label}` label: "
+                f"{violations}"
+            ),
+        )
+    return CheckResult(
+        EXIT_BLOCKED,
+        (
+            f"gate-integrity: FAIL -- PR touches {len(violations)} protected "
+            f"gate file(s) without the `{allow_label}` label: {violations}. "
+            "A pull_request gate checks out the merge ref and runs its checker "
+            "FROM that checkout, so a PR editing its own gate can green-pass "
+            "the check that gates it. Set the label to acknowledge a human "
+            "reviewed and approved the gate change."
+        ),
+    )
+
+
+def check_gate_integrity(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    allow_label: str = DEFAULT_ALLOW_LABEL,
+    token: str | None = None,
+) -> tuple[int, str]:
+    """Fetch a PR's files + labels via the API and classify the integrity.
+
+    Returns (exit_code, message). EXIT_ERROR (2) is returned when the GitHub
+    API cannot be reached or returns an error, so a cannot-see state never
+    reads as a clean pass.
+    """
+    token = token or _get_token()
+    collected = collect_pr_files(owner, repo, pr_number, token)
+    if collected is None:
+        return EXIT_ERROR, (
+            f"gate-integrity: error -- could not fetch changed files for "
+            f"PR #{pr_number} (infrastructure failure, exit {EXIT_ERROR})"
+        )
+    meta = collect_pr_meta(owner, repo, pr_number, token)
+    if meta is None:
+        return EXIT_ERROR, (
+            f"gate-integrity: error -- could not fetch labels/changed-file "
+            f"count for PR #{pr_number} (infrastructure failure, exit {EXIT_ERROR})"
+        )
+    files, record_count = collected
+    labels, changed_total = meta
+    if record_count != changed_total:
+        # GitHub's /files endpoint silently stops at 3,000 files; a diff the
+        # gate cannot fully see cannot be cleared. Fail closed, not open.
+        # Compared per-record, not per-path: renames contribute two paths
+        # from one record.
+        return EXIT_ERROR, (
+            f"gate-integrity: error -- /files returned {record_count} record(s) but "
+            f"the PR reports changed_files={changed_total}; the listing is "
+            f"truncated or inconsistent, so unseen paths cannot be cleared "
+            f"(exit {EXIT_ERROR})"
+        )
+    result = classify(files, labels, allow_label)
+    return result.exit_code, result.message
+
+
+def _detect_repo() -> tuple[str, str]:
+    """Detect (owner, repo) from GITHUB_REPOSITORY env var or git remote.
+
+    Falls back to ("jaylfc", "taOS") if neither is available. The repo is only
+    needed to build the API URL, never for authentication.
+    """
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    if env_repo and "/" in env_repo:
+        parts = env_repo.split("/")
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+        url = result.stdout.strip()
+        if "github.com" in url:
+            # Handles both https://github.com/owner/repo(.git) and
+            # SCP-style git@github.com:owner/repo(.git) remotes.
+            path = url.split("github.com", 1)[1].lstrip(":/").replace(".git", "").strip()
+            parts = path.split("/")
+            if len(parts) >= 2:
+                return parts[0], parts[1]
+    except (subprocess.CalledProcessError, FileNotFoundError, IndexError):
+        pass
+
+    return "jaylfc", "taOS"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "pr_number", type=int, help="GitHub PR number to inspect (files + labels only).",
+    )
+    parser.add_argument(
+        "--owner", default=None, help="Repo owner (default: auto-detect).",
+    )
+    parser.add_argument(
+        "--repo", default=None, help="Repo name (default: auto-detect).",
+    )
+    parser.add_argument(
+        "--label", default=DEFAULT_ALLOW_LABEL,
+        help=f"Allow label that waives the check (default: {DEFAULT_ALLOW_LABEL}).",
+    )
+    parser.add_argument(
+        "--token", default=None,
+        help="GitHub token (default: $GH_TOKEN or $GITHUB_TOKEN).",
+    )
+    args = parser.parse_args(argv)
+
+    owner = args.owner
+    repo = args.repo
+    if not owner or not repo:
+        detected_owner, detected_repo = _detect_repo()
+        owner = owner or detected_owner
+        repo = repo or detected_repo
+
+    exit_code, message = check_gate_integrity(
+        owner, repo, args.pr_number, args.label, args.token,
+    )
+    print(message)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -376,6 +376,41 @@ class TestDetectRepo:
         with patch("check_gate_integrity.subprocess.run", return_value=fake):
             assert cgi._detect_repo() == ("acme", "widgets")
 
+    def test_a_slow_git_falls_back_instead_of_crashing(self, monkeypatch) -> None:
+        """`subprocess.run(..., timeout=5)` raises TimeoutExpired, which does
+        NOT descend from CalledProcessError -- so it escaped the handler and
+        left the script to die on an uncaught traceback.
+
+        The direction that matters is which way it failed. An uncaught
+        exception exits 1, and EXIT_BLOCKED is 1, so a merely SLOW `git` was
+        indistinguishable from "this PR edits a protected gate file": an
+        innocent PR gets blocked with a traceback in place of the fallback the
+        docstring promises. Asserting only "it does not raise" would be one
+        level too coarse -- it must land on the documented default.
+        """
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        with patch(
+            "check_gate_integrity.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["git"], timeout=5),
+        ):
+            assert cgi._detect_repo() == ("jaylfc", "taOS")
+
+    def test_dot_git_is_stripped_only_as_a_suffix(self, monkeypatch) -> None:
+        """`.replace(".git", "")` is global, so it also ate `.git` from the
+        MIDDLE of a repository name and reported a repo that does not exist.
+
+        Inert for `jaylfc/taOS`, which is exactly why it survived: the fault
+        only shows on a name carrying an embedded `.git`, and this checker is
+        meant to be portable to other repos.
+        """
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        fake = subprocess.CompletedProcess(
+            args=["git"], returncode=0,
+            stdout="https://github.com/acme/widgets.git.archive.git\n", stderr="",
+        )
+        with patch("check_gate_integrity.subprocess.run", return_value=fake):
+            assert cgi._detect_repo() == ("acme", "widgets.git.archive")
+
 
 # ---------------------------------------------------------------------------
 # Live regression guards: the committed tree must not outrun the protected set

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 # scripts/ is not a package; make it importable like the other scripts/*.py
 # gate tests (see tests/test_check_secret_ignores.py).
@@ -447,6 +448,41 @@ class TestCoversRealGates:
         for path in sorted(gh_scripts.glob("**/*.py")):
             rel = path.relative_to(REPO_ROOT).as_posix()
             assert cgi.is_protected(rel), f".github gate script not protected: {rel}"
+
+    def test_workflow_subscribes_to_every_verdict_changing_activity(self) -> None:
+        """The gate's verdict is a function of (base..head diff, allow label).
+        It must therefore re-run on every activity that can change either, or a
+        stale PASS keeps satisfying the required check on an unchanged head SHA.
+
+        `edited` is the load-bearing one and the reason this test exists:
+        retargeting a PR's base fires `edited` (with `changes.base`) and NOTHING
+        else. Without it, a PR that passes against one base carries that PASS
+        onto a different base whose diff may include protected gate files --
+        with `dev` on loose protection (`strict: false`) the head SHA never
+        moves, so nothing forces a re-run and the bypass survives.
+
+        `labeled`/`unlabeled` are asserted alongside it because the
+        `gate-integrity-allow` label flips the verdict directly; dropping
+        either would make the label un-revokable in practice.
+        """
+        workflow = REPO_ROOT / ".github" / "workflows" / "gate-integrity.yml"
+        # `on:` is parsed by PyYAML 1.1 rules as the boolean True, not "on".
+        spec = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        trigger = spec.get("on", spec.get(True))
+        types = set(trigger["pull_request_target"]["types"])
+        required = {
+            "opened",
+            "synchronize",
+            "reopened",
+            "edited",
+            "labeled",
+            "unlabeled",
+        }
+        missing = required - types
+        assert not missing, (
+            f"gate-integrity.yml does not re-run on {sorted(missing)}; a verdict"
+            " that can change without a re-run is a bypass"
+        )
 
     def test_real_repo_passes_integrity(self) -> None:
         # The committed tree must be itself green: no gate script should be

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -1,0 +1,420 @@
+"""Tests for the gate-integrity guard (scripts/check_gate_integrity.py).
+
+CLASS DEFECT (tsk-o2vhcq, flagged CodeRabbit #2510): every `pull_request`
+gate checks out the PR MERGE REF and runs its checker FROM that checkout, so a
+PR can edit its own checker (or its own workflow YAML) to always-exit-0 and
+green-pass the check that gates it. A lane diff touching a gate script
+alongside its nominal change is exactly the shape the gates exist to catch --
+and today it would go green.
+
+`check_gate_integrity.py` runs on `pull_request_target` from the BASE ref and
+inspects the PR diff via the GitHub API only (no checkout, no execution of PR
+code). These tests prove the acceptance criteria:
+
+  RED   -- a PR diff that edits a gate checker to always-exit-0 trips the guard
+           (the edit to scripts/check_*.py is itself the signal; because the
+           guard runs from base, the tampered checker cannot disable it).
+  GREEN -- a PR touching neither .github/workflows/ nor a gate checker passes.
+
+The API layer is mocked at the narrowest scope (check_gate_integrity._api_get)
+so the decision logic is exercised end-to-end without network access. Cannot-
+see is never mistaken for clean: an API failure yields EXIT_ERROR (fail
+closed).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# scripts/ is not a package; make it importable like the other scripts/*.py
+# gate tests (see tests/test_check_secret_ignores.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import check_gate_integrity as cgi  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _files_payload(filenames: list[str]) -> list[dict]:
+    """Shape of GET /repos/{o}/{r}/pulls/{n}/files items: {'filename': str}."""
+    return [{"filename": f} for f in filenames]
+
+
+def _pr_payload(label_names: list[str], changed_files: int) -> list[dict]:
+    # GET /pulls/{n} is a single object; _api_get wraps it in a list.
+    return [{
+        "labels": [{"name": lbl} for lbl in label_names],
+        "changed_files": changed_files,
+    }]
+
+
+def _api_get_routing(files: list[str], labels: list[str]):
+    """Build a side_effect that routes files vs PR-object requests by URL."""
+
+    def _fake(url: str, token: str | None = None, **_: object) -> list:
+        if url.endswith("/files"):
+            return _files_payload(files)
+        # single-object /pulls/{n} endpoint; changed_files agrees with the
+        # /files listing unless a test overrides the payload deliberately.
+        return _pr_payload(labels, changed_files=len(files))
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# is_protected(path)
+# ---------------------------------------------------------------------------
+
+
+class TestIsProtected:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/workflows/bot-review-gate.yml",
+            ".github/workflows/doc-gate.yml",
+            ".github/workflows/secret-ignores-gate.yml",
+            ".github/workflows/store-wiring-gate.yml",
+            ".github/workflows/deleted-symbols-gate.yml",
+            ".github/workflows/gate-integrity.yml",
+            ".github/scripts/check_all_skip.py",
+            "docs/doc-gate.toml",
+            "pyproject.toml",
+            "tests/conftest.py",
+        ],
+    )
+    def test_gate_files_are_protected(self, path: str) -> None:
+        assert cgi.is_protected(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "scripts/check_bot_review.py",
+            "scripts/check_deleted_symbols.py",
+            "scripts/check_doc_gate.py",
+            "scripts/check_secret_ignores.py",
+            "scripts/check_store_wiring.py",
+            "scripts/check_dependency_audit_ignores.py",
+            "scripts/check_manifests.py",
+            "scripts/check_schema_migrations.py",
+            "scripts/check_retrofit_migrations.py",
+            "scripts/check_evil_merge.py",
+            "scripts/check_gate_integrity.py",
+        ],
+    )
+    def test_gate_checker_scripts_are_protected(self, path: str) -> None:
+        assert cgi.is_protected(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tinyagentos/app.py",
+            "tinyagentos/routes/foo.py",
+            "README.md",
+            "desktop/package.json",
+            "data/hub/identity.json",
+            "scripts/audit-forks.py",
+            "scripts/audit-manifests.py",
+            # .github config that is not a workflow or gate script is not blocked
+            ".github/dependabot.yml",
+            ".github/FUNDING.yml",
+            ".coderabbit.yaml",
+            "docs/something.md",
+            "changelog.d/foo.md",
+            # a check_*.py nested in a subdir is NOT matched by the single
+            # scripts/check_*.py convention the guard enforces
+            "scripts/platform/check_foo.py",
+        ],
+    )
+    def test_non_gate_paths_are_not_protected(self, path: str) -> None:
+        assert not cgi.is_protected(path)
+
+    def test_backslash_paths_normalised(self) -> None:
+        assert cgi.is_protected(".github\\workflows\\gate.yml")
+        assert not cgi.is_protected("tinyagentos\\app.py")
+
+
+# ---------------------------------------------------------------------------
+# classify(files, labels, allow_label) -- the RED / GREEN decision (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_green_when_no_protected_files(self) -> None:
+        """GREEN control: a PR touching neither workflows nor gate scripts."""
+        files = ["tinyagentos/app.py", "README.md", "desktop/src/foo.ts"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_OK
+        assert "PASS" in result.message
+
+    def test_red_when_gate_script_edited_without_label(self) -> None:
+        # RED proof: a lane edits its own checker to always-exit-0. The edit to
+        # scripts/check_bot_review.py is itself the signal; the base guard
+        # detects it and fails the PR.
+        files = [
+            "tinyagentos/some_feature.py",
+            "scripts/check_bot_review.py",
+        ]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert result.message.startswith("gate-integrity: FAIL")
+        # the offending path is named in the message for the audit trail
+        assert "scripts/check_bot_review.py" in result.message
+
+    def test_red_when_workflow_edited_without_label(self) -> None:
+        files = [".github/workflows/bot-review-gate.yml", "tinyagentos/app.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert ".github/workflows/bot-review-gate.yml" in result.message
+
+    def test_red_when_dotgithub_scripts_gate_edited(self) -> None:
+        files = [".github/scripts/check_all_skip.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+
+    def test_allow_label_waives_protected_edit(self) -> None:
+        files = ["scripts/check_bot_review.py"]
+        result = cgi.classify(
+            files, [cgi.DEFAULT_ALLOW_LABEL], cgi.DEFAULT_ALLOW_LABEL
+        )
+        assert result.exit_code == cgi.EXIT_OK
+        assert "waived" in result.message
+
+    def test_wrong_label_does_not_waive(self) -> None:
+        files = ["scripts/check_bot_review.py"]
+        # a different label name is not the allow label, so still blocked
+        result = cgi.classify(files, ["some-other-label"], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+
+    def test_multiple_protected_files_all_listed(self) -> None:
+        files = [
+            ".github/workflows/doc-gate.yml",
+            "scripts/check_doc_gate.py",
+            "scripts/check_store_wiring.py",
+            "tinyagentos/app.py",
+        ]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        assert "scripts/check_doc_gate.py" in result.message
+        assert "scripts/check_store_wiring.py" in result.message
+        assert ".github/workflows/doc-gate.yml" in result.message
+
+    def test_duplicates_collapsed_in_message(self) -> None:
+        files = ["scripts/check_bot_review.py", "scripts/check_bot_review.py"]
+        result = cgi.classify(files, [], cgi.DEFAULT_ALLOW_LABEL)
+        assert result.exit_code == cgi.EXIT_BLOCKED
+        # one protected file, even though listed twice in the diff
+        assert result.message.count("scripts/check_bot_review.py") == 1
+
+
+# ---------------------------------------------------------------------------
+# check_gate_integrity(owner, repo, pr) -- API wiring (mocked at _api_get)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGateIntegrity:
+    def test_red_integration_gate_script_edit_fails(self) -> None:
+        # Fixture: a PR diff that edits a gate checker to always-exit-0.
+        files = ["scripts/check_bot_review.py", "tinyagentos/x.py"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, []),
+        ):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_BLOCKED
+        assert "scripts/check_bot_review.py" in message
+
+    def test_green_integration_clean_pr_passes(self) -> None:
+        # GREEN control: a PR touching neither workflows nor gate scripts.
+        files = ["tinyagentos/app.py", "README.md"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, []),
+        ):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+
+    def test_green_integration_when_allow_label_present(self) -> None:
+        files = ["scripts/check_store_wiring.py"]
+        with patch(
+            "check_gate_integrity._api_get",
+            side_effect=_api_get_routing(files, [cgi.DEFAULT_ALLOW_LABEL]),
+        ):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+        assert "waived" in message
+
+    def test_truncated_file_listing_fails_closed(self) -> None:
+        # GitHub's /files endpoint caps at 3,000 names; beyond that it silently
+        # stops. A listing shorter than the PR's own changed_files count means
+        # the gate cannot see the whole diff -> EXIT_ERROR, never a pass.
+        def _fake(url: str, token: str | None = None, **_: object) -> list:
+            if url.endswith("/files"):
+                return _files_payload(["README.md", "docs/a.md"])
+            return _pr_payload([], changed_files=5)
+
+        with patch("check_gate_integrity._api_get", side_effect=_fake):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_ERROR
+        assert "truncated" in message
+
+    def test_rename_out_of_protected_path_fails_without_label(self) -> None:
+        # A rename edits BOTH paths: renaming a workflow out of
+        # .github/workflows/ disables it, yet /files reports only the new
+        # filename at top level and carries the old one in
+        # previous_filename. The protected old side must still be classified.
+        def _fake(url: str, token: str | None = None, **_: object) -> list:
+            if url.endswith("/files"):
+                return [{
+                    "filename": "docs/archived-gate.yml",
+                    "previous_filename": ".github/workflows/doc-gate.yml",
+                    "status": "renamed",
+                }]
+            return _pr_payload([], changed_files=1)
+
+        with patch("check_gate_integrity._api_get", side_effect=_fake):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_BLOCKED
+        assert ".github/workflows/doc-gate.yml" in message
+
+    def test_renamed_record_does_not_trip_truncation_check(self) -> None:
+        # Classifying both sides of a rename must not double-count records:
+        # the truncation comparison is records-vs-changed_files, so a single
+        # renamed record with changed_files=1 is a complete listing, not a
+        # truncated one.
+        def _fake(url: str, token: str | None = None, **_: object) -> list:
+            if url.endswith("/files"):
+                return [{
+                    "filename": "docs/b.md",
+                    "previous_filename": "docs/a.md",
+                    "status": "renamed",
+                }]
+            return _pr_payload([], changed_files=1)
+
+        with patch("check_gate_integrity._api_get", side_effect=_fake):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+
+    def test_missing_changed_files_count_fails_closed(self) -> None:
+        # Without the changed_files field truncation is undetectable; treat
+        # the payload as cannot-see rather than assuming the listing is whole.
+        def _fake(url: str, token: str | None = None, **_: object) -> list:
+            if url.endswith("/files"):
+                return _files_payload(["README.md"])
+            return [{"labels": []}]
+
+        with patch("check_gate_integrity._api_get", side_effect=_fake):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_ERROR
+
+    def test_infra_failure_fails_closed(self) -> None:
+        # cannot-see must not read as clean pass: None from _api_get is an
+        # infrastructure error -> EXIT_ERROR.
+        with patch("check_gate_integrity._api_get", return_value=None):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_ERROR
+
+    def test_fetches_files_then_labels(self) -> None:
+        # The guard must consult BOTH the changed files AND the labels: a PR
+        # editing a gate checker with the allow label must still pass.
+        files = ["scripts/check_bot_review.py"]
+        captured: list[str] = []
+
+        def _spy(url: str, token: str | None = None, **_: object) -> list:
+            captured.append(url)
+            return _api_get_routing(files, [cgi.DEFAULT_ALLOW_LABEL])(url, token)
+
+        with patch("check_gate_integrity._api_get", side_effect=_spy):
+            code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK
+        assert any(u.endswith("/files") for u in captured)
+        assert any(u.endswith("/pulls/42") for u in captured)
+
+
+class TestMainTokenEnvPropagation:
+    def test_main_uses_env_token_when_no_cli_token(self, monkeypatch) -> None:
+        env_token = "env-cred-value"  # neutral: not a real credential shape
+        monkeypatch.setenv("GITHUB_TOKEN", env_token)
+
+        captured: dict = {}
+
+        def fake_api_get(url, token=None, **_):
+            captured["token"] = token
+            if url.endswith("/files"):
+                return []
+            return _pr_payload([], changed_files=0)
+
+        with patch("check_gate_integrity._api_get", side_effect=fake_api_get):
+            code = cgi.main(["42", "--owner", "jaylfc", "--repo", "taOS"])
+
+        assert captured["token"] == env_token
+        assert code == cgi.EXIT_OK
+
+
+class TestDetectRepo:
+    """SCP-style remotes lack the literal `github.com/`, so the old parse
+    raised IndexError and silently fell back to the default owner/repo --
+    a misattribution the caller can never see."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/acme/widgets.git",
+            "git@github.com:acme/widgets.git",
+            "ssh://git@github.com/acme/widgets.git",
+        ],
+    )
+    def test_detects_owner_repo_across_remote_styles(self, url, monkeypatch) -> None:
+        # GITHUB_REPOSITORY short-circuits the remote parse entirely (CI always
+        # sets it); clear it so the test exercises the git-remote path.
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        fake = subprocess.CompletedProcess(
+            args=["git"], returncode=0, stdout=url + "\n", stderr="",
+        )
+        with patch("check_gate_integrity.subprocess.run", return_value=fake):
+            assert cgi._detect_repo() == ("acme", "widgets")
+
+
+# ---------------------------------------------------------------------------
+# Live regression guards: the committed tree must not outrun the protected set
+# ---------------------------------------------------------------------------
+
+
+class TestCoversRealGates:
+    def test_all_gate_checker_scripts_are_protected(self) -> None:
+        """Every scripts/check_*.py on disk is a gate checker the guard must
+        cover. If a new gate script were added outside the protected set, this
+        would fail and force the set to be extended -- so the guard never goes
+        silently blind to a gate."""
+        scripts_dir = REPO_ROOT / "scripts"
+        gate_scripts = sorted(scripts_dir.glob("check_*.py"))
+        assert gate_scripts, "expected gate checker scripts under scripts/"
+        for path in gate_scripts:
+            rel = f"scripts/{path.name}"
+            assert cgi.is_protected(rel), f"gate script not protected: {rel}"
+
+    def test_all_workflow_files_are_protected(self) -> None:
+        """Every .github/workflows/*.yml on dev is a required-check workflow
+        whose edits must be caught by the base-ref guard."""
+        workflows_dir = REPO_ROOT / ".github" / "workflows"
+        workflows = sorted(workflows_dir.glob("*.yml"))
+        assert workflows, "expected workflow files under .github/workflows"
+        for path in workflows:
+            rel = f".github/workflows/{path.name}"
+            assert cgi.is_protected(rel), f"workflow not protected: {rel}"
+
+    def test_gh_scripts_gate_checker_is_protected(self) -> None:
+        gh_scripts = REPO_ROOT / ".github" / "scripts"
+        if not gh_scripts.is_dir():
+            return
+        for path in sorted(gh_scripts.glob("**/*.py")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            assert cgi.is_protected(rel), f".github gate script not protected: {rel}"
+
+    def test_real_repo_passes_integrity(self) -> None:
+        # The committed tree must be itself green: no gate script should be
+        # mid-tamper. The PR files for the real repo's HEAD (none) trivially
+        # pass; this guards the classify/is_protected invariants together.
+        assert cgi.classify([], [], cgi.DEFAULT_ALLOW_LABEL).exit_code == cgi.EXIT_OK


### PR DESCRIPTION
## Why

`gate-integrity.yml` and `scripts/check_gate_integrity.py` have existed only on `dev`. GitHub resolves the set of **registered** workflows from the **default branch** (`master`), so this workflow was never registered and has never reported on any PR — not even PRs whose base is `dev`, where the file is present.

Measured, not assumed:

```
GET repos/jaylfc/taOS/actions/workflows/gate-integrity.yml  -> 404 Not Found
default_branch                                              -> master
git ls-tree origin/dev    .github/workflows/gate-integrity.yml -> present
git ls-tree origin/master .github/workflows/gate-integrity.yml -> absent
```

Every *other* gate in the repo is registered — `doc-gate`, `store-wiring-gate`, `deleted-symbols-gate`, `secret-ignores-gate`, `bot-review-gate`, `evil-merge-gate`, `skip-only-tests-gate`, `distrust-green-gate` — and every one of them exists on master. Gate integrity was the only one that did not, which is why it alone never fired.

## What

Three files promoted **byte-identical** to their `origin/dev` copies (sha256 verified per file), plus one doc bullet:

| file | note |
|---|---|
| `.github/workflows/gate-integrity.yml` | the workflow |
| `scripts/check_gate_integrity.py` | the checker (stdlib only — no new deps on master) |
| `tests/test_check_gate_integrity.py` | **the checker's 60 tests** |
| `.claude/skills/taos-development-skill/SKILL.md` | agent-facing bullet |

The **tests are included deliberately**. Promoting a checker without its tests puts a gate on master with zero coverage there — the same shape of un-failable gate this workflow exists to prevent.

The **SKILL.md bullet** is included because master's copy of that gates list ended one bullet short of dev's: an agent working from master could not have known the gate existed. Text is identical to dev's.

## Evidence

**Tests pass on master's tree** (run from a worktree checked out at `origin/master`, exit status read directly from `$?`, not through a pipe):

```
60 passed in 0.27s
PYTEST_EXIT=0
```

**Green case — real PR, real API.** #2543 touches no protected path:

```
$ python scripts/check_gate_integrity.py 2543
gate-integrity: PASS -- PR touches no protected gate paths
EXIT=0
```
…and its actual file list confirms that independently: `changelog.d/`, `docs/agent-coordination.md`, `tests/test_csrf_login_lockout.py`, `tinyagentos/middleware/csrf.py`, `tinyagentos/routes/auth.py`.

**Red case — this very PR.** It touches `.github/workflows/` *and* `scripts/check_*.py`, both protected. The checker run against this PR number is posted as a follow-up comment below, showing a non-zero exit. A gate that cannot be shown going red on a real bad case is not evidence of anything.

## Note on this PR gating itself

This PR cannot be blocked by the gate it adds: on `pull_request_target` the workflow is resolved from the **base** ref, and the base here is `master`, which does not have the file yet. It is inert on its own promotion and becomes live for the PR after this one.

## Follow-up owed to a human

Branch protection must add **"Gate integrity"** as a required check on `master` and `dev` once it has reported at least once. Until then the workflow runs but does not block. That is a repo-settings change, not a code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Gate Integrity check for pull requests modifying protected CI, validation, or configuration files.
  * Changes are blocked unless a human-approved exception label is present.
  * The check reviews pull request changes without executing pull request code and re-runs when relevant pull request details change.
  * Added safeguards for renamed files, incomplete change listings, and infrastructure errors.

* **Tests**
  * Added comprehensive coverage for protected-file detection, exceptions, API failures, renames, and repository configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->