### PR TITLE
SECURITY: a device bearer can approve execution and delegation grants (shipped in #2232) - refuse gate kinds on the device path, per Jay's ruling

### DIFF
--- a/changelog.d/tsk-dpnkab-refuse-gate-kinds-on-device.md
+++ b/changelog.d/tsk-dpnkab-refuse-gate-kinds-on-device.md
@@ -1,0 +1,3 @@
+### Security
+
+- Device bearers are refused gate-kind (execution, delegation, app-grant) decisions on `POST /api/decisions/{id}/answer`; the phone remains a notification surface, not an approval channel for privileged grants (#tsk-dpnkab).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -569,10 +569,12 @@ Two properties hold this together and both are enforced in code and tests:
 Device identity always comes from the verified bearer, never from the path or
 body, and a device is never admin.
 
-Note for reviewers: answering a decision on this path can apply app, execution
-and delegation grants, so a device bearer carries real authority for its own
-user. Device scoped tokens do not expire and cannot be self-rotated; the only
-revocation is `DELETE /api/devices/{id}` from a session.
+Note for reviewers: a device bearer can answer ordinary decisions for its own
+user, but gate-kind decisions (execution_gate, delegation_gate, app_grant) are
+refused with 409 on this path. The phone is a notification surface, not an
+approval channel for privileged grants. Device scoped tokens do not expire and
+cannot be self-rotated; the only revocation is `DELETE /api/devices/{id}` from
+a session.
 
 ## Share destinations (device bearer)
 

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -667,6 +667,96 @@ async def test_device_bearer_history_rejects_other_user(client, app):
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_device_bearer_execution_gate_refused(client, app):
+    """A device bearer must not approve an execution_gate decision: the phone
+    is a notification surface, not an approval channel for agent execution."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "agent-a",
+        "question": "Agent agent-a wants to run code_exec (code-exec)",
+        "type": "approve_deny",
+        "priority": "blocking",
+        "metadata": {"kind": "execution_gate", "agent_name": "agent-a",
+                     "action_class": "code-exec", "tool": "code_exec"},
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 409
+    assert await app.state.execution_policies.has_live_grant("agent-a", "code-exec") is False
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_delegation_gate_refused(client, app):
+    """A device bearer must not approve a delegation_gate decision."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "agent-a",
+        "question": "Delegate task to agent-b?",
+        "type": "approve_deny",
+        "priority": "blocking",
+        "metadata": {"kind": "delegation_gate", "from_agent": "agent-a",
+                     "to_agent": "agent-b", "task_id": "task-1", "task_title": "Task 1"},
+    })
+    assert resp.status_code == 200
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 409
+    # No delegate grant must be written.
+    policies = getattr(app.state, "execution_policies", None)
+    if policies is not None:
+        assert await policies.has_live_grant("agent-a", "delegate") is False
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_ordinary_consent_still_answered(client, app):
+    """Control: a device bearer can still answer a non-gate consent decision
+    (e.g. a plain approve_deny with no gate kind)."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    decision = await _decision_for_user(
+        app, admin_uid, question="Notify me?", type="approve_deny",
+    )
+    resp = await client.post(
+        f"/api/decisions/{decision['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "answered"
+    assert resp.json()["answer"]["value"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_session_user_execution_gate_still_approved(client, app):
+    """Control: a real session user can still approve an execution_gate."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "agent-a",
+        "question": "Agent agent-a wants to run code_exec (code-exec)",
+        "type": "approve_deny",
+        "priority": "blocking",
+        "metadata": {"kind": "execution_gate", "agent_name": "agent-a",
+                     "action_class": "code-exec", "tool": "code_exec"},
+    })
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer", json={"value": "approve"},
+    )
+    assert resp.status_code == 200
+    assert await app.state.execution_policies.has_live_grant("agent-a", "code-exec") is True
+
+
 # --------------------------------------------------------------------------- #
 # Other / free-text answer tests
 # --------------------------------------------------------------------------- #

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -32,6 +32,13 @@ router = APIRouter()
 _DEFAULT_BUS_URL = "http://127.0.0.1:7900"
 _ANSWER_THREAD = "decisions"
 
