### PR TITLE
SECURITY/AUDIT: no GitHub action in this fleet is attributable - every agent and Jay merge as `jaylfc`, so a compromised token is undetectable

### DIFF
--- a/changelog.d/tsk-jkwca4-merge-attribution.md
+++ b/changelog.d/tsk-jkwca4-merge-attribution.md
@@ -1,0 +1,4 @@
+### Added
+- `scripts/check_merge_attribution.py`: reconciliation check that reads the fleet's local JSONL merge audit log and asserts every merge commit in the repo has a matching audit entry, failing red with the unmatched SHA when one is missing.
+- `scripts/gate_merge.sh`: fleet merge wrapper that appends an actor, repo, PR, SHA, merged_by, timestamp, and script entry to `~/.fleet/merge-audit.jsonl` after every successful `gh pr merge`, giving each fleet action an append-only local audit trail without changing the GitHub `merged_by` field.
+- `tests/test_merge_attribution.py`: three acceptance proofs — a merge with no audit line goes RED naming the unmatched SHA, a normal fleet merge with an audit line reconciles clean with rc=0, and deleting the audit line for a real merge returns to RED, proving the check is load-bearing.

--- a/scripts/check_merge_attribution.py
+++ b/scripts/check_merge_attribution.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Reconcile fleet merge audit log against actual merges.
+
+For each merge commit in the fleet's repos, assert a matching local audit
+line exists. An unmatched merge is the signal that an unattributed action
+occurred.
+
+Exit codes:
+    0  PASS  -- all merges have matching audit entries
+    1  FAIL  -- one or more merges lack audit entries
+    2  ERROR -- infrastructure failure
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_ERROR = 2
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr}")
+    return result.stdout
+
+
+def find_merge_commits(repo: Path) -> list[str]:
+    """Return SHAs of merge commits in the repo."""
+    out = _git(repo, "log", "--merges", "--format=%H")
+    return [line.strip() for line in out.strip().splitlines() if line.strip()]
+
+
+def read_audit_log(audit_file: Path) -> list[dict]:
+    """Read JSONL audit log entries."""
+    if not audit_file.exists():
+        return []
+    entries = []
+    for line in audit_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def reconcile(repo: Path, audit_file: Path) -> list[str]:
+    """Return SHAs of merge commits that lack a matching audit entry."""
+    merge_shas = set(find_merge_commits(repo))
+    audit_entries = read_audit_log(audit_file)
+    audit_shas = {e.get("sha", "") for e in audit_entries if e.get("sha")}
+    return sorted(sha for sha in merge_shas if sha not in audit_shas)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconcile fleet merge audit log against actual merges",
+    )
+    parser.add_argument("--repo", type=Path, required=True, help="Git repo root")
+    parser.add_argument(
+        "--audit-file", type=Path, required=True, help="JSONL audit log path",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo.is_dir():
+        print(f"ERROR: repo not found: {args.repo}", file=sys.stderr)
+        return EXIT_ERROR
+
+    unmatched = reconcile(args.repo, args.audit_file)
+
+    if unmatched:
+        for sha in unmatched:
+            short = sha[:12] if len(sha) >= 12 else sha
+            print(f"UNMATCHED MERGE: {short} — no audit entry found")
+        return EXIT_FAIL
+
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gate_merge.sh
+++ b/scripts/gate_merge.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUDIT_LOG="${FLEET_AUDIT_LOG:-${HOME}/.fleet/merge-audit.jsonl}"
+ACTOR="${FLEET_ACTOR:-${USER:-unknown}}"
+SCRIPT_NAME="$(basename "$0")"
+
+mkdir -p "$(dirname "$AUDIT_LOG")"
+
+set +e
+gh pr merge "$@"
+rc=$?
+set -e
+
+if [ $rc -eq 0 ]; then
+    PR_NUMBER="$(gh pr view --json number --jq '.number' 2>/dev/null || echo "0")"
+    HEAD_SHA="$(gh pr view --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "unknown")"
+    MERGED_BY="$(gh pr view --json mergedBy --jq '.mergedBy.login' 2>/dev/null || echo "unknown")"
+    REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "unknown")"
+    TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    echo "{\"actor\":\"${ACTOR}\",\"repo\":\"${REPO}\",\"pr\":${PR_NUMBER},\"sha\":\"${HEAD_SHA}\",\"merged_by\":\"${MERGED_BY}\",\"timestamp\":\"${TIMESTAMP}\",\"script\":\"${SCRIPT_NAME}\"}" >> "$AUDIT_LOG"
+fi
+
+exit $rc

