### PR TITLE
fix(mobile): move the dock to the bottom edge on square displays

### DIFF
--- a/changelog.d/square-display-dock-bottom.md
+++ b/changelog.d/square-display-dock-bottom.md
@@ -1,0 +1,4 @@
+Fixed: on roughly square displays (such as the Unihertz Titan 2) the mobile dock
+sat well above the bottom edge. The fixed 54px browser-chrome reserve is now
+reduced to the standard 12px gap on square viewports, where the `100dvh` root
+already accounts for browser chrome. Tall phones are unchanged.

--- a/desktop/src/components/mobile/MobileDock.square.test.tsx
+++ b/desktop/src/components/mobile/MobileDock.square.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MobileDock } from "./MobileDock";
+
+/**
+ * Drive `window.matchMedia` the way a real device would answer it: report the
+ * aspect-ratio query as matching only when the device really is square-ish.
+ * The component is rendered unmodified and reached through its own hook, so
+ * these assert the shipped behaviour rather than a re-implementation of it.
+ */
+function mockAspectRatio({ square }: { square: boolean }) {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: q.includes("min-aspect-ratio") ? square : false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+function renderDock(isBrowserMobile: boolean) {
+  render(
+    <MobileDock
+      onOpenApp={() => {}}
+      onToggleSwitcher={() => {}}
+      onOpenLaunchpad={() => {}}
+      activeAppId={null}
+      isBrowserMobile={isBrowserMobile}
+    />,
+  );
+  return screen.getByRole("toolbar", { name: "Dock" });
+}
+
+const originalMatchMedia = window.matchMedia;
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MobileDock bottom clearance", () => {
+  it("drops the browser-chrome reserve to the small gap on a square screen", () => {
+    // A square display (Titan 2 and similar) has scarce vertical space, so the
+    // fixed 54px browser reserve strands the dock above the bottom edge.
+    mockAspectRatio({ square: true });
+    const dock = renderDock(true);
+    expect(dock).toHaveStyle({
+      paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)",
+    });
+  });
+
+  it("keeps the full browser-chrome reserve on a tall phone", () => {
+    // The control. This is the case the 54px was measured for, and it must not
+    // move — a test that only checked the square case would pass just as well
+    // if the reserve had been deleted for every device.
+    mockAspectRatio({ square: false });
+    const dock = renderDock(true);
+    expect(dock).toHaveStyle({
+      paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 54px)",
+    });
+  });
+
+  it("uses the small gap in PWA mode regardless of shape", () => {
+    // Installed PWAs have no browser chrome to clear, so the reserve never
+    // applied there. Pinned so the square-screen branch cannot leak into it.
+    for (const square of [true, false]) {
+      mockAspectRatio({ square });
+      const dock = renderDock(false);
+      expect(dock).toHaveStyle({
+        paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)",
+      });
+      cleanup();
+    }
+  });
+});

--- a/desktop/src/components/mobile/MobileDock.tsx
+++ b/desktop/src/components/mobile/MobileDock.tsx
@@ -2,6 +2,7 @@ import * as icons from "lucide-react";
 import { useMobileHomeStore } from "@/stores/mobile-home-store";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