+# Decision metadata kinds that carry privileged grant authority.  The human
+# answer path must refuse these from device bearers (a phone is a notification
+# surface, not an approval channel), and the agent mirror path must refuse them
+# so an agent cannot self-approve a gate it created.  Keeping the list in one
+# place prevents drift between the two call sites and the applier functions.
+GATE_DECISION_KINDS = ("execution_gate", "delegation_gate", "app_grant")
+
 
 def _bus_url() -> str:
     return os.environ.get("TAOS_A2A_BUS_URL", _DEFAULT_BUS_URL).rstrip("/")
@@ -475,6 +482,19 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
     if existing is None or (not user.is_admin and existing["user_id"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
 
+    # Device bearers must not answer gate-kind decisions: the phone is a
+    # notification surface, not an approval channel for privileged grants.
+    # INVARIANT (c) in device_auth.py: request.state.user_id is None on this
+    # path, so a falsy user_id means the caller authenticated as a device.
+    if not getattr(request.state, "user_id", None):
+        meta = existing.get("metadata") or {}
+        gate_kind = meta.get("kind") if isinstance(meta, dict) else None
+        if gate_kind in GATE_DECISION_KINDS:
+            return JSONResponse(
+                {"error": "gate decisions cannot be answered by a device bearer"},
+                status_code=409,
+            )
+
     # For select types, the answer may reference the declared options or use
     # the free-text Other path.  A stale or malformed client cannot record an
     # arbitrary value: explicit option values are still validated against the
@@ -797,7 +817,7 @@ async def answer_decision_as_agent(
     # card from the owner's inbox without the owner ever seeing it.
     meta = (existing.get("metadata") or {})
     gate_kind = meta.get("kind") if isinstance(meta, dict) else None
-    if gate_kind in ("execution_gate", "delegation_gate", "app_grant"):
+    if gate_kind in GATE_DECISION_KINDS:
         return JSONResponse(
             {"error": "gate decisions cannot be answered by the asking agent"},
             status_code=409,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): SECURITY: a device bearer can approve execution and delegation grants (shipped in #2232) - refuse gate kinds on the device path, per Jay's ruling

Autonomous build of board card tsk-dpnkab.

A paired device's scoped bearer can answer decisions addressed to its own
user, but execution_gate, delegation_gate, and app_grant decisions must
not be approved from the phone. Added a device-path guard in
answer_decision that rejects those kinds with 409 before any grant is
written, mirroring the precedent already set in answer_decision_as_agent.
Introduced a shared GATE_DECISION_KINDS constant so both call sites and
the applier functions reference the same list.

Tests added:
(a) device bearer + execution_gate -> 409, no execution grant written
(b) device bearer + delegation_gate -> 409, no delegate grant written
(c) device bearer + ordinary approve_deny -> still answered
(d) session user + execution_gate -> still approves and grants

Also updated docs/agent-coordination.md to reflect the new restriction.

Tests run: uv run pytest tests/test_routes_decisions.py tests/test_routes_decisions_agent.py -q --timeout=300
Result: 76 passed

Files:
 .../tsk-dpnkab-refuse-gate-kinds-on-device.md      |  3 +
 docs/agent-coordination.md                         | 10 ++-
 tests/test_routes_decisions.py                     | 90 ++++++++++++++++++++++
 tinyagentos/routes/decisions.py                    | 22 +++++-
 4 files changed, 120 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Device-authenticated phones can no longer approve execution, delegation, or app-grant decisions.
  - Privileged grant decisions now return a conflict response and create no grants when attempted from a phone.
  - Phones remain notification-only for privileged approvals.

- **Behavior**
  - Ordinary consent decisions continue to work for device bearers.
  - Session-based users retain existing approval capabilities.

- **Documentation**
  - Updated device bearer guidance to clarify approval limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->