### PR TITLE
Password reset S1 (re-cut of tsk-ycfske): ONE PasswordResetStore written fresh against origin/dev - store only, decisions pre-resolved

### DIFF
--- a/changelog.d/tsk-36llua-password-reset-store.md
+++ b/changelog.d/tsk-36llua-password-reset-store.md
@@ -1,0 +1,3 @@
+### Added
+
+- Password reset foundation: a server-side `PasswordResetStore` (`tinyagentos/password_reset_store.py`) that mints cryptographically-random reset tokens, persists only their SHA-256 hash (never the plaintext), enforces a 30-minute TTL, consumes tokens with one atomic `UPDATE ... WHERE used=0` to defeat double-spend races, invalidates a user's prior outstanding tokens when a new one is minted, and is wired on `app.state.password_reset` via the real app factory.

--- a/tests/test_password_reset_store.py
+++ b/tests/test_password_reset_store.py
@@ -1,0 +1,176 @@
+"""PasswordResetStore tests.
+
+These reach the store ONLY through the real ``create_app`` factory wiring
+(``app.state.password_reset``), never by constructing ``PasswordResetStore``
+directly for the behaviour under test. Constructing a bare instance is used
+in exactly one place -- ``test_uninitialised_store_raises`` -- to prove the
+guard on an uninitialised store; that is the narrow exception, not the rule.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from tinyagentos.app import create_app
+from tinyagentos.password_reset_store import PasswordResetStore
+
+
+def _hash(token: str) -> str:
+    """Reproduce the store's token hash (sha256) so tests can address a
+    token's row. Mirrors what the /api/password route does: hash inline, no
+    method dependency on the store under test."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+@pytest_asyncio.fixture
+async def password_store(app):
+    """Reach the store through the real app factory wiring."""
+    store = app.state.password_reset
+    await store.init()
+    yield store
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# (a) DOUBLE-SPEND: two concurrent consumes, exactly one wins -- proven by a
+# race, not by calling them in sequence. The atomic UPDATE ... WHERE used=0
+# must lose the second one.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_double_spend_allows_exactly_one(password_store):
+    token = await password_store.mint("user-1")
+    token_hash = _hash(token)
+
+    # Gather runs both consumes against the SAME store concurrently; the
+    # conditional UPDATE is the only thing that can make this lose one.
+    results = await asyncio.gather(
+        password_store.consume(token_hash),
+        password_store.consume(token_hash),
+    )
+    successes = sum(1 for ok in results if ok)
+    assert successes == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) LOOKUP by token_hash ALONE -- never by an empty/placeholder user_id.
+# A reset flow is unauthenticated, so the caller has no user_id to supply.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_without_user_id(password_store):
+    token = await password_store.mint("the-real-user")
+    token_hash = _hash(token)
+
+    row = await password_store.get_by_token_hash(token_hash)
+    assert row is not None
+    assert row["user_id"] == "the-real-user"
+    assert row["used"] == 0
+    assert "token_hash" in row and row["token_hash"] == token_hash
+
+
+# ---------------------------------------------------------------------------
+# (c) PRIOR-TOKEN INVALIDATION: a freshly minted token kills the user's
+# earlier unused token.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prior_token_invalidation(password_store):
+    first = await password_store.mint("user-1")
+    second = await password_store.mint("user-1")
+    h1 = _hash(first)
+    h2 = _hash(second)
+
+    # Minting `second` invalidated `first` atomically.
+    assert await password_store.is_valid(h1) is False
+    assert await password_store.consume(h1) is False
+
+    # The newer token must still be good and consumable.
+    assert await password_store.is_valid(h2) is True
+    assert await password_store.consume(h2) is True
+
+
+# ---------------------------------------------------------------------------
+# (d) NO PLAINTEXT: the minted token value never appears in the stored row.
+# Asserted on the DB contents (an independent connection), not the return.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_plaintext(password_store, tmp_data_dir):
+    token = await password_store.mint("user-1")
+    token_hash = _hash(token)
+
+    # Independent connection -- does not go through the store's API at all.
+    async with aiosqlite.connect(str(password_store.db_path)) as db:
+        row = await (
+            await db.execute("SELECT * FROM password_resets")
+        ).fetchone()
+    assert row is not None
+    stored = " ".join("" if v is None else str(v) for v in row)
+
+    assert token_hash in stored       # the hash IS persisted
+    assert token not in stored        # the plaintext is NOT persisted anywhere
+
+
+# ---------------------------------------------------------------------------
+# Correctness guards (green on both the defective and correct shapes, so they
+# do not pollute the defect-specific red window).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_valid_then_consumed(password_store):
+    token = await password_store.mint("user-1")
+    h = _hash(token)
+
+    assert await password_store.is_valid(h) is True
+    assert await password_store.consume(h) is True
+    assert await password_store.is_valid(h) is False
+    assert await password_store.consume(h) is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_is_invalid(password_store):
+    assert await password_store.is_valid("does-not-exist") is False
+    assert await password_store.consume("does-not-exist") is False
+
+
+@pytest.mark.asyncio
+async def test_expired_token_is_invalid(password_store):
+    token = await password_store.mint("user-1", ttl_seconds=0)
+    h = _hash(token)
+
+    assert await password_store.is_valid(h) is False
+    assert await password_store.consume(h) is False
+
+
+@pytest.mark.asyncio
+async def test_mint_invalidates_only_self_user(password_store):
+    other_first = await password_store.mint("user-other")
+    mine = await password_store.mint("user-mine")
+    _more = await password_store.mint("user-mine")  # invalidates `mine`
+
+    # Another user's token is untouched by our new mint.
+    assert await password_store.is_valid(_hash(other_first)) is True
+    # Our earlier token was invalidated by the re-mint.
+    assert await password_store.is_valid(_hash(mine)) is False
+
+
+@pytest.mark.asyncio
+async def test_uninitialised_store_raises(tmp_path):
+    store = PasswordResetStore(tmp_path / "password_resets.db")
+    with pytest.raises(RuntimeError, match="init"):
+        await store.is_valid("x")
+    with pytest.raises(RuntimeError, match="init"):
+        await store.consume("x")
+    with pytest.raises(RuntimeError, match="init"):
+        await store.mint("user-1")
+    await store.close()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -283,6 +283,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     from tinyagentos.auth_requests_store import AuthRequestsStore
     auth_requests_store = AuthRequestsStore(data_dir / "auth_requests.db")
