### PR TITLE
docs(readme): remove the star-history chart, it renders an error notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@
 >
 > **A heads-up on the catalogs:** with 100+ apps, 16 frameworks, and a large model catalog, plenty of install manifests have not been exercised on real hardware yet, so some apps, frameworks, and models will fail to install. If one does, [open an issue](https://github.com/jaylfc/taOS/issues) with the name and the error you saw and I will fix the manifest as soon as I can. These reports are genuinely useful, most manifest fixes ship same-day.
 
-<p align="center">
-<a href="https://www.star-history.com/?repos=jaylfc%2FtaOS&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&legend=top-left" />
-   <img alt="Star History Chart" width="600" src="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&legend=top-left" />
- </picture>
-</a>
-</p>
+<!-- The star-history chart was removed on 2026-08-27. GitHub restricted the
+     stargazers API to a repo's own admins and collaborators on 2026-06-30, so
+     third-party chart services can no longer build it and the embed rendered an
+     error notice instead of a chart. Please do not re-add a chart from another
+     host without opening an issue first. -->
 
 <p align="center">
   <a href="https://discord.gg/r3BaxfxVZ"><img alt="Join the taOS Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white"></a>


### PR DESCRIPTION
The README's star-history chart has been showing an error card instead of a growth curve.

**Cause is upstream at GitHub, not at the chart provider.** GitHub [restricted the stargazers API on 2026-06-30](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) to a repository's own admins and collaborators. star-history.com's servers are not collaborators on this repo, so they get a 404 and cannot build the chart.

**Why nobody noticed it break.** The embed still returns `HTTP 200` with a 60KB `image/svg+xml`, so any status-code check reads as healthy. The SVG's actual text is:

> GitHub restricted access to star data
> GitHub team is looking into it

Most of those 60KB are an embedded font, not chart data — the file contains a single `<path>` and no series.

**Why removed rather than repointed.** The data is restricted at the source, so any third-party host either cannot have it either, or is obtaining it by means we have not verified. A comment is left in place so the block is not re-added from an arbitrary host without discussion.

Supersedes #2501, which reported the same real breakage — thanks to @OctoBored for catching it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the broken star-history chart from the project README.
  * Added a note explaining its removal and requesting discussion before adding a replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->