### PR TITLE
fix-forward #2565: Postgres seam test patches the method under test, so 9 green tests survive a mutation that breaks the feature

### DIFF
--- a/changelog.d/tsk-wdplga-engine-seam.md
+++ b/changelog.d/tsk-wdplga-engine-seam.md
@@ -2,10 +2,6 @@
 
 - Engine selection support for BaseStore: Added Engine enum (SQLITE, POSTGRES) to allow stores to specify which database engine to use. Stores now have an optional `engine` parameter in their constructor and an `ENGINE` class attribute, defaulting to SQLite for backward compatibility. Added `_init_sqlite()` and `_init_postgres()` methods to BaseStore to handle engine-specific initialization.
 
-### Fixed
-
-- Stale documentation: Marked `docs/design/postgres-bounded-adoption.md` as superseded by the global Postgres migration (tsk-wdplga). The document is now noted as deprecated per Jay's ruling.
-
 ### Changed
 
 - BaseStore API: Modified `BaseStore.__init__()` to accept optional `engine` parameter. Store subclasses can now specify `ENGINE = Engine.POSTGRES` if they intend to use Postgres in future migration slices.

--- a/changelog.d/tsk-wdplga-engine-seam.md
+++ b/changelog.d/tsk-wdplga-engine-seam.md
@@ -1,0 +1,16 @@
+### Added
+
+- Engine selection support for BaseStore: Added Engine enum (SQLITE, POSTGRES) to allow stores to specify which database engine to use. Stores now have an optional `engine` parameter in their constructor and an `ENGINE` class attribute, defaulting to SQLite for backward compatibility. Added `_init_sqlite()` and `_init_postgres()` methods to BaseStore to handle engine-specific initialization.
+
+### Fixed
+
+- Stale documentation: Marked `docs/design/postgres-bounded-adoption.md` as superseded by the global Postgres migration (tsk-wdplga). The document is now noted as deprecated per Jay's ruling.
+
+### Changed
+
+- BaseStore API: Modified `BaseStore.__init__()` to accept optional `engine` parameter. Store subclasses can now specify `ENGINE = Engine.POSTGRES` if they intend to use Postgres in future migration slices.
+
+### Migration notes
+
+- **Backward compatibility:** SQLite remains the default engine. No existing stores will change behavior unless they explicitly set `ENGINE = Engine.POSTGRES`.
+- **Future migration:** This change provides the foundation for migrating stores to Postgres in follow-on slices (tsk-wdplga migration 2+). The engine selection logic is now in place and tested.

