### PR TITLE
taOS: cross-user event exposure via broadcast SSE channels

### DIFF
--- a/changelog.d/tsk-3q32qc-per-user-event-routing.md
+++ b/changelog.d/tsk-3q32qc-per-user-event-routing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cross-user event leakage via EventBus broadcast channel. Events with a `user:<id>` target are now routed only to that user's channel instead of being published to broadcast, preventing one authenticated user from seeing another user's events through `/api/events/stream` and `/api/os/events`. Notifications scoped to a specific user are also routed to the per-user channel; system-wide notifications (no `user_id`) continue to use broadcast.

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -457,3 +457,95 @@ async def test_store_list_huge_limit_clamped(tmp_path):
         assert len(rows) == 5
     finally:
         await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — per-user event routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_user_id_target_publishes_to_user_channel_not_broadcast():
+    """A target of the form ``user:<id>`` must reach that per-user channel
+    and must NOT leak to the broadcast channel."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    user_q = await bus.subscribe("user:user-1")
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user:user-1"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert user_q.get_nowait() is ev
+    assert bcast_q.empty(), "user-scoped event must not reach broadcast"
+
+
+@pytest.mark.asyncio
+async def test_user_id_target_with_explicit_broadcast_reaches_both():
+    """If ``broadcast`` is explicitly in targets alongside ``user:<id>``, both
+    channels receive the event."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    user_q = await bus.subscribe("user:user-1")
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user:user-1", "broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert user_q.get_nowait() is ev
+    assert bcast_q.get_nowait() is ev
+
+
+@pytest.mark.asyncio
+async def test_user_sentinel_alone_still_broadcasts():
+    """The ``user`` sentinel (no id) is a notification trigger, not a channel.
+    Events with only ``user`` in targets must still reach broadcast."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev
+    assert len(notifications.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_target_still_reaches_broadcast():
+    """Explicit ``broadcast`` in targets must still work."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev
+
+
+@pytest.mark.asyncio
+async def test_no_targets_still_broadcasts():
+    """An event with no targets must still reach broadcast for backward compat."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=[])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -185,3 +185,55 @@ async def test_notification_add_reaches_event_bus_broadcast(notif_store):
     received = bcast_q.get_nowait()
     assert received.kind == "notification.added"
     assert received.payload["title"] == "Push Test"
+
+
+@pytest.mark.asyncio
+async def test_notification_add_with_user_id_routes_to_user_channel(notif_store):
+    """A notification with user_id set must reach the per-user channel, not broadcast."""
+    bus = EventBus()
+    user_q = await bus.subscribe("user:alice")
+    bcast_q = await bus.subscribe("broadcast")
+
+    async def emitter(row: dict) -> None:
+        ev = SystemEvent(
+            kind="notification.added",
+            source="system",
+            targets=["broadcast"],
+            payload=row,
+        )
+        uid = row.get("user_id")
+        if uid:
+            await bus.publish_to(f"user:{uid}", ev)
+        else:
+            await bus.broadcast(ev)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("Alice only", "secret msg", user_id="alice")
+
+    assert user_q.get_nowait() is not None
+    assert bcast_q.empty(), "user-scoped notification must not leak to broadcast"
+
+
+@pytest.mark.asyncio
+async def test_notification_add_without_user_id_still_broadcasts(notif_store):
+    """A notification without user_id (system-wide) must still reach broadcast."""
+    bus = EventBus()
+    bcast_q = await bus.subscribe("broadcast")
+
+    async def emitter(row: dict) -> None:
+        ev = SystemEvent(
+            kind="notification.added",
+            source="system",
+            targets=["broadcast"],
+            payload=row,
+        )
+        uid = row.get("user_id")
+        if uid:
+            await bus.publish_to(f"user:{uid}", ev)
+        else:
+            await bus.broadcast(ev)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("System alert", "everyone sees this")
+
+    assert bcast_q.get_nowait() is not None

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1338,7 +1338,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 targets=["broadcast"],
                 payload=row,
             )
-            await app.state.event_bus.broadcast(ev)
+            user_id = row.get("user_id")
+            if user_id:
+                await app.state.event_bus.publish_to(f"user:{user_id}", ev)
+            else:
+                await app.state.event_bus.broadcast(ev)
 
         notif_store.set_event_emitter(_notify_emitter)
 

--- a/tinyagentos/events/bus.py
+++ b/tinyagentos/events/bus.py
@@ -163,11 +163,24 @@ class EventBus:
                 )
 
         # e. In-process pub/sub — deduplicate, then ensure broadcast is published
-        #    exactly once even if it appeared in targets.
+        #    exactly once even if it appeared in targets. Events whose targets
+        #    contain a ``user:<id>`` channel are scoped to that user and must
+        #    NOT leak to the broadcast channel, so they are published only to
+        #    the per-user channel(s). The ``user`` sentinel alone (no id) is a
+        #    notification trigger, not a channel, so it is skipped here.
         async with self._lock:
+            has_user_channel = False
             for target in _seen_targets:
-                await self._publish_to_channel(target, event)
-            if _BROADCAST_CHANNEL not in _seen_targets:
+                if target.startswith("user:"):
+                    await self._publish_to_channel(target, event)
+                    has_user_channel = True
+                elif target == _BROADCAST_CHANNEL:
+                    await self._publish_to_channel(target, event)
+                elif target == "user":
+                    continue
+                else:
+                    await self._publish_to_channel(target, event)
+            if not has_user_channel and _BROADCAST_CHANNEL not in _seen_targets:
                 await self._publish_to_channel(_BROADCAST_CHANNEL, event)
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOS: cross-user event exposure via broadcast SSE channels

Autonomous build of board card tsk-3q32qc.

EventBus.emit() now recognizes user:<id> targets and publishes only to
that user's channel, preventing cross-user event leakage through the
broadcast SSE channels. The notification emitter in app.py routes
user-specific notifications to user:{id} and system-wide notifications
(user_id is None) to broadcast. Backward compatible: the user sentinel
without an id still triggers notifications and reaches broadcast.

Proof: 129 tests pass across test_event_bus.py, test_event_stream.py,
test_os_events.py, test_notifications.py, test_notifications_push.py,
test_routes_events.py.

Files:
 changelog.d/tsk-3q32qc-per-user-event-routing.md |  3 +
 tests/test_event_bus.py                          | 92 ++++++++++++++++++++++++
 tests/test_event_stream.py                       | 52 ++++++++++++++
 tinyagentos/app.py                               |  6 +-
 tinyagentos/events/bus.py                        | 19 ++++-
 5 files changed, 168 insertions(+), 4 deletions(-)