### PR TITLE
Auth pages: brand mark is a Unicode glyph with inconsistent font coverage

### DIFF
--- a/changelog.d/tsk-uu6uky-auth-brand-mark-svg.md
+++ b/changelog.d/tsk-uu6uky-auth-brand-mark-svg.md
@@ -1,0 +1,8 @@
+### Fixed
+- The server-rendered sign-in (`/auth/login`) and first-run setup (`/auth/setup`)
+  pages now draw the taOS brand mark as an inline SVG instead of a bare Unicode
+  glyph (`⌗` on login, `✦` on setup). Those code points are host-font-dependent
+  and rendered as a missing-glyph box (TOFU) on machines whose installed fonts
+  lack coverage, while these pages are deliberately JS-free and CDN-free so they
+  work on any device. The SVG uses `currentColor` and scales to its `.icon`
+  container, so no external asset or webfont fetch is required (#2525).

--- a/tests/test_auth_brand_mark.py
+++ b/tests/test_auth_brand_mark.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import re
+
+from tinyagentos.routes.auth import _login_page, _setup_page
+
+# Bare Unicode glyphs that have historically been used as the taOS brand mark on
+# the server-rendered auth pages. They are host-font-dependent: a machine with
+# no font covering the code point renders a missing-glyph box (TOFU) instead of
+# the logo. The auth pages are deliberately JS-free and CDN-free so they work on
+# any device, so the mark must be an inline SVG rather than a text glyph.
+_BRAND_GLYPHS = ("⌗", "✦")
+
+
+def _icon_inner(html: str) -> str:
+    """Return the inner HTML of the `.icon` brand element.
+
+    Anchors the assertion on the brand element itself rather than on the whole
+    page -- the pages already contain other markup, so a page-level "svg"
+    check would be one level too coarse to fail on this defect.
+    """
+    match = re.search(r'<div class="icon">(.*?)</div>', html, re.DOTALL)
+    assert match, "no .icon brand element found in page"
+    return match.group(1)
+
+
+class TestAuthBrandMark:
+    def test_login_page_brand_is_inline_svg(self):
+        icon = _icon_inner(_login_page())
+        assert "<svg" in icon, "brand mark is a bare glyph"
+        for glyph in _BRAND_GLYPHS:
+            assert glyph not in icon, f"bare brand glyph {glyph!r} still present in icon"
+
+    def test_setup_page_brand_is_inline_svg(self):
+        icon = _icon_inner(_setup_page())
+        assert "<svg" in icon, "brand mark is a bare glyph"
+        for glyph in _BRAND_GLYPHS:
+            assert glyph not in icon, f"bare brand glyph {glyph!r} still present in icon"

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -417,6 +417,27 @@ def _pin_panel_html(next_url: str) -> str:
     """
 
 
+# Inline taOS brand mark for the auth pages. Rendered as an SVG rather than a
+# bare Unicode glyph (⌗ / ✦): those code points are host-font-dependent and
+# render as TOFU on machines that lack a covering font, which contradicts the
+# pages' deliberate JS-free, CDN-free robustness. The SVG scales to its
+# `.icon` container (100% x 100%) so the same mark works in both the default
+# 56px slot and the osk-open 40px slot, and uses `currentColor` so it inherits
+# the page's text colour rather than fetching a webfont.
+_AUTH_BRAND_SVG = (
+    '<svg width="100%" height="100%" viewBox="0 0 56 56" '
+    'xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">'
+    '<rect x="12" y="12" width="32" height="32" rx="4" fill="none" '
+    'stroke="currentColor" stroke-width="2.5"></rect>'
+    '<circle cx="28" cy="28" r="3.5" fill="currentColor"></circle>'
+    '<line x1="18" y1="18" x2="38" y2="38" stroke="currentColor" '
+    'stroke-width="2" stroke-linecap="round"></line>'
+    '<line x1="38" y1="18" x2="18" y2="38" stroke="currentColor" '
+    'stroke-width="2" stroke-linecap="round"></line>'
+    '</svg>'
+)
+
+
 def _login_page(
     error: str = "",
     multi_user: bool = False,
@@ -455,7 +476,7 @@ def _login_page(
 <body>
   <div class="card">
     <div class="brand">
-      <div class="icon">⌗</div>
+      <div class="icon">{_AUTH_BRAND_SVG}</div>
       <h1>taOS</h1>
       <p>Sign in to continue</p>
     </div>
@@ -512,7 +533,7 @@ def _setup_page(error: str = "", pin_offered: bool = False) -> str:
 <body>
   <form class="card" method="POST" action="/auth/setup">
     <div class="brand">
-      <div class="icon">✦</div>
+      <div class="icon">{_AUTH_BRAND_SVG}</div>
       <h1>Welcome to taOS</h1>
       <p>Set up your account to get started.</p>
     </div>


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Auth pages: brand mark is a Unicode glyph with inconsistent font coverage

Autonomous build of board card tsk-uu6uky.

Replace the host-font-dependent Unicode glyphs on the server-rendered auth
pages -- the ⌗ on /auth/login and ✦ on /auth/setup -- with a shared inline
SVG (_AUTH_BRAND_SVG). Those code points render as TOFU on hosts whose
installed fonts lack coverage, which contradicts the pages' deliberate
JS-free, CDN-free design. The SVG uses currentColor and scales to its .icon
container, so it needs no external asset or webfont fetch and stays valid
under script-src 'self'.

Proof of test (tests/test_auth_brand_mark.py) failing on the old code:

    FAILED tests/test_auth_brand_mark.py::test_login_page_brand_is_inline_svg - AssertionError: brand mark is a bare glyph
    FAILED tests/test_auth_brand_mark.py::test_setup_page_brand_is_inline_svg - AssertionError: brand mark is a bare glyph
    2 failed in 0.31s

Same tests pass after the change (2 passed), and the auth regression sweep
    tests/test_auth.py tests/test_routes_auth.py tests/test_auth_middleware.py
is green: 194 passed.

Docs-Reviewed: docs/agent-coordination.md already documents these auth pages as
self-contained (scripts served as files, never inlined; no external asset or
webfont fetches). The inline SVG uses currentColor with no fetch, so it is
consistent with that documented principle; no doc change needed.

Files:
 changelog.d/tsk-uu6uky-auth-brand-mark-svg.md |  8 ++++++
 tests/test_auth_brand_mark.py                 | 38 +++++++++++++++++++++++++++
 tinyagentos/routes/auth.py                    | 25 ++++++++++++++++--
 3 files changed, 69 insertions(+), 2 deletions(-)