### PR TITLE
test_guard_detects_stale_sniffio_namespace is import-order dependent — fails on clean dev, and its result carries no signal either way

### DIFF
--- a/changelog.d/tsk-qlra57-stale-sniffio-namespace.md
+++ b/changelog.d/tsk-qlra57-stale-sniffio-namespace.md
@@ -1,0 +1,2 @@
+### Fixed
+- `test_guard_detects_stale_sniffio_namespace` no longer passes or fails depending on whether `sniffio` was imported during pytest collection. The stale-namespace helper now evicts the target module and any submodules from `sys.modules`, calls `importlib.invalidate_caches()`, and restores the originals in `finally` so later tests see a healthy environment.

--- a/tests/test_core_deps.py
+++ b/tests/test_core_deps.py
@@ -43,21 +43,28 @@ class TestCoreDepGuard:
     not just sniffio -- the fix must not be keyed on the string 'sniffio'
     alone."""
 
-    @staticmethod
-    def _install_stale_namespace(tmp_path, name):
+    def _install_stale_namespace(self, tmp_path, name):
         """Create an empty PEP 420 namespace dir for *name* under *tmp_path*
         and prepend tmp_path to sys.path[0].  Returns the dir path."""
         pkg_dir = tmp_path / name
         pkg_dir.mkdir()
         sys.path.insert(0, str(tmp_path))
-        sys.modules.pop(name, None)
+        saved = {k: v for k, v in sys.modules.items()
+                 if k == name or k.startswith(name + ".")}
+        for key in list(saved):
+            sys.modules.pop(key, None)
+        importlib.invalidate_caches()
+        self._saved_stale_modules = saved
         return pkg_dir
 
-    @staticmethod
-    def _remove_stale_namespace(tmp_path, name):
+    def _remove_stale_namespace(self, tmp_path, name):
         """Undo _install_stale_namespace."""
         sys.path.remove(str(tmp_path))
-        sys.modules.pop(name, None)
+        for key in list(sys.modules):
+            if key == name or key.startswith(name + "."):
+                sys.modules.pop(key, None)
+        sys.modules.update(getattr(self, "_saved_stale_modules", {}))
+        self._saved_stale_modules = {}
 
     def test_contracts_include_sniffio_with_current_async_library(self):
         assert "sniffio" in _CORE_DEP_CONTRACTS


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): test_guard_detects_stale_sniffio_namespace is import-order dependent — fails on clean dev, and its result carries no signal either way

Autonomous build of board card tsk-qlra57.

_install_stale_namespace now evicts the target module and any submodules
from sys.modules, calls importlib.invalidate_caches(), and restores the
originals in _remove_stale_namespace so the test result no longer depends
on import order during pytest collection.

changelog: tsk-qlra57-stale-sniffio-namespace

Files:
 changelog.d/tsk-qlra57-stale-sniffio-namespace.md |  2 ++
 tests/test_core_deps.py                           | 19 +++++++++++++------
 2 files changed, 15 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-namespace test handling by clearing affected modules and submodules before validation.
  * Tests now restore the original module state reliably, preventing failures caused by prior imports during test collection.
* **Documentation**
  * Added a changelog entry describing the stale-namespace test fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->