### PR TITLE
test(csrf): invert the test-mode CSRF default — enforce by default, opt out explicitly

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -480,7 +480,7 @@ use `withCsrf(init)` from `desktop/src/lib/csrf.ts`, or the `taosFetch` wrapper
 production** - this exact class shipped as a bug (#1977). Bearer-token
 (agent JWT) calls are CSRF-exempt; only cookie sessions need the header.
 
-pytest used to miss this class too, and no longer does - see "CSRF in tests" below.
+pytest used to miss this class too, and no longer does - see "CSRF in tests" above.
 
 ## Agent auth model (Bearer JWT vs session)
 

--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -153,6 +153,37 @@ deps the project does not pin set `check_upgrade = false`.
 - SPA stubs: conftest creates stub `index.html`/`sw.js` so tests don't need `npm run build`
 - E2E (Playwright) tests excluded from CI and local gate
 
+### CSRF in tests - ON by default
+
+`verify_csrf` runs for real in tests. It used to be no-op'd by an autouse fixture for every
+file whose path lacked the substring `test_csrf` - measured at 788 test files, exactly ONE
+inside that carve-out, so 787 ran against an app whose CSRF dependency did nothing. That is
+what hid #2081: a repro written as an ordinary test returned 303 and PASSED, and the tell was
+that the CONTROL passed identically, which is the shape you get when the input never reaches
+the system under test.
+
+What this means when you write a test:
+
+- **The shared `client` fixture already does the right thing.** It echoes the `csrf_token`
+  cookie into `X-CSRF-Token` on mutating requests, exactly as `taosFetch` does in the SPA.
+  Nothing to remember.
+- **If you build your own `AsyncClient`, it will 403 on mutating routes** once it carries a
+  `taos_session` cookie. Fix it the way the real caller does - send the header - not by
+  disabling the check.
+- **`verify_csrf` exempts** safe methods, `Authorization: Bearer` callers, `_CREDENTIAL_PATHS`
+  (the sign-in surfaces), and any request with no `taos_session` cookie. A test that never
+  authenticates is unaffected.
+- **Opting out is `@pytest.mark.csrf_bypass`** on the test, class, or module
+  (`pytestmark = pytest.mark.csrf_bypass`). It is legacy debt, tracked, and the list must
+  shrink. Do NOT add it to silence a new red: a red means a route the real caller could not
+  reach the way your test reaches it.
+- **A filename no longer changes behaviour.** The old carve-out was a substring match on the
+  path, so renaming a file silently re-armed the bypass with no failure anywhere.
+
+Patch timing matters if you ever stub it yourself: `register_all_routers` does
+`from ... import verify_csrf` and freezes the object into `Depends(...)` at `include_router`
+time, so patching the module attribute AFTER `create_app` does nothing.
+
 ### CI matrix
 
 - Python 3.12 + 3.13 on every PR/push; 3.11 on nightly cron only
@@ -429,9 +460,11 @@ Every mutating route requires `X-CSRF-Token` on cookie-session requests (`verify
 router-wide). Any SPA `fetch` that POSTs/PUTs/PATCHes/DELETEs must attach the double-submit header:
 use `withCsrf(init)` from `desktop/src/lib/csrf.ts`, or the `taosFetch` wrapper
 (`desktop/src/lib/taos-fetch.ts`) which applies it automatically. **A raw
-`fetch("/api/...", {method:"POST"})` passes vitest AND pytest (tests bypass CSRF) but 403s
-"CSRF token missing" in production** - this exact class shipped as a bug (#1977). Bearer-token
+`fetch("/api/...", {method:"POST"})` passes vitest but 403s "CSRF token missing" in
+production** - this exact class shipped as a bug (#1977). Bearer-token
 (agent JWT) calls are CSRF-exempt; only cookie sessions need the header.
+
+pytest used to miss this class too, and no longer does - see "CSRF in tests" below.
 
 ## Agent auth model (Bearer JWT vs session)
 

--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -169,14 +169,30 @@ What this means when you write a test:
   Nothing to remember.
 - **If you build your own `AsyncClient`, it will 403 on mutating routes** once it carries a
   `taos_session` cookie. Fix it the way the real caller does - send the header - not by
-  disabling the check.
+  disabling the check. One line does it:
+
+  ```python
+  from taos_test_csrf import csrf_event_hooks   # tests/taos_test_csrf.py
+
+  AsyncClient(
+      transport=ASGITransport(app=app),
+      base_url="http://test",
+      cookies={"taos_session": token},
+      event_hooks=csrf_event_hooks(),      # <- echoes the cookie into the header
+  )
+  ```
+
+  It lives in its own module, not in `conftest.py`, because `tests/` is not a package and
+  several `conftest.py` files exist, so a bare `from conftest import ...` binds whichever one
+  is on `sys.path` first.
 - **`verify_csrf` exempts** safe methods, `Authorization: Bearer` callers, `_CREDENTIAL_PATHS`
   (the sign-in surfaces), and any request with no `taos_session` cookie. A test that never
   authenticates is unaffected.
-- **Opting out is `@pytest.mark.csrf_bypass`** on the test, class, or module
-  (`pytestmark = pytest.mark.csrf_bypass`). It is legacy debt, tracked, and the list must
-  shrink. Do NOT add it to silence a new red: a red means a route the real caller could not
-  reach the way your test reaches it.
+- **`@pytest.mark.csrf_bypass` exists but nothing uses it, and
+  `tests/test_csrf_bypass_debt.py` asserts the list stays EMPTY.** Adding a marker turns that
+  guard red on purpose. Do NOT add it to silence a new red: a red means a route the real
+  caller could not reach the way your test reaches it - give the client the event hook
+  instead.
 - **A filename no longer changes behaviour.** The old carve-out was a substring match on the
   path, so renaming a file silently re-armed the bypass with no failure anywhere.
 

--- a/changelog.d/tsk-jqcvpc-proxy-cookie-isolation.md
+++ b/changelog.d/tsk-jqcvpc-proxy-cookie-isolation.md
@@ -1,0 +1,26 @@
+### Fixed
+- All four proxies (`routes/account_proxy.py`, `routes/service_proxy.py`,
+  `routes/userspace_apps.py`, `routes/shortcut_proxy.py`) now strip every cookie
+  taOS itself issues before relaying a request upstream, instead of each
+  carrying its own hand-written strip list. Between them those four lists named
+  two of the five cookies this origin sets, so `csrf_token`, `taos_browser` (an
+  httponly session id bound to a `user_id`) and `taos_cs` were relayed to
+  taos.my, to container app backends and to shortcut targets. `csrf_token` is
+  deliberately `httponly=False` so the SPA can read it, which makes it a
+  readable origin-wide secret whose only job is proving same-origin — relaying
+  it handed an upstream exactly what satisfies `verify_csrf`. The deny-list is
+  now a single shared `TAOS_ISSUED_COOKIES` frozenset in
+  `tinyagentos/issued_cookies.py`, and `tests/test_proxy_cookie_isolation.py`
+  asserts both that all four proxies share it by identity and that it covers
+  every `set_cookie` call in the package (#tsk-jqcvpc).
+
+### Changed
+- CSRF is enforced for real in the test suite. The autouse fixture that replaced
+  `verify_csrf` with a no-op for every test file whose path lacked the substring
+  `test_csrf` is gone; opting out is now the explicit `@pytest.mark.csrf_bypass`
+  marker, which nothing uses and which `tests/test_csrf_bypass_debt.py` asserts
+  stays unused. The shared `client` fixture echoes the `csrf_token` cookie into
+  `X-CSRF-Token` on mutating requests the way the SPA's `taosFetch` does, so
+  tests satisfy the real check rather than switching it off. Because the old
+  carve-out matched on filename, renaming a test file silently re-armed the
+  bypass; that is no longer possible (#tsk-jqcvpc).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -486,11 +486,66 @@ the exemption list cannot grow past the surface that is reachable without a
 credential. Adding a route here is a security decision — anything that acts on
 an already-valid session must stay protected.
 
-Note for anyone writing tests against these routes: `tests/conftest.py` has an
-autouse fixture that replaces `verify_csrf` with a no-op for **every** test file
-whose path does not contain `test_csrf`. A test of CSRF behaviour written
-anywhere else measures the fixture and passes green against broken code. Put it
-in a `test_csrf*.py` file and assert the real dependency is installed.
+Note for anyone writing tests against these routes: **`verify_csrf` runs for
+real.** It used to be no-op'd by an autouse fixture for every test file whose
+path did not contain the substring `test_csrf` — 788 test files, exactly one
+inside the carve-out — so a CSRF repro written as an ordinary test passed
+against broken code, which is how #2081 stayed hidden. The opt-out is now the
+explicit marker `@pytest.mark.csrf_bypass`, and `tests/test_csrf_bypass_debt.py`
+asserts nothing uses it; a filename no longer changes behaviour, so a rename
+cannot silently re-arm the bypass.
+
+The shared `client` fixture echoes the `csrf_token` cookie into `X-CSRF-Token`
+on mutating requests, exactly as `taosFetch` does in the SPA, so tests *satisfy*
+the real check rather than switching it off. A hand-built `AsyncClient` needs
+`event_hooks=csrf_event_hooks()` (from `tests/taos_test_csrf.py` — its own
+module, because `tests/` is not a package and a bare `from conftest import ...`
+binds whichever `conftest.py` is first on `sys.path`). If your test 403s, that
+means the real caller could not reach the route the way your test does: send the
+header, do not add the marker. See "CSRF in tests" in the development skill for
+the full rules.
+
+## Proxy cookie isolation (all four proxies, one shared set)
+
+taOS forwards requests to three different kinds of upstream — the taos.my
+account service, container-backed userspace apps, and shortcut targets — through
+four proxy modules. **None of them may relay a cookie this origin issued.**
+
+| module | upstream |
+| --- | --- |
+| `routes/account_proxy.py` | taos.my account service |
+| `routes/service_proxy.py` | local services |
+| `routes/userspace_apps.py` | container app backends |
+| `routes/shortcut_proxy.py` | shortcut targets |
+
+The deny-list lives in **`tinyagentos/issued_cookies.py`** as
+`TAOS_ISSUED_COOKIES`, and all four import it. Do not restate it locally: each
+proxy used to carry its own hand-written copy, and between them those four
+copies named **two** of the five cookies taOS issues. The other three —
+`csrf_token`, `taos_browser` (an httponly session id bound to a `user_id`) and
+`taos_cs` — leaked from all four. `csrf_token` is the sharp one: it is
+`httponly=False` on purpose so the SPA can read it, which makes it a readable
+origin-wide secret whose only job is proving same-origin, so relaying it hands
+an upstream exactly what satisfies `verify_csrf`.
+
+It is a deny-list rather than an allow-list because an allow-list is not
+writable here: upstream's cookie names appear nowhere in this repo —
+`account_proxy` relays upstream `Set-Cookie` verbatim (`_rewrite_set_cookie`)
+and never enumerates one. What *this* origin issues is knowable and finite.
+
+**Adding a cookie anywhere in the package means adding it to
+`TAOS_ISSUED_COOKIES`.** Two guards in `tests/test_proxy_cookie_isolation.py`
+enforce this: one asserts all four proxies share the set by **identity**, so
+re-forking a private copy fails even if the names match; the other scans every
+`set_cookie` call in the package and fails if a cookie is issued but missing
+from the set. That second check is the one whose absence caused the bug — all
+three leaked cookies were added long after the strip lists were written, and
+nothing forced anyone back.
+
+When testing a proxy, the client must hold the cookies whose leak you are
+guarding against, and the assertion must name a genuine upstream cookie that
+*survives*: a test asserting only "nothing leaked" is satisfied by dropping the
+Cookie header wholesale, which would break every proxied login.
 
 ## Device bearer self-service (second, narrower passthrough)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,11 @@ timeout_method = "thread"
 markers = [
     "e2e: End-to-end browser tests (require running server)",
     "slow: Tests requiring a live stack (skipped in local CI; run with pytest -m slow)",
+    # Opt OUT of real CSRF enforcement for this test/class/module. CSRF is ON
+    # by default (tests/conftest.py); this marker is the only way to disable
+    # it, and every module carrying it is inventoried in
+    # tests/test_csrf_bypass_debt.py so the list cannot grow unnoticed.
+    "csrf_bypass: run this test with verify_csrf stubbed to a no-op (legacy debt)",
 ]
 filterwarnings = [
     # Asyncio teardown emits unraisable RuntimeError("Event loop is closed")

--- a/tests/coding_sessions/test_routes_coding_sessions.py
+++ b/tests/coding_sessions/test_routes_coding_sessions.py
@@ -3,6 +3,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 def _make_body(**overrides):
@@ -47,7 +48,7 @@ async def test_create_returns_starting_status(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body())
         assert resp.status_code == 200
         data = resp.json()
@@ -67,7 +68,7 @@ async def test_invalid_cli_returns_400(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(cli="vim"))
         assert resp.status_code == 400
         assert "cli" in resp.json()["error"]
@@ -82,7 +83,7 @@ async def test_invalid_launch_target_returns_400(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(launch_target="docker"))
         assert resp.status_code == 400
         assert "launch_target" in resp.json()["error"]
@@ -97,7 +98,7 @@ async def test_worker_lxc_without_worker_returns_400(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(
             launch_target="worker-lxc", worker=None
         ))
@@ -114,7 +115,7 @@ async def test_worker_lxc_with_worker_succeeds(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(
             launch_target="worker-lxc", worker="pi-worker-01"
         ))
@@ -131,7 +132,7 @@ async def test_list_returns_created_session(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         create_resp = await c.post("/api/coding-sessions", json=_make_body())
         sid = create_resp.json()["id"]
 
@@ -150,7 +151,7 @@ async def test_get_returns_session(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         create_resp = await c.post("/api/coding-sessions", json=_make_body())
         sid = create_resp.json()["id"]
         get_resp = await c.get(f"/api/coding-sessions/{sid}")
@@ -167,7 +168,7 @@ async def test_get_missing_returns_404(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.get("/api/coding-sessions/cs-missing")
         assert resp.status_code == 404
     await app.state.coding_session_store.close()
@@ -201,7 +202,7 @@ async def test_non_owner_gets_404(tmp_path):
     # non-existent user_id (the auth middleware will still accept any valid token).
     fake_token = app.state.auth.create_session(user_id="fake-user-id", long_lived=True)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": fake_token}) as c:
+                           cookies={"taos_session": fake_token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.get(f"/api/coding-sessions/{sid}")
         assert resp.status_code == 404
 
@@ -216,7 +217,7 @@ async def test_stop_transitions_status(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         create_resp = await c.post("/api/coding-sessions", json=_make_body())
         sid = create_resp.json()["id"]
         stop_resp = await c.post(f"/api/coding-sessions/{sid}/stop")
@@ -233,7 +234,7 @@ async def test_archive_transitions_status(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         create_resp = await c.post("/api/coding-sessions", json=_make_body())
         sid = create_resp.json()["id"]
         archive_resp = await c.post(f"/api/coding-sessions/{sid}/archive")
@@ -250,7 +251,7 @@ async def test_list_excludes_archived_by_default(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         s1 = (await c.post("/api/coding-sessions", json=_make_body(alias="active"))).json()
         s2 = (await c.post("/api/coding-sessions", json=_make_body(alias="archived"))).json()
         await c.post(f"/api/coding-sessions/{s2['id']}/archive")
@@ -275,7 +276,7 @@ async def test_create_registers_in_agent_registry(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(alias="reg-test"))
         assert resp.status_code == 200
         sid = resp.json()["id"]
@@ -301,7 +302,7 @@ async def test_create_succeeds_even_if_registry_unavailable(tmp_path):
     app.state.agent_registry = None
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions", json=_make_body(alias="no-registry"))
         assert resp.status_code == 200
         assert resp.json()["status"] == "starting"
@@ -315,7 +316,7 @@ async def test_rename_updates_alias_and_registry(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         create_resp = await c.post("/api/coding-sessions", json=_make_body(alias="old-name"))
         sid = create_resp.json()["id"]
         resp = await c.patch(f"/api/coding-sessions/{sid}", json={"alias": "new-name"})
@@ -364,7 +365,7 @@ async def test_rename_empty_alias_returns_400(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
         resp = await c.patch(f"/api/coding-sessions/{sid}", json={"alias": "   "})
         assert resp.status_code == 400
@@ -380,7 +381,7 @@ async def test_start_host_folder_runs_and_captures(tmp_path):
     app.state.coding_launcher = _FakeLauncher()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
         resp = await c.post(f"/api/coding-sessions/{sid}/start")
         assert resp.status_code == 200
@@ -403,7 +404,7 @@ async def test_rename_missing_session_returns_404(tmp_path):
     uid, token = await _make_client(app)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.patch("/api/coding-sessions/cs-does-not-exist", json={"alias": "x"})
         assert resp.status_code == 404
     await app.state.coding_session_store.close()
@@ -418,7 +419,7 @@ async def test_start_non_host_folder_returns_501(tmp_path):
     app.state.coding_launcher = _FakeLauncher()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         body = _make_body(launch_target="worker-lxc", worker="linstation")
         sid = (await c.post("/api/coding-sessions", json=body)).json()["id"]
         resp = await c.post(f"/api/coding-sessions/{sid}/start")
@@ -435,7 +436,7 @@ async def test_stop_kills_tmux_and_records_status(tmp_path):
     app.state.coding_launcher = _FakeLauncher()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
         await c.post(f"/api/coding-sessions/{sid}/start")
         resp = await c.post(f"/api/coding-sessions/{sid}/stop")
@@ -454,7 +455,7 @@ async def test_stop_does_not_resurrect_archived_session(tmp_path):
     app.state.coding_launcher = _FakeLauncher()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         sid = (await c.post("/api/coding-sessions", json=_make_body())).json()["id"]
         await c.post(f"/api/coding-sessions/{sid}/archive")
         resp = await c.post(f"/api/coding-sessions/{sid}/stop")
@@ -473,7 +474,7 @@ async def test_start_missing_session_returns_404(tmp_path):
     app.state.coding_launcher = _FakeLauncher()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test",
-                           cookies={"taos_session": token}) as c:
+                           cookies={"taos_session": token}, event_hooks=csrf_event_hooks()) as c:
         resp = await c.post("/api/coding-sessions/cs-nope/start")
         assert resp.status_code == 404
     await app.state.coding_session_store.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 import sys
 import time
+from http.cookies import SimpleCookie
 from unittest.mock import patch
 
 import pytest
@@ -17,15 +18,43 @@ from tinyagentos.routes.desktop import SPA_DIR
 
 
 # ---------------------------------------------------------------------------
-# Test-mode CSRF bypass — the verify_csrf dependency is enforced globally
-# on all routers via register_all_routers().  Existing tests were written
-# before CSRF was enforced and do not include CSRF tokens.  Rather than
-# updating every test fixture, we monkey-patch verify_csrf to a no-op
-# during test runs.  The dedicated CSRF tests (test_csrf.py) import the
-# real function directly and test it in isolation.
+# CSRF in tests — ON by default, opted OUT explicitly.
+#
+# This used to be inverted: an autouse fixture no-op'd `verify_csrf` for every
+# test file whose path did not contain the substring "test_csrf".  Measured on
+# dev at the time of the change: 788 test files, exactly ONE inside that
+# carve-out, so 787 ran against an app whose CSRF dependency did nothing, and
+# 223 of those issue POSTs.
+#
+# That is an over-privileged fixture: it grants the test more privilege than
+# the real caller has, so the test cannot observe the check the real caller
+# must satisfy.  It is what hid #2081 (the CSRF login lockout).  A first repro
+# written as an ordinary test returned 303 and PASSED, and the tell was that
+# the CONTROL passed identically — the shape you get when the input never
+# reaches the system under test.
+#
+# Two properties of the replacement matter:
+#
+#   * The default is the REAL implementation.  A test written tomorrow gets
+#     production behaviour without anyone remembering to ask for it, and a new
+#     CSRF regression is red by default rather than invisible by default.
+#   * Opting out is an explicit MARKER, not a filename.  The old carve-out was
+#     a substring match on the path, so renaming a file silently re-armed the
+#     bypass with no failure anywhere.  A marker cannot be triggered by
+#     accident, it is greppable, and `tests/test_csrf_bypass_debt.py` holds the
+#     list of modules that still use it so the debt cannot grow unnoticed.
+#
+# To opt a whole module out, put this at module scope:
+#
+#     pytestmark = pytest.mark.csrf_bypass
+#
+# Do NOT add it to silence a new red.  A red here is a route that the real
+# caller could not reach the way the test reaches it.
 # ---------------------------------------------------------------------------
 
 from starlette.requests import HTTPConnection as _HTTPConnection
+
+CSRF_BYPASS_MARKER = "csrf_bypass"
 
 
 def _noop_verify_csrf(conn: _HTTPConnection) -> None:
@@ -36,14 +65,77 @@ def _noop_verify_csrf(conn: _HTTPConnection) -> None:
     return
 
 
+# The shared `client` fixture's half of the double-submit pair.  Any value
+# works -- the check is that the header equals the cookie -- but it must look
+# like a token so a failure message is self-explanatory.
+_TEST_CSRF_TOKEN = "testsuite-csrf-token-0123456789abcdef0123456789abcdef"
+
+
+async def _echo_csrf_cookie_into_header(request) -> None:
+    """Do what the SPA does: echo the CSRF cookie into the request header.
+
+    This is NOT a bypass.  The double-submit check is safe because a
+    third-party origin cannot READ the cookie and therefore cannot set a
+    matching header; a same-origin caller like our own SPA reads its own cookie
+    and echoes it, and that is the caller this fixture stands in for.  Tests
+    using the shared client therefore satisfy the real `verify_csrf` rather
+    than switching it off.
+
+    Safe methods are skipped because `verify_csrf` exempts them, and an
+    explicitly-set header is never overwritten -- a test that deliberately
+    sends a wrong or missing token is asserting something about CSRF itself
+    and must keep control of it.
+    """
+    if request.method.upper() in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        return
+    if "x-csrf-token" in request.headers:
+        return
+
+    # Read the value actually on the wire rather than assuming the seeded
+    # constant. CSRFMiddleware issues a fresh token whenever a request arrives
+    # without one, so a client that picked one up mid-test holds a value this
+    # module never chose; echoing the constant would then MISMATCH and 403.
+    cookie_header = request.headers.get("cookie", "")
+    jar = SimpleCookie()
+    jar.load(cookie_header)
+    morsel = jar.get("csrf_token")
+
+    if morsel is not None:
+        request.headers["x-csrf-token"] = morsel.value
+        return
+
+    # No CSRF cookie yet. A real browser would already hold one, because
+    # CSRFMiddleware sets it on the first response -- but this fixture injects
+    # the session directly instead of navigating, so no response has reached
+    # the jar. Supply BOTH halves, which is the state that navigation would
+    # have produced.
+    #
+    # Injected here rather than seeded on the client's cookie jar so that SAFE
+    # requests still arrive without a CSRF cookie. The jar applies to every
+    # request, and a GET carrying the cookie makes CSRFMiddleware skip issuing
+    # one -- which silently breaks the tests asserting that it does issue one.
+    request.headers["cookie"] = (
+        f"{cookie_header}; csrf_token={_TEST_CSRF_TOKEN}"
+        if cookie_header
+        else f"csrf_token={_TEST_CSRF_TOKEN}"
+    )
+    request.headers["x-csrf-token"] = _TEST_CSRF_TOKEN
+
+
 @pytest.fixture(autouse=True)
 def _bypass_csrf_in_tests(request):
-    """Replace verify_csrf with a no-op in the module under test.
+    """Run against the REAL verify_csrf unless the test opts out.
 
-    Skips patching when the test file is test_csrf.py so those tests
-    exercise the real implementation.
+    Opt out with ``@pytest.mark.csrf_bypass`` on the test, its class, or the
+    module (``pytestmark``).  ``get_closest_marker`` sees all three.
+
+    The patch must be in place BEFORE the app is built: `register_all_routers`
+    does ``from ... import verify_csrf`` and freezes the resulting object into
+    ``Depends(...)`` at ``include_router`` time, so patching the module
+    attribute after ``create_app`` changes nothing.  Wrapping the whole test —
+    as this fixture does — is what makes it take effect.
     """
-    if "test_csrf" in str(request.node.fspath):
+    if request.node.get_closest_marker(CSRF_BYPASS_MARKER) is None:
         yield
         return
 
@@ -617,6 +709,12 @@ async def client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        # Supplies the CSRF half of a signed-in browser's state on mutating
+        # requests -- see _echo_csrf_cookie_into_header. Without it this client
+        # is authenticated but holds no CSRF cookie, a state no real browser is
+        # ever in, and every mutating request 403s for a reason that has
+        # nothing to do with the route under test.
+        event_hooks={"request": [_echo_csrf_cookie_into_header]},
     ) as c:
         yield c
     await canvas_store.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import os
 import sqlite3
 import sys
 import time
-from http.cookies import SimpleCookie
 from unittest.mock import patch
 
 import pytest
@@ -65,61 +64,17 @@ def _noop_verify_csrf(conn: _HTTPConnection) -> None:
     return
 
 
-# The shared `client` fixture's half of the double-submit pair.  Any value
-# works -- the check is that the header equals the cookie -- but it must look
-# like a token so a failure message is self-explanatory.
-_TEST_CSRF_TOKEN = "testsuite-csrf-token-0123456789abcdef0123456789abcdef"
-
-
-async def _echo_csrf_cookie_into_header(request) -> None:
-    """Do what the SPA does: echo the CSRF cookie into the request header.
-
-    This is NOT a bypass.  The double-submit check is safe because a
-    third-party origin cannot READ the cookie and therefore cannot set a
-    matching header; a same-origin caller like our own SPA reads its own cookie
-    and echoes it, and that is the caller this fixture stands in for.  Tests
-    using the shared client therefore satisfy the real `verify_csrf` rather
-    than switching it off.
-
-    Safe methods are skipped because `verify_csrf` exempts them, and an
-    explicitly-set header is never overwritten -- a test that deliberately
-    sends a wrong or missing token is asserting something about CSRF itself
-    and must keep control of it.
-    """
-    if request.method.upper() in ("GET", "HEAD", "OPTIONS", "TRACE"):
-        return
-    if "x-csrf-token" in request.headers:
-        return
-
-    # Read the value actually on the wire rather than assuming the seeded
-    # constant. CSRFMiddleware issues a fresh token whenever a request arrives
-    # without one, so a client that picked one up mid-test holds a value this
-    # module never chose; echoing the constant would then MISMATCH and 403.
-    cookie_header = request.headers.get("cookie", "")
-    jar = SimpleCookie()
-    jar.load(cookie_header)
-    morsel = jar.get("csrf_token")
-
-    if morsel is not None:
-        request.headers["x-csrf-token"] = morsel.value
-        return
-
-    # No CSRF cookie yet. A real browser would already hold one, because
-    # CSRFMiddleware sets it on the first response -- but this fixture injects
-    # the session directly instead of navigating, so no response has reached
-    # the jar. Supply BOTH halves, which is the state that navigation would
-    # have produced.
-    #
-    # Injected here rather than seeded on the client's cookie jar so that SAFE
-    # requests still arrive without a CSRF cookie. The jar applies to every
-    # request, and a GET carrying the cookie makes CSRFMiddleware skip issuing
-    # one -- which silently breaks the tests asserting that it does issue one.
-    request.headers["cookie"] = (
-        f"{cookie_header}; csrf_token={_TEST_CSRF_TOKEN}"
-        if cookie_header
-        else f"csrf_token={_TEST_CSRF_TOKEN}"
-    )
-    request.headers["x-csrf-token"] = _TEST_CSRF_TOKEN
+# The header-echoing hook lives in its own module so that the ~11 test modules
+# building their own AsyncClient can import it without a bare
+# `from conftest import ...` -- `tests/` is not a package and several
+# conftest.py files exist, so that import binds whichever one is on sys.path
+# first (card `tsk-xplzqy`).  Re-exported here under the old private names so
+# the shared `client` fixture below reads unchanged.
+from taos_test_csrf import (  # noqa: E402
+    TEST_CSRF_TOKEN as _TEST_CSRF_TOKEN,
+    csrf_event_hooks,
+    echo_csrf_cookie_into_header as _echo_csrf_cookie_into_header,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -714,7 +669,7 @@ async def client(app, tmp_data_dir):
         # is authenticated but holds no CSRF cookie, a state no real browser is
         # ever in, and every mutating request 403s for a reason that has
         # nothing to do with the route under test.
-        event_hooks={"request": [_echo_csrf_cookie_into_header]},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await canvas_store.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -867,6 +867,9 @@ async def client_with_qmd(app_with_qmd):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        # Same reason as the `client` fixture above: this is a signed-in
+        # browser, so every mutating request needs the double-submit header.
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await canvas_store.close()

--- a/tests/notes/test_notes_routes.py
+++ b/tests/notes/test_notes_routes.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.notes.shared_docs_store import SharedDocsStore
+from taos_test_csrf import csrf_event_hooks
 
 
 # --------------------------------------------------------------------- helpers
@@ -49,6 +50,7 @@ async def client(tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -84,9 +86,11 @@ async def two_user_clients(tmp_path):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
     ) as alice, AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": bob_token},
+        event_hooks=csrf_event_hooks(),
     ) as bob:
         yield alice, bob, app
 
@@ -494,6 +498,7 @@ async def test_add_entry_triggers_agent_dm(tmp_path, monkeypatch):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         doc = (await c.post("/api/notes", json={"title": "Ideas"})).json()
         doc_id = doc["id"]
@@ -552,6 +557,7 @@ async def test_add_entry_no_agent_members_no_send(tmp_path):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         doc = (await c.post("/api/notes", json={"title": "Solo"})).json()
         await c.post(f"/api/notes/{doc['id']}/entries", json={"text": "Just me"})
@@ -758,6 +764,7 @@ async def test_list_notes_filters_by_kind(tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as client:
         # Create a note (kind="note") — should be visible
         note = (await client.post("/api/notes", json={"title": "My Note"})).json()

--- a/tests/notes/test_revisions.py
+++ b/tests/notes/test_revisions.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.notes.shared_docs_store import CHECKPOINT_EVERY, SharedDocsStore
+from taos_test_csrf import csrf_event_hooks
 
 
 # ------------------------------------------------------------------ fixtures
@@ -49,6 +50,7 @@ async def client(tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await shared_docs_store.close()
@@ -76,9 +78,11 @@ async def two_user_clients(tmp_path):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
     ) as alice, AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": bob_token},
+        event_hooks=csrf_event_hooks(),
     ) as bob:
         yield alice, bob, app
     await shared_docs_store.close()

--- a/tests/projects/test_routes_beads.py
+++ b/tests/projects/test_routes_beads.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.mark.asyncio
@@ -34,6 +35,7 @@ def _auth_client(app):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/projects/test_strike_wiring.py
+++ b/tests/projects/test_strike_wiring.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 def _auth_client(app):
@@ -23,6 +24,7 @@ def _auth_client(app):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -6,6 +6,7 @@ import uuid
 import pytest
 import yaml
 from fastapi.testclient import TestClient
+from taos_test_csrf import arm_test_client
 
 from tinyagentos.app import create_app
 from tinyagentos.shortcuts.capabilities import CAP_AGENT_SHELL
@@ -42,7 +43,11 @@ def test_client(app):
     # The app must be initialised enough for auth to work.  create_app sets up
     # app.state.auth eagerly, so this is fine without running lifespan.
     with TestClient(app, raise_server_exceptions=True) as client:
-        yield client
+        # Auth arrives as a Cookie header per request rather than on the jar, so
+        # these are signed-in browsers and `verify_csrf` applies to them. The
+        # hook echoes the csrf_token the way the SPA does; without it every
+        # mutating route here 403s for a reason unrelated to the route.
+        yield arm_test_client(client)
 
 
 def _create_user_with_caps(auth_mgr, username: str, caps: list[str]) -> str:

--- a/tests/routes/desktop_browser/test_agent_pin_routes.py
+++ b/tests/routes/desktop_browser/test_agent_pin_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 from unittest.mock import AsyncMock
+from taos_test_csrf import csrf_event_hooks
 
 
 def _get_user_id(app):
@@ -26,6 +27,7 @@ def _make_auth_client(app, tmp_data_dir):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/desktop_browser/test_bookmark_routes.py
+++ b/tests/routes/desktop_browser/test_bookmark_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+from taos_test_csrf import csrf_event_hooks
 
 
 def _get_user_id(app):
@@ -24,6 +25,7 @@ def _make_auth_client(app, tmp_data_dir):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/desktop_browser/test_capability_routes.py
+++ b/tests/routes/desktop_browser/test_capability_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+from taos_test_csrf import csrf_event_hooks
 
 
 def _get_user_id(app):
@@ -25,6 +26,7 @@ def _make_auth_client(app, tmp_data_dir):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/desktop_browser/test_copilot_agent_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_agent_ws.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
+from taos_test_csrf import arm_test_client
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +53,7 @@ def ws_client(ws_app):
     token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
     with TestClient(ws_app, raise_server_exceptions=False) as c:
         c.cookies.set("taos_session", token)
+        arm_test_client(c)
         yield c
 
 

--- a/tests/routes/desktop_browser/test_copilot_ws.py
+++ b/tests/routes/desktop_browser/test_copilot_ws.py
@@ -9,6 +9,7 @@ import yaml
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from starlette.websockets import WebSocketDisconnect
+from taos_test_csrf import arm_test_client, csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +181,7 @@ class TestMintTicketEndpoint:
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": token_b},
+            event_hooks=csrf_event_hooks(),
         ) as b_client:
             resp = await b_client.post(
                 "/api/desktop/browser/copilot/ticket",
@@ -356,6 +358,7 @@ def ws_client(ws_app):
     token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
     with TestClient(ws_app, raise_server_exceptions=False) as c:
         c.cookies.set("taos_session", token)
+        arm_test_client(c)
         yield c
 
 

--- a/tests/routes/desktop_browser/test_push_routes.py
+++ b/tests/routes/desktop_browser/test_push_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 
 import pytest
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +33,7 @@ def _make_auth_client(app, tmp_data_dir):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/desktop_browser/test_site_permission_routes.py
+++ b/tests/routes/desktop_browser/test_site_permission_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pytest
+from taos_test_csrf import csrf_event_hooks
 
 
 def _get_user_id(app):
@@ -25,6 +26,7 @@ def _make_auth_client(app, tmp_data_dir):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/routes/test_browser_sessions_routes.py
+++ b/tests/routes/test_browser_sessions_routes.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.browser_sessions import BrowserSessionManager, BrowserWorkerError
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +96,7 @@ async def client(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -121,6 +123,7 @@ async def client_no_node(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -265,6 +268,7 @@ async def test_get_other_users_session_returns_404(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get(f"/api/browser/sessions/{session_id}")
 
@@ -384,6 +388,7 @@ async def client_host_capable(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -413,6 +418,7 @@ async def client_no_capable_node(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -512,6 +518,7 @@ async def test_migrate_session_calls_migrate_and_returns_session(app, tmp_path):
             transport=transport,
             base_url="http://test",
             cookies={"taos_session": token},
+            event_hooks=csrf_event_hooks(),
         ) as c:
             resp = await c.post(
                 f"/api/browser/sessions/{sid}/migrate",
@@ -547,6 +554,7 @@ async def test_migrate_session_unknown_session_returns_404(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.post("/api/browser/sessions/no-such-id/migrate", json={"target": "node-1"})
 
@@ -612,6 +620,7 @@ async def test_migrate_session_unknown_target_returns_409(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.post(
             f"/api/browser/sessions/{sid}/migrate",
@@ -661,6 +670,7 @@ async def test_list_sessions_returns_own_and_agent_sessions(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get("/api/browser/sessions")
 
@@ -688,6 +698,7 @@ async def test_list_sessions_excludes_stopped(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get("/api/browser/sessions")
 
@@ -725,6 +736,7 @@ async def test_get_agent_session_in_config_returns_200_with_stream_token(app, tm
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get(f"/api/browser/sessions/{sid}")
 
@@ -758,6 +770,7 @@ async def test_get_agent_session_not_in_config_returns_404(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get(f"/api/browser/sessions/{sid}")
 
@@ -880,6 +893,7 @@ async def test_get_session_over_tailscale_rewrites_neko_url(app, tmp_path):
         base_url="http://test",
         cookies={"taos_session": token},
         headers={"host": "100.64.0.5:6969"},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         resp = await c.get(f"/api/browser/sessions/{sid}")
 

--- a/tests/taos_test_csrf.py
+++ b/tests/taos_test_csrf.py
@@ -1,0 +1,126 @@
+"""Shared CSRF plumbing for tests that build their own ``httpx.AsyncClient``.
+
+Tests run against the REAL ``verify_csrf`` (see ``tests/conftest.py``).  A test
+client that injects a ``taos_session`` cookie is therefore a signed-in browser,
+and a signed-in browser that POSTs without ``X-CSRF-Token`` gets a 403 — exactly
+as it would in production.
+
+The fix is NOT to switch the check off.  It is to make the test client do what
+the SPA does: read the ``csrf_token`` cookie and echo it into the header.  The
+double-submit check is safe because a third-party origin cannot READ the cookie
+and so cannot set a matching header; a same-origin caller reads its own cookie
+and echoes it.  That is the caller these tests stand in for.
+
+Usage at a client construction site::
+
+    from taos_test_csrf import csrf_event_hooks
+
+    AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
+    )
+
+This lives in its own module rather than in ``conftest.py`` on purpose:
+``tests/`` is not a package and there are several ``conftest.py`` files, so a
+bare ``from conftest import ...`` binds whichever one the run happens to put on
+``sys.path`` first — which is what makes ``pytest tests/`` abort collection
+today (card ``tsk-xplzqy``).  A uniquely named module cannot collide.
+"""
+
+from http.cookies import SimpleCookie
+
+__all__ = [
+    "TEST_CSRF_TOKEN",
+    "echo_csrf_cookie_into_header",
+    "csrf_event_hooks",
+    "sync_csrf_event_hooks",
+    "arm_test_client",
+]
+
+
+# Any value works — the check is that the header equals the cookie — but it must
+# look like a token so a failure message is self-explanatory.
+TEST_CSRF_TOKEN = "testsuite-csrf-token-0123456789abcdef0123456789abcdef"
+
+
+def _echo(request) -> None:
+    """Do what the SPA does: echo the CSRF cookie into the request header.
+
+    Safe methods are skipped because ``verify_csrf`` exempts them, and an
+    explicitly-set header is never overwritten — a test that deliberately sends
+    a wrong or missing token is asserting something about CSRF itself and must
+    keep control of it.
+    """
+    if request.method.upper() in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        return
+    if "x-csrf-token" in request.headers:
+        return
+
+    # Read the value actually on the wire rather than assuming the seeded
+    # constant.  CSRFMiddleware issues a fresh token whenever a request arrives
+    # without one, so a client that picked one up mid-test holds a value this
+    # module never chose; echoing the constant would then MISMATCH and 403.
+    cookie_header = request.headers.get("cookie", "")
+    jar = SimpleCookie()
+    jar.load(cookie_header)
+    morsel = jar.get("csrf_token")
+
+    if morsel is not None:
+        request.headers["x-csrf-token"] = morsel.value
+        return
+
+    # No CSRF cookie yet.  A real browser would already hold one, because
+    # CSRFMiddleware sets it on the first response — but these clients inject
+    # the session directly instead of navigating, so no response has reached the
+    # jar.  Supply BOTH halves, which is the state navigation would have
+    # produced.
+    #
+    # Injected here rather than seeded on the client's cookie jar so that SAFE
+    # requests still arrive without a CSRF cookie.  The jar applies to every
+    # request, and a GET carrying the cookie makes CSRFMiddleware skip issuing
+    # one — which silently breaks the tests asserting that it does issue one.
+    request.headers["cookie"] = (
+        f"{cookie_header}; csrf_token={TEST_CSRF_TOKEN}"
+        if cookie_header
+        else f"csrf_token={TEST_CSRF_TOKEN}"
+    )
+    request.headers["x-csrf-token"] = TEST_CSRF_TOKEN
+
+
+async def echo_csrf_cookie_into_header(request) -> None:
+    """Async hook, for ``httpx.AsyncClient``."""
+    _echo(request)
+
+
+def echo_csrf_cookie_into_header_sync(request) -> None:
+    """Sync hook, for ``httpx.Client`` and ``fastapi.testclient.TestClient``.
+
+    A sync client rejects a coroutine hook, so the two transports need separate
+    entry points around the same body.
+    """
+    _echo(request)
+
+
+def csrf_event_hooks() -> dict:
+    """``event_hooks=`` value that makes an AsyncClient behave like the SPA.
+
+    Returns a fresh dict per call so a client cannot mutate the shared one.
+    """
+    return {"request": [echo_csrf_cookie_into_header]}
+
+
+def sync_csrf_event_hooks() -> dict:
+    """The same, for a SYNC client (``TestClient``)."""
+    return {"request": [echo_csrf_cookie_into_header_sync]}
+
+
+def arm_test_client(client):
+    """Attach the sync hook to an already-built ``TestClient``.
+
+    ``TestClient.__init__`` has a fixed signature and takes no ``event_hooks``,
+    so the hook goes on after construction.  Returns the client for chaining.
+    """
+    client.event_hooks = sync_csrf_event_hooks()
+    return client

--- a/tests/taos_test_csrf.py
+++ b/tests/taos_test_csrf.py
@@ -71,6 +71,17 @@ def _echo(request) -> None:
         request.headers["x-csrf-token"] = morsel.value
         return
 
+    # No session cookie either, so `verify_csrf` exempts this request outright
+    # and there is nothing to satisfy.  Returning here is not just an
+    # optimisation: injecting a csrf_token cookie makes CSRFMiddleware treat the
+    # caller as already holding one and skip ISSUING it, so a test that signs in
+    # and then reads `csrf_token` off the login response would read an empty
+    # string and send an empty header.  That is the same shape that broke
+    # `test_csrf.py::test_csrf_cookie_set_on_response` when this was seeded on
+    # the cookie jar instead.
+    if jar.get("taos_session") is None:
+        return
+
     # No CSRF cookie yet.  A real browser would already hold one, because
     # CSRFMiddleware sets it on the first response — but these clients inject
     # the session directly instead of navigating, so no response has reached the

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -20,6 +20,7 @@ from tinyagentos.agent_registry_store import (
     load_or_create_signing_keypair,
     mint_registry_token,
 )
+from taos_test_csrf import csrf_event_hooks
 
 _BUS_PATCH = "tinyagentos.routes.a2a_bus.httpx.AsyncClient"
 
@@ -96,6 +97,7 @@ async def bus_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         c._app = app
         c._test_admin_uid = uid

--- a/tests/test_agent_alias.py
+++ b/tests/test_agent_alias.py
@@ -9,6 +9,7 @@ Covers:
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -34,6 +35,7 @@ async def client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -14,6 +14,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_registry_store import AgentRegistryStore
+from taos_test_csrf import csrf_event_hooks
 
 
 def test_allowed_scopes_matches_canonical_valid_scopes():
@@ -98,6 +99,7 @@ async def mint_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         c._app = app
         yield c

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -25,6 +25,7 @@ from tinyagentos.agent_registry_store import (
 )
 from tinyagentos.routes.agent_registry import _ALLOWED_SCOPES
 from datetime import datetime, timezone
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -416,6 +417,7 @@ async def registry_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         # Expose the admin uid so tests can assert token claims
         c._test_admin_uid = uid
@@ -625,6 +627,7 @@ async def feeds_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         c._test_admin_uid = uid
         c._app = app
@@ -858,6 +861,7 @@ class TestRegistryWriteExistenceHiding:
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": session},
+            event_hooks=csrf_event_hooks(),
         )
 
     async def _register(self, registry_client):

--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -20,6 +20,7 @@ from tinyagentos.agent_registry_store import (
 )
 from tinyagentos.agent_grants_store import AgentGrantsStore
 from tinyagentos.agent_scope_requests_store import AgentScopeRequestsStore
+from taos_test_csrf import csrf_event_hooks
 
 
 class _Env:
@@ -289,6 +290,7 @@ async def test_non_owner_cannot_approve(client, monkeypatch, tmp_path):
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": bob_session},
+            event_hooks=csrf_event_hooks(),
         ) as bob_client:
             resp = await bob_client.post(
                 f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
@@ -453,6 +455,7 @@ async def test_create_authorizes_before_scope_vocab(client, monkeypatch, tmp_pat
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": carol_session},
+            event_hooks=csrf_event_hooks(),
         ) as carol_client:
             resp = await carol_client.post(
                 f"/api/agents/registry/{cid}/scope-requests",
@@ -626,6 +629,7 @@ async def test_create_scope_request_non_owner_and_nonexistent_identical(
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": carol_session},
+            event_hooks=csrf_event_hooks(),
         ) as carol_client:
             resp_owner = await carol_client.post(
                 f"/api/agents/registry/{cid}/scope-requests",
@@ -668,6 +672,7 @@ async def test_approve_scope_request_non_owner_and_nonexistent_identical(
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": carol_session},
+            event_hooks=csrf_event_hooks(),
         ) as carol_client:
             resp_owner = await carol_client.post(
                 f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
@@ -707,6 +712,7 @@ async def test_deny_scope_request_non_owner_and_nonexistent_identical(
             transport=ASGITransport(app=app),
             base_url="http://test",
             cookies={"taos_session": carol_session},
+            event_hooks=csrf_event_hooks(),
         ) as carol_client:
             resp_owner = await carol_client.post(
                 f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/deny",

--- a/tests/test_app_csrf_wiring.py
+++ b/tests/test_app_csrf_wiring.py
@@ -1,0 +1,154 @@
+"""A signed-in caller's POST must be rejected without a CSRF header.
+
+WHY THIS FILE EXISTS, AND WHY IT IS NAMED THIS WAY
+--------------------------------------------------
+`tests/conftest.py` used to install an autouse fixture that replaced
+`verify_csrf` with a no-op for every test file whose path did NOT contain the
+substring "test_csrf".  Measured on origin/dev: 788 test files, exactly ONE
+inside the carve-out, so 787 ran against an app in which the CSRF dependency
+did nothing -- and 223 of those issue POSTs.  That fixture is what hid #2081
+(the CSRF login lockout): a first repro written as an ordinary test returned
+303 and PASSED, and the tell was that the CONTROL passed identically -- the
+shape you get when the input never reaches the system under test.
+
+This module's name deliberately does NOT contain "test_csrf", so it sits
+OUTSIDE the old carve-out.  That is the point: it is exactly the file the old
+fixture would have silenced, and it must be RED under that fixture.
+
+WHY THE ASSERTIONS DRIVE THE REAL CALLER
+----------------------------------------
+Checking `verify_csrf.__name__` catches the one bypass mechanism we happen to
+have today (patching the module attribute) and nothing else: it cannot see an
+`app.dependency_overrides` entry, and any stub that copies the right `__name__`
+satisfies it.  Route introspection is barely better -- when the bypass IS
+active the installed callable is a conftest function, so a locator keyed on the
+csrf module reports "not wired", which cannot tell a DISABLED check from a
+REMOVED one.
+
+So these tests sign in for real and then act as that signed-in browser would.
+Rejected-vs-accepted is the property the real caller depends on, and it is the
+granularity at which the defect lives.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.auth import AuthManager
+
+PASSWORD = "correct horse battery staple"
+USERNAME = "tester"
+
+# POST /auth/logout carries `Depends(verify_csrf)` explicitly AND sits under a
+# router registered with the router-wide `dependencies=_csrf` list, so it
+# exercises both wiring paths.  On success it answers 303; a rejected request
+# answers 403.  Those are distinguishable without inspecting a body.
+PROTECTED_PATH = "/auth/logout"
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    """A real app with one real account.
+
+    `register_all_routers` does `from ... import verify_csrf` and freezes the
+    resulting object into `Depends(...)` at `include_router` time, so what ends
+    up installed is decided by whatever the module attribute was AT BUILD TIME.
+    Building the app inside the test is what makes an active bypass observable.
+    """
+    from tinyagentos.app import create_app
+
+    monkeypatch.setenv("TINYAGENTOS_DATA_DIR", str(tmp_path))
+    built = create_app()
+    mgr = AuthManager(tmp_path)
+    mgr.setup_user(USERNAME, "Bring-up Test", "", PASSWORD)
+    built.state.auth = mgr
+    return built
+
+
+@pytest_asyncio.fixture()
+async def signed_in(app):
+    """A client holding a REAL session, exactly as a browser would.
+
+    A hand-made `taos_session` cookie would be rejected by auth before the CSRF
+    dependency ever runs, so the test would pass on the wrong status code.
+    Signing in for real is what puts the request into the state `verify_csrf`
+    is meant to guard.
+
+    `/auth/login` is in `_CREDENTIAL_PATHS` and is CSRF-exempt by design, which
+    is why signing in needs no token of its own.
+    """
+    transport = ASGITransport(app=app, client=("127.0.0.1", 51234))
+    async with AsyncClient(
+        transport=transport, base_url="http://testserver", follow_redirects=False
+    ) as client:
+        resp = await client.post(
+            "/auth/login", json={"username": USERNAME, "password": PASSWORD}
+        )
+        assert resp.status_code == 200, resp.text
+        # Both halves of the double-submit pair must be present, or the
+        # assertions below would be measuring a cookie-less caller -- which
+        # verify_csrf exempts, so they would pass vacuously.
+        assert client.cookies.get("taos_session"), "no session cookie after sign-in"
+        assert client.cookies.get("csrf_token"), "no csrf cookie after sign-in"
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_signed_in_post_without_a_csrf_header_is_rejected(signed_in):
+    """The RED case.
+
+    Under the old autouse bypass this returns 303 (the logout succeeds) instead
+    of 403, which is the correct and intended report: the app under test had a
+    CSRF dependency that could not reject anything.
+    """
+    resp = await signed_in.post(PROTECTED_PATH)
+
+    assert resp.status_code == 403, (
+        f"expected 403 for a signed-in POST with no X-CSRF-Token, got "
+        f"{resp.status_code}. The CSRF dependency on the built app is not "
+        f"enforcing."
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_in_post_with_a_mismatched_csrf_header_is_rejected(signed_in):
+    """A check that only looks for PRESENCE is not a double-submit check."""
+    resp = await signed_in.post(PROTECTED_PATH, headers={"X-CSRF-Token": "b" * 64})
+
+    assert resp.status_code == 403, (
+        f"expected 403 for a mismatched X-CSRF-Token, got {resp.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_in_post_with_a_matching_csrf_header_succeeds(signed_in):
+    """The positive control.
+
+    Without this, a dependency that rejected unconditionally would satisfy both
+    tests above while breaking every legitimate caller -- and a 403-only pair
+    of assertions could not tell the two apart.
+    """
+    token = signed_in.cookies.get("csrf_token")
+
+    resp = await signed_in.post(PROTECTED_PATH, headers={"X-CSRF-Token": token})
+
+    assert resp.status_code == 303, resp.text
+
+
+def test_this_module_is_outside_any_csrf_bypass():
+    """Guard the guard.
+
+    Every assertion above is only evidence while this module runs against the
+    REAL `verify_csrf`.  If a future conftest change (or a rename of this file)
+    puts it back under a bypass, the tests above would go green while measuring
+    nothing -- the exact failure this card exists to remove.  Assert the
+    installed function's identity rather than trusting the filename.
+    """
+    from tinyagentos.middleware import csrf
+
+    assert csrf.verify_csrf.__module__ == "tinyagentos.middleware.csrf", (
+        f"verify_csrf is patched to {csrf.verify_csrf!r} -- this module is "
+        f"running under a CSRF bypass and proves nothing."
+    )
+    assert csrf.verify_csrf.__name__ == "verify_csrf"

--- a/tests/test_apps_installed.py
+++ b/tests/test_apps_installed.py
@@ -14,6 +14,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +47,8 @@ async def apps_client(apps_app):
     )
     transport = ASGITransport(app=apps_app)
     async with AsyncClient(
-        transport=transport, base_url="http://test", cookies={"taos_session": token}
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c, apps_app.state.installed_apps
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,6 +7,7 @@ import time
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.auth import (
     AuthManager,
@@ -250,7 +251,14 @@ async def auth_client(app):
         await relationship_mgr.close()
     await relationship_mgr.init()
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        # Tests here pass `cookies=login.cookies` per request rather than
+        # seeding the jar, so the hook is the only place that sees the
+        # csrf_token this client actually carries.
+        event_hooks=csrf_event_hooks(),
+    ) as c:
         yield c
     await relationship_mgr.close()
     await channel_store.close()
@@ -848,7 +856,14 @@ async def no_cookie_client(app):
     # Configure auth so the app isn't in onboarding mode
     app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        # Tests here pass `cookies=login.cookies` per request rather than
+        # seeding the jar, so the hook is the only place that sees the
+        # csrf_token this client actually carries.
+        event_hooks=csrf_event_hooks(),
+    ) as c:
         yield c
     await relationship_mgr.close()
     await channel_store.close()

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.auth_requests_store import AuthRequestsStore
 from tinyagentos.agent_grants_store import AgentGrantsStore
@@ -226,6 +227,7 @@ async def consent_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         c._test_admin_uid = uid
         yield c
@@ -275,6 +277,7 @@ async def consent_client_nonadmin(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": member_token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 
@@ -541,6 +544,7 @@ class TestAuthRequestRoutes:
                 transport=ASGITransport(app=consent_client._transport.app),
                 base_url="http://test",
                 cookies=cookies,
+                event_hooks=csrf_event_hooks(),
             ) as c:
                 return await c.post(
                     f"/api/agents/auth-requests/{request_id}/approve",

--- a/tests/test_channel_project.py
+++ b/tests/test_channel_project.py
@@ -2,6 +2,7 @@ import pytest
 import pytest_asyncio
 
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.app import create_app
 
@@ -40,6 +41,7 @@ async def client(app):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 

--- a/tests/test_chat_attachments.py
+++ b/tests/test_chat_attachments.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from pathlib import Path
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 from tinyagentos.chat.message_store import ChatMessageStore
 
 
@@ -76,6 +77,7 @@ async def _authed_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 
@@ -132,6 +134,7 @@ async def _authed_msg_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 

--- a/tests/test_chat_edit_delete.py
+++ b/tests/test_chat_edit_delete.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 
 
 def _make_app(tmp_path):
@@ -28,6 +29,7 @@ async def _authed_client(tmp_path, username="admin"):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client, rec
 

--- a/tests/test_chat_help.py
+++ b/tests/test_chat_help.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 from tinyagentos.chat.help import handle_help, KNOWN_TOPICS
 
 
@@ -29,6 +30,7 @@ async def _authed_help_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 

--- a/tests/test_chat_mark_unread.py
+++ b/tests/test_chat_mark_unread.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 from tinyagentos.chat.channel_store import ChatChannelStore
 
 
@@ -68,6 +69,7 @@ async def _authed_unread_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client, rec
 

--- a/tests/test_chat_pins.py
+++ b/tests/test_chat_pins.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 from tinyagentos.chat.message_store import ChatMessageStore
 
 
@@ -29,6 +30,7 @@ async def _authed_pins_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client, rec
 

--- a/tests/test_chat_threads.py
+++ b/tests/test_chat_threads.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from httpx import AsyncClient, ASGITransport
+from taos_test_csrf import csrf_event_hooks
 from unittest.mock import AsyncMock, MagicMock
 from tinyagentos.chat.message_store import ChatMessageStore
 from tinyagentos.chat.threads import resolve_thread_recipients
@@ -170,6 +171,7 @@ async def _authed_thread_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -3,6 +3,7 @@
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -47,10 +48,12 @@ async def two_member_clients(app, tmp_data_dir):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
     ) as alice_c:
         async with AsyncClient(
             transport=transport, base_url="http://test",
             cookies={"taos_session": bob_token},
+            event_hooks=csrf_event_hooks(),
         ) as bob_c:
             alice_c._test_uid = alice_uid
             alice_c._test_app = app

--- a/tests/test_csrf_bypass_debt.py
+++ b/tests/test_csrf_bypass_debt.py
@@ -1,0 +1,105 @@
+"""The `csrf_bypass` escape hatch exists, works, and is used by NOTHING.
+
+`tests/conftest.py` runs every test against the real `verify_csrf` and offers
+``@pytest.mark.csrf_bypass`` as an explicit opt-out.  An escape hatch that
+nobody watches becomes the default again: the mechanism this replaced was a
+path-substring carve-out that silently covered 787 of 788 test files.
+
+So this module asserts the stronger property.  Not "the bypass list matches a
+frozen set of names" -- a frozenset has to be edited to grow, but editing it is
+a one-line change nobody reviews as a privilege grant.  The assertion here is
+that the list is **EMPTY**: no test anywhere opts out.  Every module that
+builds its own signed-in client sends `X-CSRF-Token` the way the SPA does (see
+`tests/taos_test_csrf.py`), so none of them needs the hatch.
+
+If you are here because this test went red: adding a marker is almost certainly
+the wrong fix.  A red under real CSRF means a test reaches a route in a way the
+real caller cannot.  Give that test's client `event_hooks=csrf_event_hooks()`
+instead.  Marking it is a privilege grant to the test, and the point of #2081
+is that such a grant hides real defects.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# Matches `@pytest.mark.csrf_bypass` and `pytestmark = pytest.mark.csrf_bypass`,
+# but NOT a function whose *name* merely contains "csrf_bypass" (there is one:
+# `test_app_csrf_wiring.py::test_this_module_is_outside_any_csrf_bypass`) and
+# not conftest's `CSRF_BYPASS_MARKER = "csrf_bypass"` string constant.
+_MARKER_USE = re.compile(r"\bmark\.csrf_bypass\b")
+
+
+def _modules_using_the_bypass(root: Path = TESTS_DIR) -> list[str]:
+    """Every test module that opts out of real CSRF, by source inspection.
+
+    Source inspection rather than a pytest hook because a marker on a test that
+    is skipped, deselected, or collected only in another shard is still debt --
+    and a collection-time query would not see it.
+
+    This module excludes itself: `test_the_bypass_marker_still_works` below is
+    deliberately marked, so counting it would make the guard permanently red on
+    its own proof.
+    """
+    found = []
+    # Only test modules: a marker is what pytest reads off a collected test, so
+    # `conftest.py` -- which DOCUMENTS the marker in its comments and docstrings
+    # -- is not debt, and matching it would make this guard permanently red on
+    # the very text that explains it.
+    for path in sorted(root.rglob("test_*.py")):
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        if _MARKER_USE.search(path.read_text(encoding="utf-8", errors="replace")):
+            found.append(str(path.relative_to(root)))
+    return found
+
+
+def test_no_test_module_opts_out_of_csrf():
+    using = _modules_using_the_bypass()
+
+    assert using == [], (
+        "These modules opt out of real CSRF with @pytest.mark.csrf_bypass:\n  "
+        + "\n  ".join(using)
+        + "\n\nThe bypass list is meant to stay EMPTY. A test that 403s under "
+        "real CSRF is reaching a route in a way the real caller cannot; give "
+        "its client `event_hooks=csrf_event_hooks()` (tests/taos_test_csrf.py) "
+        "so it sends X-CSRF-Token like the SPA, rather than switching the "
+        "check off."
+    )
+
+
+def test_the_scanner_can_actually_see_a_marker(tmp_path):
+    """Guard the guard.
+
+    A scanner that matches nothing would report an empty debt list on a tree
+    full of markers -- passing for the same reason it would pass on a clean
+    tree.  Point it at a directory that DOES contain one and require a hit.
+    """
+    (tmp_path / "test_marked.py").write_text(
+        "import pytest\npytestmark = pytest.mark.csrf_bypass\n"
+    )
+    (tmp_path / "test_named_only.py").write_text(
+        "def test_this_module_is_outside_any_csrf_bypass():\n    pass\n"
+    )
+
+    assert _modules_using_the_bypass(tmp_path) == ["test_marked.py"]
+
+
+@pytest.mark.csrf_bypass
+def test_the_bypass_marker_still_works():
+    """The hatch is unused, so prove here that it is not merely broken.
+
+    An opt-out nobody exercises can rot into a no-op -- and a no-op opt-out
+    reads as "nothing needs it" for exactly the wrong reason.  Under the marker
+    the installed `verify_csrf` must be conftest's stub, not the real one.
+    """
+    from tinyagentos.middleware import csrf
+
+    assert csrf.verify_csrf.__module__ != "tinyagentos.middleware.csrf", (
+        "the csrf_bypass marker did not replace verify_csrf -- the documented "
+        "escape hatch is broken"
+    )

--- a/tests/test_csrf_bypass_debt.py
+++ b/tests/test_csrf_bypass_debt.py
@@ -50,7 +50,17 @@ def _modules_using_the_bypass(root: Path = TESTS_DIR) -> list[str]:
     # `conftest.py` -- which DOCUMENTS the marker in its comments and docstrings
     # -- is not debt, and matching it would make this guard permanently red on
     # the very text that explains it.
-    for path in sorted(root.rglob("test_*.py")):
+    #
+    # BOTH default patterns, not just `test_*.py`. pyproject.toml sets no
+    # `python_files`, so pytest's default discovery collects `test_*.py` AND
+    # `*_test.py`. Scanning only the first would let a module named
+    # `something_test.py` carry the marker, be collected and run with CSRF
+    # switched off, and stay invisible here -- the guard would then pass
+    # vacuously, which is the failure mode it exists to prevent. It is also the
+    # exact defect this PR removed from the bypass itself: behaviour that hangs
+    # on what a file is NAMED.
+    candidates = set(root.rglob("test_*.py")) | set(root.rglob("*_test.py"))
+    for path in sorted(candidates):
         if path.resolve() == Path(__file__).resolve():
             continue
         if _MARKER_USE.search(path.read_text(encoding="utf-8", errors="replace")):
@@ -87,6 +97,25 @@ def test_the_scanner_can_actually_see_a_marker(tmp_path):
     )
 
     assert _modules_using_the_bypass(tmp_path) == ["test_marked.py"]
+
+
+def test_the_scanner_sees_both_pytest_filename_patterns(tmp_path):
+    """The scanner's file set must match what pytest actually collects.
+
+    `pyproject.toml` sets no `python_files`, so pytest collects `test_*.py` AND
+    `*_test.py`.  A scanner covering only the first is one level coarser than
+    the thing it guards: a marker in `something_test.py` would run with CSRF
+    switched off and this guard would still report an empty debt list.
+
+    The sibling test above CANNOT catch that -- it only ever writes
+    `test_*.py` files, so it passes identically with either glob.  This one
+    fails on the narrow glob and passes on the correct one.
+    """
+    (tmp_path / "legacy_test.py").write_text(
+        "import pytest\npytestmark = pytest.mark.csrf_bypass\n"
+    )
+
+    assert _modules_using_the_bypass(tmp_path) == ["legacy_test.py"]
 
 
 @pytest.mark.csrf_bypass

--- a/tests/test_feedback_route.py
+++ b/tests/test_feedback_route.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 import pytest
 import pytest_asyncio
@@ -199,6 +200,7 @@ async def test_post_feedback_rate_limit_per_user(client, app):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as user2_client:
         resp = await user2_client.post(
             "/api/feedback",

--- a/tests/test_knowledge_ownership.py
+++ b/tests/test_knowledge_ownership.py
@@ -22,6 +22,7 @@ import pytest
 import pytest_asyncio
 import yaml
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.app import create_app
 from tinyagentos.auth import get_current_user
@@ -181,6 +182,7 @@ def _make_client(app, token: str) -> AsyncClient:
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from httpx import ASGITransport, AsyncClient
 from tinyagentos.app import create_app
 import yaml
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -40,6 +41,7 @@ async def knowledge_client(tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 

--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient, ASGITransport
 
 from tinyagentos.installers.lxc_installer import LXCInstaller
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +553,8 @@ async def lxc_client(tmp_data_dir, lxc_catalog_dir):
     )
     transport = ASGITransport(app=app)
     async with AsyncClient(
-        transport=transport, base_url="http://test", cookies={"taos_session": _token}
+        transport=transport, base_url="http://test", cookies={"taos_session": _token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await installed_apps.close()

--- a/tests/test_model_sources.py
+++ b/tests/test_model_sources.py
@@ -15,6 +15,7 @@ from tinyagentos.model_sources import (
     get_huggingface_model_files,
     _cache,
 )
+from taos_test_csrf import csrf_event_hooks
 
 
 # --- Unit tests for helper functions ---
@@ -317,7 +318,7 @@ async def search_client(search_app):
     _rec = search_app.state.auth.find_user("admin")
     _token = search_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=search_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await search_app.state.qmd_client.close()

--- a/tests/test_notifications_push.py
+++ b/tests/test_notifications_push.py
@@ -14,6 +14,7 @@ from pywebpush import WebPushException
 from tinyagentos.notifications import NotificationStore
 from tinyagentos.notifications_push import NotificationPushStore, send_web_push
 from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+from taos_test_csrf import csrf_event_hooks
 
 # A real VAPID keypair once for the whole module - pywebpush parses the PEM,
 # but every send is mocked so no network call is ever made.
@@ -466,7 +467,8 @@ class TestPushRoutes:
 
         cookies = {"taos_session": _admin_token(app)} if authed else {}
         return AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test", cookies=cookies
+            transport=ASGITransport(app=app), base_url="http://test", cookies=cookies,
+            event_hooks=csrf_event_hooks(),
         )
 
     async def test_vapid_public_key_requires_auth(self, route_app):
@@ -517,6 +519,7 @@ class TestPushRoutes:
             transport=ASGITransport(app=route_app),
             base_url="http://test",
             cookies={"taos_session": token_b},
+            event_hooks=csrf_event_hooks(),
         ) as cb:
             r = await cb.post(
                 "/api/notifications/push/unsubscribe", json={"endpoint": endpoint}

--- a/tests/test_proxy_cookie_isolation.py
+++ b/tests/test_proxy_cookie_isolation.py
@@ -20,8 +20,8 @@ invisible. Every test below therefore hands the proxy a header holding ALL of
 them and asserts NONE survives.
 """
 
+import ast
 import pathlib
-import re
 
 import pytest
 
@@ -111,6 +111,61 @@ def test_every_proxy_shares_one_deny_list():
         )
 
 
+def _cookie_names_the_code_issues(pkg: pathlib.Path) -> set[str]:
+    """Every cookie name passed to a ``set_cookie`` call under *pkg*.
+
+    Parsed with ``ast`` rather than matched with a regex because the name is
+    not always a literal at the call site. ``middleware/csrf.py`` holds it in a
+    module constant::
+
+        _COOKIE_NAME = "csrf_token"      # line 36
+        response.set_cookie(_COOKIE_NAME, token, ...)   # line 94
+
+    A literal-only scanner sees four of the five cookies taOS issues and misses
+    exactly ``csrf_token`` -- the one this whole module exists for. It would
+    have reported a clean tree while a rename of ``_COOKIE_NAME`` leaked the
+    new cookie through all four proxies. So module-level ``NAME = "literal"``
+    assignments are resolved and the constant call shape is covered too.
+    """
+    names: set[str] = set()
+    for path in pkg.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:  # pragma: no cover - the package parses
+            continue
+
+        consts: dict[str, str] = {}
+        for node in tree.body:
+            targets: list[ast.expr] = []
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+            elif isinstance(node, ast.AnnAssign):
+                targets = [node.target]
+            value = getattr(node, "value", None)
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = value.value
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if called != "set_cookie":
+                continue
+            # Both call shapes in the tree: positional name, or key="name".
+            arg: ast.expr | None = node.args[0] if node.args else None
+            if arg is None:
+                arg = next((kw.value for kw in node.keywords if kw.arg == "key"), None)
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                names.add(arg.value)
+            elif isinstance(arg, ast.Name) and arg.id in consts:
+                names.add(consts[arg.id])
+    return names
+
+
 def test_deny_list_covers_every_cookie_the_code_issues():
     """Drift guard: a cookie added tomorrow must not silently start leaking.
 
@@ -120,22 +175,53 @@ def test_deny_list_covers_every_cookie_the_code_issues():
     the four strip lists were written, and nothing forced anyone back here.
     """
     pkg = pathlib.Path(__file__).resolve().parent.parent / "tinyagentos"
-    # Matches both call shapes in the tree: set_cookie("name", ...) and
-    # set_cookie(key="name", ...), including when the name is on the next line.
-    pattern = re.compile(r"set_cookie\(\s*(?:key\s*=\s*)?[\"']([a-zA-Z_][\w-]*)[\"']")
-    found: set[str] = set()
-    for path in pkg.rglob("*.py"):
-        found |= set(pattern.findall(path.read_text(encoding="utf-8", errors="ignore")))
+    found = _cookie_names_the_code_issues(pkg)
 
     # The scanner must be able to SEE something, or an empty result would make
     # this test vacuously green -- the exact failure mode this suite is about.
-    assert "taos_session" in found, (
-        f"scanner found no taos_session among {sorted(found)}; it is broken, "
-        f"not the tree. An empty scan would pass this test while proving nothing."
-    )
+    # Both shapes are named on purpose: taos_session is a literal at its call
+    # site, csrf_token is a module constant. Asserting only the literal one
+    # would pass identically with constant resolution removed, so it could not
+    # fail on the defect that resolution exists to fix.
+    for shape, name in [("literal", "taos_session"), ("module constant", "csrf_token")]:
+        assert name in found, (
+            f"scanner found no {name} ({shape} call shape) among {sorted(found)}; "
+            f"it is broken, not the tree. An empty or partial scan would pass "
+            f"this test while proving nothing."
+        )
 
     leaking = found - TAOS_ISSUED_COOKIES
     assert not leaking, (
         f"these cookies are issued by taOS but absent from TAOS_ISSUED_COOKIES, "
         f"so every proxy will relay them upstream: {sorted(leaking)}"
     )
+
+
+def test_the_scanner_resolves_a_name_held_in_a_constant(tmp_path):
+    """The scanner must cover the call shape ``csrf_token`` actually uses.
+
+    The sibling test above runs against the real tree, where a regression in
+    constant resolution shows up as a missing name. This one pins the
+    behaviour in isolation: a literal-only scanner returns just the literal
+    cookie here and fails, which is precisely how ``csrf_token`` stayed
+    invisible to this guard.
+    """
+    (tmp_path / "constant_named.py").write_text(
+        '_COOKIE_NAME = "held_in_a_constant"\n'
+        "def f(response, token):\n"
+        "    response.set_cookie(_COOKIE_NAME, token, httponly=False)\n"
+    )
+    (tmp_path / "literal_named.py").write_text(
+        "def g(response, token):\n"
+        '    response.set_cookie("held_as_a_literal", token)\n'
+    )
+    (tmp_path / "kwarg_named.py").write_text(
+        "def h(response, token):\n"
+        '    response.set_cookie(key="held_as_a_kwarg", value=token)\n'
+    )
+
+    assert _cookie_names_the_code_issues(tmp_path) == {
+        "held_in_a_constant",
+        "held_as_a_literal",
+        "held_as_a_kwarg",
+    }

--- a/tests/test_proxy_cookie_isolation.py
+++ b/tests/test_proxy_cookie_isolation.py
@@ -1,0 +1,141 @@
+"""Every proxy must deny EVERY cookie taOS itself issues, not just taos_session.
+
+The defect this file exists to prevent: four independent proxies each carried
+their own hand-written list of cookies to strip, and between them those lists
+named exactly two of the five cookies taOS issues. So a real signed-in browser
+relayed this origin's ``csrf_token`` -- plus ``taos_browser``, an httponly
+session id bound to a user_id -- to taos.my and to *untrusted container app*
+backends on every proxied request.
+
+``csrf_token`` is the sharp one. ``middleware/csrf.py`` sets it
+``httponly=False`` on purpose (the SPA must read it), so it is a readable,
+origin-wide secret whose ONLY job is proving same-origin. Handing it to an
+upstream hands over exactly what satisfies ``verify_csrf``.
+
+The old tests could not catch this: they asserted the relayed Cookie header was
+empty while driving a test client that carried no ``csrf_token`` cookie at all
+-- a caller that does not exist in production. A test whose client holds only
+one of the cookies CANNOT fail on a leak of the other, which is how this stayed
+invisible. Every test below therefore hands the proxy a header holding ALL of
+them and asserts NONE survives.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+from tinyagentos.issued_cookies import TAOS_ISSUED_COOKIES
+from tinyagentos.routes import account_proxy, service_proxy, shortcut_proxy, userspace_apps
+
+# A header shaped like the one a real signed-in browser sends: every cookie taOS
+# issues, plus one that genuinely belongs upstream and MUST survive. The
+# upstream cookie is the discriminator -- an implementation that simply dropped
+# the Cookie header wholesale would pass a "nothing leaked" assertion while
+# breaking every proxied login.
+_UPSTREAM = "upstream_sess=keepme"
+_BROWSER_HEADER = "; ".join(
+    [f"{name}=leaked-{name}" for name in sorted(TAOS_ISSUED_COOKIES)] + [_UPSTREAM]
+)
+
+
+def _assert_no_taos_cookie_survives(relayed: str | None) -> None:
+    """No taOS-issued cookie may appear in *relayed*, and upstream must remain."""
+    assert relayed is not None, "proxy dropped the Cookie header entirely"
+    for name in TAOS_ISSUED_COOKIES:
+        assert name not in relayed, (
+            f"{name} was relayed upstream: {relayed!r}. Every cookie taOS issues "
+            f"is controller-scoped and must never leave this origin."
+        )
+    assert _UPSTREAM in relayed, (
+        f"the upstream cookie was dropped: {relayed!r}. Stripping controller "
+        f"cookies must not break cookies that legitimately belong upstream."
+    )
+
+
+def test_account_proxy_denies_every_taos_cookie():
+    """account_proxy -> taos.my. Its docstring claimed 'only the cookies that
+    belong upstream are forwarded'; it forwarded everything but taos_session."""
+    _assert_no_taos_cookie_survives(
+        account_proxy._strip_local_session_cookie(_BROWSER_HEADER)
+    )
+
+
+def test_service_proxy_denies_every_taos_cookie():
+    _assert_no_taos_cookie_survives(service_proxy._strip_taos_cookies(_BROWSER_HEADER))
+
+
+def test_userspace_apps_denies_every_taos_cookie():
+    """The worst of the four by the code's own word: the backend here is an
+    'untrusted container-app backend'."""
+    _assert_no_taos_cookie_survives(
+        userspace_apps._strip_taos_session_cookie(_BROWSER_HEADER)
+    )
+
+
+def test_shortcut_proxy_denies_every_taos_cookie():
+    filtered = shortcut_proxy._filter_proxy_headers({"Cookie": _BROWSER_HEADER})
+    _assert_no_taos_cookie_survives(filtered.get("Cookie"))
+
+
+@pytest.mark.parametrize(
+    "strip",
+    [
+        pytest.param(account_proxy._strip_local_session_cookie, id="account_proxy"),
+        pytest.param(service_proxy._strip_taos_cookies, id="service_proxy"),
+        pytest.param(userspace_apps._strip_taos_session_cookie, id="userspace_apps"),
+    ],
+)
+def test_taos_only_header_relays_nothing(strip):
+    """When the browser holds ONLY taOS cookies, the proxy must send no Cookie
+    header at all rather than an empty or comma-noise one."""
+    only_taos = "; ".join(f"{n}=x" for n in sorted(TAOS_ISSUED_COOKIES))
+    assert not strip(only_taos)
+
+
+def test_every_proxy_shares_one_deny_list():
+    """Four hand-written lists is what let them drift apart in the first place.
+
+    This asserts identity with the shared set, not mere equality of contents, so
+    a future edit that re-forks a local copy fails here even if it happens to
+    start with the same names.
+    """
+    for module, attr in [
+        (service_proxy, "_STRIPPED_COOKIES"),
+        (userspace_apps, "_PROXY_STRIPPED_COOKIES"),
+        (shortcut_proxy, "_STRIPPED_PROXY_COOKIES"),
+    ]:
+        assert getattr(module, attr) is TAOS_ISSUED_COOKIES, (
+            f"{module.__name__}.{attr} is a private copy, not the shared "
+            f"TAOS_ISSUED_COOKIES set -- that is how the lists drifted apart."
+        )
+
+
+def test_deny_list_covers_every_cookie_the_code_issues():
+    """Drift guard: a cookie added tomorrow must not silently start leaking.
+
+    Scans every ``set_cookie`` call in the package for the name it issues and
+    asserts the deny-list already covers it. This is the check whose absence
+    let csrf_token, taos_browser and taos_cs leak -- each was added long after
+    the four strip lists were written, and nothing forced anyone back here.
+    """
+    pkg = pathlib.Path(__file__).resolve().parent.parent / "tinyagentos"
+    # Matches both call shapes in the tree: set_cookie("name", ...) and
+    # set_cookie(key="name", ...), including when the name is on the next line.
+    pattern = re.compile(r"set_cookie\(\s*(?:key\s*=\s*)?[\"']([a-zA-Z_][\w-]*)[\"']")
+    found: set[str] = set()
+    for path in pkg.rglob("*.py"):
+        found |= set(pattern.findall(path.read_text(encoding="utf-8", errors="ignore")))
+
+    # The scanner must be able to SEE something, or an empty result would make
+    # this test vacuously green -- the exact failure mode this suite is about.
+    assert "taos_session" in found, (
+        f"scanner found no taos_session among {sorted(found)}; it is broken, "
+        f"not the tree. An empty scan would pass this test while proving nothing."
+    )
+
+    leaking = found - TAOS_ISSUED_COOKIES
+    assert not leaking, (
+        f"these cookies are issued by taOS but absent from TAOS_ISSUED_COOKIES, "
+        f"so every proxy will relay them upstream: {sorted(leaking)}"
+    )

--- a/tests/test_registry_governance_lifecycle.py
+++ b/tests/test_registry_governance_lifecycle.py
@@ -23,6 +23,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_registry_store import AgentRegistryStore
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -397,6 +398,7 @@ async def gov_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c, uid
 
@@ -443,6 +445,7 @@ async def gov_member_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": member_token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 

--- a/tests/test_routes_agent_browsers.py
+++ b/tests/test_routes_agent_browsers.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.agent_browsers import AgentBrowsersManager
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -43,7 +44,7 @@ async def browsers_client(tmp_path):
     _rec = app.state.auth.find_user("admin")
     _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
 
     await browsers_mgr.close()

--- a/tests/test_routes_agent_org.py
+++ b/tests/test_routes_agent_org.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -27,6 +28,7 @@ async def org_client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport, base_url="http://test", cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c, uid
 
@@ -53,6 +55,7 @@ async def org_member_client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport, base_url="http://test", cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c, member_uid
 
@@ -251,6 +254,7 @@ class TestUpdateOrgFields:
 
         member_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test", cookies={"taos_session": token},
+            event_hooks=csrf_event_hooks(),
         )
         try:
             resp = await member_client.put(

--- a/tests/test_routes_canvas.py
+++ b/tests/test_routes_canvas.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
+from taos_test_csrf import arm_test_client
 
 
 # ---------------------------------------------------------------------------
@@ -48,6 +49,7 @@ def authed_client(ws_app):
     token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
     with TestClient(ws_app, raise_server_exceptions=False) as c:
         c.cookies.set("taos_session", token)
+        arm_test_client(c)
         yield c
 
 

--- a/tests/test_routes_chat_admin.py
+++ b/tests/test_routes_chat_admin.py
@@ -4,6 +4,7 @@ import yaml
 
 from httpx import AsyncClient, ASGITransport
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 def _make_app(tmp_path):
@@ -30,6 +31,7 @@ async def _setup_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 

--- a/tests/test_routes_chat_slash_guard.py
+++ b/tests/test_routes_chat_slash_guard.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
 from tinyagentos.app import create_app
 from tinyagentos.routes.chat import _validate_slash_target
+from taos_test_csrf import arm_test_client, csrf_event_hooks
 
 
 def _make_app(tmp_path):
@@ -39,6 +40,7 @@ async def _setup_client(tmp_path):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
     return app, client
 
@@ -206,6 +208,7 @@ def test_ws_unaddressed_slash_in_group_returns_error_frame(tmp_path):
 
     with TestClient(app, raise_server_exceptions=False) as client:
         client.cookies.set("taos_session", token)
+        arm_test_client(client)
         with client.websocket_connect("/ws/chat") as ws:
             ws.send_text(json.dumps({
                 "type": "message",
@@ -231,6 +234,7 @@ def test_ws_addressed_slash_in_group_is_delivered(tmp_path):
 
     with TestClient(app, raise_server_exceptions=False) as client:
         client.cookies.set("taos_session", token)
+        arm_test_client(client)
         with client.websocket_connect("/ws/chat") as ws:
             ws.send_text(json.dumps({
                 "type": "join", "channel_id": ch_id,

--- a/tests/test_routes_images.py
+++ b/tests/test_routes_images.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient, Request as HttpxRequest, Response
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.fixture
@@ -31,7 +32,7 @@ async def images_client(images_app):
     _rec = images_app.state.auth.find_user("admin")
     _token = images_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=images_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await images_app.state.qmd_client.close()
@@ -99,7 +100,7 @@ class TestImagesGenerate:
         _rec = app.state.auth.find_user("admin")
         _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
         transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
             resp = await c.post("/api/images/generate", json={"prompt": "test"})
         assert resp.status_code == 503
         assert "error" in resp.json()

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -12,6 +12,7 @@ from tinyagentos.routes.models import (
     get_downloaded_models,
 )
 from tinyagentos.vram_reservation import VramReservationManager
+from taos_test_csrf import csrf_event_hooks
 
 
 class TestDefaultModelsDir:
@@ -107,7 +108,7 @@ async def models_client(models_app):
     _rec = models_app.state.auth.find_user("admin")
     _token = models_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=models_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await models_app.state.qmd_client.close()
@@ -586,7 +587,7 @@ async def _make_auth_client(app):
     _rec = app.state.auth.find_user("admin")
     _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token})
+    return AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks())
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_music.py
+++ b/tests/test_routes_music.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient, Request as HttpxRequest, Response
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.fixture
@@ -27,7 +28,7 @@ async def music_client(music_app):
     _rec = music_app.state.auth.find_user("admin")
     _token = music_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=music_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await music_app.state.qmd_client.close()

--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -11,6 +11,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_registry_store import mint_registry_token
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.fixture(autouse=True)
@@ -497,6 +498,7 @@ def _non_owner_client(app):
         transport=ASGITransport(app=app),
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     )
 
 

--- a/tests/test_routes_project_ownership.py
+++ b/tests/test_routes_project_ownership.py
@@ -17,6 +17,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.projects.project_store import ProjectStore
 from tinyagentos.auth_context import CurrentUser, require_owner_or_admin
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +188,7 @@ async def member_client(app, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         c._test_uid = member_uid
         c._test_app = app
@@ -211,10 +213,12 @@ async def two_member_clients(app, tmp_data_dir):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
     ) as alice_c:
         async with AsyncClient(
             transport=transport, base_url="http://test",
             cookies={"taos_session": bob_token},
+            event_hooks=csrf_event_hooks(),
         ) as bob_c:
             alice_c._test_uid = alice_uid
             alice_c._test_app = app
@@ -335,6 +339,7 @@ async def test_admin_sees_all_projects(two_member_clients):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": admin_token},
+        event_hooks=csrf_event_hooks(),
     ) as admin_c:
         # default status=active; alice and bob's projects are active
         resp = await admin_c.get("/api/projects")
@@ -359,6 +364,7 @@ async def test_admin_can_get_any_project(two_member_clients):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": admin_token},
+        event_hooks=csrf_event_hooks(),
     ) as admin_c:
         resp = await admin_c.get(f"/api/projects/{pid}")
         assert resp.status_code == 200
@@ -380,6 +386,7 @@ async def test_admin_can_update_any_project(two_member_clients):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": admin_token},
+        event_hooks=csrf_event_hooks(),
     ) as admin_c:
         resp = await admin_c.patch(f"/api/projects/{pid}", json={"name": "Admin Updated"})
         assert resp.status_code == 200
@@ -482,6 +489,7 @@ async def test_legacy_row_hidden_from_members(app, tmp_data_dir):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": member_token},
+        event_hooks=csrf_event_hooks(),
     ) as member_c:
         # Member cannot see legacy row in list (legacy rows have status='active')
         resp = await member_c.get("/api/projects")
@@ -495,6 +503,7 @@ async def test_legacy_row_hidden_from_members(app, tmp_data_dir):
     async with AsyncClient(
         transport=transport, base_url="http://test",
         cookies={"taos_session": admin_token},
+        event_hooks=csrf_event_hooks(),
     ) as admin_c:
         # Admin CAN see legacy row in list (legacy rows have status='active')
         resp = await admin_c.get("/api/projects")

--- a/tests/test_routes_routines.py
+++ b/tests/test_routes_routines.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.mark.asyncio
@@ -260,9 +261,11 @@ async def two_owner_clients(app, tmp_data_dir):
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport, base_url="http://test", cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
     ) as alice_c:
         async with AsyncClient(
             transport=transport, base_url="http://test", cookies={"taos_session": bob_token},
+            event_hooks=csrf_event_hooks(),
         ) as bob_c:
             yield alice_c, bob_c
 

--- a/tests/test_routes_store.py
+++ b/tests/test_routes_store.py
@@ -3,6 +3,7 @@ import pytest_asyncio
 import yaml
 from httpx import AsyncClient, ASGITransport
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.fixture
@@ -45,7 +46,7 @@ async def store_client(app_with_store):
     _rec = app_with_store.state.auth.find_user("admin")
     _token = app_with_store.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=app_with_store)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await app_with_store.state.qmd_client.close()
@@ -143,7 +144,7 @@ class TestCategoryPassthrough:
         _rec = app.state.auth.find_user("admin")
         _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
         transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
             yield c
         await store.close()
         await app.state.qmd_client.close()
@@ -337,7 +338,7 @@ class TestDockerInstallRecordsRuntimeLocation:
         _rec = app.state.auth.find_user("admin")
         _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
         transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
             yield c, app
         await store.close()
         await app.state.qmd_client.close()

--- a/tests/test_routes_video.py
+++ b/tests/test_routes_video.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient, Request as HttpxRequest, Response
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 async def _drain_background_tasks(app) -> None:
@@ -37,7 +38,7 @@ async def video_client(video_app):
     _rec = video_app.state.auth.find_user("admin")
     _token = video_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=video_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await store.close()
     await video_app.state.qmd_client.close()
@@ -65,7 +66,7 @@ class TestVideoGenerate:
         _rec = app.state.auth.find_user("admin")
         _token = app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
         transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+        async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
             resp = await c.post("/api/video/generate", json={"prompt": "test"})
         assert resp.status_code == 503
         assert "error" in resp.json()

--- a/tests/test_store_submissions.py
+++ b/tests/test_store_submissions.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from tinyagentos.app import create_app
 from tinyagentos.auth import hash_password
 from tinyagentos.store_submissions import StoreSubmissionStore
+from taos_test_csrf import csrf_event_hooks
 
 
 def _add_non_admin_user(auth_mgr, username, password):
@@ -59,6 +60,7 @@ async def client_with_store_submissions(app_with_store_submissions, tmp_data_dir
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await store.close()
@@ -79,6 +81,7 @@ async def client_non_admin(app_with_store_submissions, tmp_data_dir):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": _token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await store.close()

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -18,6 +18,7 @@ import yaml
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +62,7 @@ async def client(app):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await ds.close()

--- a/tests/test_taos_agent_config.py
+++ b/tests/test_taos_agent_config.py
@@ -7,6 +7,7 @@ import yaml
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +51,7 @@ async def client(app):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await ds.close()

--- a/tests/test_taos_agent_route.py
+++ b/tests/test_taos_agent_route.py
@@ -10,6 +10,7 @@ import yaml
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest.fixture
@@ -49,6 +50,7 @@ async def client(app):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
     await ds.close()

--- a/tests/test_token_rotation.py
+++ b/tests/test_token_rotation.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_registry_store import mint_registry_token
 from tinyagentos.agent_token_auth import check_agent_scope
+from taos_test_csrf import csrf_event_hooks
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +98,7 @@ def _make_nonadmin_client(
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ), uid
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,6 +6,7 @@ from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.app import create_app
 from tinyagentos.training import TrainingManager
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -37,7 +38,7 @@ async def training_client(training_app):
     _rec = training_app.state.auth.find_user("admin")
     _token = training_app.state.auth.create_session(user_id=_rec["id"] if _rec else "", long_lived=True)
     transport = ASGITransport(app=training_app)
-    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}) as c:
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"taos_session": _token}, event_hooks=csrf_event_hooks()) as c:
         yield c
     await training.close()
     await store.close()

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -1,6 +1,7 @@
 import pytest
 import pytest_asyncio
 from tinyagentos.user_memory import UserMemoryStore
+from taos_test_csrf import csrf_event_hooks
 
 
 @pytest_asyncio.fixture
@@ -127,7 +128,8 @@ async def mem_client(app, tmp_data_dir):
     app.state._startup_complete = True
     transport = ASGITransport(app=app)
     async with HttpxAsyncClient(
-        transport=transport, base_url="http://test", cookies={"taos_session": token}
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c, store
     await store.close()

--- a/tests/test_ws_auth.py
+++ b/tests/test_ws_auth.py
@@ -10,6 +10,7 @@ import yaml
 import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
+from taos_test_csrf import arm_test_client
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +53,7 @@ def authed_client(ws_app):
     token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
     with TestClient(ws_app, raise_server_exceptions=False) as c:
         c.cookies.set("taos_session", token)
+        arm_test_client(c)
         yield c
 
 
@@ -83,6 +85,7 @@ class TestTerminalWsAuth:
 
         with TestClient(ws_app, raise_server_exceptions=False) as c:
             c.cookies.set("taos_session", "not-a-real-session-token")
+            arm_test_client(c)
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with c.websocket_connect("/ws/terminal") as ws:
                     ws.receive_text()
@@ -106,6 +109,7 @@ class TestChatWsAuth:
     def test_invalid_session_cookie_is_rejected(self, ws_app):
         with TestClient(ws_app, raise_server_exceptions=False) as c:
             c.cookies.set("taos_session", "invalid-token")
+            arm_test_client(c)
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with c.websocket_connect("/ws/chat") as ws:
                     ws.receive_text()
@@ -135,6 +139,7 @@ class TestCanvasWsAuth:
     def test_invalid_session_cookie_is_rejected(self, ws_app):
         with TestClient(ws_app, raise_server_exceptions=False) as c:
             c.cookies.set("taos_session", "bad-token")
+            arm_test_client(c)
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with c.websocket_connect("/ws/canvas/test-canvas-id") as ws:
                     ws.receive_text()
@@ -163,6 +168,7 @@ class TestWebchatWsAuth:
     def test_invalid_session_cookie_is_rejected(self, ws_app):
         with TestClient(ws_app, raise_server_exceptions=False) as c:
             c.cookies.set("taos_session", "bad-token")
+            arm_test_client(c)
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with c.websocket_connect("/ws/chat/some-agent") as ws:
                     ws.receive_text()

--- a/tests/userspace/conftest.py
+++ b/tests/userspace/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_asyncio
 import yaml
 from httpx import ASGITransport, AsyncClient
+from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.app import create_app
 from tinyagentos.userspace.store import UserspaceAppStore
@@ -66,6 +67,7 @@ async def client(app, tmp_path):
         transport=transport,
         base_url="http://test",
         cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
     ) as c:
         yield c
 

--- a/tinyagentos/issued_cookies.py
+++ b/tinyagentos/issued_cookies.py
@@ -1,0 +1,41 @@
+"""The single source of truth for cookies taOS itself issues on this origin.
+
+Every one of these is controller-scoped: it is meaningful only to this host and
+must never be relayed to an upstream by any proxy. They are collected here, in
+one importable set, because the alternative was tried and failed -- four proxies
+(``account_proxy``, ``service_proxy``, ``userspace_apps``, ``shortcut_proxy``)
+each carried a private hand-written list, and between them those lists named
+two of the five cookies below. The other three leaked.
+
+Why a DENY-list and not an allow-list: an allow-list is unimplementable here.
+Upstream's cookie names appear nowhere in this repo -- ``account_proxy`` relays
+upstream ``Set-Cookie`` verbatim (see ``_rewrite_set_cookie``) and never
+enumerates one. You cannot allow-list names you do not know. What this origin
+issues, by contrast, is knowable and finite, and
+``tests/test_proxy_cookie_isolation.py`` mechanically asserts this set covers
+every ``set_cookie`` call in the package.
+
+ADDING A COOKIE? Add it here too. The drift guard in that test file will fail
+until you do -- that is deliberate, and it is the check whose absence caused
+this bug.
+"""
+
+TAOS_ISSUED_COOKIES = frozenset({
+    # The local admin session credential. A taos.my log leak or a compromised
+    # container would otherwise expose valid local admin session tokens.
+    "taos_session",
+    # The CSRF double-submit token. Set httponly=False ON PURPOSE so the SPA can
+    # read it, which makes it a readable origin-wide secret whose only job is
+    # proving same-origin. Relaying it hands an upstream exactly what satisfies
+    # verify_csrf(). This is the one that motivated the sweep.
+    "csrf_token",
+    # Shortcut-proxy session credential.
+    "taos_shortcut",
+    # Browser-proxy session id, httponly, bound to a user_id -- a credential.
+    "taos_browser",
+    # Colour-scheme UI hint. Carries no security value, but it is ours and has
+    # no business upstream. Denying everything we issue is a rule that can be
+    # checked mechanically; "deny the sensitive ones" needs a judgement call at
+    # every future call site, and that is what drifted.
+    "taos_cs",
+})

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
 from tinyagentos.taosnet import mesh, mesh_credentials
+from tinyagentos.issued_cookies import TAOS_ISSUED_COOKIES
 from tinyagentos.peer import resolve_local_identity_id
 
 logger = logging.getLogger(__name__)
@@ -134,21 +135,23 @@ def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
     return "; ".join(kept)
 
 
-# The local admin session cookie. The browser presents it on every same-origin
-# /api/account/* call, but it must never be relayed to the upstream taos.my: a
+# Cookies this origin issues. The browser presents them on every same-origin
+# /api/account/* call, but none may be relayed to the upstream taos.my: a
 # taos.my log leak or compromise would otherwise expose valid local admin
-# session tokens. Only the cookies that belong upstream are forwarded.
-_LOCAL_SESSION_COOKIE = "taos_session"
+# session tokens -- and, until this was fixed, the CSRF token that satisfies
+# verify_csrf() for this origin. Only the cookies that belong upstream are
+# forwarded. See tinyagentos/issued_cookies.py for why this is a deny-list.
+_LOCAL_COOKIES = TAOS_ISSUED_COOKIES
 
 
 def _strip_local_session_cookie(cookie_header: str) -> str | None:
-    """Return ``cookie_header`` with the local ``taos_session`` cookie removed.
+    """Return ``cookie_header`` with every taOS-issued cookie removed.
 
-    Parses the incoming Cookie header and drops only the local session cookie,
-    preserving every other cookie (the upstream taos.my session cookie, etc.).
-    Returns ``None`` when no cookies remain, so the relayed request sends no
-    Cookie header at all. A malformed Cookie header is returned untouched rather
-    than dropping unrelated cookies.
+    Parses the incoming Cookie header and drops every cookie this origin issues,
+    preserving the rest (the upstream taos.my session cookie, etc.). Returns
+    ``None`` when no cookies remain, so the relayed request sends no Cookie
+    header at all. A malformed Cookie header is returned untouched rather than
+    dropping unrelated cookies.
     """
     kept: list[str] = []
     for part in cookie_header.split(";"):
@@ -156,7 +159,7 @@ def _strip_local_session_cookie(cookie_header: str) -> str | None:
         if not p:
             continue
         name = p.split("=", 1)[0].strip().lower()
-        if name == _LOCAL_SESSION_COOKIE:
+        if name in _LOCAL_COOKIES:
             continue
         kept.append(p)
     if not kept:

--- a/tinyagentos/routes/service_proxy.py
+++ b/tinyagentos/routes/service_proxy.py
@@ -17,6 +17,7 @@ import logging
 import httpx
 from fastapi import APIRouter, Request, WebSocket
 from fastapi.responses import RedirectResponse, StreamingResponse
+from tinyagentos.issued_cookies import TAOS_ISSUED_COOKIES
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +37,12 @@ _HOP_BY_HOP = frozenset({
 })
 
 # Controller-scoped credentials must never leak to the upstream service
-# container. The taos_session cookie is stripped out of Cookie; everything
-# else in the cookie header passes through unchanged.
+# container. Every cookie this origin issues is stripped out of Cookie;
+# everything else in the cookie header passes through unchanged. The shared set
+# is imported rather than restated -- four local copies is exactly how
+# csrf_token, taos_browser and taos_cs came to leak from all four proxies.
 _SENSITIVE_HEADERS = frozenset({"authorization"})
-_STRIPPED_COOKIES = frozenset({"taos_session"})
+_STRIPPED_COOKIES = TAOS_ISSUED_COOKIES
 
 
 # Module-level HTTP client for proxying — avoids per-request connection churn

--- a/tinyagentos/routes/shortcut_proxy.py
+++ b/tinyagentos/routes/shortcut_proxy.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 import httpx
 from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 from fastapi.responses import RedirectResponse, StreamingResponse
+from tinyagentos.issued_cookies import TAOS_ISSUED_COOKIES
 
 from tinyagentos.shortcuts.tickets import validate_ticket, _GLOBAL_JTI_TRACKER
 from tinyagentos.cluster.worker_registry import get_local_worker
@@ -87,8 +88,10 @@ _HOP_BY_HOP_PROXY = frozenset({
     "host",
 })
 
-# Controller cookies that must not leak to upstream containers.
-_STRIPPED_PROXY_COOKIES = frozenset({"taos_session", "taos_shortcut"})
+# Controller cookies that must not leak to upstream containers. Imported from
+# the one shared set rather than restated here: this list named two of the five
+# cookies taOS issues, and the other three leaked.
+_STRIPPED_PROXY_COOKIES = TAOS_ISSUED_COOKIES
 
 
 def _filter_proxy_headers(headers: dict[str, str]) -> dict[str, str]:

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import httpx
 from fastapi import APIRouter, Form, Request, UploadFile, File
 from fastapi.responses import JSONResponse, FileResponse, RedirectResponse, Response, StreamingResponse
+from tinyagentos.issued_cookies import TAOS_ISSUED_COOKIES
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
@@ -485,15 +486,16 @@ async def serve_bundle(request: Request, app_id: str, path: str):
 
 
 # Hop-by-hop headers must not be forwarded between the proxy and the
-# upstream/client (RFC 2616 §13.5.1). Authorization is stripped too, and the
-# taos_session cookie is scrubbed out of Cookie -- an untrusted container-app
-# backend must never see the controller session credential.
+# upstream/client (RFC 2616 §13.5.1). Authorization is stripped too, and every
+# cookie this origin issues is scrubbed out of Cookie -- an untrusted
+# container-app backend must never see the controller session credential, nor
+# the CSRF token that proves same-origin for this host.
 _PROXY_HOP_BY_HOP = frozenset({
     "connection", "keep-alive", "proxy-authorization", "te",
     "trailer", "transfer-encoding", "upgrade", "host",
 })
 _PROXY_SENSITIVE_HEADERS = frozenset({"authorization"})
-_PROXY_STRIPPED_COOKIES = frozenset({"taos_session"})
+_PROXY_STRIPPED_COOKIES = TAOS_ISSUED_COOKIES
 
 # Module-level HTTP client for the container-app proxy -- avoids per-request
 # connection churn, mirrors service_proxy.py's pattern.


### PR DESCRIPTION
**DRAFT — opened to let CI enumerate the true red set across its 8 shards.** My local env cannot produce a trustworthy number (it lacks the optional extras, so a large fraction of the suite errors on both this branch and the baseline). Do not merge yet: the remaining reds still need triage.

## The defect

`tests/conftest.py` installed an autouse fixture that replaced `verify_csrf` with a no-op for every test file whose path did not contain the substring `test_csrf`.

Measured on `origin/dev`, not estimated:

```
test files under tests/ matching test_*.py : 788
inside the carve-out (path contains 'test_csrf') : 1   (tests/test_csrf.py)
running with CSRF DISABLED : 787
of those, files that issue a POST : 223
```

This is an over-privileged fixture: it grants the test more privilege than the real caller has, so the test cannot observe the check the real caller must satisfy. It is what hid #2081 (the CSRF login lockout) — a first repro written as an ordinary test returned 303 and PASSED, and the tell was that the CONTROL passed identically, which is the shape you get when the input never reaches the system under test.

## RED FIRST

`tests/test_app_csrf_wiring.py` signs in for real and then acts as that signed-in browser would. Its name deliberately lacks the `test_csrf` substring, so it sits OUTSIDE the old carve-out — it is exactly the file the old fixture would have silenced.

Against the **old** conftest (exit read directly, not through a pipe):

```
3 failed, 1 passed in 5.73s     EXIT=1

E  AssertionError: expected 403 for a signed-in POST with no X-CSRF-Token, got 303.
E  AssertionError: expected 403 for a mismatched X-CSRF-Token, got 303
E  assert 'conftest' == 'tinyagentos.middleware.csrf'
```

`303` means the logout **succeeded** — the CSRF dependency on the built app could not reject anything. The positive control (matching token → 303) **passed**, so this is real discrimination, not everything-fails.

After the change: `25 passed, exit 0` across `test_app_csrf_wiring.py`, `test_csrf.py` and `test_csrf_login_lockout.py`.

The assertions drive the real caller rather than checking `verify_csrf.__name__`. A name check cannot see an `app.dependency_overrides` entry and passes for any stub that copies the right name; and route introspection cannot tell a DISABLED check from a REMOVED one (when the bypass is active the installed callable's `__module__` is `conftest`, so a locator keyed on the csrf module reports "not wired" for both cases).

## What changed

1. **The default is the real implementation.** Opting out is an explicit `@pytest.mark.csrf_bypass`, not a filename. The old carve-out was a substring match on the path, so a rename silently re-armed the bypass with no failure anywhere. A marker cannot be triggered by accident, and it is greppable.

2. **The shared `client` fixture now does what the SPA does** — echoes the `csrf_token` cookie into `X-CSRF-Token` on mutating requests. This is *not* a bypass: a third-party origin cannot READ the cookie and therefore cannot set a matching header, whereas a same-origin caller reads its own cookie and echoes it. Tests using the shared client SATISFY the real check rather than switching it off.

   The echo is injected per-request rather than seeded onto the cookie jar, so SAFE requests still arrive with no CSRF cookie. A GET carrying one makes `CSRFMiddleware` skip issuing it — I broke `test_csrf.py::test_csrf_cookie_set_on_response` that way first, which is what surfaced the distinction.

## Known remaining work — not silently omitted

Sampled 8 route-test files that use the shared fixture: baseline `121 passed, exit 0`; this branch `27 failed, 94 passed`. Those 27 build their **own** clients through local helpers (e.g. `_authed_pins_client`), so the shared fixture's hook never reaches them. **138 test files construct their own `AsyncClient`.**

The plan for those, once CI reports the full set:

* mark the still-red modules `pytestmark = pytest.mark.csrf_bypass` so the tree is green,
* add `tests/test_csrf_bypass_debt.py` pinning that list so it cannot grow unnoticed,
* card the per-file conversion as claimable lane work — those files are not gate-protected, so lanes can land them.

That narrows the bypass from 787 files to a finite, enumerated list; it does not re-widen it.

## Gate note

This PR edits `tests/conftest.py` and `pyproject.toml`, both gate-protected as of #2544, so **Gate integrity will fail until a human applies `gate-integrity-allow`.** That is working as intended, not a defect in this PR.

Refs tsk-eioojd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy cookie isolation by preventing controller-issued cookies from being forwarded to upstream services.
  * Automated request and WebSocket coverage now consistently exercises CSRF protection.
  * Added safeguards to detect CSRF enforcement gaps and incomplete cookie isolation.

* **Documentation**
  * Updated testing and security guidance for CSRF handling and proxy cookie isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->