### PR TITLE
Settings panels render errors that no screen reader ever announces: sweep the role=alert class across UpdatesPanel, LogsPanel, ThemesPanel and UsersPanel

### DIFF
--- a/changelog.d/tsk-yktook-settings-alert-roles.md
+++ b/changelog.d/tsk-yktook-settings-alert-roles.md
@@ -1,0 +1,2 @@
+### Fixed
+- Error and failure messages in the Updates, Logs, Themes, and Users settings panels are now announced to screen-reader users via `role="alert"` live regions, matching the pattern already used in the Notifications and Account panels. Routine success/progress text is intentionally left without a live region so it does not train users to ignore alerts.

--- a/desktop/src/apps/SettingsApp/LogsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.test.tsx
@@ -49,4 +49,55 @@ describe("LogsSection", () => {
       expect(urls.some((u) => u.includes("/api/client-logs?level=error"))).toBe(true);
     });
   });
+
+  it("announces a system-log fetch error via role=alert", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes("/api/system-logs/sources")) {
+        return Promise.resolve(
+          jsonResponse([{ id: "controller", label: "Controller", kind: "controller", available: true }]),
+        );
+      }
+      if (u.includes("/api/system-logs/controller")) {
+        return Promise.resolve(new Response(null, { status: 500 }));
+      }
+      if (u.includes("/api/client-logs")) {
+        return Promise.resolve(jsonResponse({ items: [] }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    render(<LogsSection />);
+    const tab = await screen.findByRole("tab", { name: "Controller" });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not read this log source.",
+    );
+  });
+
+  it("does not render an alert when system logs load successfully", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes("/api/system-logs/sources")) {
+        return Promise.resolve(
+          jsonResponse([{ id: "controller", label: "Controller", kind: "controller", available: true }]),
+        );
+      }
+      if (u.includes("/api/system-logs/controller")) {
+        return Promise.resolve(
+          jsonResponse({ source: "controller", lines: ["line one", "line two"], cursor: null }),
+        );
+      }
+      if (u.includes("/api/client-logs")) {
+        return Promise.resolve(jsonResponse({ items: [] }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    render(<LogsSection />);
+    const tab = await screen.findByRole("tab", { name: "Controller" });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+    expect(await screen.findByText(/line one/)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });

--- a/desktop/src/apps/SettingsApp/LogsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.tsx
@@ -222,7 +222,7 @@ function SystemLogsTab({ source }: { source: SystemLogSource }) {
 
       {!loading && error && displayLines.length === 0 && (
         <Card className="p-4">
-          <p className="text-sm flex items-center gap-2 text-amber-400">
+          <p role="alert" className="text-sm flex items-center gap-2 text-amber-400">
             <ScrollText size={14} /> {error}
           </p>
         </Card>

--- a/desktop/src/apps/SettingsApp/ThemesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/ThemesPanel.tsx
@@ -22,6 +22,7 @@ const EMPTY_CONFIG: ThemeConfig = { tokens: {}, structure: {}, effects: [], requ
 
 export function ThemesPanel() {
   const [themes, setThemes] = useState<InstalledTheme[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [priorConfig, setPriorConfig] = useState<ThemeConfig>(EMPTY_CONFIG);
 
@@ -41,6 +42,7 @@ export function ThemesPanel() {
         setThemes(merged);
       })
       .catch(() => {
+        setError("Could not load installed themes. Showing built-in themes.");
         setThemes([...BUILTIN_THEMES]);
       });
   }, []);
@@ -84,6 +86,11 @@ export function ThemesPanel() {
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        {error && (
+          <p role="alert" className="text-xs text-amber-400 col-span-full">
+            {error}
+          </p>
+        )}
         {themes.map((theme) => {
           const isActive = theme.theme_id === activeThemeId;
           const isPreviewing = theme.theme_id === previewId;

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
@@ -180,3 +180,82 @@ describe("UpdatesPanel -- optional apps section", () => {
     expect(screen.getByRole("button", { name: /scroll to system update/i })).toBeInTheDocument();
   });
 });
+
+describe("UpdatesPanel -- error announcements", () => {
+  it("announces an update-check failure (non-ok) via role=alert", async () => {
+    let checkCalls = 0;
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+      if (url === "/api/settings/update-check") {
+        checkCalls++;
+        if (checkCalls === 1) return jResp({ has_updates: false, current_version: "1.0.0-beta.2", current_commit: "abc x" });
+        return new Response(null, { status: 500 });
+      }
+      if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+      return jResp({});
+    });
+    render(<UpdatesPanel />);
+    await screen.findByText("1.0.0-beta.2");
+    fireEvent.click(screen.getByRole("button", { name: /check now/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Update check not available.");
+  });
+
+  it("announces a network error during update check via role=alert", async () => {
+    let checkCalls = 0;
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+      if (url === "/api/settings/update-check") {
+        checkCalls++;
+        if (checkCalls === 1) return jResp({ has_updates: false, current_version: "1.0.0-beta.2", current_commit: "abc x" });
+        return Promise.reject(new Error("network"));
+      }
+      if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+      return jResp({});
+    });
+    render(<UpdatesPanel />);
+    await screen.findByText("1.0.0-beta.2");
+    fireEvent.click(screen.getByRole("button", { name: /check now/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not reach update server.");
+  });
+
+  it("announces an apply-update failure via role=alert", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+      if (url === "/api/settings/update-check")
+        return jResp({ has_updates: true, current_version: "1.0.0", new_version: "1.0.1", current_commit: "abc", new_commit: "xyz" });
+      if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+      if (url === "/api/settings/update") return new Response(null, { status: 500 });
+      return jResp({});
+    });
+    render(<UpdatesPanel />);
+    await screen.findByText("1.0.0");
+    fireEvent.click(screen.getByRole("button", { name: /install update/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Update failed.");
+  });
+
+  it("announces a frontend-rebuild failure via role=alert", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+      if (url === "/api/settings/update-check") return jResp({ has_updates: false, current_version: "1.0.0", current_commit: "abc" });
+      if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+      if (url === "/api/settings/rebuild-frontend") return new Response(null, { status: 500 });
+      return jResp({});
+    });
+    render(<UpdatesPanel />);
+    await screen.findByText("1.0.0");
+    fireEvent.click(screen.getByRole("button", { name: /force rebuild/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Frontend rebuild failed.");
+  });
+
+  it("does not render an alert on a successful update check (no success chatter)", async () => {
+    render(<UpdatesPanel />);
+    await screen.findByText("1.0.0-beta.2");
+    fireEvent.click(screen.getByRole("button", { name: /check now/i }));
+    await waitFor(() => expect(screen.getByText("You are up to date.")).toBeInTheDocument());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -112,6 +112,7 @@ export function UpdatesPanel() {
   const [rebuilding, setRebuilding] = useState(false);
   const [info, setInfo] = useState<UpdateInfo | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [prefs, setPrefs] = useState<AutoUpdatePrefs>({ check_enabled: true });
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [showRestartModal, setShowRestartModal] = useState(false);
@@ -189,6 +190,7 @@ export function UpdatesPanel() {
   const checkUpdates = async () => {
     setChecking(true);
     setStatus(null);
+    setError(null);
     try {
       const res = await fetch("/api/settings/update-check");
       if (res.ok) {
@@ -196,10 +198,10 @@ export function UpdatesPanel() {
         setInfo(data);
         setStatus(data.has_updates ? "A new version is available." : "You are up to date.");
       } else {
-        setStatus("Update check not available.");
+        setError("Update check not available.");
       }
     } catch {
-      setStatus("Could not reach update server.");
+      setError("Could not reach update server.");
     }
     setChecking(false);
   };
@@ -207,6 +209,7 @@ export function UpdatesPanel() {
   const applyUpdate = async () => {
     setApplying(true);
     setStatus(null);
+    setError(null);
     try {
       const res = await fetch("/api/settings/update", { method: "POST" });
       if (res.ok) {
@@ -214,10 +217,10 @@ export function UpdatesPanel() {
         setShowRestartModal(true);
       } else {
         const err = await res.json().catch(() => ({}));
-        setStatus((err as { error?: string }).error ?? "Update failed.");
+        setError((err as { error?: string }).error ?? "Update failed.");
       }
     } catch {
-      setStatus("Could not apply update.");
+      setError("Could not apply update.");
     }
     setApplying(false);
   };
@@ -225,30 +228,32 @@ export function UpdatesPanel() {
   const rebuildFrontend = async () => {
     setRebuilding(true);
     setStatus(null);
+    setError(null);
     try {
       const res = await fetch("/api/settings/rebuild-frontend", { method: "POST" });
       const data = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
       if (res.ok) {
         setStatus(data.message ?? "Frontend rebuilt — hard-refresh the browser to see changes.");
       } else {
-        setStatus(data.error ?? "Frontend rebuild failed.");
+        setError(data.error ?? "Frontend rebuild failed.");
       }
     } catch {
-      setStatus("Could not reach rebuild endpoint.");
+      setError("Could not reach rebuild endpoint.");
     }
     setRebuilding(false);
   };
 
   const triggerRestart = async () => {
+    setError(null);
     try {
       const res = await fetch("/api/system/restart/prepare", { method: "POST" });
       if (res.ok) {
         setShowRestartModal(true);
       } else {
-        setStatus("Could not start restart.");
+        setError("Could not start restart.");
       }
     } catch {
-      setStatus("Could not reach the restart endpoint.");
+      setError("Could not reach the restart endpoint.");
     }
   };
 
@@ -269,10 +274,10 @@ export function UpdatesPanel() {
           setCustomBranch(ch ? "" : data.current);
           branchFetched.current = true;
         } else {
-          setStatus("Could not load branch list.");
+          setError("Could not load branch list.");
         }
       } catch {
-        setStatus("Could not reach branch endpoint.");
+        setError("Could not reach branch endpoint.");
       }
     })();
   }, [advancedOpen]);
@@ -281,6 +286,7 @@ export function UpdatesPanel() {
     setShowSwitchConfirm(false);
     setSwitching(true);
     setStatus(null);
+    setError(null);
     // When a channel option was selected (and custom is blank), use the
     // channel's branch. Otherwise use the free-text custom branch input.
     const branch = customBranch.trim() || selectedBranch;
@@ -296,10 +302,10 @@ export function UpdatesPanel() {
         setStatus(data.message ?? data.snapshot ?? `Switching to ${data.branch ?? branch}…`);
         setShowRestartModal(true);
       } else {
-        setStatus(data.error ?? "Branch switch failed.");
+        setError(data.error ?? "Branch switch failed.");
       }
     } catch {
-      setStatus("Could not reach the update-channel endpoint.");
+      setError("Could not reach the update-channel endpoint.");
     }
     setSwitching(false);
   };
@@ -396,6 +402,13 @@ export function UpdatesPanel() {
             {rebuilding ? "Rebuilding..." : "Rebuild Frontend"}
           </Button>
         </div>
+
+        {error && (
+          <div className="flex items-start gap-2 text-xs" role="alert">
+            <AlertCircle size={14} className="text-amber-400 shrink-0 mt-0.5" />
+            <span className="text-amber-400">{error}</span>
+          </div>
+        )}
 
         {status && (
           <div className="flex items-start gap-2 text-xs">

--- a/desktop/src/apps/SettingsApp/UsersPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/UsersPanel.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { UsersSection } from "./UsersPanel";
+
+function jsonResponse(obj: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("UsersPanel", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("announces a profile-save failure via role=alert", async () => {
+    const mockUser = {
+      username: "jay",
+      full_name: "Jay",
+      email: "jay@example.com",
+      is_admin: true,
+    };
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/auth/status")) {
+        return Promise.resolve(
+          jsonResponse({ authenticated: true, user: mockUser, multi_user: true }),
+        );
+      }
+      if (url.includes("/auth/users") && !url.includes("/profile")) {
+        return Promise.resolve(jsonResponse({ users: [] }));
+      }
+      if (url.includes("/profile")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: "Save failed" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 401 }));
+    });
+    render(<UsersSection />);
+    await screen.findByDisplayValue("jay@example.com");
+    fireEvent.change(screen.getByLabelText("Full name"), {
+      target: { value: "Jay Test" },
+    });
+    fireEvent.click(screen.getByText("Save changes"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Save failed");
+  });
+
+  it("does not render an alert when the profile saves successfully", async () => {
+    const mockUser = {
+      username: "jay",
+      full_name: "Jay",
+      email: "jay@example.com",
+      is_admin: true,
+    };
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/auth/status")) {
+        return Promise.resolve(
+          jsonResponse({ authenticated: true, user: mockUser, multi_user: true }),
+        );
+      }
+      if (url.includes("/auth/users") && !url.includes("/profile")) {
+        return Promise.resolve(jsonResponse({ users: [] }));
+      }
+      if (url.includes("/profile")) {
+        return Promise.resolve(jsonResponse({ ok: true }));
+      }
+      return Promise.resolve(new Response(null, { status: 401 }));
+    });
+    render(<UsersSection />);
+    await screen.findByDisplayValue("jay@example.com");
+    fireEvent.change(screen.getByLabelText("Full name"), {
+      target: { value: "Jay Test" },
+    });
+    fireEvent.click(screen.getByText("Save changes"));
+    await waitFor(() => expect(screen.getByText("Saved")).toBeInTheDocument());
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/SettingsApp/UsersPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UsersPanel.tsx
@@ -150,7 +150,7 @@ function AddUserModal({ onClose, onAdded }: { onClose: () => void; onAdded: () =
               onKeyDown={(e) => { if (e.key === "Enter") submit(); }}
             />
           </div>
-          {error && <p className="text-xs text-red-400">{error}</p>}
+          {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
           <div className="flex gap-2 justify-end">
             <Button variant="outline" size="sm" onClick={onClose}>Cancel</Button>
             <Button size="sm" onClick={submit} disabled={loading || !username.trim()}>
@@ -206,7 +206,7 @@ function ResetPasswordModal({ username, onClose, onReset }: { username: string; 
           <p className="text-sm text-shell-text-secondary">
             This will revoke {username}'s current password and sessions. A new invite code will be generated.
           </p>
-          {error && <p className="text-xs text-red-400">{error}</p>}
+          {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
           <div className="flex gap-2 justify-end">
             <Button variant="outline" size="sm" onClick={onClose}>Cancel</Button>
             <Button size="sm" onClick={doReset} disabled={loading}>
@@ -281,9 +281,9 @@ function ChangePasswordModal({ username, onClose }: { username: string; onClose:
               className="mt-1"
               aria-invalid={confirm.length > 0 && !matches}
             />
-            {confirm.length > 0 && !matches && <p className="text-[11px] text-red-400 mt-1">Passwords don't match.</p>}
+            {confirm.length > 0 && !matches && <p className="text-[11px] text-red-400 mt-1" role="alert">Passwords don't match.</p>}
           </div>
-          {error && <p className="text-xs text-red-400">{error}</p>}
+          {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
           <div className="flex gap-2 justify-end">
             <Button variant="outline" size="sm" onClick={onClose}>Cancel</Button>
             <Button size="sm" disabled={!valid || loading} onClick={submit}>
@@ -327,7 +327,7 @@ function DeleteUserModal({ username, onClose, onDeleted }: { username: string; o
         <p className="text-sm text-shell-text-secondary">
           This will remove {username} and revoke all their sessions. This cannot be undone.
         </p>
-        {error && <p className="text-xs text-red-400">{error}</p>}
+        {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
         <div className="flex gap-2 justify-end">
           <Button variant="outline" size="sm" onClick={onClose}>Cancel</Button>
           <Button size="sm" onClick={doDelete} disabled={loading}
@@ -457,7 +457,7 @@ export function UsersSection() {
         </div>
 
         {profileError && (
-          <p className="text-xs text-red-400 flex items-center gap-1.5"><AlertCircle size={12} /> {profileError}</p>
+          <p className="text-xs text-red-400 flex items-center gap-1.5" role="alert"><AlertCircle size={12} /> {profileError}</p>
         )}
 
         <div className="flex items-center gap-2">

--- a/desktop/src/apps/SettingsApp/__tests__/ThemesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/__tests__/ThemesPanel.test.tsx
@@ -26,4 +26,16 @@ describe("ThemesPanel", () => {
     expect(await screen.findByText("taOS Dark")).toBeInTheDocument();
     expect(screen.getByText("taOS Light")).toBeInTheDocument();
   });
+
+  it("announces a themes-fetch failure via role=alert", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    render(<ThemesPanel />);
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+  });
+
+  it("does not render an alert when themes load successfully", async () => {
+    render(<ThemesPanel />);
+    await screen.findByText("Ocean Blue");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Settings panels render errors that no screen reader ever announces: sweep the role=alert class across UpdatesPanel, LogsPanel, ThemesPanel and UsersPanel

Autonomous build of board card tsk-yktook.

Four settings panels (Updates, Logs, Themes, Users) rendered error
and failure messages as plain text, silent to assistive tech. This
adds role=alert live regions to those messages, matching the pattern
already used in NotificationsPanel and AccountPanel.

String classification:
- UpdatesPanel: failure messages (Could not reach..., Update failed.,
  Branch switch failed., etc.) moved to a separate error state with
  role=alert. Success messages (You are up to date., A new version is
  available.) remain as plain status text without a live region to
  avoid alert fatigue.
- LogsPanel: the system log fetch error paragraph gains role=alert.
- ThemesPanel: adds an error state for the themes fetch failure,
  rendered with role=alert.
- UsersPanel: all error paragraphs (profile save, add user, reset
  password, change password, delete user, and Passwords don't match
  validation) gain role=alert.

Tests assert through the accessibility tree with findByRole(alert),
not findByText, so they fail on the pre-fix markup and pass after.

Proof -- 7 findByRole(alert) tests FAIL on unmodified code:
  Test Files  4 failed (4)
        Tests  7 failed | 21 passed (28)

Proof -- all 28 tests PASS after fix:
  Test Files  4 passed (4)
        Tests  28 passed (28)

Files:
 desktop/src/apps/SettingsApp/LogsPanel.tsx         |  2 +-
 desktop/src/apps/SettingsApp/ThemesPanel.tsx       |  7 ++
 desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx | 79 ++++++++++++++++++++
 desktop/src/apps/SettingsApp/UpdatesPanel.tsx      | 37 ++++++----
 desktop/src/apps/SettingsApp/UsersPanel.test.tsx   | 83 ++++++++++++++++++++++
 desktop/src/apps/SettingsApp/UsersPanel.tsx        | 12 ++--
 .../SettingsApp/__tests__/ThemesPanel.test.tsx     | 12 ++++
 9 files changed, 266 insertions(+), 19 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Error and failure messages in the Updates, Logs, Themes, and Users settings panels are now announced to screen readers as alerts.
  * Routine success and progress messages remain non-alert notifications.

* **Bug Fixes**
  * Theme-loading failures are now displayed clearly while built-in themes remain available.

* **Tests**
  * Added coverage confirming alerts appear for failures and remain absent after successful operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->