### PR TITLE
test_routes_shortcuts.py mutates the global FRAMEWORKS dict and never restores it, so test_openclaw_shortcuts_exact fails by test ORDER

### DIFF
--- a/tests/shortcuts/test_framework_shortcuts.py
+++ b/tests/shortcuts/test_framework_shortcuts.py
@@ -4,6 +4,14 @@ from tinyagentos.frameworks import FRAMEWORKS
 from tinyagentos.shortcuts.validation import validate_shortcuts
 
 
+# Snapshot of the canonical openclaw shortcut kinds, captured at module import
+# (collection) time -- before any test runs. tsk-yjdeom: test_routes_shortcuts
+# patches FRAMEWORKS['openclaw'] in-process; this snapshot is the reference the
+# guard compares against so the assertion cannot be silently weakened by merely
+# editing a hardcoded count.
+_OPENCLAW_SHORTCUT_KINDS = [s["kind"] for s in FRAMEWORKS["openclaw"]["shortcuts"]]
+
+
 def _shortcuts(name: str) -> list:
     fw = FRAMEWORKS.get(name)
     assert fw is not None, f"Framework '{name}' not in FRAMEWORKS"
@@ -62,3 +70,27 @@ def test_shell_only_frameworks():
 def test_all_framework_shortcuts_validate(fw_name):
     """validate_shortcuts() passes without raising for every beta framework."""
     validate_shortcuts(_shortcuts(fw_name))
+
+
+# ---------------------------------------------------------------------------
+# tsk-yjdeom: order-coupled regression guard.
+#
+# ``tests/test_routes_shortcuts.py::_seed_agent`` rewrites
+# FRAMEWORKS['openclaw']['shortcuts'] in-process. Without teardown the patched
+# 2-entry list leaks across the whole session and silently breaks order-coupled
+# assertions (the symptom: ``test_openclaw_shortcuts_exact`` saw 2 where the real
+# manifest has 4). This test runs AFTER that module (same process, see the repro
+# ``pytest tests/test_routes_shortcuts.py tests/shortcuts``) and asserts the live
+# global still equals the canonical manifest captured at import time above.
+#
+# A run of ``tests/shortcuts`` ALONE cannot go red here -- that is precisely why
+# the defect stayed invisible -- so this guard is order-coupled by design.
+# Fails when the FRAMEWORKS patch is not restored on teardown.
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_shortcuts_unchanged_after_routes_shortcuts_pollution():
+    assert (
+        [s["kind"] for s in FRAMEWORKS["openclaw"]["shortcuts"]]
+        == _OPENCLAW_SHORTCUT_KINDS
+    )

--- a/tests/test_routes_shortcuts.py
+++ b/tests/test_routes_shortcuts.py
@@ -27,8 +27,15 @@ def _setup_worker_registry(monkeypatch) -> None:
     monkeypatch.setattr(wr_mod, "_active_manager", mgr)
 
 
-def _seed_agent(client, framework="openclaw", shortcuts=None):
-    """Append a test agent to app.state.config.agents and patch FRAMEWORKS."""
+def _seed_agent(client, monkeypatch, framework="openclaw", shortcuts=None):
+    """Append a test agent to app.state.config.agents and patch FRAMEWORKS.
+
+    The FRAMEWORKS entry is written through ``monkeypatch.setitem`` so the
+    process-global dict is restored on teardown -- including DELETING the key
+    when ``framework`` was absent (the old ``.get(default)`` silently invented
+    one that then leaked for the rest of the process and poisoned order-coupled
+    tests such as ``test_openclaw_shortcuts_exact``; see tsk-yjdeom).
+    """
     import uuid
 
     import tinyagentos.frameworks as fw_mod
@@ -54,7 +61,7 @@ def _seed_agent(client, framework="openclaw", shortcuts=None):
 
     original = fw_mod.FRAMEWORKS.get(framework, {"id": framework, "name": framework})
     patched_entry = {**original, "shortcuts": shortcuts}