+    from tinyagentos.password_reset_store import PasswordResetStore
+    password_reset_store = PasswordResetStore(data_dir / "password_resets.db")
     from tinyagentos.agent_scope_requests_store import AgentScopeRequestsStore
     agent_scope_requests_store = AgentScopeRequestsStore(data_dir / "agent_scope_requests.db")
     from tinyagentos.agent_grants_store import AgentGrantsStore
@@ -532,6 +534,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state._startup_complete = False
         await agent_registry_store.init()
         await auth_requests_store.init()
+        await password_reset_store.init()
         await agent_scope_requests_store.init()
         await agent_grants_store.init()
         app.state.agent_grants = agent_grants_store
@@ -1545,6 +1548,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await license_acceptances_store.close()
         await agent_model_key_store.close()
         await auth_requests_store.close()
+        await password_reset_store.close()
         await cluster_pairing_store.close()
         await agent_registry_store.close()
         await github_identities_store.close()
@@ -1769,6 +1773,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.agent_registry_keypair = agent_registry_keypair
     app.state.agent_model_keys = agent_model_key_store
     app.state.auth_requests = auth_requests_store
+    app.state.password_reset = password_reset_store
     app.state.agent_scope_requests = agent_scope_requests_store
     app.state.agent_grants = agent_grants_store
     app.state.app_grants = app_grants_store

