### PR TITLE
doc-gate blocks every dependabot workflow bump: the waiver is a commit trailer the bot cannot write

### DIFF
--- a/changelog.d/tsk-4gkzrj-doc-gate-workflow-pin-bump.md
+++ b/changelog.d/tsk-4gkzrj-doc-gate-workflow-pin-bump.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `scripts/check_doc_gate.py`: a workflow change that bumps only `uses: <action>@<ref>` pins no longer trips the `contributor-skill` doc-gate rule, so dependency-update PRs for GitHub Actions can turn green on their own instead of stalling red until a maintainer force-pushes a `Docs-Reviewed:` trailer that the bot cannot author. The exemption is content-based: a substantive workflow edit by any author still fails the gate.

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -129,6 +129,11 @@ hint = "agent-facing behaviour changed; review the agent manual or coordination 
 # The contributor skill documents how to contribute, test and ship. When CI,
 # packaging or the contribution rules move, it goes stale silently because
 # nothing imports it.
+# A workflow-file change that bumps only `uses: <action>@<ref>` pins (a
+# dependency-bot version update) is detected by scripts/check_doc_gate.py and
+# treated as non-structural, so it does NOT trip this rule and dependency-update
+# PRs for GitHub Actions can pass without a trailer the bot cannot author. The
+# exemption is content-based: a substantive workflow edit by any author still does.
 [[rules]]
 name = "contributor-skill"
 on_modify = true

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -316,12 +316,20 @@ def _is_test_path(path: str) -> bool:
 # `#` so a trailing comment (e.g. `@<sha>  # v2.6.1`) does not poison the match.
 # A `uses:` without an `@<ref>` (a non-pinned or local action) is NOT a pin
 # line and keeps the change substantive.
-_USES_PIN_LINE = re.compile(r"^\s*[-*]?\s*uses:\s+[^@\s]+@[^@\s#]+")
+_USES_PIN_LINE = re.compile(r"^\s*[-*]?\s*uses:\s+(?P<target>[^@\s]+)@[^@\s#]+")
+
+
+def _uses_pin_target(line: str) -> str | None:
+    """Return the action TARGET (the text before `@`) of a `uses:` pin line,
+    or None when the line is not a pin line at all."""
+    m = _USES_PIN_LINE.match(line)
+    return m.group("target") if m else None
 
 
 def _path_diff_is_uses_pin_only(diff_output: str) -> bool:
-    """True iff every content line in `git diff --unified=0` output is a
-    `uses: <action>@<ref>` pin bump.
+    """True iff `git diff --unified=0` output is a pure `uses:` pin bump --
+    every content line is a `uses: <action>@<ref>` pin AND, within each hunk,
+    the removed and added lines name the SAME set of action targets.
 
     A dependency-bot version bump changes nothing but the `@ref` on existing
     `uses:` lines -- e.g. `uses: actions/checkout@v4` -> `@v5`. Such a change
@@ -334,14 +342,36 @@ def _path_diff_is_uses_pin_only(diff_output: str) -> bool:
     rewrite still fails the gate without a trailer. Author is irrelevant: a
     human who also changes only pins is exempt, and a bot that rewrites steps
     is not -- the decision is content-based, not identity-based.
