### PR TITLE
fix(assistant-studio): confirm before changing the assigned PA

### DIFF
--- a/changelog.d/assistant-studio-pa-confirm.md
+++ b/changelog.d/assistant-studio-pa-confirm.md
@@ -1,4 +1,4 @@
 - Assistant Studio now asks before changing your assigned personal assistant.
   Notes, tasks, calendar and deliverables are all scoped to the assigned PA, so
   an accidental pick in the dropdown used to re-scope the whole workspace with
-  no way to notice. First-time assignment is unaffected.
+  no way to notice. First-time assignment is unaffected (#2569).

--- a/changelog.d/assistant-studio-pa-confirm.md
+++ b/changelog.d/assistant-studio-pa-confirm.md
@@ -1,0 +1,4 @@
+- Assistant Studio now asks before changing your assigned personal assistant.
+  Notes, tasks, calendar and deliverables are all scoped to the assigned PA, so
+  an accidental pick in the dropdown used to re-scope the whole workspace with
+  no way to notice. First-time assignment is unaffected.

--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -137,16 +137,22 @@ describe("PA change confirmation", () => {
   });
 
   it("does NOT prompt when there is no PA yet — nothing to move away from", async () => {
-    // The agents fetch failing leaves the picker with no auto-defaulted PA, so
-    // `pa` is empty. Selecting from that state is a first assignment, not a
+    // Assigning a PA from an empty selection is a first assignment, not a
     // change, and must not interrupt the user.
-    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => [] })));
-    render(<AssistantStudioApp />);
-    const select = await screen.findByLabelText(
-      "Select the agent to act as your personal assistant",
-    );
+    //
+    // This has to reach the picker with `pa` EMPTY and then choose a REAL
+    // agent. Selecting the empty option on its own returns through the `!name`
+    // branch, so a test that stops there still passes with the
+    // first-assignment guard deleted — it asserts nothing. Clearing first and
+    // then picking "atlas" is the only path that runs through `!pa`, and it
+    // goes red if that guard is removed.
+    localStorage.setItem("taos.assistantStudio.pa", "hermes");
+    const select = await openStudio();
+
     fireEvent.change(select, { target: { value: "" } });
+    fireEvent.change(select, { target: { value: "atlas" } });
 
     expect(screen.queryByRole("dialog")).toBeNull();
+    expect(localStorage.getItem("taos.assistantStudio.pa")).toBe("atlas");
   });
 });

--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -73,3 +73,80 @@ describe("AssistantStudioApp", () => {
     expect(screen.getByText("hello journal")).toBeInTheDocument();
   });
 });