--- a/tests/test_storage_engine.py
+++ b/tests/test_storage_engine.py
@@ -1,0 +1,165 @@
+"""Tests for storage engine selection (SQLite vs Postgres)."""
+import aiosqlite
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from tinyagentos.base_store import BaseStore, Engine
+
+
+class TestStore(BaseStore):
+    """Test store implementation."""
+    SCHEMA = """
+        CREATE TABLE IF NOT EXISTS test_data (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL
+        );
+    """
+    MIGRATIONS = []
+
+
+class TestStoreWithMigrations(BaseStore):
+    """Test store with migrations."""
+    SCHEMA = ""
+    MIGRATIONS = [
+        (1, "CREATE TABLE IF NOT EXISTS migrated (id INTEGER PRIMARY KEY, data TEXT)"),
+    ]
+
+
+class TestStorePostgres(BaseStore):
+    """Test store using Postgres engine."""
+    SCHEMA = """
+        CREATE TABLE IF NOT EXISTS pg_test_data (
+            id   INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        );
+    """
+    MIGRATIONS = []
+    ENGINE = Engine.POSTGRES
+
+
+@pytest.mark.asyncio
+class TestEngineSelection:
+    """Tests for storage engine selection."""
+
+    async def test_default_engine_is_sqlite(self, tmp_path):
+        """Test that stores default to SQLite engine."""
+        store = TestStore(tmp_path / "test.db")
+        assert store.engine == Engine.SQLITE
+
+    async def test_explicit_sqlite_engine(self, tmp_path):
+        """Test that explicit SQLite engine works."""
+        store = TestStore(tmp_path / "test.db", engine=Engine.SQLITE)
+        assert store.engine == Engine.SQLITE
+        await store.init()
+        try:
+            cursor = await store._db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='test_data'"
+            )
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == "test_data"
+        finally:
+            await store.close()
+
+    async def test_postgres_engine_selected(self, tmp_path):
+        """Test that Postgres engine can be selected."""
+        store = TestStorePostgres(tmp_path / "test.pg")
+        assert store.engine == Engine.POSTGRES
+
+    async def test_postgres_fails_when_unavailable(self, tmp_path):
+        """Test that Postgres startup fails loudly when unavailable."""
+        # This test validates that when a store explicitly selects Postgres
+        # but Postgres is unavailable, startup fails rather than falling back
+        # to SQLite.
+        
+        # Mock the postgres connection to simulate unavailability
+        with patch.object(BaseStore, '_init_postgres', new_callable=AsyncMock) as mock_postgres:
+            mock_postgres.side_effect = RuntimeError("Postgres unavailable")
+            
+            store = TestStorePostgres(tmp_path / "test.pg")
+            
+            # The store should attempt to initialize Postgres and fail
+            with pytest.raises(RuntimeError, match="Postgres unavailable"):
+                await store.init()
+
+    async def test_sqlite_fallback_when_no_engine_specified(self, tmp_path):
+        """Test that SQLite remains the default and works when no engine is configured."""
+        store = TestStore(tmp_path / "test.db")
+        assert store.engine == Engine.SQLITE
+        
+        await store.init()
+        try:
+            cursor = await store._db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='test_data'"
+            )
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == "test_data"
+        finally:
+            await store.close()
+
+
+@pytest.mark.asyncio
+class TestPostgresIntegration:
+    """Integration tests for Postgres engine behavior."""
+
+    async def test_postgres_engine_fails_silently_if_not_implemented(self, tmp_path):
+        """Test that selecting Postgres but having it unimplemented raises NotImplementedError."""
+        store = TestStorePostgres(tmp_path / "test.pg")
+        
+        with pytest.raises(NotImplementedError, match="Postgres engine not yet implemented"):
+            await store.init()
+
+    async def test_sqlite_engine_works_normally(self, tmp_path):
+        """Test that SQLite engine works normally (baseline)."""
+        store = TestStore(tmp_path / "test.db")
+        
+        await store.init()
+        try:
+            cursor = await store._db.execute("INSERT INTO test_data (name) VALUES (?)", ("test",))
+            await store._db.commit()
+            
+            cursor = await store._db.execute("SELECT id, name FROM test_data")
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][1] == "test"
+        finally:
+            await store.close()
+
+    async def test_engine_selection_is_preserved_across_close_open(self, tmp_path):
+        """Test that engine selection is preserved when store is closed and reopened."""
+        # Create store with Postgres engine
+        store = TestStorePostgres(tmp_path / "test.pg")
+        assert store.engine == Engine.POSTGRES
+        
+        # Close it
+        await store.close()
+        
+        # Engine should still be Postgres after close
+        assert store.engine == Engine.POSTGRES
+        
+        # Note: We can't reopen with Postgres as it's not implemented yet
+        # but the attribute should be preserved
+
+    async def test_migration_chain_runs_for_sqlite(self, tmp_path):
+        """Test that migrations still run when using SQLite."""
+        store = TestStoreWithMigrations(tmp_path / "test.db")
+        
+        await store.init()
+        try:
+            cursor = await store._db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='migrated'"
+            )
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == "migrated"
+            
+            cursor = await store._db.execute(
+                "SELECT version FROM schema_migrations WHERE store_name = ?",
+                ("TestStoreWithMigrations",),
+            )
+            versions = [row[0] for row in await cursor.fetchall()]
+            assert 1 in versions
+        finally:
+            await store.close()

--- a/tests/test_storage_engine.py
+++ b/tests/test_storage_engine.py
@@ -69,19 +69,9 @@ class TestEngineSelection:
 
     async def test_postgres_fails_when_unavailable(self, tmp_path):
         """Test that Postgres startup fails loudly when unavailable."""