+
+    THE TARGETS MUST BE PAIRED, NOT MERELY CLASSIFIED (#2568 review). Both
+    sides of
+
+        -        uses: actions/checkout@v4
+        +        uses: attacker/checkout@v1
+
+    are syntactically pin lines, so a per-line classifier calls that a version
+    bump and hands an attacker-owned action a gate exemption. Comparing the
+    removed against the added targets is what makes a swapped action, a newly
+    introduced action, or a removed one substantive again. Pairing is per hunk
+    so a genuine bump in one hunk cannot vouch for a swap in another.
     """
+    hunks: list[tuple[list[str], list[str]]] = [([], [])]
     for line in diff_output.splitlines():
+        if line.startswith("@@"):
+            hunks.append(([], []))
+            continue
         if not line or line[0] not in "+-":
             continue
         # Skip the +++ / --- extended file headers; they are not content.
         if line.startswith(("+++", "---")):
             continue
-        if not _USES_PIN_LINE.match(line[1:]):
+        target = _uses_pin_target(line[1:])
+        if target is None:
+            return False
+        hunks[-1][0 if line[0] == "-" else 1].append(target)
+
+    for removed, added in hunks:
+        if sorted(removed) != sorted(added):
             return False
     return True
 

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -17,6 +17,12 @@ Two layers:
                  a rule by matching a require_doc glob; a renamed, copied, or
                  deleted require_doc does NOT count.
 
+  A workflow-file modification whose diff changes only `uses: <action>@<ref>`
+  pins -- a pure version bump, as a dependency bot produces -- is treated as
+  non-structural, so it does not trip the contributor-skill rule on its own.
+  Any other changed line in the same file keeps the change substantive,
+  regardless of author (the exemption is content-based, not identity-based).
+
 Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
 editing the TOML, no changes to this file required.
 
@@ -304,10 +310,47 @@ def _is_test_path(path: str) -> bool:
     )
 
 
+# A `uses:` pin line as it appears in a workflow file, after the diff's leading
+# +/- marker has been stripped: optional indent, an optional YAML list marker
+# (- or *), then `uses: <owner>/<repo>@<ref>`. The ref excludes whitespace and
+# `#` so a trailing comment (e.g. `@<sha>  # v2.6.1`) does not poison the match.
+# A `uses:` without an `@<ref>` (a non-pinned or local action) is NOT a pin
+# line and keeps the change substantive.
+_USES_PIN_LINE = re.compile(r"^\s*[-*]?\s*uses:\s+[^@\s]+@[^@\s#]+")
+
+
+def _path_diff_is_uses_pin_only(diff_output: str) -> bool:
+    """True iff every content line in `git diff --unified=0` output is a
+    `uses: <action>@<ref>` pin bump.
+
+    A dependency-bot version bump changes nothing but the `@ref` on existing
+    `uses:` lines -- e.g. `uses: actions/checkout@v4` -> `@v5`. Such a change
+    does not alter CI behaviour, packaging, or contribution rules, so it must
+    not trip the contributor-skill rule even though the file lives under
+    `.github/workflows/`.
+
+    Any other changed line -- a new step, an altered `with:` input, a `name:`
+    tweak, an environment change -- makes this False, so a substantive workflow
+    rewrite still fails the gate without a trailer. Author is irrelevant: a
+    human who also changes only pins is exempt, and a bot that rewrites steps
+    is not -- the decision is content-based, not identity-based.
+    """
+    for line in diff_output.splitlines():
+        if not line or line[0] not in "+-":
+            continue
+        # Skip the +++ / --- extended file headers; they are not content.
+        if line.startswith(("+++", "---")):
+            continue
+        if not _USES_PIN_LINE.match(line[1:]):
+            return False
+    return True
+
+
 def evaluate_rules(
     changed_status: list[tuple[str, str]],
     commit_messages: list[str],
     config: dict,
+    pin_only_paths: set[str] | None = None,
 ) -> list[str]:
     """Layer B: run every configured rule against a changeset.
 
@@ -322,9 +365,15 @@ def evaluate_rules(
     Test paths are never structural and are always excluded.
     commit_messages: full text of each commit message in range (empty list
     when there is no finalized commit yet, i.e. --staged mode).
+    pin_only_paths: paths whose modification changes only `uses:` action pins
+    (a dependency-bot version bump); these are not structural and so never
+    trigger a rule. Computed by _collect_pin_only_paths from the live diff.
     """
     trailer = get_trailer(config)
     rules = config.get("rules", [])
+
+    if pin_only_paths is None:
+        pin_only_paths = set()
 
     all_paths = [path for status, path in changed_status if status in ("A", "M")]
 
@@ -346,6 +395,7 @@ def evaluate_rules(
             path for status, path in changed_status
             if (status in ("A", "D", "R", "C") or (on_modify and status == "M"))
             and not _is_test_path(path)
+            and path not in pin_only_paths
         ]
 
         triggered = any(_match_any(p, when_changed) for p in rule_structural_paths)
@@ -427,6 +477,38 @@ def _git_commits_with_messages(base_ref: str) -> list[tuple[str, str, str]]:
     return commits
 
 
+def _collect_pin_only_paths(
+    changed: list[tuple[str, str]], base_ref: str | None = None
+) -> set[str]:
+    """Return the subset of MODIFIED (status M) workflow files whose diff
+    against `base_ref` changes only `uses: <action>@<ref>` pins.
+
+    When `base_ref` is None the diff is read from the staged index (--cached),
+    used by the pre-commit / commit-msg hooks; otherwise it is the
+    `<base_ref>...HEAD` range used by CI. Only `.github/workflows/` files are
+    inspected: those are the only paths the contributor-skill structural rule
+    matches, and a pin-only change is meaningless for `pyproject.toml` or
+    `CONTRIBUTING.md`, which are always re-evaluated by the rule.
+
+    A git failure diffing a single path is treated as "not known to be
+    pin-only" (that path is skipped), never as a gate failure: a workflow
+    change that cannot be inspected is re-evaluated by the rule as-is, which
+    is the fail-closed side. Author is never consulted.
+    """
+    pin_only: set[str] = set()
+    range_arg = "--cached" if base_ref is None else f"{base_ref}...HEAD"
+    for status, path in changed:
+        if status != "M" or not path.startswith(".github/workflows/"):
+            continue
+        try:
+            diff = _run_git(["diff", "--unified=0", range_arg, "--", path], ref=base_ref)
+        except GitCommandError:
+            continue
+        if _path_diff_is_uses_pin_only(diff):
+            pin_only.add(path)
+    return pin_only
+
+
 def _log_trailer_usage(commits: list[tuple[str, str, str]], trailer: str) -> None:
     """Print a log line for each commit that carries a non-empty trailer."""
     for commit_hash, author, message in commits:
@@ -498,7 +580,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"doc-gate: git error: {e}", file=sys.stderr)
         return EXIT_GIT_ERROR
 
-    failures = evaluate_rules(changed, commit_messages, config)
+    # A workflow-file change that only bumps `uses:` action pins (a dependabot
+    # version bump) is not a contribution-rules change: detect it here, against
+    # the live diff, so bot-authored bumps can go green without a trailer that
+    # the bot cannot author. Author is NOT consulted -- a substantive edit by
+    # any identity is still red.
+    pin_only_paths = _collect_pin_only_paths(changed, args.base)
+
+    failures = evaluate_rules(changed, commit_messages, config, pin_only_paths=pin_only_paths)
     return _report(failures)
 
 

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -904,3 +904,236 @@ class TestGitHooksTrailerEnforcement:
             cwd=repo, capture_output=True,
         )
         assert result.returncode != 0, "Commit should have failed with empty trailer"
+
+
+CONTRIBUTOR_SKILL_CONFIG = {
+    "gate": {"trailer": "Docs-Reviewed:"},
+    "rules": [
+        {
+            "name": "contributor-skill",
+            "on_modify": True,
+            "when_changed": [".github/workflows/*.yml", "pyproject.toml", "CONTRIBUTING.md"],
+            "require_doc": [".claude/skills/taos-development-skill/*.md", "docs/*.md"],
+            "hint": "CI, packaging or contribution rules changed; review the contributor skill and docs",
+        }
+    ],
+}
+
+
+class TestUsesPinOnlyDiff:
+    """Content-based detection of a pure `uses:` action-pin version bump."""
+
+    def test_pin_bump_diff_is_pin_only(self):
+        """The exact shape of the #2507 dependabot bump: v7 -> v9 on one line."""
+        diff = (
+            "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml\n"
+            "--- a/.github/workflows/ci.yml\n"
+            "+++ b/.github/workflows/ci.yml\n"
+            "@@ -42,1 +42,1 @@\n"
+            "-        uses: actions/github-script@v7\n"
+            "+        uses: actions/github-script@v9\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is True
+
+    def test_two_parallel_pin_bumps_are_pin_only(self):
+        diff = (
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: actions/checkout@v5\n"
+            "-      - uses: actions/setup-python@v4\n"
+            "+      - uses: actions/setup-python@v5\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is True
+
+    def test_sha_pin_with_trailing_comment_is_pin_only(self):
+        """A SHA pin carrying a `# vX` comment is still just a pin line."""
+        diff = (
+            "-        uses: org/action@1111111111111111111111111111111111111111  # v2.6.1\n"
+            "+        uses: org/action@2222222222222222222222222222222222222222  # v2.6.1\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is True
+
+    def test_new_step_makes_diff_substantive(self):
+        diff = (
+            "--- a/.github/workflows/ci.yml\n"
+            "+++ b/.github/workflows/ci.yml\n"
+            "@@ -10,1 +10,2 @@\n"
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: actions/checkout@v5\n"
+            "+      - run: echo bye\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_adding_a_with_input_is_substantive(self):
+        diff = (
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: actions/checkout@v5\n"
+            "+          persist-credentials: false\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_non_pinned_uses_is_substantive(self):
+        """A `uses:` with no @ref is not a pin; changing it is substantive."""
+        diff = (
+            "-        uses: actions/checkout\n"
+            "+        uses: actions/checkout@v5\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_empty_diff_is_vacuously_pin_only(self):
+        assert dg._path_diff_is_uses_pin_only("") is True
+
+
+class TestEvaluateRulesPinOnlyPaths:
+    """The CONTRIBUTOR-SKILL half of #2507: a version-only workflow bump is
+    exempt, a substantive workflow edit is not -- regardless of author.
+
+    The exemption is content-based (driven by a caller-computed pin_only_paths
+    set), so evaluate_rules itself never inspects identity.
+    """
+
+    WF = ".github/workflows/distrust-green-gate.yml"
+
+    def test_version_only_bump_goes_green_without_trailer(self):
+        """RED -> GREEN: a version-only workflow change marked pin-only trips no
+        rule, so no Docs-Reviewed trailer is needed."""
+        changed = [("M", self.WF)]
+        failures = dg.evaluate_rules(
+            changed, [], CONTRIBUTOR_SKILL_CONFIG, pin_only_paths={self.WF}
+        )
+        assert failures == []
+
+    def test_substantive_workflow_edit_is_red_without_trailer(self):
+        """GREEN must not go inert: a substantive (non-pin) workflow edit still
+        fails without a trailer."""
+        changed = [("M", self.WF)]
+        failures = dg.evaluate_rules(
+            changed, [], CONTRIBUTOR_SKILL_CONFIG, pin_only_paths=set()
+        )
+        assert len(failures) == 1
+        assert "contributor-skill" in failures[0]
+
+    def test_substantive_bot_edit_is_red_without_trailer(self):
+        """The escape hatch is NOT identity-based: a bot (or any author) making a
+        substantive workflow edit still fails without a trailer."""
+        changed = [("M", self.WF)]
+        messages = ["chore: edit workflow\n\nSigned-off-by: dependabot[bot] <x@x.com>\n"]
+        failures = dg.evaluate_rules(
+            changed, messages, CONTRIBUTOR_SKILL_CONFIG, pin_only_paths=set()
+        )
+        assert len(failures) == 1
+        assert "contributor-skill" in failures[0]
+
+    def test_default_pin_only_paths_keeps_rule_firing(self):
+        """Omitting pin_only_paths (the pre-fix behaviour) still fails a bare M."""
+        changed = [("M", self.WF)]
+        failures = dg.evaluate_rules(changed, [], CONTRIBUTOR_SKILL_CONFIG)
+        assert len(failures) == 1
+        assert "contributor-skill" in failures[0]
+
+    def test_added_workflow_file_is_not_exempt(self):
+        """A brand-new (status A) workflow file is substantive even if its only
+        lines are `uses:` pins -- pin-only detection is M-only."""
+        changed = [("A", ".github/workflows/new-ci.yml")]
+        failures = dg.evaluate_rules(changed, [], CONTRIBUTOR_SKILL_CONFIG)
+        assert len(failures) == 1
+        assert "contributor-skill" in failures[0]
+
+
+class TestEndToEndPinOnlyWorkflowBump:
+    """End-to-end over a real temp git repo, exercising `diff-gate --base` with
+    the live diff and the live pin-only detection (no mocking of git).
+
+    A dependabot-style version-only bump (no Docs-Reviewed trailer) goes GREEN;
+    a substantive workflow edit by a human still goes RED (#2507).
+    """
+
+    CONTRIBUTOR_CONFIG = (
+        '[gate]\ntrailer = "Docs-Reviewed:"\n\n'
+        '[[rules]]\n'
+        'name = "contributor-skill"\n'
+        'on_modify = true\n'
+        'when_changed = [".github/workflows/*.yml", "pyproject.toml", "CONTRIBUTING.md"]\n'
+        'require_doc = [".claude/skills/taos-development-skill/*.md", "docs/*.md"]\n'
+        'hint = "CI, packaging or contribution rules changed"\n'
+    )
+
+    def _setup_repo(self, tmp_path: Path) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        wf_dir = repo / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "ci.yml").write_text(
+            "name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n"
+            "    steps:\n      - uses: actions/checkout@v4\n"
+        )
+        docs_dir = repo / "docs"
+        docs_dir.mkdir()
+        config_path = docs_dir / "doc-gate.toml"
+        config_path.write_text(self.CONTRIBUTOR_CONFIG)
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "dev@example.com"], cwd=repo, check=True
+        )
+        subprocess.run(["git", "config", "user.name", "dev"], cwd=repo, check=True)
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        return repo, config_path
+
+    def test_version_only_bump_is_green(self, tmp_path: Path, monkeypatch):
+        repo, cfg = self._setup_repo(tmp_path)
+        wf = repo / ".github" / "workflows" / "ci.yml"
+        wf.write_text(wf.read_text().replace("actions/checkout@v4", "actions/checkout@v5"))
+        # Author it like the bot that actually produces these bumps.
+        subprocess.run(
+            ["git", "-c", "user.name=dependabot[bot]", "-c", "user.email=bot@bot", "add", "."],
+            cwd=repo, check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "chore(deps): bump actions/checkout from 4 to 5"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = dg.main(["--config", str(cfg), "diff-gate", "--base", "HEAD~1"])
+        assert rc == dg.EXIT_OK
+
+    def test_version_only_bump_is_green_staged(self, tmp_path: Path, monkeypatch):
+        """The pre-commit/commit-msg hooks run `diff-gate --staged`; the same
+        exemption must apply there so a local version-only bump is not wedged."""
+        repo, cfg = self._setup_repo(tmp_path)
+        wf = repo / ".github" / "workflows" / "ci.yml"
+        wf.write_text(wf.read_text().replace("actions/checkout@v4", "actions/checkout@v5"))
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = dg.main(["--config", str(cfg), "diff-gate", "--staged"])
+        assert rc == dg.EXIT_OK
+
+    def test_substantive_workflow_change_is_red_staged(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        repo, cfg = self._setup_repo(tmp_path)
+        wf = repo / ".github" / "workflows" / "ci.yml"
+        wf.write_text(wf.read_text() + "      - run: echo bye\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = dg.main(["--config", str(cfg), "diff-gate", "--staged"])
+        assert rc == dg.EXIT_VIOLATION
+        assert "contributor-skill" in capsys.readouterr().out
+
+    def test_substantive_workflow_change_is_red(self, tmp_path: Path, monkeypatch, capsys):
+        """A substantive (non-pin) workflow edit by a human still fails the gate
+        under the real --base diff path."""
+        repo, cfg = self._setup_repo(tmp_path)
+        wf = repo / ".github" / "workflows" / "ci.yml"
+        wf.write_text(wf.read_text() + "      - run: echo bye\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "human edit: add a run step"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        monkeypatch.setattr(dg, "REPO_ROOT", repo)
+        rc = dg.main(["--config", str(cfg), "diff-gate", "--base", "HEAD~1"])
+        assert rc == dg.EXIT_VIOLATION
+        assert "contributor-skill" in capsys.readouterr().out

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -979,6 +979,50 @@ class TestUsesPinOnlyDiff:
         )
         assert dg._path_diff_is_uses_pin_only(diff) is False
 
+    def test_action_target_replacement_is_substantive(self):
+        """A swapped action TARGET must never be exempt (supply-chain swap).
+
+        Both sides are syntactically `uses: <x>@<ref>` pin lines, so a
+        per-line classifier calls this a pin bump and lets an attacker-owned
+        action through the gate. Only pairing removed with added entries
+        catches it.
+        """
+        diff = (
+            "@@ -10,1 +10,1 @@\n"
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: attacker/checkout@v1\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_target_replacement_keeping_the_ref_is_substantive(self):
+        """Same ref, different owner — the ref alone proves nothing."""
+        diff = (
+            "@@ -10,1 +10,1 @@\n"
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: evil/checkout@v4\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_real_bump_in_one_hunk_does_not_launder_a_swap_in_another(self):
+        """A genuine bump must not vouch for a target swap elsewhere."""
+        diff = (
+            "@@ -10,1 +10,1 @@\n"
+            "-        uses: actions/checkout@v4\n"
+            "+        uses: actions/checkout@v5\n"
+            "@@ -40,1 +40,1 @@\n"
+            "-        uses: actions/setup-python@v4\n"
+            "+        uses: attacker/setup-python@v4\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
+    def test_added_pin_line_without_a_removed_counterpart_is_substantive(self):
+        """A brand-new action added to the file is not a version bump."""
+        diff = (
+            "@@ -10,0 +11,1 @@\n"
+            "+        uses: actions/cache@v4\n"
+        )
+        assert dg._path_diff_is_uses_pin_only(diff) is False
+
     def test_empty_diff_is_vacuously_pin_only(self):
         assert dg._path_diff_is_uses_pin_only("") is True
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): doc-gate blocks every dependabot workflow bump: the waiver is a commit trailer the bot cannot write

Autonomous build of board card tsk-4gkzrj.

A dependabot workflow version bump changes only `uses: <action>@<ref>` pins,
but it tripped the contributor-skill rule with no way to clear it, since
dependabot cannot author the Docs-Reviewed trailer. check_doc_gate now treats
a workflow-file diff that changes only `uses:` pins as non-structural, so
such bumps go green on their own. The exemption is content-based, not
identity-based: a substantive workflow edit by any author still fails without
a trailer.

- scripts/check_doc_gate.py: add _path_diff_is_uses_pin_only and
  _collect_pin_only_paths; evaluate_rules takes pin_only_paths and excludes
  them from structural detection; wired into main for both --base and --staged.
- tests/test_doc_gate.py: detection, evaluate_rules, and end-to-end --base
  and --staged coverage (version-only green, substantive red, bot author not
  exempted).
- docs/doc-gate.toml: note on the contributor-skill exemption.
- changelog.d/tsk-4gkzrj-doc-gate-workflow-pin-bump.md.

Proof: uv run --group dev pytest tests/test_doc_gate.py tests/test_check_doc_gate.py -q
129 passed. Reproducing #2507 against dependabot commit a3ab38e1 now exits 0
instead of 1.

Files:
 .../tsk-4gkzrj-doc-gate-workflow-pin-bump.md       |   3 +
 docs/doc-gate.toml                                 |   5 +
 scripts/check_doc_gate.py                          |  91 +++++++-
 tests/test_doc_gate.py                             | 233 +++++++++++++++++++++
 4 files changed, 331 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub Actions updates that only change existing action version pins can now pass the documentation gate without a documentation-review trailer.
  * Action swaps, added or removed actions, and other substantive workflow edits continue to require documentation review.
* **Documentation**
  * Clarified documentation-gate behavior for dependency-only workflow pin updates.
* **Tests**
  * Added coverage for pin updates, SHA pins, staged changes, and substantive workflow edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->