### PR TITLE
Fix-forward #2491 (evil-merge gate): wire the gate into CI + tighten the predicate

### DIFF
--- a/.github/workflows/evil-merge-gate.yml
+++ b/.github/workflows/evil-merge-gate.yml
@@ -1,0 +1,35 @@
+name: Evil-merge gate
+
+# Detects PRs whose merge resolution invents test content that neither
+# parent reviewed.  Uses ``git merge-tree --write-tree`` as the automatic
+# baseline so ordinary non-conflicting auto-merges stay green.
+#
+# See scripts/check_evil_merge.py for the implementation.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master, dev]
+
+jobs:
+  evil-merge-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Fetch base branch
+        run: git fetch origin "$BASE_REF"
+
+      - name: Check for evil merges in test files
+        run: python scripts/check_evil_merge.py --head "$PR_HEAD"

--- a/changelog.d/tsk-hlnd2t-evil-merge-guard.md
+++ b/changelog.d/tsk-hlnd2t-evil-merge-guard.md
@@ -1,0 +1,2 @@
+### Added
+- `scripts/check_evil_merge.py`: gate that detects evil merges in test files by comparing the merge result blob against both parent blobs and failing when the resolution matches neither parent.

--- a/changelog.d/tsk-m44uf7-evil-merge-gate.md
+++ b/changelog.d/tsk-m44uf7-evil-merge-gate.md
@@ -1,0 +1,2 @@
+### Fixed
+- `scripts/check_evil_merge.py`: compare merge blobs against `git merge-tree --write-tree` baseline instead of parent blobs, eliminating false positives on clean auto-merges. Wired the gate into `.github/workflows/evil-merge-gate.yml`. Batched blob lookups via `ls-tree -r -z`.

--- a/scripts/check_evil_merge.py
+++ b/scripts/check_evil_merge.py
@@ -2,14 +2,15 @@
 """Evil-merge detection guard for test files.
 
 For a PR whose head is a merge commit M with parents P1 and P2,
-for every file under tests/ : if the blob at M matches NEITHER
-the blob at P1 NOR the blob at P2, the resolution invented content
-that neither side reviewed.
+compare every file under tests/ at M against the blob git would
+have produced automatically via ``git merge-tree --write-tree P1 P2``.
+Content a human introduced during resolution fails; content git
+produced by itself stays green.
 
 Scope is tests/ only so ordinary semantic hand-merges in source do not
 produce false positives.  A resolution that takes one side wholesale
-matches a parent and stays green; a genuine hand-merge is exactly the
-case that deserves a human read.
+or lets git auto-merge matches the baseline and stays green; a genuine
+hand-merge is exactly the case that deserves a human read.
 
 Usage:
     python3 scripts/check_evil_merge.py --head HEAD
@@ -65,13 +66,22 @@ def _get_parents(repo_root: Path, ref: str) -> list[str]:
     return [line for line in out.splitlines() if line.strip()]
 
 
-def _get_test_files(repo_root: Path, ref: str) -> list[str]:
-    """Return every file path under ``tests/`` that exists at ``ref``."""
+def _get_blob_hashes_for_ref(repo_root: Path, ref: str) -> dict[str, str]:
+    """Return a mapping of path -> blob hash for every file under ``tests/``
+    that exists at ``ref``.  Uses a single ``git ls-tree -r -z`` call."""
     try:
-        out = _run_git(["ls-tree", "-r", "--name-only", ref, "tests/"], cwd=repo_root)
+        out = _run_git(["ls-tree", "-r", "-z", ref, "tests/"], cwd=repo_root)
     except subprocess.CalledProcessError:
-        return []
-    return [line for line in out.splitlines() if line.strip()]
+        return {}
+    result: dict[str, str] = {}
+    for entry in out.split("\0"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        meta, path = entry.split("\t", 1)
+        _, _, blob_hash = meta.split(" ", 2)
+        result[path] = blob_hash
+    return result
 
 
 def check_evil_merge(
@@ -81,7 +91,8 @@ def check_evil_merge(
     """Detect evil merges in test files under ``head_ref``.
 
     Returns an empty list when ``head_ref`` is not a merge commit or when
