### PR TITLE
fix-forward #2570: _cap_context_snapshot slices serialized JSON then reparses it, so every oversized snapshot collapses to a bare _truncated marker (60119 bytes in, 68 out)

### DIFF
--- a/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
+++ b/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` no longer collapses oversized snapshots to an empty `_truncated` marker: it now drops the largest fields first until the serialized form fits within 32768 bytes, preserving smaller fields and recording the dropped field names in the marker.

--- a/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
+++ b/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resume notes no longer carry an unbounded `context_snapshot` to `POST /resume`: `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates it to a 32768-byte suffix with a `_truncated` marker, so an oversized transcript no longer saturates the woken agent's input window and restarts into the same overflow.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -117,9 +117,10 @@ without limit if the agent dumps its transcript or memory into it. An oversized
 snapshot saturates the framework's input window at wake, so the agent restarts
 into the same overflow every time and the recovery note is never consumed.
 
-`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
-snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
-posted. Do not bypass it: any code that writes a resume note by hand must still
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` caps the
+snapshot by dropping the largest fields first until the serialized form fits
+within 32768 bytes, then records the dropped field names in a `_truncated`
+marker. Do not bypass it: any code that writes a resume note by hand must still
 route it through that guard, lest a 32 KB transcript become a 32 KB failure.
 
 ## Credentials, grants and the things that bite

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -110,6 +110,18 @@ reach it, and write your pid to a pidfile. Under a systemd unit, `systemctl
 --user show -p MainPID` is authoritative; a startup-only pidfile can lie between
 restarts if a second instance started last.
 
+## Resume notes: context snapshot must be bounded
+
+A resume note's `context_snapshot` is carried through `POST /resume` and can grow
+without limit if the agent dumps its transcript or memory into it. An oversized
+snapshot saturates the framework's input window at wake, so the agent restarts
+into the same overflow every time and the recovery note is never consumed.
+
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
+snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
+posted. Do not bypass it: any code that writes a resume note by hand must still
+route it through that guard, lest a 32 KB transcript become a 32 KB failure.
+
 ## Credentials, grants and the things that bite
 
 **Your token is shown once and cannot be recovered.** Not by you, not by the

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -170,9 +170,30 @@ class TestCapContextSnapshot:
         original_size = len(json.dumps(big, separators=(",", ":")))
         assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
         ro._cap_context_snapshot(note)
-        capped_size = len(json.dumps(note["context_snapshot"], separators=(",", ":")))
+        capped = note["context_snapshot"]
+        capped_size = len(json.dumps(capped, separators=(",", ":")))
         assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
-        assert note["context_snapshot"] is not big
+        assert capped is not big
+        assert "_truncated" in capped
+        assert isinstance(capped["_truncated"], dict)
+        assert "dropped_fields" in capped["_truncated"]
+
+    def test_oversized_snapshot_keeps_required_fields(self):
+        snapshot = {
+            "agent_id": "a" * 100,
+            "session_id": "b" * 100,
+            "transcript": "x" * 60000,
+            "memory": "y" * 1000,
+        }
+        note = {"context_snapshot": snapshot}
+        ro._cap_context_snapshot(note)
+        capped = note["context_snapshot"]
+        assert "agent_id" in capped
+        assert "session_id" in capped
+        json.dumps(capped)
+        assert len(json.dumps(capped, separators=(",", ":"))) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert "transcript" not in capped
+        assert capped["_truncated"]["dropped_fields"][0] == "transcript"
 
     def test_empty_snapshot_is_noop(self):
         for val in [{}, None, "", "str"]:

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -156,3 +156,72 @@ class TestResumeAgentsFromNotes:
 
         state.notifications.add.assert_not_awaited()
         assert not state._background_tasks
+
+
+class TestCapContextSnapshot:
+    def test_leaves_small_snapshot_untouched(self):
+        note = {"context_snapshot": {"key": "value"}}
+        ro._cap_context_snapshot(note)
+        assert note["context_snapshot"] == {"key": "value"}
+
+    def test_truncates_oversized_snapshot(self):
+        big = {f"field_{i}": "x" * 200 for i in range(500)}
+        note = {"context_snapshot": big}
+        original_size = len(json.dumps(big, separators=(",", ":")))
+        assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        ro._cap_context_snapshot(note)
+        capped_size = len(json.dumps(note["context_snapshot"], separators=(",", ":")))
+        assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert note["context_snapshot"] is not big
+
+    def test_empty_snapshot_is_noop(self):
+        for val in [{}, None, "", "str"]:
+            note = {"context_snapshot": val}
+            ro._cap_context_snapshot(note)
+            assert note["context_snapshot"] == val
+
+    def test_missing_snapshot_is_noop(self):
+        note = {"reason": "pause"}
+        ro._cap_context_snapshot(note)
+        assert "context_snapshot" not in note
+
+
+class TestResumeRetryLoopCapsSnapshot:
+    @pytest.mark.asyncio
+    async def test_retry_loop_caps_oversized_snapshot(self, tmp_path, monkeypatch):
+        """When the first resume attempt fails (agent slow to boot), the
+        retry loop re-loads the note from disk and posts it again. The
+        context_snapshot must still be capped on every retry, not only on
+        the initial attempt."""
+        agent = {"name": "slow", "host": "10.0.0.7", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "slow"
+        note_dir.mkdir(parents=True)
+        big_snapshot = {f"field_{i}": "x" * 200 for i in range(500)}
+        (note_dir / "resume_note.json").write_text(
+            json.dumps({"reason": "pause", "context_snapshot": big_snapshot})
+        )
+
+        posted_notes = []
+        attempts = {"n": 0}
+
+        async def flaky_post(host, port, note):
+            attempts["n"] += 1
+            posted_notes.append(dict(note))
+            return attempts["n"] >= 2
+
+        monkeypatch.setattr(ro, "_post_resume", flaky_post)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 5)
+
+        await ro.resume_agents_from_notes(state)
+
+        for task in list(state._background_tasks):
+            await task
+
+        assert attempts["n"] == 2
+        for posted in posted_notes:
+            encoded = json.dumps(
+                posted["context_snapshot"], separators=(",", ":")
+            )
+            assert len(encoded) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -272,11 +272,37 @@ def _cap_context_snapshot(note: dict) -> None:
         overflow,
         len(encoded),
     )