--- a/tinyagentos/password_reset_store.py
+++ b/tinyagentos/password_reset_store.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+"""SQLite-backed store for password-reset tokens.
+
+Token lifecycle:
+
+  - ``mint`` generates a cryptographically-random reset token, persists ONLY
+    its SHA-256 hash, and returns the plaintext token once so the caller (the
+    ``POST /api/password/request`` route plus the SMTP slice) can deliver it
+    out-of-band. The plaintext token never touches the database and is never
+    logged.
+
+  - ``get_by_token_hash`` resolves a token by hash ALONE (no ``user_id``).
+    A reset flow is unauthenticated, so the caller has no user identity yet;
+    the owning ``user_id`` is recovered from the token.
+
+  - ``is_valid`` checks existence, the single-use flag, and the TTL.
+
+  - ``consume`` marks a token used in ONE atomic ``UPDATE ... WHERE used=0``,
+    so two concurrent consumes cannot both win a read-then-write race.
+
+  - Minting a new token for a user atomically invalidates that user's prior
+    unused tokens (``UPDATE ... SET used=1 WHERE user_id=? AND used=0``) so a
+    re-issued link cannot be replayed.
+
+Single class, single source of truth for storage: routes must not define
+their own token storage methods.
+"""
+
+import hashlib
+import secrets
+import time
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+#: Server-side TTL for a reset token: 30 minutes. Matches the window the
+#: SMTP slice is told the link is good for; never persisted or trusted from
+#: the client.
+PASSWORD_RESET_TTL_SECONDS = 1800
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS password_resets (
+    token_hash  TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER NOT NULL,
+    used        INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_password_resets_user ON password_resets(user_id);
+"""
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    return {k: row[k] for k in row.keys()}
+
+
+class PasswordResetStore(BaseStore):
+    """Persistent store for password-reset tokens.
+
+    Exactly one place owns token storage so routes cannot drift into a
+    split-brain implementation. Tokens are stored only as SHA-256 hashes;
+    the plaintext is returned from ``mint`` for one-shot delivery and is
+    never persisted or logged.
+    """
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    @staticmethod
+    def hash_token(token: str) -> str:
+        """Return the SHA-256 hex digest of a plaintext reset token.
+
+        Shared by ``mint`` (write side) and the route that validates a token
+        supplied via the reset link, so the hashing scheme cannot drift
+        between mint and consume. The plaintext is never stored.
+        """
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def mint(
+        self,
+        user_id: str,
+        *,
+        ttl_seconds: int = PASSWORD_RESET_TTL_SECONDS,
+    ) -> str:
+        """Mint a fresh reset token for *user_id*.
+
+        Returns the plaintext token (for out-of-band delivery, e.g. email).
+        Only the SHA-256 hash is persisted. Any prior UNUSED token for this
+        user is atomically invalidated so a re-issued link cannot be
+        replayed after a new one is generated.
+        """
+        if self._db is None:
+            raise RuntimeError("PasswordResetStore not initialised -- call init() first")
+        if not user_id:
+            raise ValueError("user_id is required")
+
+        token = secrets.token_urlsafe(32)
+        token_hash = self.hash_token(token)
+        now = int(time.time())
+        expires_at = now + int(ttl_seconds)
+
+        # Invalidate prior unused tokens for this user in ONE atomic UPDATE,
+        # so a previously-issued (and possibly leaked) link is dead before the
+        # new one is handed out.
+        await self._db.execute(
+            "UPDATE password_resets SET used = 1 "
+            "WHERE user_id = ? AND used = 0",
+            (user_id,),
+        )
+        await self._db.execute(
+            "INSERT INTO password_resets "
+            "(token_hash, user_id, created_at, expires_at, used) "
+            "VALUES (?, ?, ?, ?, 0)",
+            (token_hash, user_id, now, expires_at),
+        )
+        await self._db.commit()
+        return token
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def get_by_token_hash(self, token_hash: str) -> Optional[dict]:
+        """Return the row for *token_hash*, looked up by hash ALONE.
+
+        No ``user_id`` parameter: a reset flow is unauthenticated, so the
+        caller cannot supply one. Returning the row lets the route recover the
+        owning ``user_id`` from the token itself.
+        """
+        if self._db is None:
+            raise RuntimeError("PasswordResetStore not initialised -- call init() first")
+        row = await (
+            await self._db.execute(
+                "SELECT token_hash, user_id, created_at, expires_at, used "
+                "FROM password_resets WHERE token_hash = ?",
+                (token_hash,),
+            )
+        ).fetchone()
+        return _row_to_dict(row) if row else None
+
+    async def is_valid(self, token_hash: str) -> bool:
+        """True iff the token exists, is unused, and is within its TTL."""
+        if self._db is None:
+            raise RuntimeError("PasswordResetStore not initialised -- call init() first")
+        row = await self.get_by_token_hash(token_hash)
+        if row is None:
+            return False
+        now = int(time.time())
+        return row["used"] == 0 and row["expires_at"] > now
+
+    # ------------------------------------------------------------------
+    # Consume
+    # ------------------------------------------------------------------
+
+    async def consume(self, token_hash: str) -> bool:
+        """Atomically consume a token.
+
+        ONE ``UPDATE ... WHERE used=0`` (plus the TTL guard) -- no
+        read-then-write. Returns True iff the token was still unused and
+        unexpired and is now marked used. Two concurrent consumes cannot both
+        win: the conditional UPDATE matches at most one row.
+        """
+        if self._db is None:
+            raise RuntimeError("PasswordResetStore not initialised -- call init() first")
+        now = int(time.time())
+        cur = await self._db.execute(
+            "UPDATE password_resets SET used = 1 "
+            "WHERE token_hash = ? AND used = 0 AND expires_at > ?",
+            (token_hash, now),
+        )
+        await self._db.commit()
+        return cur.rowcount > 0


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Password reset S1 (re-cut of tsk-ycfske): ONE PasswordResetStore written fresh against origin/dev - store only, decisions pre-resolved

Autonomous build of board card tsk-36llua.

Scope: ONE complete PasswordResetStore wired on app.state. No SMTP, routes,
rate limiting, session revocation, UI, or /validate -- those are follow-on
slices that will be filed separately. The store owns storage alone; no route
file defines storage methods (fix of the split-brain defect from take 2),
and lookup is by token_hash alone (fix of the empty-user_id defect from
take 2).

Red proof -- tests/test_password_reset_store.py run against a take-2-shaped
defect store (non-atomic read-then-write consume with no `WHERE used=0`
guard, and no get_by_token_hash method):

  $ uv run pytest tests/test_password_reset_store.py -q
  FAILED tests/test_password_reset_store.py::test_double_spend_allows_exactly_one
    assert 2 == 1
  FAILED tests/test_password_reset_store.py::test_lookup_without_user_id
    AttributeError: 'PasswordResetStore' object has no attribute 'get_by_token_hash'
  2 failed, 7 passed

Green -- tests run against the fresh PasswordResetStore (branch cut on
origin/dev, not on exec/tsk-nxjpju):

  $ uv run pytest tests/test_password_reset_store.py -q
  9 passed

The remaining red cases pass because take 2 already hashed tokens and
invalidated prior tokens; they are correctness guards, not defect
discriminators.

Verifications:
  $ uv run python scripts/check_store_wiring.py --base origin/dev
  store-wiring-guard: clean
  $ uv run python scripts/check_doc_gate.py diff-gate --base origin/dev
  doc-gate: clean
  $ uv run python scripts/check_schema_migrations.py
  schema-migration-guard: clean
  $ uv run python scripts/check_retrofit_migrations.py
  retrofit-migration-guard: clean
  $ uv run --no-sync python -m compileall tinyagentos/password_reset_store.py tinyagentos/app.py -q
  0

Files:
 changelog.d/tsk-36llua-password-reset-store.md |   3 +
 tests/test_password_reset_store.py             | 176 ++++++++++++++++++++++++
 tinyagentos/app.py                             |   5 +
 tinyagentos/password_reset_store.py            | 183 +++++++++++++++++++++++++
 4 files changed, 367 insertions(+)