### PR TITLE
`pytest tests/` aborts the WHOLE suite: test_core_deps.py does a bare `from conftest import ...` that binds tests/e2e/conftest.py

### DIFF
--- a/changelog.d/tsk-xplzqy-no-bare-conftest-import.md
+++ b/changelog.d/tsk-xplzqy-no-bare-conftest-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `pytest tests/` run from the repo root no longer aborts collection with `Interrupted: 1 error during collection` (exit 2, zero tests run). `tests/test_core_deps.py` bound the shared core-dependency guard helpers with a bare `from conftest import`, a name resolved by `sys.path` order; on a full-suite run pytest put `tests/e2e/conftest.py` first, so the import resolved to the e2e shim (which lacks the helpers) and aborted the whole suite, while CI stayed green only because CI runs `pytest tests/ --ignore=tests/e2e`. The helpers are now loaded from `tests/conftest.py` by absolute file path, and a new regression sweep fails if any `tests/`.py file binds the bare `conftest` name again (tsk-xplzqy).

--- a/tests/test_core_deps.py
+++ b/tests/test_core_deps.py
@@ -7,15 +7,32 @@ case is 'sniffio': anyio calls sniffio.current_async_library on every async
 test; a partial sniffio raises AttributeError instead of ModuleNotFoundError,
 producing 500+ identical tracebacks attributed to whichever PR happened to
 run.
+
+The helpers under test live in ``tests/conftest.py`` and are bound here by
+absolute file path, never by the bare name ``conftest``: ``tests/`` is not a
+package and ``tests/e2e/conftest.py`` exists, so ``from conftest import ...``
+resolves to the e2e shim under ``pytest tests/`` and aborts the whole-suite
+collection -- ``Interrupted: 1 error during collection``, exit 2, zero tests
+run (card ``tsk-xplzqy``).
 """
 from __future__ import annotations
 
-import importlib
+import importlib.util
 import sys
+from pathlib import Path
 
 import pytest
 
-from conftest import _CORE_DEP_CONTRACTS, _check_core_deps, _verify_core_deps
+_SPEC = importlib.util.spec_from_file_location(
+    "tests_tinyagentos_conftest",
+    Path(__file__).resolve().parent / "conftest.py",
+)
+_conftest = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_conftest)  # type: ignore[union-attr]
+
+_CORE_DEP_CONTRACTS = _conftest._CORE_DEP_CONTRACTS
+_check_core_deps = _conftest._check_core_deps
+_verify_core_deps = _conftest._verify_core_deps
 
 
 class TestSniffioContract:

--- a/tests/test_no_bare_conftest_import.py
+++ b/tests/test_no_bare_conftest_import.py
@@ -1,0 +1,45 @@
+"""Regression guard for card ``tsk-xplzqy``.
+
+A bare ``from conftest import ...`` / ``import conftest`` is resolved by
+``sys.path`` order, not by which file the author meant. When ``tests/e2e/``
+is collected alongside ``tests/``, that name binds to
+``tests/e2e/conftest.py`` -- a session-scoped shim that defines none of the
+shared helpers -- so the import raises ``ImportError`` and pytest prints
+``Interrupted: 1 error during collection`` and runs ZERO tests (exit 2).
+
+This is the exact defect that used to break ``pytest tests/`` on an unmodified
+tree, while CI stayed green because CI runs ``pytest tests/ --ignore=tests/e2e``.
+The regression lives here, outside ``tests/conftest.py``, so it cannot be
+silenced by editing the very file the anti-pattern targets.
+
+It fails at the granularity of the defect -- the bare ``conftest`` name
+binding -- not on a mere syntax error. Mirrors::
+
+    grep -rn "^from conftest import|^import conftest" tests/
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_TESTS = Path(__file__).resolve().parent
+_SELF = Path(__file__).resolve()
+_FORBIDDEN = re.compile(r"^\s*(?:from\s+conftest\s+import\b|import\s+conftest\b)")
+
+
+def test_no_test_module_binds_bare_conftest() -> None:
+    violations: list[str] = []
+    for path in sorted(_TESTS.rglob("*.py")):
+        if path.resolve() == _SELF:
+            continue
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _FORBIDDEN.match(line):
+                violations.append(f"{path}:{lineno}: {line.strip()!r}")
+    assert not violations, (
+        "tsk-xplzqy: no module under tests/ may bind the bare name "
+        "`conftest` -- it resolves to the wrong conftest.py under `pytest "
+        "tests/` and aborts the whole-suite collection. Import shared helpers "
+        "from a uniquely-named module instead. Violations:\n  "
+        + "\n  ".join(violations)
+    )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): `pytest tests/` aborts the WHOLE suite: test_core_deps.py does a bare `from conftest import ...` that binds tests/e2e/conftest.py

Autonomous build of board card tsk-xplzqy.

tests/test_core_deps.py bound the core-dependency guard helpers with a bare
`from conftest import`. tests/ is not a package and tests/e2e/conftest.py
exists, so under `pytest tests/` the name `conftest` resolves to the e2e
shim, which lacks the helpers. Collection aborts with
"Interrupted: 1 error during collection", exit 2, zero tests run. CI stayed
green only because it runs `pytest tests/ --ignore=tests/e2e`.

tests/conftest.py is a gate-integrity protected path and is left untouched.
The helpers are imported from tests/conftest.py by absolute file path, so the
binding is deterministic regardless of which conftest pytest places on
sys.path first. A regression sweep asserts the bare name never returns.

PROOF (uv run --no-sync):
  red   : pytest tests/ --collect-only -q                    -> exit 2
          "Interrupted: 1 error during collection", 1 error
          ImportError: cannot import name '_CORE_DEP_CONTRACTS'
          from 'conftest' (.../tests/e2e/conftest.py)
          ERROR tests/test_core_deps.py
  green : pytest tests/ --collect-only -q                    -> exit 0
          12315 tests collected, 0 errors
  green : pytest tests/ --collect-only -q --ignore=tests/e2e -> exit 0
          12225 tests collected, 0 errors
  sweep : grep -rn "^from conftest import|^import conftest" tests/ -> 0 matches

Added tests/test_no_bare_conftest_import.py (regression sweep) and a
changelog fragment.

Refs: tsk-xplzqy

Files:
 changelog.d/tsk-xplzqy-no-bare-conftest-import.md |  3 ++
 tests/test_core_deps.py                           | 21 ++++++++++-
 tests/test_no_bare_conftest_import.py             | 45 +++++++++++++++++++++++
 3 files changed, 67 insertions(+), 2 deletions(-)