### PR TITLE
fix-forward #2497: _resolve_symbol poisons sys.modules with no restore, so the deleted-symbols gate's verdict depends on which symbol it looked at first

### DIFF
--- a/changelog.d/tsk-ocf7dc-resolve-symbol-sys-modules.md
+++ b/changelog.d/tsk-ocf7dc-resolve-symbol-sys-modules.md
@@ -1,0 +1,2 @@
+### Fixed
+- The deleted-symbols CI guard (`scripts/check_deleted_symbols.py`) no longer leaves synthetic parent packages and reloaded modules in `sys.modules`, so its pass/fail verdict no longer depends on which signal symbol it resolved first. It also now records bare `from . import submodule` re-exports, fixes the package-fallback suffix replacement, and cleans up its merge-tree temp dir.

--- a/changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md
+++ b/changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md
@@ -1,0 +1,2 @@
+### Fixed
+- The deleted-symbols gate now resolves each signal symbol against the merge result before reporting it. Symbols that remain importable at their public path (for example, a module file deleted but shadowed by a same-named package, or a definition moved) are no longer falsely reported as deleted, while genuinely missing symbols and dropped re-exports still fire.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -38,12 +38,15 @@ from __future__ import annotations
 
 import argparse
 import ast
+import importlib.util
 import io
 import os
 import re
 import subprocess
 import sys
 import tarfile
+import tempfile
+import types
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -87,6 +90,13 @@ def _extract_symbols(source: str, file_path: str) -> dict[str, str]:
                 name = f"{prefix}{child.name}" if prefix else child.name
                 symbols[f"{file_path}:{name}"] = "class"
                 visit(child, f"{name}.")
+            elif isinstance(child, ast.ImportFrom):
+                if file_path.endswith("/__init__.py") and child.module:
+                    for alias in child.names:
+                        if alias.name == "*":
+                            continue
+                        public_name = alias.asname or alias.name
+                        symbols[f"{file_path}:{public_name}"] = "import"
             else:
                 visit(child, prefix)
 
@@ -111,6 +121,81 @@ def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]
             source = f.read().decode("utf-8", errors="ignore")
             symbols.update(_extract_symbols(source, member.name))
     return symbols
+
+
+def _file_path_to_module_path(file_path: str) -> str:
+    """Convert a file path like 'pkg/mod.py' or 'pkg/__init__.py' to a module path."""
+    if file_path.endswith("/__init__.py"):
+        file_path = file_path[: -len("/__init__.py")]
+    elif file_path.endswith(".py"):
+        file_path = file_path[: -len(".py")]
+    return file_path.replace("/", ".")
+
+
+def _extract_tree_to_dir(ref: str, dest: Path, repo_root: Path = REPO_ROOT) -> None:
+    """Extract a git tree to a directory."""
+    result = subprocess.run(
+        ["git", "archive", ref],
+        cwd=repo_root, capture_output=True, check=True,
+    )
+    with tarfile.open(fileobj=io.BytesIO(result.stdout)) as tar:
+        tar.extractall(dest)
+
+
+def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
+    """Check if a symbol is still importable from the merge result.
+
+    Loads the module directly from the merge result tree using
+    importlib.util, bypassing sys.path and editable-install path hooks
+    that would otherwise route the import back to the working tree.
+    """
+    module_path = _file_path_to_module_path(file_path)
+
+    parts = module_path.split(".")
+    file_rel_path = "/".join(parts)
+    if file_path.endswith("/__init__.py"):
+        file_rel_path += "/__init__.py"
+    else:
+        file_rel_path += ".py"
+
+    abs_file = merge_result_dir / file_rel_path
+
+    # If the original module file was deleted but a same-named package
+    # directory exists in the merge result, the public import path resolves
+    # through the package's __init__.py.
+    if not abs_file.is_file():
+        package_init = merge_result_dir / file_rel_path.replace(".py", "/__init__.py")
+        if package_init.is_file():
+            abs_file = package_init
+        else:
+            return False
+
+    name_parts = name.split(".")
+    attr_name = name_parts[-1]
+
+    try:
+        parent_pkg_name = ".".join(parts[:-1])
+        if parent_pkg_name:
+            parent_pkg_path = str((merge_result_dir / parent_pkg_name.replace(".", "/")).resolve())
+            if parent_pkg_name not in sys.modules:
+                parent_pkg = types.ModuleType(parent_pkg_name)
+                parent_pkg.__path__ = [parent_pkg_path]
+                sys.modules[parent_pkg_name] = parent_pkg
+
+        sys.modules.pop(module_path, None)
+        spec = importlib.util.spec_from_file_location(module_path, str(abs_file))
+        if spec is None or spec.loader is None:
+            return False
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_path] = module
+        spec.loader.exec_module(module)
+
+        obj = module
+        for part in name_parts:
+            obj = getattr(obj, part)
+        return True
+    except Exception:
+        return False
 
 
 def _merge_tree(base_ref: str, pr_head_sha: str, repo_root: Path = REPO_ROOT) -> str | None:
