### PR TITLE
fix(auth): set the brand as the taOS wordmark instead of the drawn glyph

### DIFF
--- a/changelog.d/auth-wordmark-brand.md
+++ b/changelog.d/auth-wordmark-brand.md
@@ -1,0 +1,14 @@
+### Changed: the sign-in and setup pages carry the taOS wordmark
+
+- The auth pages previously showed a drawn mark — a rounded square with a
+  centre dot and an X through it. An X in a box on a sign-in screen reads as
+  an error badge or a close affordance rather than a logo, so the brand is now
+  set as type: the product name in the page's own font stack.
+- The mark stays plain ASCII, so the pages keep the property the inline SVG was
+  introduced for — no webfont to fetch, and no code point that can render as a
+  missing-glyph box on a device without a covering font. These pages are
+  deliberately JS-free and CDN-free, so a text glyph would have lost that.
+- The setup page keeps its welcome in the subheading; no copy is dropped.
+- `tests/test_auth_brand_mark.py` anchors on the `.brand` block rather than the
+  whole page, and fails both on the drawn mark returning and on a regression to
+  a bare Unicode glyph.

--- a/tests/test_auth_brand_mark.py
+++ b/tests/test_auth_brand_mark.py
@@ -12,16 +12,35 @@ from tinyagentos.routes.auth import _login_page, _setup_page
 _BRAND_GLYPHS = ("⌗", "✦")
 
 
+_BRAND_OPEN = re.compile(r'<div\b[^>]*\bclass="[^"]*\bbrand\b[^"]*"[^>]*>', re.DOTALL)
+_DIV_EDGE = re.compile(r"<div\b|</div\s*>", re.IGNORECASE)
+
+
 def _brand_inner(html: str) -> str:
     """Return the inner HTML of the `.brand` block.
 
     Anchors every assertion on the brand block itself rather than the whole
     page: the auth pages carry other markup, so a page-level check would be one
     level coarser than the defect and could not fail on a mark rendered here.
+
+    Matches the opening tag on the `brand` class token rather than on the exact
+    string `<div class="brand">`, so a modifier class or an added attribute does
+    not turn every assertion below into a "no .brand element" error, and walks
+    nested `<div>`s to the *matching* close. A non-greedy `(.*?)</div>` would
+    stop at the first close tag instead: nest one `<div>` in the brand block and
+    the drawn-mark assertions would only ever scan the part before it, which is
+    the shape that lets a mark come back while the test stays green.
     """
-    match = re.search(r'<div class="brand">(.*?)</div>', html, re.DOTALL)
-    assert match, "no .brand element found in page"
-    return match.group(1)
+    open_tag = _BRAND_OPEN.search(html)
+    assert open_tag, "no .brand element found in page"
+
+    depth = 1
+    pos = open_tag.end()
+    for edge in _DIV_EDGE.finditer(html, pos):
+        depth += 1 if edge.group(0).lower().startswith("<div") else -1
+        if depth == 0:
+            return html[open_tag.end() : edge.start()]
+    raise AssertionError("unbalanced .brand element: no matching </div>")
 
 
 class TestAuthBrandMark:
@@ -59,3 +78,15 @@ class TestAuthBrandMark:
             brand = _brand_inner(page)
             for glyph in _BRAND_GLYPHS:
                 assert glyph not in brand, f"bare brand glyph {glyph!r} is back in the brand block"
+
+    def test_no_bare_glyph_anywhere_on_the_auth_pages(self):
+        """The brand-scoped checks above cannot see a glyph that reappears
+        outside the brand block — as a header ornament or a submit-button
+        affordance, say. These pages are JS-free and CDN-free precisely so they
+        render on any device, so the TOFU risk is page-wide, not brand-local.
+        Kept alongside the scoped checks rather than replacing them: this one
+        cannot tell us the *mark* regressed, only that a glyph is present.
+        """
+        for name, page in (("login", _login_page()), ("setup", _setup_page())):
+            for glyph in _BRAND_GLYPHS:
+                assert glyph not in page, f"bare glyph {glyph!r} is back on the {name} page"

--- a/tests/test_auth_brand_mark.py
+++ b/tests/test_auth_brand_mark.py
@@ -8,31 +8,54 @@ from tinyagentos.routes.auth import _login_page, _setup_page
 # the server-rendered auth pages. They are host-font-dependent: a machine with
 # no font covering the code point renders a missing-glyph box (TOFU) instead of
 # the logo. The auth pages are deliberately JS-free and CDN-free so they work on
