### PR TITLE
NotificationsPanel error state is a dead end - no retry, recovery needs a full reload

### DIFF
--- a/changelog.d/tsk-wqyzfr-notifications-retry.md
+++ b/changelog.d/tsk-wqyzfr-notifications-retry.md
@@ -1,0 +1,2 @@
+### Fixed
+- The Notifications settings panel is no longer a terminal dead end when the prefs fetch fails. It now renders a Retry control that re-issues the request through the same code path as the initial load, so a transient backend blip recovers without a full desktop reload.

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
@@ -68,4 +68,47 @@ describe("NotificationsPanel", () => {
     render(<NotificationsPanel />);
     expect(await screen.findByText("Loading...")).toBeInTheDocument();
   });
+
+  it("recovers to the toggle list when Retry succeeds after a rejected fetch", async () => {
+    let callCount = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) return Promise.reject(new Error("network"));
+      return Promise.resolve(
+        jsonResponse([
+          { event_type: "worker.join", muted: false },
+          { event_type: "backend.up", muted: true },
+        ]),
+      );
+    });
+    render(<NotificationsPanel />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not reach backend.");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    // loadPrefs resets state before re-fetching, so the loading state returns.
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    expect(await screen.findByText("Worker joined")).toBeInTheDocument();
+    expect(screen.getByText("Backend up")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-shows the error when Retry still fails (not a blank panel or spinner)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    render(<NotificationsPanel />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not reach backend.");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    // The loading state confirms `loaded` was reset to false before the re-fetch.
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    // The error returns once the re-fetch rejects, rather than a blank panel or a
+    // permanent spinner (which a broken `loaded` reset would produce).
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not reach backend.");
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { Card, Label, Switch } from "@/components/ui";
+import { useState, useEffect, useCallback } from "react";
+import { Button, Card, Label, Switch } from "@/components/ui";
 
 interface NotifPref {
   event_type: string;
@@ -27,7 +27,9 @@ export function NotificationsPanel() {
   const [error, setError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
+  const loadPrefs = useCallback(() => {
+    setError(null);
+    setLoaded(false);
     fetch("/api/notifications/prefs")
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
@@ -37,6 +39,10 @@ export function NotificationsPanel() {
       .catch(() => setError("Could not reach backend."))
       .finally(() => setLoaded(true));
   }, []);
+
+  useEffect(() => {
+    loadPrefs();
+  }, [loadPrefs]);
 
   const toggle = async (eventType: string, muted: boolean) => {
     setSaving(eventType);
@@ -83,9 +89,14 @@ export function NotificationsPanel() {
         </p>
 
         {error && (
-          <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
-            {error}
-          </p>
+          <>
+            <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+              {error}
+            </p>
+            <Button variant="outline" size="sm" onClick={loadPrefs}>
+              Retry
+            </Button>
+          </>
         )}
       </section>
     );


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): NotificationsPanel error state is a dead end - no retry, recovery needs a full reload

Autonomous build of board card tsk-wqyzfr.

NotificationsPanel renders a legible error when the prefs fetch fails
but the state was terminal -- the effect ran once on mount with no
recovery path short of a full SPA reload.

Extract the fetch chain into a reusable loadPrefs() (useCallback, same
code path for mount and Retry) and add a Retry button to the !prefs
error branch. loadPrefs resets error to null and loaded to false
synchronously before issuing the fetch, so the panel returns to the
loading state instead of flashing a stale error next to a live request.

Tests:
- first fetch rejects -> Retry (now succeeding) renders the toggle list
  and clears the error; fetch called exactly twice
- first fetch rejects -> Retry (still failing) re-shows the error (not a
  blank panel, not a permanent spinner); fetch called exactly twice
- verified both new tests fail when the loaded/error reset is omitted

Suite: 7/7 pass on NotificationsPanel.test.tsx (47/47 SettingsApp).
Build: tsc + vite build pass.

Files:
 changelog.d/tsk-wqyzfr-notifications-retry.md      |  2 +
 .../apps/SettingsApp/NotificationsPanel.test.tsx   | 43 ++++++++++++++++++++++
 .../src/apps/SettingsApp/NotificationsPanel.tsx    | 23 +++++++++---
 3 files changed, 62 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Retry** button to the Notifications settings panel when preferences fail to load.
  * Retrying shows the loading state and restores notification settings when successful.
  * Errors remain visible if the retry attempt also fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->