-    fw_mod.FRAMEWORKS[framework] = patched_entry
+    monkeypatch.setitem(fw_mod.FRAMEWORKS, framework, patched_entry)
 
     agent_id = uuid.uuid4().hex[:12]
     agent = {
@@ -75,23 +82,23 @@ def _seed_agent(client, framework="openclaw", shortcuts=None):
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_returns_200(client):
-    agent = _seed_agent(client)
+async def test_list_shortcuts_returns_200(client, monkeypatch):
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.get(f"/api/agents/{agent['id']}/shortcuts")
     assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_returns_list(client):
-    agent = _seed_agent(client)
+async def test_list_shortcuts_returns_list(client, monkeypatch):
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.get(f"/api/agents/{agent['id']}/shortcuts")
     data = resp.json()
     assert isinstance(data, list)
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_admin_sees_all(client):
-    agent = _seed_agent(client)
+async def test_list_shortcuts_admin_sees_all(client, monkeypatch):
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.get(f"/api/agents/{agent['id']}/shortcuts")
     data = resp.json()
     assert len(data) == 2
@@ -110,18 +117,19 @@ async def test_list_shortcuts_unknown_agent_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_by_name(client):
-    agent = _seed_agent(client)
+async def test_list_shortcuts_by_name(client, monkeypatch):
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.get(f"/api/agents/{agent['name']}/shortcuts")
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_capability_filtered(client):
+async def test_list_shortcuts_capability_filtered(client, monkeypatch):
     """Shortcuts requiring agent.admin are not visible to a normal admin."""
     agent = _seed_agent(
         client,
+        monkeypatch,
         shortcuts=[
             {
                 "kind": "tui",
@@ -138,18 +146,18 @@ async def test_list_shortcuts_capability_filtered(client):
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_no_shortcuts_returns_empty(client):
+async def test_list_shortcuts_no_shortcuts_returns_empty(client, monkeypatch):
     """Agent with a framework that has no shortcuts returns empty list."""
-    agent = _seed_agent(client, shortcuts=[])
+    agent = _seed_agent(client, monkeypatch, shortcuts=[])
     resp = await client.get(f"/api/agents/{agent['id']}/shortcuts")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 @pytest.mark.asyncio
-async def test_list_shortcuts_does_not_expose_requires_capability(client):
+async def test_list_shortcuts_does_not_expose_requires_capability(client, monkeypatch):
     """The requires_capability field must not leak to the frontend."""
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.get(f"/api/agents/{agent['id']}/shortcuts")
     for entry in resp.json():
         assert "requires_capability" not in entry
@@ -163,7 +171,7 @@ async def test_list_shortcuts_does_not_expose_requires_capability(client):
 @pytest.mark.asyncio
 async def test_launch_shortcut_returns_redirect_url(client, monkeypatch):
     _setup_worker_registry(monkeypatch)
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.post(f"/api/agents/{agent['id']}/shortcuts/0/launch")
     assert resp.status_code == 200
     data = resp.json()
@@ -175,7 +183,7 @@ async def test_launch_shortcut_returns_redirect_url(client, monkeypatch):
 @pytest.mark.asyncio
 async def test_launch_shortcut_includes_ticket_token(client, monkeypatch):
     _setup_worker_registry(monkeypatch)
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.post(f"/api/agents/{agent['id']}/shortcuts/0/launch")
     redirect_url = resp.json()["redirect_url"]
     assert "t=" in redirect_url
@@ -184,7 +192,7 @@ async def test_launch_shortcut_includes_ticket_token(client, monkeypatch):
 @pytest.mark.asyncio
 async def test_launch_shortcut_idx_out_of_range(client, monkeypatch):
     _setup_worker_registry(monkeypatch)
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.post(f"/api/agents/{agent['id']}/shortcuts/99/launch")
     assert resp.status_code == 404
 
@@ -199,7 +207,7 @@ async def test_launch_shortcut_unknown_agent(client, monkeypatch):
 @pytest.mark.asyncio
 async def test_launch_shortcut_negative_idx(client, monkeypatch):
     _setup_worker_registry(monkeypatch)
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     resp = await client.post(f"/api/agents/{agent['id']}/shortcuts/-1/launch")
     assert resp.status_code == 404
 
@@ -215,6 +223,6 @@ async def test_launch_shortcut_no_worker_raises_error(client, monkeypatch):
     from tinyagentos.cluster import worker_registry
 
     monkeypatch.setattr(worker_registry, "_active_manager", None)
-    agent = _seed_agent(client)
+    agent = _seed_agent(client, monkeypatch)
     with pytest.raises(RuntimeError, match="No active ClusterManager"):
         await client.post(f"/api/agents/{agent['id']}/shortcuts/0/launch")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): test_routes_shortcuts.py mutates the global FRAMEWORKS dict and never restores it, so test_openclaw_shortcuts_exact fails by test ORDER

Autonomous build of board card tsk-yjdeom.

tests/test_routes_shortcuts.py::_seed_agent wrote test shortcuts into the process-global tinyagentos.frameworks.FRAMEWORKS['openclaw'] and never restored the entry. Because FRAMEWORKS is a module-level dict, the 2-element list leaked for the rest of the process and broke order-coupled tests in tests/shortcuts whenever test_routes_shortcuts ran first in one process (test_openclaw_shortcuts_exact saw 2 where the real manifest has 4).

Write the patch through monkeypatch.setitem so teardown restores the original entry -- and deletes the key when the framework was absent (the old .get(default) silently invented a key that leaked). Matches the existing _setup_worker_registry(monkeypatch) helper style. All _seed_agent call sites now pass monkeypatch.

Add order-coupled regression guard test_openclaw_shortcuts_unchanged_after_routes_shortcuts_pollution, which snapshots the canonical openclaw shortcut kinds at import (collection) time and asserts the live global still equals it after the polluting module runs in the same process.

Proof, one process, no:randomly:
  uv run --group dev pytest tests/test_routes_shortcuts.py tests/shortcuts/test_framework_shortcuts.py -q
  before fix: 2 failed, 29 passed (test_openclaw_shortcuts_exact: assert 2 == 4;
            guard: kinds ['container-terminal','dashboard'] != 4-entry snapshot)
  after fix:  31 passed

Files:
 tests/shortcuts/test_framework_shortcuts.py | 32 ++++++++++++++++++
 tests/test_routes_shortcuts.py              | 50 +++++++++++++++++------------
 2 files changed, 61 insertions(+), 21 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut handling so temporary test configurations are properly restored.
  * Prevented shortcut settings from leaking between operations, improving consistency and reliability.
  * Added regression coverage to detect unexpected changes to the canonical shortcut list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->