-# any device, so the mark must be an inline SVG rather than a text glyph.
+# any device, so the mark must never regress to a text glyph.
 _BRAND_GLYPHS = ("⌗", "✦")
 
 
-def _icon_inner(html: str) -> str:
-    """Return the inner HTML of the `.icon` brand element.
+def _brand_inner(html: str) -> str:
+    """Return the inner HTML of the `.brand` block.
 
-    Anchors the assertion on the brand element itself rather than on the whole
-    page -- the pages already contain other markup, so a page-level "svg"
-    check would be one level too coarse to fail on this defect.
+    Anchors every assertion on the brand block itself rather than the whole
+    page: the auth pages carry other markup, so a page-level check would be one
+    level coarser than the defect and could not fail on a mark rendered here.
     """
-    match = re.search(r'<div class="icon">(.*?)</div>', html, re.DOTALL)
-    assert match, "no .icon brand element found in page"
+    match = re.search(r'<div class="brand">(.*?)</div>', html, re.DOTALL)
+    assert match, "no .brand element found in page"
     return match.group(1)
 
 
 class TestAuthBrandMark:
-    def test_login_page_brand_is_inline_svg(self):
-        icon = _icon_inner(_login_page())
-        assert "<svg" in icon, "brand mark is a bare glyph"
-        for glyph in _BRAND_GLYPHS:
-            assert glyph not in icon, f"bare brand glyph {glyph!r} still present in icon"
+    """The auth pages carry the taOS wordmark, not a drawn glyph.
 
-    def test_setup_page_brand_is_inline_svg(self):
-        icon = _icon_inner(_setup_page())
-        assert "<svg" in icon, "brand mark is a bare glyph"
-        for glyph in _BRAND_GLYPHS:
-            assert glyph not in icon, f"bare brand glyph {glyph!r} still present in icon"
+    The mark these pages shipped with was a rounded square with a centre dot
+    and an X through it. On a sign-in screen that reads as an error badge or a
+    close affordance rather than a logo, so the brand is set as type instead.
+    """
+
+    def test_login_page_brand_is_wordmark(self):
+        brand = _brand_inner(_login_page())
+        assert '<h1 class="wordmark">taOS</h1>' in brand, "login page lost the taOS wordmark"
+
+    def test_setup_page_brand_is_wordmark(self):
+        brand = _brand_inner(_setup_page())
+        assert '<h1 class="wordmark">taOS</h1>' in brand, "setup page lost the taOS wordmark"
+
+    def test_login_page_brand_has_no_drawn_mark(self):
+        brand = _brand_inner(_login_page())
+        assert "<svg" not in brand, "a drawn brand mark is back on the login page"
+        assert "<line" not in brand, "the crossing-lines (X) mark is back on the login page"
+        assert 'class="icon"' not in brand, "the brand icon tile is back on the login page"
+
+    def test_setup_page_brand_has_no_drawn_mark(self):
+        brand = _brand_inner(_setup_page())
+        assert "<svg" not in brand, "a drawn brand mark is back on the setup page"
+        assert "<line" not in brand, "the crossing-lines (X) mark is back on the setup page"
+        assert 'class="icon"' not in brand, "the brand icon tile is back on the setup page"
+
+    def test_brand_does_not_regress_to_a_bare_glyph(self):
+        """Dropping the drawn mark must not reintroduce the TOFU-prone glyphs
+        it originally replaced."""
+        for page in (_login_page(), _setup_page()):
+            brand = _brand_inner(page)
+            for glyph in _BRAND_GLYPHS:
+                assert glyph not in brand, f"bare brand glyph {glyph!r} is back in the brand block"

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -152,7 +152,6 @@ body.osk-open label.field { margin-bottom: 6px; }
 body.osk-open .brand { margin-bottom: 8px; gap: 6px; }
 body.osk-open .brand h1.wordmark { font-size: 26px; }
 body.osk-open .brand p { display: none; }
-.brand h1 { margin: 0; font-size: 18px; font-weight: 600; }
 /* The wordmark IS the brand mark on these pages: the product name set as type,
    carrying the card visually on its own. It replaces an earlier drawn glyph —
    a rounded square with a centre dot and an X through it — which on a sign-in
@@ -161,6 +160,7 @@ body.osk-open .brand p { display: none; }
    and no code point that can land as TOFU on a device missing a covering font,
    which is what the JS-free, CDN-free auth pages need. */
 .brand h1.wordmark {
+  margin: 0;
   font-size: 34px;
   font-weight: 600;
   letter-spacing: -0.02em;

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -143,13 +143,6 @@ body {
   gap: 12px;
   margin-bottom: 22px;
 }
-.brand .icon {
-  width: 56px; height: 56px;
-  border-radius: 16px;
-  display: flex; align-items: center; justify-content: center;
-  background: linear-gradient(135deg, #8b92a3, #5b6170);
-  font-size: 26px;
-}
 /* The on-screen keyboard takes roughly half of a 600px panel, so while it is
    open the card sheds decorative height to keep its actions above the keys.
    The body is scrollable in that state either way, but a sign-in the user has
@@ -157,9 +150,22 @@ body {
 body.osk-open .card { padding: 16px 20px 12px; }
 body.osk-open label.field { margin-bottom: 6px; }
 body.osk-open .brand { margin-bottom: 8px; gap: 6px; }
-body.osk-open .brand .icon { width: 40px; height: 40px; border-radius: 12px; font-size: 20px; }
+body.osk-open .brand h1.wordmark { font-size: 26px; }
 body.osk-open .brand p { display: none; }
 .brand h1 { margin: 0; font-size: 18px; font-weight: 600; }
+/* The wordmark IS the brand mark on these pages: the product name set as type,
+   carrying the card visually on its own. It replaces an earlier drawn glyph —
+   a rounded square with a centre dot and an X through it — which on a sign-in
+   screen read as an error badge or a close affordance rather than a logo.
+   Plain ASCII in the page's own font stack, so there is no webfont to fetch
+   and no code point that can land as TOFU on a device missing a covering font,
+   which is what the JS-free, CDN-free auth pages need. */
+.brand h1.wordmark {
+  font-size: 34px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
 .brand p { margin: 0; font-size: 12px; color: rgba(255,255,255,0.5); text-align: center; }
 label.field {
   display: block;
@@ -417,27 +423,6 @@ def _pin_panel_html(next_url: str) -> str:
     """
 
 