-    every tests/ blob at head matches at least one parent.
+    every tests/ blob at head matches the blob git would have produced
+    automatically.
     """
     parents = _get_parents(repo_root, head_ref)
     if len(parents) < 2:
@@ -91,17 +102,41 @@ def check_evil_merge(
     parent1 = parents[0]
     parent2 = parents[1]
 
+    merge_blobs = _get_blob_hashes_for_ref(repo_root, head_ref)
+    p1_blobs = _get_blob_hashes_for_ref(repo_root, parent1)
+    p2_blobs = _get_blob_hashes_for_ref(repo_root, parent2)
+
+    try:
+        auto_tree = _run_git(
+            ["merge-tree", "--write-tree", parent1, parent2],
+            cwd=repo_root,
+        ).strip()
+    except subprocess.CalledProcessError:
+        auto_tree = None
+
+    if auto_tree:
+        auto_blobs = _get_blob_hashes_for_ref(repo_root, auto_tree)
+        use_new_predicate = True
+    else:
+        use_new_predicate = False
+
     violations: list[Violation] = []
-    for path in _get_test_files(repo_root, head_ref):
-        head_blob = _get_blob_hash(repo_root, head_ref, path)
-        p1_blob = _get_blob_hash(repo_root, parent1, path)
-        p2_blob = _get_blob_hash(repo_root, parent2, path)
-
-        if head_blob is None:
-            continue
-
-        if head_blob != p1_blob and head_blob != p2_blob:
-            violations.append(Violation(path, merge_sha, parent1, parent2))
+    for path, actual_blob in merge_blobs.items():
+        if use_new_predicate:
+            auto_blob = auto_blobs.get(path)
+            if auto_blob is None:
+                p1_blob = p1_blobs.get(path)
+                p2_blob = p2_blobs.get(path)
+                if p1_blob is None and p2_blob is None:
+                    continue
+                violations.append(Violation(path, merge_sha, parent1, parent2))
+            elif actual_blob != auto_blob:
+                violations.append(Violation(path, merge_sha, parent1, parent2))
+        else:
+            p1_blob = p1_blobs.get(path)
+            p2_blob = p2_blobs.get(path)
+            if actual_blob != p1_blob and actual_blob != p2_blob:
+                violations.append(Violation(path, merge_sha, parent1, parent2))
 
     return violations
 
@@ -129,7 +164,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     v = violations[0]
-    print(f"EVIL-MERGE FAIL: {v.path} matches neither parent")
+    print(f"EVIL-MERGE FAIL: {v.path} differs from automatic merge baseline")
     print(f"  merge   M  {v.merge_hash[:8]}")
     print(f"  parent1 P1 {v.parent1_hash[:8]}")
     print(f"  parent2 P2 {v.parent2_hash[:8]}")

--- a/scripts/check_evil_merge.py
+++ b/scripts/check_evil_merge.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Evil-merge detection guard for test files.
+
+For a PR whose head is a merge commit M with parents P1 and P2,
+for every file under tests/ : if the blob at M matches NEITHER
+the blob at P1 NOR the blob at P2, the resolution invented content
+that neither side reviewed.
+
+Scope is tests/ only so ordinary semantic hand-merges in source do not
+produce false positives.  A resolution that takes one side wholesale
+matches a parent and stays green; a genuine hand-merge is exactly the
+case that deserves a human read.
+
+Usage:
+    python3 scripts/check_evil_merge.py --head HEAD
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class Violation:
+    def __init__(
+        self,
+        path: str,
+        merge_hash: str,
+        parent1_hash: str,
+        parent2_hash: str,
+    ) -> None:
+        self.path = path
+        self.merge_hash = merge_hash
+        self.parent1_hash = parent1_hash
+        self.parent2_hash = parent2_hash
+
+
+def _run_git(args: list[str], cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _get_blob_hash(repo_root: Path, ref: str, path: str) -> str | None:
+    """Return the blob hash of ``path`` at ``ref``, or None if the path does
+    not exist at that ref."""
+    try:
+        out = _run_git(["rev-parse", f"{ref}:{path}"], cwd=repo_root)
+        return out.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _get_parents(repo_root: Path, ref: str) -> list[str]:
+    """Return the list of parent SHAs for ``ref``."""
+    out = _run_git(["rev-parse", f"{ref}^@"], cwd=repo_root)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _get_test_files(repo_root: Path, ref: str) -> list[str]:
+    """Return every file path under ``tests/`` that exists at ``ref``."""
+    try:
+        out = _run_git(["ls-tree", "-r", "--name-only", ref, "tests/"], cwd=repo_root)
+    except subprocess.CalledProcessError:
+        return []
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def check_evil_merge(
+    repo_root: Path,
+    head_ref: str = "HEAD",
+) -> list[Violation]:
+    """Detect evil merges in test files under ``head_ref``.
+
+    Returns an empty list when ``head_ref`` is not a merge commit or when
+    every tests/ blob at head matches at least one parent.
+    """
+    parents = _get_parents(repo_root, head_ref)
+    if len(parents) < 2:
+        return []
+
+    merge_sha = _run_git(["rev-parse", head_ref], cwd=repo_root).strip()
+    parent1 = parents[0]
+    parent2 = parents[1]
+
+    violations: list[Violation] = []
+    for path in _get_test_files(repo_root, head_ref):
+        head_blob = _get_blob_hash(repo_root, head_ref, path)
+        p1_blob = _get_blob_hash(repo_root, parent1, path)
+        p2_blob = _get_blob_hash(repo_root, parent2, path)
+
+        if head_blob is None:
+            continue
+
+        if head_blob != p1_blob and head_blob != p2_blob:
+            violations.append(Violation(path, merge_sha, parent1, parent2))
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--head",
+        default="HEAD",
+        help="Git ref to check (default: HEAD)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        violations = check_evil_merge(REPO_ROOT, args.head)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"evil-merge guard: git error: {exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not violations:
+        print("evil-merge guard: clean")
+        return 0
+
+    v = violations[0]
+    print(f"EVIL-MERGE FAIL: {v.path} matches neither parent")
+    print(f"  merge   M  {v.merge_hash[:8]}")
+    print(f"  parent1 P1 {v.parent1_hash[:8]}")
+    print(f"  parent2 P2 {v.parent2_hash[:8]}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_evil_merge.py
+++ b/tests/test_check_evil_merge.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Tests for the evil-merge guard (scripts/check_evil_merge.py).
+
+Each integration test builds a synthetic git repo in a temp directory,
+creates two branches with contradictory test changes, merges them, and
+then calls check_evil_merge() directly against the merge result.  The
+RED case hand-resolves a tests/ file to content matching neither parent;
+the three GREEN controls keep the resolution clean.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_evil_merge as cem  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _git_capture(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=False,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "branch", "-M", "main")
+
+
+def _commit_file(repo: Path, rel_path: str, content: str, message: str) -> None:
+    full = repo / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", message)
+
+
+def _branch(repo: Path, name: str) -> None:
+    _git(repo, "branch", name)
+
+
+def _checkout(repo: Path, name: str) -> None:
+    _git(repo, "checkout", "-q", name)
+
+
+def _get_head(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_merge(repo: Path, branch: str) -> None:
+    """Run git merge, allowing conflicts (exit 1)."""
+    result = subprocess.run(
+        ["git", "merge", branch, "--no-edit"],
+        cwd=repo, capture_output=True, text=True, check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, result.stdout, result.stderr,
+        )
+
+
+def _resolve_and_commit(repo: Path, rel_path: str, content: str) -> None:
+    (repo / rel_path).write_text(content, encoding="utf-8")
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "--no-edit")
+
+
+# ---------------------------------------------------------------------------
+# RED case + GREEN controls
+# ---------------------------------------------------------------------------
+
+
+class TestEvilMergeGuard:
+    """RED case and three GREEN controls."""
+
+    def test_evil_merge_invents_test_content_neither_parent(self, tmp_path: Path):
+        """RED: two branches assert contradictory outcomes for the same
+        scenario; the merge resolution invents test content matching neither
+        parent.  The guard must fail and name the path."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        neither = "def test_principal():\n    assert check_principal()\n"
+        _resolve_and_commit(repo, "tests/test_widget.py", neither)
+
+        violations = cem.check_evil_merge(repo)
+
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.path == "tests/test_widget.py"
+        assert v.merge_hash
+        assert v.parent1_hash
+        assert v.parent2_hash
+        assert v.merge_hash != v.parent1_hash
+        assert v.merge_hash != v.parent2_hash
+
+    def test_merge_taking_one_side_wholesale_stays_green(self, tmp_path: Path):
+        """CONTROL A: same two branches, but resolve by taking side-a
+        wholesale.  The test file blob matches a parent, so the guard passes."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        side_a_content = "def test_principal():\n    assert principal_is_accepted()\n"
+        _resolve_and_commit(repo, "tests/test_widget.py", side_a_content)
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_ordinary_non_merge_commit_stays_green(self, tmp_path: Path):
+        """CONTROL B: an ordinary non-merge commit touching the same test
+        file.  The guard exits clean because HEAD is not a merge commit."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_merge_with_untouched_tests_stays_green(self, tmp_path: Path):
+        """CONTROL C: a merge whose tests/ files are untouched by the
+        resolution.  The guard exits clean."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "feat: add function_a",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    return 'a'\n",
+            "feat: update function_a on side-a",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    return 'b'\n",
+            "feat: update function_a on side-b",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEvilMergeGuardEdgeCases:
+    """Edge cases for the evil-merge guard."""
+
+    def test_non_merge_commit_returns_empty(self, tmp_path: Path):
+        """A regular commit (single parent) returns no violations."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_no_test_files_returns_empty(self, tmp_path: Path):
+        """A merge commit with no tests/ files returns no violations."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "feat: add function_a",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    return 'a'\n",
+            "feat: update on side-a",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    return 'b'\n",
+            "feat: update on side-b",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_new_test_file_in_merge_inventing_content(self, tmp_path: Path):
+        """A test file invented during merge resolution (not present in either
+        parent) is flagged as an evil merge."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        # Remove the existing test file and invent a brand-new one.
+        (repo / "tests/test_widget.py").unlink()
+        _git(repo, "add", "tests/test_widget.py")
+        _resolve_and_commit(repo, "tests/test_new.py", "def test_invented():\n    assert True\n")
+
+        violations = cem.check_evil_merge(repo)
+
+        assert len(violations) == 1
+        assert violations[0].path == "tests/test_new.py"
+
+    def test_head_ref_parameter(self, tmp_path: Path):
+        """The head_ref parameter lets the caller point at a specific ref
+        rather than trusting the checkout's HEAD."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        neither = "def test_principal():\n    assert check_principal()\n"
+        _resolve_and_commit(repo, "tests/test_widget.py", neither)
+        evil_merge_sha = _get_head(repo)
+
+        # Move HEAD away from the evil merge to prove head_ref is honoured.
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    pass\n",
+            "feat: unrelated commit after evil merge",
+        )
+
+        # When head_ref points at the evil merge the guard still finds it.
+        violations = cem.check_evil_merge(repo, head_ref=evil_merge_sha)
+        assert len(violations) == 1
+        assert violations[0].path == "tests/test_widget.py"

--- a/tests/test_check_evil_merge.py
+++ b/tests/test_check_evil_merge.py
@@ -5,7 +5,10 @@ Each integration test builds a synthetic git repo in a temp directory,
 creates two branches with contradictory test changes, merges them, and
 then calls check_evil_merge() directly against the merge result.  The
 RED case hand-resolves a tests/ file to content matching neither parent;
-the three GREEN controls keep the resolution clean.
+the GREEN controls keep the resolution clean.
+
+Real-world RED fixtures caught by this gate include ad5cdfb0c
+(tests/test_model_manifest_integrity.py).
 """
 from __future__ import annotations
 