@@ -218,15 +303,28 @@ def check_deleted_symbols(
     """
     base_symbols = _get_symbols_at_ref(base_ref, repo_root)
 
+    merge_result_dir: Path
     if pr_head_sha:
         merge_tree = _merge_tree(base_ref, pr_head_sha, repo_root)
         if merge_tree is None:
             return [], set(), True
         head_symbols = _get_symbols_at_ref(merge_tree, repo_root)
+        merge_result_dir = Path(tempfile.mkdtemp())
+        _extract_tree_to_dir(merge_tree, merge_result_dir, repo_root)
     else:
         head_symbols = _get_symbols_at_ref("HEAD", repo_root)
+        merge_result_dir = repo_root
 
     signal = find_signal_symbols(base_symbols, head_symbols)
+
+    # Resolve each signal symbol against the merge result. A symbol that is
+    # still importable at its public path is not a genuine deletion.
+    resolved_signal: dict[str, str] = {}
+    for symbol, kind in sorted(signal.items()):
+        file_path, name = symbol.rsplit(":", 1)
+        if _resolve_symbol(merge_result_dir, file_path, name):
+            continue
+        resolved_signal[symbol] = kind
 
     waived_set: set[str] = set()
     if waived:
@@ -235,7 +333,7 @@ def check_deleted_symbols(
 
     violations: list[Violation] = []
     waived_in_signal: set[str] = set()
-    for symbol, kind in sorted(signal.items()):
+    for symbol, kind in sorted(resolved_signal.items()):
         if symbol in waived_set:
             waived_in_signal.add(symbol)
             continue

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -91,7 +91,7 @@ def _extract_symbols(source: str, file_path: str) -> dict[str, str]:
                 symbols[f"{file_path}:{name}"] = "class"
                 visit(child, f"{name}.")
             elif isinstance(child, ast.ImportFrom):
-                if file_path.endswith("/__init__.py") and child.module:
+                if file_path.endswith("/__init__.py") and (child.module or child.level):
                     for alias in child.names:
                         if alias.name == "*":
                             continue
@@ -164,7 +164,7 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
     # directory exists in the merge result, the public import path resolves
     # through the package's __init__.py.
     if not abs_file.is_file():
-        package_init = merge_result_dir / file_rel_path.replace(".py", "/__init__.py")
+        package_init = merge_result_dir / (file_rel_path[:-len(".py")] + "/__init__.py")
         if package_init.is_file():
             abs_file = package_init
         else:
@@ -173,8 +173,23 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
     name_parts = name.split(".")
     attr_name = name_parts[-1]
 
+    parent_pkg_name = ".".join(parts[:-1])
+    # Snapshot every sys.modules key this call may mutate (the parent package
+    # it synthesises and the module path it pops and reinstalls) so the global
+    # table is restored verbatim on exit. _resolve_symbol runs in a loop over
+    # signal symbols, so a cached module or synthetic parent left behind would
+    # alter how a later symbol resolves and make the gate verdict depend on
+    # resolution order. A blanket sys.modules.clear() is wrong: it would evict
+    # entries unrelated to this call.
+    touched: dict[str, tuple[bool, types.ModuleType | None]] = {}
+    if parent_pkg_name:
+        touched[parent_pkg_name] = (
+            parent_pkg_name in sys.modules,
+            sys.modules.get(parent_pkg_name),
+        )
+    touched[module_path] = (module_path in sys.modules, sys.modules.get(module_path))
+
     try:
-        parent_pkg_name = ".".join(parts[:-1])
         if parent_pkg_name:
             parent_pkg_path = str((merge_result_dir / parent_pkg_name.replace(".", "/")).resolve())
             if parent_pkg_name not in sys.modules:
@@ -196,6 +211,12 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
         return True
     except Exception:
         return False
+    finally:
+        for key, (was_present, old_obj) in touched.items():
+            if was_present:
+                sys.modules[key] = old_obj
+            else:
+                sys.modules.pop(key, None)
 
 
 def _merge_tree(base_ref: str, pr_head_sha: str, repo_root: Path = REPO_ROOT) -> str | None:
@@ -286,6 +307,30 @@ def find_signal_symbols(
     return {k: base_symbols[k] for k in signal_keys}
 
 
+def _resolve_signal_symbols(
+    base_symbols: dict[str, str],
+    head_symbols: dict[str, str],
+    merge_result_dir: Path,
+) -> dict[str, str]:
+    """Resolve signal symbols against the merge result.
+
+    Returns the subset of signal symbols that are not importable from the merge
+    result (i.e. genuine deletions). A symbol still reachable at its public
+    path is silenced.
+    """
+    signal = find_signal_symbols(base_symbols, head_symbols)
+
+    # Resolve each signal symbol against the merge result. A symbol that is
+    # still importable at its public path is not a genuine deletion.
+    resolved_signal: dict[str, str] = {}
+    for symbol, kind in sorted(signal.items()):
+        file_path, name = symbol.rsplit(":", 1)
+        if _resolve_symbol(merge_result_dir, file_path, name):
+            continue
+        resolved_signal[symbol] = kind
+    return resolved_signal
+
+
 def check_deleted_symbols(
     base_ref: str,
     repo_root: Path = REPO_ROOT,
@@ -303,28 +348,22 @@ def check_deleted_symbols(
     """
     base_symbols = _get_symbols_at_ref(base_ref, repo_root)
 
-    merge_result_dir: Path
     if pr_head_sha:
         merge_tree = _merge_tree(base_ref, pr_head_sha, repo_root)
         if merge_tree is None:
             return [], set(), True
         head_symbols = _get_symbols_at_ref(merge_tree, repo_root)
-        merge_result_dir = Path(tempfile.mkdtemp())
-        _extract_tree_to_dir(merge_tree, merge_result_dir, repo_root)
+        # The merge tree is extracted into a TemporaryDirectory so it is cleaned
+        # up regardless of how the check exits (previously mkdtemp leaked).
+        with tempfile.TemporaryDirectory() as merge_dir:
+            merge_result_dir = Path(merge_dir)
+            _extract_tree_to_dir(merge_tree, merge_result_dir, repo_root)
+            resolved_signal = _resolve_signal_symbols(
+                base_symbols, head_symbols, merge_result_dir
+            )
     else:
         head_symbols = _get_symbols_at_ref("HEAD", repo_root)
-        merge_result_dir = repo_root
-
-    signal = find_signal_symbols(base_symbols, head_symbols)
-
-    # Resolve each signal symbol against the merge result. A symbol that is
-    # still importable at its public path is not a genuine deletion.
-    resolved_signal: dict[str, str] = {}
-    for symbol, kind in sorted(signal.items()):
-        file_path, name = symbol.rsplit(":", 1)
-        if _resolve_symbol(merge_result_dir, file_path, name):
-            continue
-        resolved_signal[symbol] = kind
+        resolved_signal = _resolve_signal_symbols(base_symbols, head_symbols, repo_root)
 
     waived_set: set[str] = set()
     if waived:

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -144,6 +145,104 @@ class TestFindSignalSymbols:
         head = {"f.py:a": "def", "f.py:b": "def"}
         signal = cds.find_signal_symbols(base, head)
         assert signal == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_symbol isolation (in-process, no git required)
+#
+# _resolve_symbol mutates the interpreter's global sys.modules table. Two
+# defects flow from it never restoring that table:
+#   1. A synthetic parent package (with __path__ into the extracted merge
+#      tree) and the reloaded module are left installed for the rest of the
+#      run, so the verdict for a later symbol depends on which symbol was
+#      resolved first.
+#   2. A real module pre-existing at a touched key is popped and replaced
+#      with a merge-tree module and never put back.
+# The red assertions below fail on the buggy shape and pass once
+# _resolve_symbol restores sys.modules in a finally.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSymbolIsolation:
+    @staticmethod
+    def _write_tree(tmp_path: Path, files: dict[str, str]) -> Path:
+        root = tmp_path / "merge"
+        for rel, content in files.items():
+            full = root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content, encoding="utf-8")
+        return root
+
+    @staticmethod
+    def _purge_package(name: str) -> None:
+        for key in list(sys.modules):
+            if key == name or key.startswith(name + "."):
+                del sys.modules[key]
+
+    def test_resolve_symbol_leaves_sys_modules_unchanged(self, tmp_path: Path):
+        """_resolve_symbol must not leak into sys.modules: the key set must be
+        unchanged and any entry it replaces (its module path) must keep its
+        original object identity."""
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/__init__.py": "",
+                "tinyagentos/foo.py": "def func_a():\n    pass\n",
+            },
+        )
+        # Pre-seed a real module object at the path the function writes so the
+        # identity of a pre-existing entry is asserted, not just the key set.
+        sentinel = types.ModuleType("tinyagentos.foo")
+        self._purge_package("tinyagentos")
+        sys.modules["tinyagentos.foo"] = sentinel
+        before = set(sys.modules)
+        assert "tinyagentos" not in sys.modules
+
+        try:
+            cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a")
+            after = set(sys.modules)
+            gained = after - before
+            lost = before - after
+            assert not gained, f"sys.modules gained {gained}"
+            assert not lost, f"sys.modules lost {lost}"
+            assert (
+                sys.modules.get("tinyagentos.foo") is sentinel
+            ), "sys.modules entry identity changed"
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_second_symbol_verdict_is_order_independent(self, tmp_path: Path):
+        """Resolving symbol A before symbol B must yield the same verdict for B
+        as resolving B alone in a fresh state. The merge tree keeps both a
+        module file (tinyagentos/foo.py, func_a) and a same-named package
+        (tinyagentos/foo/__init__.py, func_b); bar.py re-exports func_b via
+        `from .foo import func_b`. Resolving the module caches tinyagentos.foo
+        as the func_a-only module, which then shadows the package for a later
+        bar.py resolution."""
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/__init__.py": "",
+                "tinyagentos/foo.py": "def func_a():\n    pass\n",
+                "tinyagentos/foo/__init__.py": "def func_b():\n    pass\n",
+                "tinyagentos/bar.py": "from .foo import func_b\n",
+            },
+        )
+        bar_file, bar_name = "tinyagentos/bar.py", "func_b"
+        foo_file, foo_name = "tinyagentos/foo.py", "func_a"
+
+        self._purge_package("tinyagentos")
+        verdict_alone = cds._resolve_symbol(merge, bar_file, bar_name)
+        assert verdict_alone is True
+
+        self._purge_package("tinyagentos")
+        try:
+            cds._resolve_symbol(merge, foo_file, foo_name)
+            verdict_after_a = cds._resolve_symbol(merge, bar_file, bar_name)
+
+            assert verdict_after_a == verdict_alone
+        finally:
+            self._purge_package("tinyagentos")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -442,6 +442,66 @@ class TestCheckDeletedSymbols:
         assert "function_c" in violations[0].symbol
         assert "tinyagentos/foo.py:function_b" in waived
 