+import { useIsSquareViewport } from "@/hooks/use-is-square-viewport";
 
 interface Props {
   onOpenApp: (appId: string) => void;
@@ -30,7 +31,20 @@ export function MobileDock({ onOpenApp, onToggleSwitcher, onOpenLaunchpad, activ
   // content that ends just above it) always clears the home indicator. In PWA
   // mode the inset is non-zero (notch devices); in browser mode it is 0, so we
   // add extra room to keep the dock above Safari's ~50 px URL/tab bar.
-  const dockBaseGap = isBrowserMobile ? 54 : 12;
+  //
+  // That browser reserve is a fixed guess, and on a square screen it is a bad
+  // trade. The root is already sized with 100dvh (see .taos-mobile-root), and
+  // the dynamic viewport unit ALREADY excludes whatever browser chrome is
+  // showing — so the reserve is belt-and-braces on top of a fit that is
+  // correct. On a tall phone the extra 54px is barely noticeable; on a roughly
+  // square display it strands the dock well above the bottom edge, because the
+  // same fixed cost is a much larger share of a much shorter screen.
+  //
+  // So keep the full reserve where it was measured and is cheap, and shrink it
+  // to the PWA gap on square screens, where dvh is doing the real work anyway.
+  const isSquareViewport = useIsSquareViewport();
+  const browserGap = isSquareViewport ? 12 : 54;
+  const dockBaseGap = isBrowserMobile ? browserGap : 12;
   const dockPaddingBottom = `calc(env(safe-area-inset-bottom, 0px) + ${dockBaseGap}px)`;
 
   return (

--- a/desktop/src/hooks/use-is-square-viewport.ts
+++ b/desktop/src/hooks/use-is-square-viewport.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+/**
+ * True when the viewport is roughly square or wider — height is no more than
+ * `1 / minRatio` times the width.
+ *
+ * Ordinary phones are tall and narrow (9:19.5 is a width/height ratio of about
+ * 0.46), so they never match. Square-screen devices like the Unihertz Titan 2
+ * sit at about 1.0 and always do. The default threshold of 3/4 (0.75) leaves a
+ * wide margin either side of both cases, so a device has to be genuinely
+ * square-ish to match rather than merely short.
+ *
+ * Vertical space is scarce on these screens, so any fixed-pixel reserve costs a
+ * visibly larger slice of the display than it does on a tall phone. Callers use
+ * this to shrink such reserves instead of paying a tall-phone tax on a screen
+ * that is not tall.
+ *
+ * Note this is deliberately NOT `(orientation: portrait)`: that matches every
+ * screen where height >= width, which includes square displays, and doing so
+ * already caused a wallpaper bug on exactly this class of device (see the
+ * comment on the wallpaper media query in theme/tokens.css).
+ */
+/**
+ * `minRatio` is a CSS ratio written as a fraction, e.g. "3/4". It is passed
+ * through verbatim rather than as a decimal: a single-number ratio is only
+ * Media Queries Level 4 and does not parse on older Safari, where the query
+ * would silently never match. The fraction form is understood everywhere.
+ * Should it ever fail to parse, the hook returns false and the caller keeps
+ * its previous behaviour, so the failure mode is "no change", not a broken
+ * layout.
+ */
+export function useIsSquareViewport(minRatio = "3/4"): boolean {
+  const query = `(min-aspect-ratio: ${minRatio})`;
+
+  const [isSquare, setIsSquare] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(query);
+    const update = () => setIsSquare(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [query]);
+
+  return isSquare;
+}


### PR DESCRIPTION
Jay reported that on square displays like his Titan 2 the dock needs to sit closer to the bottom of the screen.

## Cause
`MobileDock` adds a fixed **54px** browser-chrome reserve in browser mode to clear Safari's URL/tab bar. But `.taos-mobile-root` is already sized with `100dvh`, and the dynamic viewport unit **already excludes whatever browser chrome is showing** — so the reserve is belt-and-braces on top of a fit that is already correct. On a tall phone 54px is barely noticeable; on a square screen the same fixed cost is a much larger share of a much shorter screen and strands the dock above a visible band of dead space.

## Fix
Shrink the reserve to the standard 12px gap **on square viewports only**. Tall phones keep the full 54px, so the case the 54px was measured for does not move.

The threshold is a named `useIsSquareViewport` hook, not an inline magic number. Two deliberate choices:
- **Not `(orientation: portrait)`** — that matches every screen where height >= width, which includes square displays, and using it that way already caused a wallpaper bug on exactly this class of device (see the comment on the wallpaper media query in `theme/tokens.css`).
- **Ratio emitted as the fraction `3/4`, not a decimal** — a single-number ratio is Media Queries Level 4 and does not parse on older Safari, where the query would silently never match. If it ever fails to parse, the hook returns false and the previous behaviour stands, so the failure mode is "no change", not a broken layout.

## Verification — measured in a real browser, not reasoned about
Chromium against the running app, reading the live `getBoundingClientRect`:

| viewport | before | after |
|---|---|---|
| 718x728 (Titan 2-like, square) | 54px | **12px** |
| 390x844 (tall phone, control) | 54px | **54px** |

`dvh` was confirmed equal to `innerHeight` in both, which is the measurement behind the claim that the reserve double-counts.

## Tests
`MobileDock.square.test.tsx` covers the square branch, the tall-phone control, and PWA mode. **Mutation-checked:** restoring `browserGap = 54` reds *only* the square-screen test and leaves the tall-phone control and PWA case green — so the control cannot pass by having deleted the reserve for every device.

Full mobile + hooks + dock-store suites: 201 passed (28 files). `tsc -b` clean.

## Note for review
I could not test on a real iOS device. The change is scoped so iOS tall phones are untouched. There is a **follow-up worth considering**: if `dvh` is trusted, the 54px is arguably redundant on *every* device, not just square ones — but that would change iOS behaviour I cannot verify here, so I deliberately did not do it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile dock spacing on square displays by reducing unnecessary bottom clearance.
  * Preserved existing spacing on tall phones and in PWA mode.
  * Added responsive handling as screen dimensions change.

* **Tests**
  * Added coverage for square displays, tall phones, and PWA layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->