--- a/tests/test_merge_attribution.py
+++ b/tests/test_merge_attribution.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tests for merge attribution audit and reconciliation.
+
+Three acceptance proofs:
+(a) A merge with no audit line makes reconciliation go RED naming the
+    unmatched sha, rc captured directly.
+(b) CONTROL: a normal fleet merge with an audit line reconciles clean, rc=0.
+(c) Deleting the audit line for a real merge makes reconciliation go RED again,
+    proving the check is load-bearing.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_merge_attribution as cma  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "branch", "-M", "main")
+
+
+def _commit_file(repo: Path, rel_path: str, content: str, message: str) -> str:
+    full = repo / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", message)
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_merge(repo: Path, branch: str) -> str:
+    """Merge branch into current HEAD and return the merge commit SHA."""
+    _git(repo, "merge", branch, "--no-edit")
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def setup_diverged_repo(repo: Path) -> None:
+    """Set up a repo with diverged main and feature branches."""
+    _init_repo(repo)
+    _commit_file(repo, "README.md", "# Main\n", "initial")
+    _git(repo, "checkout", "-b", "feature")
+    _commit_file(repo, "feat.txt", "feature\n", "add feature")
+    _git(repo, "checkout", "main")
+    _commit_file(repo, "main.txt", "main work\n", "main work")
+
+
+def _write_audit(audit_file: Path, sha: str) -> None:
+    entry = {
+        "actor": "test-agent",
+        "repo": "test-org/test-repo",
+        "pr": 1,
+        "sha": sha,
+        "merged_by": "test-agent",
+        "timestamp": "2026-08-27T11:29:48Z",
+        "script": "gate_merge.sh",
+    }
+    audit_file.parent.mkdir(parents=True, exist_ok=True)
+    with audit_file.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+class TestMergeAttributionReconciliation:
+    """Proofs for the merge attribution audit mechanism."""
+
+    def test_merge_without_audit_line_fails_reconciliation(
+        self, tmp_path: Path,
+    ) -> None:
+        """(a) A merge with NO audit line makes reconciliation RED."""
+        repo = tmp_path / "repo"
+        setup_diverged_repo(repo)
+
+        merge_sha = _make_merge(repo, "feature")
+
+        audit_file = tmp_path / "audit.jsonl"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/check_merge_attribution.py"),
+                "--repo", str(repo),
+                "--audit-file", str(audit_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == cma.EXIT_FAIL
+        assert merge_sha[:12] in result.stdout
+
+    def test_merge_with_audit_line_passes_reconciliation(
+        self, tmp_path: Path,
+    ) -> None:
+        """(b) CONTROL: a normal fleet merge reconciles clean, rc=0."""
+        repo = tmp_path / "repo"
+        setup_diverged_repo(repo)
+
+        merge_sha = _make_merge(repo, "feature")
+
+        audit_file = tmp_path / "audit.jsonl"
+        _write_audit(audit_file, merge_sha)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/check_merge_attribution.py"),
+                "--repo", str(repo),
+                "--audit-file", str(audit_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == cma.EXIT_OK
+
+    def test_deleting_audit_line_makes_reconciliation_fail(
+        self, tmp_path: Path,
+    ) -> None:
+        """(c) Deleting the audit line for a real merge makes reconciliation RED."""
+        repo = tmp_path / "repo"
+        setup_diverged_repo(repo)
+
+        merge_sha = _make_merge(repo, "feature")
+
+        audit_file = tmp_path / "audit.jsonl"
+        _write_audit(audit_file, merge_sha)
+
+        # Verify it passes first
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/check_merge_attribution.py"),
+                "--repo", str(repo),
+                "--audit-file", str(audit_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == cma.EXIT_OK
+
+        # Now delete the audit line
+        audit_file.write_text("", encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts/check_merge_attribution.py"),
+                "--repo", str(repo),
+                "--audit-file", str(audit_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == cma.EXIT_FAIL
+        assert merge_sha[:12] in result.stdout


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): SECURITY/AUDIT: no GitHub action in this fleet is attributable - every agent and Jay merge as `jaylfc`, so a compromised token is undetectable

Autonomous build of board card tsk-jkwca4.

- scripts/gate_merge.sh: fleet merge wrapper that appends an actor, repo,
  PR, SHA, merged_by, timestamp, and script entry to the local JSONL
  audit log after every successful gh pr merge
- scripts/check_merge_attribution.py: reconciliation check that asserts
  every merge commit in a repo has a matching local audit entry, failing
  red with the unmatched SHA when one is missing
- tests/test_merge_attribution.py: three acceptance proofs -- (a) a merge
  with no audit line goes RED naming the unmatched sha, (b) a normal fleet
  merge with an audit line reconciles clean rc=0, (c) deleting the audit
  line for a real merge returns to RED proving the check is load-bearing
- changelog fragment for tsk-jkwca4

Proof: 3 tests pass (uv run pytest tests/test_merge_attribution.py -q)

Files:
 changelog.d/tsk-jkwca4-merge-attribution.md |   4 +
 scripts/check_merge_attribution.py          |  96 ++++++++++++++
 scripts/gate_merge.sh                       |  25 ++++
 tests/test_merge_attribution.py             | 189 ++++++++++++++++++++++++++++
 4 files changed, 314 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added merge attribution auditing to record details after successful merges.
  - Added reconciliation checks to identify merges missing audit records.
  - Added clear command results for successful checks, unmatched merges, and configuration errors.

- **Tests**
  - Added coverage for missing, valid, and deleted audit records to verify reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->