+    def test_module_shadowed_by_package_is_silent(self, tmp_path: Path):
+        """A module file deleted but shadowed by a same-named package is
+        SILENT: the public import path still resolves through the package."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tinyagentos/containers/__init__.py",
+            "class ContainerInfo:\n    pass\n",
+            "init: add containers package",
+        )
+        _commit_file(
+            repo, "tinyagentos/containers.py",
+            "class ContainerInfo:\n    pass\n",
+            "init: add containers module (shadowed by package)",
+        )
+        base_tip = _get_head(repo)
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _delete_file(repo, "tinyagentos/containers.py")
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr-branch", "--no-edit")
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert violations == []
+        assert waived == set()
+
+    def test_reexport_dropped_from_init_fires(self, tmp_path: Path):
+        """A re-export dropped from __init__.py while the def survives FIREs:
+        the public name in the package namespace is gone."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit_file(
+            repo, "tinyagentos/foo.py",
+            "def function_a():\n    pass\n\ndef function_b():\n    pass\n",
+            "init: add function_a and function_b",
+        )
+        _commit_file(
+            repo, "tinyagentos/__init__.py",
+            "from .foo import function_b\n",
+            "init: re-export function_b",
+        )
+        base_tip = _get_head(repo)
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _commit_file(
+            repo, "tinyagentos/__init__.py",
+            "",
+            "refactor: drop re-export",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr-branch", "--no-edit")
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert len(violations) == 1
+        assert "function_b" in violations[0].symbol
+        assert "tinyagentos/__init__.py" in violations[0].symbol
+        assert violations[0].added_by != "unknown"
+
 
 # ---------------------------------------------------------------------------
 # --pr-head (merge-tree recomputation) path


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2497: _resolve_symbol poisons sys.modules with no restore, so the deleted-symbols gate's verdict depends on which symbol it looked at first

Autonomous build of board card tsk-ocf7dc.

REVISION: built on `exec/tsk-tdwpwz` (cut at `0824adeb9a137e69b5c7eb8946bcfc07d7457403`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

_resolve_symbol mutated the interpreter's global sys.modules table and never
put it back: a synthetic parent package (with __path__ into the extracted merge
tree) and the reloaded module were left installed, so resolving symbol A changed
the verdict for a later symbol B. The gate resolves sorted(signal.items()), so
the wrong answer was reproducible rather than correct. Snapshot and restore the
touched keys (parent package and module path) in a finally; never blanket-clear
sys.modules, which would evict unrelated imports.

Ancillary fixes from the same review: record bare `from . import submodule`
re-exports (previously skipped, so a removed re-export stayed out of the signal
set), slice the .py suffix in the package fallback instead of str.replace
(which replaced every occurrence), and clean up the merge-tree temp dir via
TemporaryDirectory instead of mkdtemp.

Proof (tests/test_check_deleted_symbols.py):
before fix: `python -m pytest tests/test_check_deleted_symbols.py -q -k
"sys_modules or order"` -> 2 failed, sys.modules gained {'tinyagentos'}; assert
False == True.
after fix: `python -m pytest tests/test_check_deleted_symbols.py -q` -> 33 passed.

Files:
 .../tsk-ocf7dc-resolve-symbol-sys-modules.md       |   2 +
 changelog.d/tsk-tdwpwz-deleted-symbols-resolve.md  |   2 +
 scripts/check_deleted_symbols.py                   | 143 +++++++++++++++++-
 tests/test_check_deleted_symbols.py                | 159 +++++++++++++++++++++
 4 files changed, 303 insertions(+), 3 deletions(-)