-# Inline taOS brand mark for the auth pages. Rendered as an SVG rather than a
-# bare Unicode glyph (⌗ / ✦): those code points are host-font-dependent and
-# render as TOFU on machines that lack a covering font, which contradicts the
-# pages' deliberate JS-free, CDN-free robustness. The SVG scales to its
-# `.icon` container (100% x 100%) so the same mark works in both the default
-# 56px slot and the osk-open 40px slot, and uses `currentColor` so it inherits
-# the page's text colour rather than fetching a webfont.
-_AUTH_BRAND_SVG = (
-    '<svg width="100%" height="100%" viewBox="0 0 56 56" '
-    'xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">'
-    '<rect x="12" y="12" width="32" height="32" rx="4" fill="none" '
-    'stroke="currentColor" stroke-width="2.5"></rect>'
-    '<circle cx="28" cy="28" r="3.5" fill="currentColor"></circle>'
-    '<line x1="18" y1="18" x2="38" y2="38" stroke="currentColor" '
-    'stroke-width="2" stroke-linecap="round"></line>'
-    '<line x1="38" y1="18" x2="18" y2="38" stroke="currentColor" '
-    'stroke-width="2" stroke-linecap="round"></line>'
-    '</svg>'
-)
-
-
 def _login_page(
     error: str = "",
     multi_user: bool = False,
@@ -476,8 +461,7 @@ def _login_page(
 <body>
   <div class="card">
     <div class="brand">
-      <div class="icon">{_AUTH_BRAND_SVG}</div>
-      <h1>taOS</h1>
+      <h1 class="wordmark">taOS</h1>
       <p>Sign in to continue</p>
     </div>
     {err}
@@ -533,9 +517,8 @@ def _setup_page(error: str = "", pin_offered: bool = False) -> str:
 <body>
   <form class="card" method="POST" action="/auth/setup">
     <div class="brand">
-      <div class="icon">{_AUTH_BRAND_SVG}</div>
-      <h1>Welcome to taOS</h1>
-      <p>Set up your account to get started.</p>
+      <h1 class="wordmark">taOS</h1>
+      <p>Welcome — set up your account to get started.</p>
     </div>
     {err}
     <label class="field">


### PR DESCRIPTION
Jay's ruling: the auth pages carry the **taOS wordmark**, and the drawn glyph goes.

#2549 shipped a lane-invented mark — a rounded square with a centre dot and an X through it. It was not a regression, but an X in a box on a sign-in screen reads as an error badge or a close affordance rather than a logo, and the real mark was never Jay's to begin with. Rather than invent a second one, the brand is now set as type.

### What changed

- `_AUTH_BRAND_SVG` and the `.icon` tile are gone from both the login and setup pages; the `taOS` wordmark is the mark, styled at 34px with tight tracking so it still carries the card.
- The wordmark **is** the `h1`, so each page keeps exactly one top-level heading rather than gaining a decorative element above it.
- The setup page keeps its welcome — it moves from the heading into the subheading, so no copy is dropped.
- Dead `body.osk-open .brand .icon` sizing is replaced by a wordmark rule, so the on-screen-keyboard layout still sheds height on a kiosk panel.

### Why the mark was an SVG, and why type is still safe

The SVG replaced bare Unicode glyphs (`⌗` / `✦`) because those are host-font-dependent and land as TOFU on a device with no covering font — these pages are deliberately JS-free and CDN-free. A wordmark keeps that property: it is plain ASCII in the page's own font stack, so there is nothing to fetch and nothing that can fail to render. The test guards that explicitly, so this cannot quietly regress to a glyph later.

### Test evidence — red first

The tests anchor on the `.brand` block, not the page, so they sit at the same granularity as the defect. Against `origin/dev` (the drawn mark):

```console
$ python -m pytest tests/test_auth_brand_mark.py -q
FAILED test_login_page_brand_is_wordmark
FAILED test_setup_page_brand_is_wordmark
FAILED test_login_page_brand_has_no_drawn_mark
FAILED test_setup_page_brand_has_no_drawn_mark
4 failed, 1 passed in 0.33s
```

Against this branch:

```console
$ python -m pytest tests/test_auth_brand_mark.py -q
5 passed in 0.29s
```

The one test that passes in both states is the TOFU-glyph guard — correctly, since the old code had no bare glyph either. It is carried forward to protect the property the SVG existed for.

Both pages were rendered and screenshotted headless to confirm the wordmark actually carries the card at 520px, rather than trusting the markup.


---

## Review items actioned (`c9fb14d7`)

Kilo raised four. Three were real and are fixed; one is declined with a reason.

- **The brand-block scan had a hole.** `_brand_inner` matched
  `<div class="brand">(.*?)</div>`, and the non-greedy body stops at the FIRST
  close tag — so nesting a `<div>` inside the brand block truncates the capture
  and the drawn-mark assertions only ever scan the part before it. Mutation with
  nesting as the only variable: an `<svg><line>` placed after a nested div left
  the old helper **green**; the balanced walk fails on it. The opening tag now
  matches on the `brand` class token, so a modifier class no longer turns every
  assertion into a "no .brand element" error.
- **The glyph check was brand-scoped only.** Added a page-wide one alongside it,
  not instead of it — the scoped checks cannot see a glyph that returns outside
  the brand block, and the TOFU risk on JS-free, CDN-free pages is page-wide.
- **`.brand h1` was dead** for `font-size`/`font-weight` under `.brand h1.wordmark`
  — but it also carried `margin: 0`, which `.wordmark` did not redeclare. Deleting
  it outright would have restored the default h1 margin, so it was folded first.
- **Declined:** demoting the setup `h1` back to "Welcome to taOS". An `h1` naming
  the product is the conventional accessible pattern, matches the login page, and
  the page purpose stays in the first paragraph.

## Deleted symbols — deliberate

The three symbols below asserted that the brand mark **is an inline SVG**. This PR
replaces that mark with a wordmark, so they assert the exact thing it removes;
keeping them would be self-contradictory. `_icon_inner` was their helper and has no
other caller. Verified locally with the trailer as the only variable: the gate exits
1 without it and 0 with it.

Removes-Intentionally: tests/test_auth_brand_mark.py:TestAuthBrandMark.test_login_page_brand_is_inline_svg, tests/test_auth_brand_mark.py:TestAuthBrandMark.test_setup_page_brand_is_inline_svg, tests/test_auth_brand_mark.py:_icon_inner
