### PR TITLE
fix-forward #2495: the presence regression test recomputes MessagesApp.tsx's own argument assembly, so it passes whether or not the production line exists

### DIFF
--- a/changelog.d/tsk-564mgr-regression-test.md
+++ b/changelog.d/tsk-564mgr-regression-test.md
@@ -1,0 +1,2 @@
+### Added
+- Add regression test for bound project channel presence in standalone mode (tsk-564mgr)

--- a/changelog.d/tsk-6rtg6o-presence-test-binds-caller.md
+++ b/changelog.d/tsk-6rtg6o-presence-test-binds-caller.md
@@ -1,0 +1,2 @@
+### Fixed
+- MessagesApp sidebar presence now assembles bound channels through the shared `collectBoundChannels` helper, and the standalone project-channel regression test binds to that call instead of a hand-built copy, so it genuinely covers the production path

--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   bucketAgentChannels,
   buildAgentPresence,
+  collectBoundChannels,
   computeAgentPresence,
   type AgentSectionChannel,
   type AgentSectionLiveAgent,
@@ -225,7 +226,7 @@ describe("buildAgentPresence", () => {
       const workingSlugs = new Set(["hermes"]);
       const agentPresence = buildAgentPresence(
         dmSections,
-        [...grouped.topic, ...grouped.group, ...projectGroups.flatMap((g) => g.channels)],
+        collectBoundChannels(grouped, projectGroups),
         workingSlugs,
       );
       expect(agentPresence).toEqual({ p1: "working" });
@@ -240,7 +241,7 @@ describe("buildAgentPresence", () => {
       const workingSlugs = new Set();
       const agentPresence = buildAgentPresence(
         dmSections,
-        [...grouped.topic, ...grouped.group, ...projectGroups.flatMap((g) => g.channels)],
+        collectBoundChannels(grouped, projectGroups),
         workingSlugs,
       );
       expect(agentPresence).toEqual({});

--- a/desktop/src/apps/MessagesApp.agentSections.test.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.test.ts
@@ -208,4 +208,42 @@ describe("buildAgentPresence", () => {
     );
     expect(presence).toEqual({});
   });
+
+  describe("MessagesApp presence assembly (regression test for standalone project channels)", () => {
+    const ch = (id: string, agent?: string) => ({
+      id,
+      settings: agent ? { taostalk_agent: agent } : undefined,
+    });
+
+    it("bound project channel gets presence when its agent is thinking", () => {
+      const projectGroups = [
+        { channels: [ch("p1", "hermes")] },
+        { channels: [ch("p2")], },
+      ];
+      const dmSections = { live: [], suspended: [], archived: [] };
+      const grouped = { topic: [], group: [] };
+      const workingSlugs = new Set(["hermes"]);
+      const agentPresence = buildAgentPresence(
+        dmSections,
+        [...grouped.topic, ...grouped.group, ...projectGroups.flatMap((g) => g.channels)],
+        workingSlugs,
+      );
+      expect(agentPresence).toEqual({ p1: "working" });
+    });
+
+    it("bound project channel gets no presence when its agent is not thinking", () => {
+      const projectGroups = [
+        { channels: [ch("p1", "hermes")] },
+      ];
+      const dmSections = { live: [], suspended: [], archived: [] };
+      const grouped = { topic: [], group: [] };
+      const workingSlugs = new Set();
+      const agentPresence = buildAgentPresence(
+        dmSections,
+        [...grouped.topic, ...grouped.group, ...projectGroups.flatMap((g) => g.channels)],
+        workingSlugs,
+      );
+      expect(agentPresence).toEqual({});
+    });
+  });
 });

--- a/desktop/src/apps/MessagesApp.agentSections.ts
+++ b/desktop/src/apps/MessagesApp.agentSections.ts
@@ -73,6 +73,12 @@ export interface PresenceSourceChannel {
   settings?: { taostalk_agent?: string };
 }
 
+/** Channel groups that may carry a bound agent in the sidebar. */
+export interface BoundChannelGroups<C> {
+  topic: C[];
+  group: C[];
+}
+
 /**
  * Build the sidebar presence map from the bucketed agent DM sections plus
  * the topic/group channels that may carry an agent binding.
@@ -109,6 +115,29 @@ export function buildAgentPresence<C extends PresenceSourceChannel>(
     }
   }
   return presence;
+}
+
+/**
+ * Collect every channel that may carry a bound agent and therefore needs a
+ * presence dot in the sidebar: the standalone-mode topic/group channels plus
+ * the project channels.
+ *
+ * Bound channels from all three buckets: standalone-mode project channels are
+ * excluded from `grouped`, so include them explicitly or a working bound
+ * project channel renders no dot.
+ *
+ * Pure function -- exported so the presence regression test can bind to the
+ * caller instead of hand-building the argument list.
+ */
+export function collectBoundChannels<C extends PresenceSourceChannel>(
+  grouped: BoundChannelGroups<C>,
+  projectGroups: { channels: C[] }[],
+): C[] {
+  return [
+    ...grouped.topic,
+    ...grouped.group,
+    ...projectGroups.flatMap((g) => g.channels),
+  ];
 }
 
 /** The agent identity a DM channel points at: its name or its non-"user" member. */

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -58,7 +58,7 @@ import {
   readLastChannel,
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
-import { bucketAgentChannels, buildAgentPresence } from "./MessagesApp.agentSections";
+import { bucketAgentChannels, buildAgentPresence, collectBoundChannels } from "./MessagesApp.agentSections";
 import {
   pickWatchAgent,
   computeStallInfo,
@@ -2074,11 +2074,7 @@ export function MessagesApp({
     // Bound channels from all three buckets: standalone-mode project
     // channels are excluded from `grouped`, so include them explicitly or
     // a working bound project channel renders no dot.
-    [
-      ...grouped.topic,
-      ...grouped.group,
-      ...projectGroups.flatMap((g) => g.channels),
-    ],
+    collectBoundChannels(grouped, projectGroups),
     workingSlugs,
   );
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2495: the presence regression test recomputes MessagesApp.tsx's own argument assembly, so it passes whether or not the production line exists

Autonomous build of board card tsk-6rtg6o.

REVISION: built on `exec/tsk-564mgr` (cut at `cd80ae68afb91d0531cee3b3ee3a208b0fe564a7`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

The regression test in MessagesApp.agentSections.test.ts hand-built the
bound-channel argument (a verbatim copy of the inline assembly in
MessagesApp.tsx), so it passed whether or not the production assembly
existed -- the exact defect the card was cut to fix, one level down.

Extract the bound-channel assembly into collectBoundChannels() in
MessagesApp.agentSections.ts, call it from MessagesApp.tsx, and have the
two regression tests obtain the bound-channel argument from that single
function. There is now exactly one definition of this assembly in the repo.

Proof -- mutation of collectBoundChannels dropping the
projectGroups.flatMap(...) term (edited in place; no file deleted or
renamed):

  Mutated: npx vitest run src/apps/MessagesApp.agentSections.test.ts
    FAILED  ... > MessagesApp presence assembly > bound project channel
    gets presence when its agent is thinking
    AssertionError: expected {} to deeply equal { p1: 'working' }
    Tests  1 failed | 23 passed

  Control (mutation reverted): 24 passed

  Contrast that makes the fix meaningful: the OLD hand-built version of
  the two tests stays GREEN under that same mutation (24 passed), because
  it never calls collectBoundChannels. A test that goes red only once it
  shares the production definition is the fix; a test that stays green is
  the bug.

Files:
 changelog.d/tsk-564mgr-regression-test.md          |  2 ++
 .../tsk-6rtg6o-presence-test-binds-caller.md       |  2 ++
 desktop/src/apps/MessagesApp.agentSections.test.ts | 39 ++++++++++++++++++++++
 desktop/src/apps/MessagesApp.agentSections.ts      | 29 ++++++++++++++++
 desktop/src/apps/MessagesApp.tsx                   |  8 ++---
 5 files changed, 74 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar presence indicators for standalone project channels.
  * Project channels now correctly show an active “working” status when an agent is thinking.
  * Prevented presence indicators from appearing when the agent is inactive.

* **Tests**
  * Added regression coverage to verify project-channel presence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->