### PR TITLE
fix(gate): restore sys.modules exactly in _resolve_symbol and its tests (dev is red)

### DIFF
--- a/changelog.d/resolve-symbol-sys-modules-full-restore.md
+++ b/changelog.d/resolve-symbol-sys-modules-full-restore.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- The deleted-symbols gate no longer leaks modules into `sys.modules`. `_resolve_symbol`
+  executes the module under inspection, so its transitive imports were loading out of the
+  merge tree and staying resolvable under their real names; its tests also purged
+  `tinyagentos.*` without restoring it. Both are now restored exactly, so a later
+  `mock.patch` target cannot resolve to a different module object.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -188,6 +188,15 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
             sys.modules.get(parent_pkg_name),
         )
     touched[module_path] = (module_path in sys.modules, sys.modules.get(module_path))
+    # exec_module() runs the target's module-level code, which imports whatever
+    # that module imports. Those transitive modules are resolved through the
+    # synthesised parent's __path__, so they load OUT OF THE MERGE TREE and land
+    # in sys.modules under their real names. Snapshotting only the two keys above
+    # left them behind: a later importer -- including the rest of a pytest
+    # process, since this function is exercised in-process by its own tests --
+    # then got the merge-tree copy instead of the installed one, and any
+    # mock.patch target resolved to a different module object.
+    preexisting_keys = set(sys.modules)
 
     try:
         if parent_pkg_name:
@@ -212,6 +221,11 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
     except Exception:
         return False
     finally:
+        # Drop everything exec_module() added, then restore the explicitly
+        # snapshotted entries. Order matters: the generic sweep would otherwise
+        # delete a key we are about to put back.
+        for key in set(sys.modules) - preexisting_keys:
+            sys.modules.pop(key, None)
         for key, (was_present, old_obj) in touched.items():
             if was_present:
                 sys.modules[key] = old_obj

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -164,6 +164,25 @@ class TestFindSignalSymbols:
 
 
 class TestResolveSymbolIsolation:
+    @pytest.fixture(autouse=True)
+    def _restore_sys_modules(self):
+        """Restore sys.modules EXACTLY after every test in this class.
+
+        These tests deliberately purge and repopulate `tinyagentos.*` to isolate
+        _resolve_symbol. Without this, the purge escapes the test: sibling test
+        modules imported `tinyagentos.deployer` at collection time and hold that
+        object, while a later mock.patch("tinyagentos.deployer...") re-imports
+        and patches a DIFFERENT object -- so the patch silently misses and the
+        real binary runs. That is what turned 43 deployer tests red on dev with
+        FileNotFoundError: 'incus'.
+        """
+        saved = dict(sys.modules)
+        try:
+            yield
+        finally:
+            sys.modules.clear()
+            sys.modules.update(saved)
+
     @staticmethod
     def _write_tree(tmp_path: Path, files: dict[str, str]) -> Path:
         root = tmp_path / "merge"
@@ -208,6 +227,40 @@ class TestResolveSymbolIsolation:
             assert (
                 sys.modules.get("tinyagentos.foo") is sentinel
             ), "sys.modules entry identity changed"
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_resolve_symbol_does_not_leak_transitive_imports(self, tmp_path: Path):
+        """The module under inspection is EXECUTED, so whatever it imports is
+        imported too -- out of the merge tree, under real names.
+
+        The sibling test above uses a module with no imports, so it cannot fail
+        on this: it is one level coarser than the defect. Leaked transitive
+        modules shadow the installed ones for the rest of the process, which is
+        how this turned 43 unrelated deployer tests red on dev -- their
+        mock.patch targets resolved to a different module object than the code
+        under test was using.
+        """
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/__init__.py": "",
+                "tinyagentos/leaky_helper.py": "VALUE = 'from-merge-tree'\n",
+                "tinyagentos/leaky_main.py": (
+                    "from tinyagentos import leaky_helper\n"
+                    "def func_a():\n"
+                    "    return leaky_helper.VALUE\n"
+                ),
+            },
+        )
+        self._purge_package("tinyagentos")
+        before = set(sys.modules)
+
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/leaky_main.py", "func_a")
+            gained = set(sys.modules) - before
+            assert not gained, f"sys.modules gained {gained}"
+            assert "tinyagentos.leaky_helper" not in sys.modules
         finally:
             self._purge_package("tinyagentos")
 


### PR DESCRIPTION
**dev is currently RED and this fixes it.** CI on dev HEAD `087ba293` failed with 74 failures across `test_deployer.py`, `test_deploy_secrets.py`, `test_deploy_ssh_keys.py` and `test_deploy_cloud_model_resolution.py`, mostly `FileNotFoundError: 'incus'`. dev was green through `1f26f8a5` and went red after #2558 merged.

**This is my regression.** I reviewed #2558, noticed that `_resolve_symbol` restores only two `sys.modules` keys, and waved it through as "harmless for this script — it is a short-lived CLI". That was wrong: the function is exercised **in-process by its own tests**, so the leak is live inside pytest.

**Two separate leaks, both from #2558:**

1. `_resolve_symbol` calls `spec.loader.exec_module()`, which runs the target's module-level code and imports whatever it imports. Those transitive modules resolve through the synthesised parent's `__path__`, load **out of the merge tree**, and remained in `sys.modules` under their real names. Now everything the call added is dropped before the snapshotted entries are restored.
2. `TestResolveSymbolIsolation._purge_package` deleted `tinyagentos.*` and never restored it. Sibling test modules import `tinyagentos.deployer` at collection time and hold that object; a later `mock.patch("tinyagentos.deployer...")` re-imported and patched a **different** object, so the patch silently missed and the real `incus` binary ran. An autouse fixture now restores `sys.modules` exactly after each test.

**Why the existing test could not catch it:** `test_resolve_symbol_leaves_sys_modules_unchanged` inspects a module with **no imports**, one level coarser than the defect. Added `test_resolve_symbol_does_not_leak_transitive_imports`, which uses a module importing a sibling and **fails on the unpatched code** (verified by stashing the source fix: `1 failed`).

**Evidence:**
| check | before | after |
|---|---|---|
| `test_deployer.py` alone | 58 passed | 58 passed |
| `test_check_deleted_symbols.py` + `test_deployer.py` | **43 failed** | **92 passed** |
| full deploy family CI failed on | 74 failed in CI | **118 passed** |

Ordering matters in the fix: the generic sweep runs before restoring the snapshotted entries, or it would delete a key being put back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deleted-symbol validation to prevent temporary module loading from affecting later imports or patching operations.
  * Ensured module state is fully restored after symbol checks, avoiding interference with unrelated operations.

* **Tests**
  * Added coverage verifying import isolation and exact restoration of module state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->