-        # This test validates that when a store explicitly selects Postgres
-        # but Postgres is unavailable, startup fails rather than falling back
-        # to SQLite.
-        
-        # Mock the postgres connection to simulate unavailability
-        with patch.object(BaseStore, '_init_postgres', new_callable=AsyncMock) as mock_postgres:
-            mock_postgres.side_effect = RuntimeError("Postgres unavailable")
-            
-            store = TestStorePostgres(tmp_path / "test.pg")
-            
-            # The store should attempt to initialize Postgres and fail
-            with pytest.raises(RuntimeError, match="Postgres unavailable"):
-                await store.init()
+        store = TestStorePostgres(tmp_path / "test.pg")
+        with pytest.raises(NotImplementedError, match="Postgres engine not yet implemented"):
+            await store.init()
 
     async def test_sqlite_fallback_when_no_engine_specified(self, tmp_path):
         """Test that SQLite remains the default and works when no engine is configured."""

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -45,7 +45,7 @@ class BaseStore:
 
     async def init(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         if self.engine == Engine.POSTGRES:
             await self._init_postgres()
         else:
@@ -54,7 +54,7 @@ class BaseStore:
     async def _init_sqlite(self) -> None:
         import aiosqlite
         from tinyagentos.db_migrations import apply_wal_pragmas_async, run_migrations_async
-        
+
         self._db = await aiosqlite.connect(str(self.db_path))
         await apply_wal_pragmas_async(self._db)
         if self.SCHEMA:

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 from pathlib import Path
-import aiosqlite
+from enum import Enum
 
-from tinyagentos.db_migrations import apply_wal_pragmas_async, run_migrations_async
+
+class Engine(Enum):
+    """Database engine selection."""
+    SQLITE = "sqlite"
+    POSTGRES = "postgres"
 
 
 class BaseStore:
@@ -31,13 +35,26 @@ class BaseStore:
     SCHEMA: str = ""
     # List of (version: int, sql_or_callable) pairs. See db_migrations.py.
     MIGRATIONS: list = []
+    # Database engine: SQLITE (default) or POSTGRES
+    ENGINE: Engine = Engine.SQLITE
 
-    def __init__(self, db_path: Path):
+    def __init__(self, db_path: Path, engine: Engine | None = None):
         self.db_path = db_path
-        self._db: aiosqlite.Connection | None = None
+        self.engine = engine if engine is not None else self.ENGINE
+        self._db = None
 
     async def init(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        if self.engine == Engine.POSTGRES:
+            await self._init_postgres()
+        else:
+            await self._init_sqlite()
+
+    async def _init_sqlite(self) -> None:
+        import aiosqlite
+        from tinyagentos.db_migrations import apply_wal_pragmas_async, run_migrations_async
+        
         self._db = await aiosqlite.connect(str(self.db_path))
         await apply_wal_pragmas_async(self._db)
         if self.SCHEMA:
@@ -47,6 +64,9 @@ class BaseStore:
             await run_migrations_async(self._db, self.MIGRATIONS,
                                        namespace=self.__class__.__name__)
         await self._post_init()
+
+    async def _init_postgres(self) -> None:
+        raise NotImplementedError("Postgres engine not yet implemented")
 
     async def _post_init(self) -> None:
         """Override in subclasses for seeding data after schema creation."""


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2565: Postgres seam test patches the method under test, so 9 green tests survive a mutation that breaks the feature

Autonomous build of board card tsk-6cg7gx.

REVISION: built on `exec/tsk-wdplga` (cut at `335a759173a6ba0742103ab076df31504bc329de`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

- Rewrite test_postgres_fails_when_unavailable to drive the real seam
  (NotImplementedError from _init_postgres) with no patch on the method
  under test. The previous version patched BaseStore._init_postgres with
  an AsyncMock, so it asserted mock behaviour, not production behaviour.

- Remove the false '### Fixed' entry from the changelog fragment. The
  fragment claimed docs/design/postgres-bounded-adoption.md was marked
  superseded, but that doc is not touched in this PR.

- Fix trailing whitespace and missing EOF newline in base_store.py.

MUTATION PROOF (flipped _init_postgres to SQLite fallback):
  CONTROL  (original code):  9 passed
  MUTATED  (silent fallback): 2 failed, 7 passed

  FAILED tests/test_storage_engine.py::TestEngineSelection::test_postgres_fails_when_unavailable
  FAILED tests/test_storage_engine.py::TestPostgresIntegration::test_postgres_engine_fails_silently_if_not_implemented

Both failures come from tests that do NOT patch their own target.

Files:
 changelog.d/tsk-wdplga-engine-seam.md |  12 +++
 tests/test_storage_engine.py          | 155 ++++++++++++++++++++++++++++++++++
 tinyagentos/base_store.py             |  28 +++++-
 3 files changed, 191 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable database engine selection for storage.
  - SQLite remains the default engine, preserving existing behavior.
  - Added support for explicitly selecting SQLite when initializing storage.
  - Added Postgres engine recognition as groundwork for future support.

- **Bug Fixes**
  - Improved storage initialization handling so the selected engine remains consistent throughout the store lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->