-    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
-    try:
-        note["context_snapshot"] = json.loads(kept)
-    except json.JSONDecodeError:
-        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+    snapshot = dict(snapshot)
+    note["context_snapshot"] = snapshot
+    fields = sorted(
+        snapshot.items(),
+        key=lambda kv: len(json.dumps(kv[1], separators=(",", ":"))),
+        reverse=True,
+    )
+    dropped = []
+    for key, _value in fields:
+        if len(json.dumps(snapshot, separators=(",", ":"))) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+            break
+        dropped.append(key)
+        snapshot.pop(key)
+    _MAX_DROPPED = 100
+    reported = dropped[:_MAX_DROPPED]
+    if len(dropped) > _MAX_DROPPED:
+        reported.append(f"...and {len(dropped) - _MAX_DROPPED} more")
+    snapshot["_truncated"] = {
+        "dropped_fields": reported,
+        "reason": "snapshot exceeded context window; largest fields dropped first",
+    }
+    while len(json.dumps(snapshot, separators=(",", ":"))) > _MAX_CONTEXT_SNAPSHOT_BYTES:
+        remaining = sorted(
+            (kv for kv in snapshot.items() if kv[0] != "_truncated"),
+            key=lambda kv: len(json.dumps(kv[1], separators=(",", ":"))),
+            reverse=True,
+        )
+        if not remaining:
+            break
+        key, _value = remaining[0]
+        snapshot.pop(key)
 
 
 def _load_or_synthesize_note(note_path: Path) -> dict:

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -256,6 +256,28 @@ async def apply_pending_restart_check(app_state) -> None:
 _RESUME_RETRY_INTERVAL_S = 30
 _RESUME_RETRY_WINDOW_S = 600
 
+_MAX_CONTEXT_SNAPSHOT_BYTES = 32768
+
+
+def _cap_context_snapshot(note: dict) -> None:
+    snapshot = note.get("context_snapshot")
+    if not isinstance(snapshot, dict) or not snapshot:
+        return
+    encoded = json.dumps(snapshot, separators=(",", ":"))
+    if len(encoded) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+        return
+    overflow = len(encoded) - _MAX_CONTEXT_SNAPSHOT_BYTES
+    logger.warning(
+        "resume note context_snapshot capped: %d bytes over limit (%d bytes total)",
+        overflow,
+        len(encoded),
+    )
+    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
+    try:
+        note["context_snapshot"] = json.loads(kept)
+    except json.JSONDecodeError:
+        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+
 
 def _load_or_synthesize_note(note_path: Path) -> dict:
     if note_path.exists():
@@ -350,6 +372,7 @@ async def resume_agents_from_notes(app_state) -> None:
             continue
 
         note = _load_or_synthesize_note(note_path)
+        _cap_context_snapshot(note)
         if await _post_resume(host, port, note):
             finalize.append((agent, note_path))
             resumed.append(name)
@@ -438,6 +461,7 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
                     continue
                 note_path = data_dir / "agent-memory" / name / "resume_note.json"
                 note = _load_or_synthesize_note(note_path)
+                _cap_context_snapshot(note)
                 if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
                     # Per-agent config write is fine here: retry successes are
                     # rare, isolated events (one agent per 30s tick at worst),


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2570: _cap_context_snapshot slices serialized JSON then reparses it, so every oversized snapshot collapses to a bare _truncated marker (60119 bytes in, 68 out)

Autonomous build of board card tsk-ekc4ct.

REVISION: built on `exec/tsk-kkxn6f` (cut at `b4f1742d8b38b7f5d277e33720b32b8f99711299`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

_cap_context_snapshot() now drops the largest fields first until the
serialized form fits within 32768 bytes, preserving smaller fields and
recording the dropped field names in a _truncated marker. The previous
byte-slice approach produced invalid JSON so every oversized snapshot
collapsed to an empty marker, losing all context.

Tests now assert that required keys survive and the result is valid
JSON, not just that the size is under the limit. A size assertion
remains as a control but is no longer the only check.

Docs updated to describe field dropping instead of suffix truncation.

Files:
 changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md |  3 +
 .../tsk-kkxn6f-resume-context-snapshot-cap.md      |  3 +
 docs/agent-coordination.md                         | 13 ++++
 tests/test_restart_orchestrator_resume.py          | 90 ++++++++++++++++++++++
 tinyagentos/restart_orchestrator.py                | 50 ++++++++++++
 5 files changed, 159 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resume context snapshots are now limited to 32,768 bytes.
  * Oversized snapshots retain smaller fields and required suffix information while recording dropped fields in a truncation marker.
  * Snapshot limits are enforced consistently during initial resumes and retry attempts.

* **Documentation**
  * Added guidance for keeping hand-written resume notes within the snapshot size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->