+
+describe("PA change confirmation", () => {
+  const agents = [
+    { name: "hermes", display_name: "Hermes" },
+    { name: "atlas", display_name: "Atlas" },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        String(url).includes("/api/agents")
+          ? { ok: true, json: async () => agents }
+          : { ok: true, json: async () => [] },
+      ),
+    );
+  });
+
+  async function openStudio() {
+    render(<AssistantStudioApp />);
+    return await screen.findByLabelText(
+      "Select the agent to act as your personal assistant",
+    );
+  }
+
+  it("does NOT commit the change until it is confirmed", async () => {
+    localStorage.setItem("taos.assistantStudio.pa", "hermes");
+    const select = await openStudio();
+
+    fireEvent.change(select, { target: { value: "atlas" } });
+
+    // The dialog is up and the stored PA is still the old one. This is the
+    // assertion that goes red if the guard is removed: without it, the change
+    // is written to localStorage synchronously on change.
+    expect(
+      screen.getByRole("dialog", { name: /change your personal assistant/i }),
+    ).toBeTruthy();
+    expect(localStorage.getItem("taos.assistantStudio.pa")).toBe("hermes");
+  });
+
+  it("keeps the old PA when cancelled", async () => {
+    localStorage.setItem("taos.assistantStudio.pa", "hermes");
+    const select = await openStudio();
+
+    fireEvent.change(select, { target: { value: "atlas" } });
+    fireEvent.click(screen.getByText("Keep current PA"));
+
+    expect(localStorage.getItem("taos.assistantStudio.pa")).toBe("hermes");
+    expect((select as HTMLSelectElement).value).toBe("hermes");
+  });
+
+  it("applies the new PA when confirmed", async () => {
+    localStorage.setItem("taos.assistantStudio.pa", "hermes");
+    const select = await openStudio();
+
+    fireEvent.change(select, { target: { value: "atlas" } });
+    fireEvent.click(screen.getByText("Change PA"));
+
+    expect(localStorage.getItem("taos.assistantStudio.pa")).toBe("atlas");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("does NOT prompt when there is no PA yet — nothing to move away from", async () => {
+    // The agents fetch failing leaves the picker with no auto-defaulted PA, so
+    // `pa` is empty. Selecting from that state is a first assignment, not a
+    // change, and must not interrupt the user.
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => [] })));
+    render(<AssistantStudioApp />);
+    const select = await screen.findByLabelText(
+      "Select the agent to act as your personal assistant",
+    );
+    fireEvent.change(select, { target: { value: "" } });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/desktop/src/apps/AssistantStudioApp.tsx
+++ b/desktop/src/apps/AssistantStudioApp.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { ConfirmDialog } from "../components/ConfirmDialog";
 import {
   LayoutDashboard,
   NotebookPen,
@@ -138,6 +139,28 @@ export function AssistantStudioApp({ windowId: _windowId }: { windowId: string }
     localStorage.setItem(PA_KEY, name);
   };
 
+  const labelFor = useCallback(
+    (name: string) => {
+      const a = agents.find((x) => x.name === name);
+      return a?.display_name || a?.handle || name;
+    },
+    [agents],
+  );
+
+  // Every surface in this app is scoped to the assigned PA, so changing it
+  // swaps the whole workspace at once. Confirm first — but only for a real
+  // CHANGE: the first assignment has no previous PA to move away from, so
+  // interrupting it would be a prompt with nothing at stake.
+  const [pendingPa, setPendingPa] = useState<string | null>(null);
+
+  const requestPaChange = (name: string) => {
+    if (!name || name === pa || !pa) {
+      choosePa(name);
+      return;
+    }
+    setPendingPa(name);
+  };
+
   const paAgent = useMemo(
     () => agents.find((a) => a.name === pa),
     [agents, pa],
@@ -146,6 +169,25 @@ export function AssistantStudioApp({ windowId: _windowId }: { windowId: string }
 
   return (
     <div className="flex h-full w-full bg-zinc-950 text-zinc-100">
+      {/* Not `danger`: switching PA is reversible and deletes nothing, so a red
+          destructive button would overstate it. The point is that the change is
+          easy to make by accident and re-scopes every panel at once. */}
+      <ConfirmDialog
+        open={pendingPa !== null}
+        title="Change your personal assistant?"
+        message={
+          `Notes, tasks, calendar and deliverables here are all scoped to the assigned PA. ` +
+          `Switching from ${labelFor(pa)} to ${labelFor(pendingPa ?? "")} moves the whole ` +
+          `workspace over to ${labelFor(pendingPa ?? "")}. Nothing is deleted, and you can switch back.`
+        }
+        confirmLabel="Change PA"
+        cancelLabel="Keep current PA"
+        onConfirm={() => {
+          if (pendingPa) choosePa(pendingPa);
+          setPendingPa(null);
+        }}
+        onCancel={() => setPendingPa(null)}
+      />
       {/* Left rail */}
       <nav
         className="flex w-44 flex-shrink-0 flex-col border-r border-zinc-800 bg-zinc-900/60"
@@ -189,7 +231,7 @@ export function AssistantStudioApp({ windowId: _windowId }: { windowId: string }
           <select
             id="pa-select"
             value={pa}
-            onChange={(e) => choosePa(e.target.value)}
+            onChange={(e) => requestPaChange(e.target.value)}
             className="w-full rounded bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100 border border-zinc-700 focus:border-sky-500 outline-none"
             aria-label="Select the agent to act as your personal assistant"
           >


### PR DESCRIPTION
Jay asked for a confirmation dialogue when changing the assigned PA.

**The problem.** Every surface in Assistant Studio — notes, tasks, calendar, deliverables — is scoped to the assigned PA, but the picker called `choosePa` straight from `onChange` and wrote to `localStorage` immediately. A mis-click re-scoped the entire workspace to a different agent with nothing to signal it had happened.

**The change.** The picker now routes through the shared `ConfirmDialog` rather than a new modal — it already handles focus trapping, Escape and backdrop dismissal, so this adds no new a11y surface to get wrong. The `<select>` is controlled, so cancelling reverts it to the current PA on its own.

Two deliberate calls:
- **Only a real change prompts.** The first assignment has no previous PA to move away from, so prompting there would be a dialog with nothing at stake.
- **Not styled as destructive.** Switching PA is reversible and deletes nothing; a red button would overstate it. The message says so explicitly.

**Verification.** 8 passed in `AssistantStudioApp.test.tsx`; `tsc -b` clean (rc captured directly). Mutation-checked: restoring the direct `choosePa` call on change reds **exactly** the three confirmation tests, while the no-PA-yet test stays green because it does not depend on the guard.

**Note for @jaylfc, not addressed here:** the Assistant Studio re-skin onto the taOS design system has never been done — card `tsk-pftmwh` is open at **p0**, which is the very bottom of a board whose live top is 97, so it will never dispatch where it sits. This PR deliberately matches the app's existing zinc/sky styling rather than half-re-skinning one control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when switching an assigned personal assistant.
  * The dialog identifies the affected workspace and lets you confirm or cancel the change.
  * Initial assignment and reselecting the current or empty assistant remain immediate.

* **Bug Fixes**
  * Canceling a switch preserves the currently assigned personal assistant.
  * Changes are saved only after confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->