@@ -230,6 +233,44 @@ class TestEvilMergeGuard:
             repo, "tinyagentos/foo.py",
             "def function_a():\n    return 'b'\n",
             "feat: update function_a on side-b",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_clean_auto_merge_stays_green(self, tmp_path: Path):
+        """CONTROL D: two branches edit different parts of one test file.
+        Git auto-merges cleanly with no conflict.  The guard must stay green
+        because the resolution is git's own automatic merge, not human
+        invention."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_accepted():\n    pass\n\ndef test_rejected():\n    pass\n",
+            "test: add two tests",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_accepted():\n    assert principal_is_accepted()\n\ndef test_rejected():\n    pass\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_accepted():\n    pass\n\ndef test_rejected():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
         )
 
         _checkout(repo, "main")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward #2491 (evil-merge gate): wire the gate into CI + tighten the predicate

Autonomous build of board card tsk-m44uf7.

REVISION: built on `exec/tsk-hlnd2t` (cut at `4a41b3e8988f27f4bd30be2996e5cefde89f6a55`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

- add .github/workflows/evil-merge-gate.yml so the guard runs on PRs
- switch comparison to git merge-tree --write-tree baseline to eliminate
  false positives on clean auto-merges (e.g. 0a1b20b28)
- batch test-file blob lookups via ls-tree -r -z instead of per-file rev-parse
- add test_clean_auto_merge_stays_green GREEN control
- document ad5cdfb0c as real-world RED fixture

Proof: ad5cdfb0c still fires RED, 0a1b20b28 now passes GREEN, 9 tests pass.

Files:
 .github/workflows/evil-merge-gate.yml      |  35 +++
 changelog.d/tsk-hlnd2t-evil-merge-guard.md |   2 +
 changelog.d/tsk-m44uf7-evil-merge-gate.md  |   2 +
 scripts/check_evil_merge.py                | 175 ++++++++++++
 tests/test_check_evil_merge.py             | 429 +++++++++++++++++++++++++++++
 5 files changed, 643 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated safeguards to detect unreviewed test changes introduced during pull request merges.
  * Checks run automatically for pull requests targeting the primary development branches.

* **Bug Fixes**
  * Prevented false positives for clean, automatically resolved merges.

* **Tests**
  * Added coverage for conflicting resolutions, clean merges, non-merge commits, and newly added test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->