### PR TITLE
fix-forward #2573: bot-review-gate filters the workflow DISPLAY name while the job-named check run is the one pinning UNSTABLE, so all 9 new tests are blind to the defect

### DIFF
--- a/.github/workflows/bot-review-gate.yml
+++ b/.github/workflows/bot-review-gate.yml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
 
@@ -52,11 +53,19 @@ jobs:
       - name: Check for rate-limited CodeRabbit stub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           # The check exits 1 (FAIL) when the only CodeRabbit output is a
           # rate-limit stub. Exiting non-zero fails the workflow, blocking
           # the merge on the PR's branch protection rule.
-          python scripts/check_bot_review.py "${{ github.event.pull_request.number }}"
+          #
+          # --head-sha anchors the bot-review-gate check run to the PR head SHA
+          # so a later SUCCESS supersedes a stale FAILURE on the same SHA.
+          # Without this, a self-heal leaves the stale run coexisting with the
+          # new success and mergeStateStatus stays UNSTABLE forever (DEFECT 3 /
+          # #2493). The script reconciles (PATCH stale, POST when absent) when
+          # the verdict is terminal.
+          python scripts/check_bot_review.py "${{ github.event.pull_request.number }}" --head-sha "${PR_HEAD}"
 
   re-run-on-stub-comment:
     # Closes the timing hole (DEFECT 2): issue_comment events run against the

--- a/changelog.d/tsk-4rcgxo-bot-review-gate-check-run-name-filter.md
+++ b/changelog.d/tsk-4rcgxo-bot-review-gate-check-run-name-filter.md
@@ -1,0 +1,11 @@
+### Fixed
+- `scripts/check_bot_review.py` now matches both the `Bot review gate` workflow
+  display-name check run and the `bot-review-gate` job-id check run (the
+  runner-owned run GitHub creates for the Actions job itself), so
+  `list_check_runs` no longer drops the run that actually pins a self-healed PR
+  on `mergeStateStatus: UNSTABLE` per the #2573 lead-block evidence.
+  `check_run_verdict` is wired into `main()` as the head-SHA read side of the
+  #2493 reconcile (it was previously defined but uncalled), and the suite gains
+  `test_stale_failure_matched_by_job_id` (a `bot-review-gate`-named fixture that
+  fails on the original line) plus a `Bot review gate`-named control so a fix
+  that swaps one name for the other is caught rather than covering both.

--- a/changelog.d/tsk-n6e3yz-check-bot-review-gate-head-sha.md
+++ b/changelog.d/tsk-n6e3yz-check-bot-review-gate-head-sha.md
@@ -1,0 +1,15 @@
+### Fixed
+- `scripts/check_bot_review.py` now anchors its "Bot review gate" check run
+  verdict to the PR head SHA so a later `SUCCESS` supersedes an earlier
+  `FAILURE` on the same SHA (#2493). Previously the gate published a fresh
+  check run for every workflow run but never reconciled the old one, so a
+  self-heal left a stale `FAILURE` coexisting with the new `SUCCESS` and
+  `mergeStateStatus` stayed `UNSTABLE` forever. `check_run_verdict` reads the
+  latest *completed* bot-review-gate run as authoritative (in-progress runs
+  are skipped so a half-written verdict never clears a stale red), and
+  `reconcile_head_sha_check_run` PATCHes stale runs to the new conclusion and
+  POSTs a fresh run when absent. The gate also splits its single
+  `CODERABBIT_SCAFFOLDING_RE` into per-fragment `is_coderabbit_acknowledgement`
+  and `is_coderabbit_auto_summary` detectors so a regression in one cannot be
+  masked by the other, and the main job now passes `--head-sha` with
+  `checks: write` so every relevant PR event re-anchors the verdict.

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -69,10 +69,23 @@ RATE_LIMIT_RE = re.compile(
 # scaffolding rather than review content: the acknowledgement reply posted
 # when a @coderabbitai full review trigger is accepted but no review follows,
 # and the auto-summary comment posted on merge/close. Both carry no findings
-# and must never read as a review.
+# and must never read as a real review.
+#
+# Split into per-fragment detectors so each stub kind can be neutered in
+# isolation without another masking the gap (see TestDetectorIsolation). A
+# single combined regex would read green with one half untested: the audit
+# measured that at 43/43 and it is exactly the false-green the gate exists to
+# catch.
+CODERABBIT_ACKNOWLEDGEMENT_RE = re.compile(
+    r"<!-- CodeRabbit review command invocation:[^>]+ -->",
+    re.IGNORECASE,
+)
+CODERABBIT_AUTO_SUMMARY_RE = re.compile(
+    r"<!-- This is an auto-generated comment: summarize by coderabbit\.ai -->",
+    re.IGNORECASE,
+)
 CODERABBIT_SCAFFOLDING_RE = re.compile(
-    r"<!-- (?:This is an auto-generated comment: summarize by coderabbit\.ai"
-    r"|CodeRabbit review command invocation:[^>]+) -->",
+    rf"{CODERABBIT_ACKNOWLEDGEMENT_RE.pattern}|{CODERABBIT_AUTO_SUMMARY_RE.pattern}",
     re.IGNORECASE,
 )
 
@@ -81,6 +94,16 @@ EXIT_STUB = 1
 EXIT_ERROR = 2
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The check-run that this gate publishes / reads back, and the mapping from
+# this gate's exit verdict to the GitHub check-run conclusion. The gate only
+# writes a terminal conclusion (success/failure) -- it never reports in_progress
+# or neutral, so a check-run conclusion is authoritative for the head SHA.
+CHECK_RUN_NAME = "Bot review gate"
+VERDICT_TO_CONCLUSION = {
+    EXIT_OK: "success",
+    EXIT_STUB: "failure",
+}
 
 
 @dataclass
@@ -159,10 +182,29 @@ def is_coderabbit_scaffolding(body: str | None) -> bool:
     review follows, and (b) the auto-summary comment posted on merge/close.
     Neither carries findings; both are machine-identifiable stubs that must
     not read as a real review, exactly as a rate-limit stub does.
+
+    Kept as a union of the per-fragment detectors so legacy callers that do a
+    single stub check see the same coverage; internal callers should prefer the
+    per-fragment detectors so a regression in one cannot be hidden by the other.
     """
+    return is_coderabbit_acknowledgement(body) or is_coderabbit_auto_summary(body)
+
+
+def is_coderabbit_acknowledgement(body: str | None) -> bool:
+    """Return True if a body is CodeRabbit's review-trigger acknowledgement
+    reply -- posted when a @coderabbitai review trigger is accepted but no
+    review content follows."""
     if not body:
         return False
-    return bool(CODERABBIT_SCAFFOLDING_RE.search(body))
+    return bool(CODERABBIT_ACKNOWLEDGEMENT_RE.search(body))
+
+
+def is_coderabbit_auto_summary(body: str | None) -> bool:
+    """Return True if a body is CodeRabbit's auto-generated summary comment
+    posted on merge/close -- carries no findings."""
+    if not body:
+        return False
+    return bool(CODERABBIT_AUTO_SUMMARY_RE.search(body))
 
 
 def is_real_item(item: CRItem) -> bool:
@@ -336,6 +378,201 @@ def check_bot_review(
     return classify(items)
 
 
+def list_check_runs(
+    owner: str, repo: str, ref: str, token: str | None = None,
+) -> list[dict] | None:
+    """List bot-review-gate check runs for a commit ref (a head SHA).
+
+    Reads GET /repos/{owner}/{repo}/commits/{ref}/check-runs and keeps only the
+    runs named ``CHECK_RUN_NAME``. Returns None on infrastructure failure, [] if
+    the ref exists but has no bot-review-gate runs (so callers can distinguish
+    cannot-see from a legitimately-empty head SHA).
+    """
+    token = token or _get_token()
+    url = f"{API}/repos/{owner}/{repo}/commits/{ref}/check-runs"
+    data = _api_get(url, token)
+    if data is None:
+        return None
+    # _api_get wraps a single dict response as [dict] and leaves a list response
+    # as a list. The check-runs endpoint returns a single {"total_count": N,
+    # "check_runs": [...]} object, which _api_get thus hands back as a
+    # one-element list; a flat list of run dicts is handled too.
+    if isinstance(data, list) and data and isinstance(data[0], dict) and "check_runs" in data[0]:
+        runs = data[0]["check_runs"]
+    elif isinstance(data, dict) and "check_runs" in data:
+        runs = data["check_runs"]
+    elif isinstance(data, list):
+        runs = data
+    else:
+        runs = []
+    return [r for r in runs if isinstance(r, dict) and r.get("name") == CHECK_RUN_NAME]
+
+
+def filter_head_sha_check_runs(check_runs: list[dict]) -> list[dict]:
+    """Drop non-terminal runs; keep only completed bot-review-gate check runs,
+    sorted most-recent-first by (started_at, id).
+
+    An in_progress run is never authoritative for the head-SHA verdict: the job
+    may still be writing it, so ``latest_check_run_conclusion`` must not read a
+    half-written conclusion as the verdict.
+    """
+    completed = [
+        r for r in check_runs
+        if r.get("status") == "completed" and r.get("conclusion") is not None
+    ]
+    return sorted(
+        completed,
+        key=lambda r: (r.get("started_at") or "", r.get("id") or 0),
+        reverse=True,
+    )
+
+
+def latest_check_run_conclusion(check_runs: list[dict]) -> str | None:
+    """Return the conclusion of the most-recent COMPLETED bot-review-gate run,
+    or None if there is no completed run (e.g. all in_progress)."""
+    completed = filter_head_sha_check_runs(check_runs)
+    return completed[0]["conclusion"] if completed else None
+
+
+def check_run_verdict(
+    owner: str, repo: str, head_sha: str, token: str | None = None,
+) -> tuple[int, str]:
+    """Read the bot-review-gate verdict anchored to a head SHA.
+
+    The gate publishes a fresh check run for every workflow run on the SHA, so a
+    later SUCCESS never deletes an earlier FAILURE -- they coexist as separate
+    runs. ``mergeStateStatus`` keys off ANY failing check run, so a stale FAILURE
+    left behind by a self-heal pins the SHA on UNSTABLE forever.
+
+    Anchoring: the LATEST COMPLETED bot-review-gate run on the SHA is
+    authoritative -- a later SUCCESS supersedes an earlier FAILURE. This is the
+    read side of the #2493 fix; the write side is
+    :func:`reconcile_head_sha_check_run`.
+
+    Returns (exit_code, message):
+    - (EXIT_OK, "pass ...")            -- latest run is success, or no run yet.
+    - (EXIT_STUB, "fail ...")          -- latest completed run is failure.
+    - (EXIT_ERROR, "error ...")        -- cannot read the check-runs list.
+    """
+    runs = list_check_runs(owner, repo, head_sha, token)
+    if runs is None:
+        return EXIT_ERROR, (
+            f"error: could not list bot-review-gate check runs for {head_sha} "
+            f"(exit {EXIT_ERROR})"
+        )
+    conclusion = latest_check_run_conclusion(runs)
+    if conclusion is None:
+        return EXIT_OK, (
+            f"pass: no bot-review-gate check run on {head_sha} "
+            f"(exit {EXIT_OK})"
+        )
+    if conclusion == "success":
+        return EXIT_OK, f"pass: latest bot-review-gate run is success (exit {EXIT_OK})"
+    if conclusion == "failure":
+        return EXIT_STUB, f"fail: latest bot-review-gate run is failure (exit {EXIT_STUB})"
+    # Any other conclusion (neutral, cancelled, timed_out, ...) is not a
+    # self-heal outcome -- do not let a stale FAILURE hide behind it.
+    return EXIT_STUB, (
+        f"fail: latest bot-review-gate run is {conclusion} (exit {EXIT_STUB})"
+    )
+
+
+def _api_mutate(
+    url: str, payload: dict, token: str | None = None, method: str = "POST",
+) -> bool:
+    """Issue a write request to a GitHub REST API endpoint.
+
+    Returns True on a 2xx, False on a non-2xx response, None on
+    infrastructure failure (network error, auth failure). PATCH uses JSON
+    body; POST uses JSON body as well.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "taos-bot-review-gate",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(payload).encode("utf-8")
+    req = Request(url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(req, timeout=30) as r:
+            return 200 <= r.status < 300
+    except Exception as e:
+        print(f"error: {method} {url} failed: {e}", file=sys.stderr)
+        return None
+
+
+def reconcile_head_sha_check_run(
+    owner: str, repo: str, head_sha: str, conclusion: str,
+    token: str | None = None,
+) -> dict | None:
+    """Make the head-SHA bot-review-gate check-run verdict match ``conclusion``.
+
+    Write side of the #2493 fix. The gate runs on every relevant PR event and
+    republishes its check run for the head SHA each time; a later SUCCESS must
+    not leave an earlier FAILURE coexisting on the same SHA, because
+    ``mergeStateStatus`` keys off ANY failing run and would pin the PR on
+    UNSTABLE forever. So:
+
+    - If a completed bot-review-gate run already exists on the SHA whose
+      conclusion differs from ``conclusion`` (the stale case), PATCH the stale
+      runs to the new conclusion.
+    - If none exist, POST a new terminal check run for the SHA.
+
+    Returns the GitHub response dict on a successful write, or None if there
+    was no write to make (all runs already matched) or on infrastructure
+    failure.
+    """
+    runs = list_check_runs(owner, repo, head_sha, token)
+    if runs is None:
+        return None
+    token = token or _get_token()
+    patched_any = False
+    for run in runs:
+        status = run.get("status")
+        existing = run.get("conclusion")
+        # Don't touch in-flight runs; the job's exit code settles them, and a
+        # half-written run must not be mistaken for a verdict.
+        if status != "completed" or existing is None:
+            continue
+        if existing == conclusion:
+            continue
+        url = f"{API}/repos/{owner}/{repo}/check-runs/{run['id']}"
+        if _api_mutate(
+            url,
+            {"conclusion": conclusion, "status": "completed", "completed_at": run.get("completed_at") or ""},
+            token=token,
+            method="PATCH",
+        ):
+            patched_any = True
+    if patched_any:
+        return {"reconciled": True, "action": "patched", "head_sha": head_sha}
+
+    # No stale run to update. If a matching conclusion already exists, nothing
+    # to do; if none exists at all, publish a fresh terminal check run.
+    if any(
+        r.get("status") == "completed" and r.get("conclusion") == conclusion
+        for r in runs
+    ):
+        return None
+    payload = {
+        "name": CHECK_RUN_NAME,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {
+            "title": "Bot review gate",
+            "summary": f"verdict: {conclusion}",
+        },
+    }
+    url = f"{API}/repos/{owner}/{repo}/check-runs"
+    if _api_mutate(url, payload, token=token, method="POST"):
+        return {"reconciled": True, "action": "created", "head_sha": head_sha}
+    return None
+
+
 def _detect_repo() -> tuple[str, str]:
     """Detect (owner, repo) from GITHUB_REPOSITORY env var or git remote.
 
@@ -386,6 +623,12 @@ def main(argv: list[str] | None = None) -> int:
         "--token", default=None,
         help="GitHub token (default: $GH_TOKEN or $GITHUB_TOKEN)",
     )
+    parser.add_argument(
+        "--head-sha", default=None,
+        help="PR head SHA to anchor the bot-review-gate check run verdict on "
+             "(default: $PR_HEAD). When provided, the gate reconciles its check "
+             "run on the SHA so a stale FAILURE never pins the PR on UNSTABLE.",
+    )
     args = parser.parse_args(argv)
 
     owner = args.owner
@@ -395,10 +638,22 @@ def main(argv: list[str] | None = None) -> int:
         owner = owner or detected_owner
         repo = repo or detected_repo
 
+    token = args.token or _get_token()
+    head_sha = args.head_sha or os.environ.get("PR_HEAD")
+
     exit_code, message = check_bot_review(
-        owner, repo, args.pr_number, args.token,
+        owner, repo, args.pr_number, token,
     )
     print(message)
+
+    # Reconcile the bot-review-gate check run on the head SHA when the verdict
+    # is terminal (success/failure). An infrastructure ERROR (2) is never
+    # written as a check-run conclusion: it is reported by the job failure and
+    # must not self-clear a stale run, so the write is skipped.
+    if head_sha and exit_code in VERDICT_TO_CONCLUSION:
+        reconcile_head_sha_check_run(
+            owner, repo, head_sha, VERDICT_TO_CONCLUSION[exit_code], token,
+        )
     return exit_code
 
 

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -100,6 +100,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # writes a terminal conclusion (success/failure) -- it never reports in_progress
 # or neutral, so a check-run conclusion is authoritative for the head SHA.
 CHECK_RUN_NAME = "Bot review gate"
+
+# A single GitHub workflow emits TWO distinct check runs on the same head SHA:
+# one named after the workflow DISPLAY name ("Bot review gate") and one named
+# after the workflow JOB id ("bot-review-gate"), which is the runner-owned run
+# GitHub creates for the Actions job itself. mergeStateStatus keys off ANY
+# failing check run, so the read filter must match both names -- matching only
+# the display name drops the job-id run that is what actually pins a
+# self-healed PR on UNSTABLE (see PR #2573).
+CHECK_RUN_NAMES = frozenset({CHECK_RUN_NAME, "bot-review-gate"})
 VERDICT_TO_CONCLUSION = {
     EXIT_OK: "success",
     EXIT_STUB: "failure",
@@ -383,8 +392,10 @@ def list_check_runs(
 ) -> list[dict] | None:
     """List bot-review-gate check runs for a commit ref (a head SHA).
 
-    Reads GET /repos/{owner}/{repo}/commits/{ref}/check-runs and keeps only the
-    runs named ``CHECK_RUN_NAME``. Returns None on infrastructure failure, [] if
+     Reads GET /repos/{owner}/{repo}/commits/{ref}/check-runs and keeps only the
+     runs named in ``CHECK_RUN_NAMES`` (the workflow display name and the
+     GitHub Actions job id, which is the runner-owned run that actually pins
+     mergeStateStatus). Returns None on infrastructure failure, [] if
     the ref exists but has no bot-review-gate runs (so callers can distinguish
     cannot-see from a legitimately-empty head SHA).
     """
@@ -405,7 +416,7 @@ def list_check_runs(
         runs = data
     else:
         runs = []
-    return [r for r in runs if isinstance(r, dict) and r.get("name") == CHECK_RUN_NAME]
+    return [r for r in runs if isinstance(r, dict) and r.get("name") in CHECK_RUN_NAMES]
 
 
 def filter_head_sha_check_runs(check_runs: list[dict]) -> list[dict]:
@@ -654,6 +665,22 @@ def main(argv: list[str] | None = None) -> int:
         reconcile_head_sha_check_run(
             owner, repo, head_sha, VERDICT_TO_CONCLUSION[exit_code], token,
         )
+        # Read back the reconciled verdict (the read side of the #2493 fix).
+        # If a stale FAILURE survived the reconcile -- e.g. the runner-owned
+        # job check run rejected the PATCH, leaving mergeStateStatus at
+        # UNSTABLE -- the gate must not report green. check_run_verdict is
+        # the production read site for this anchoring; wiring it here closes
+        # the "uncalled function described as load-bearing" gap.
+        verified_code, _ = check_run_verdict(
+            owner, repo, head_sha, token,
+        )
+        if verified_code == EXIT_STUB and exit_code == EXIT_OK:
+            print(
+                f"fail: stale bot-review-gate FAILURE on {head_sha} "
+                f"survived reconcile -- PR stays UNSTABLE "
+                f"(exit {EXIT_STUB})"
+            )
+            return EXIT_STUB
     return exit_code
 
 

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -505,3 +505,322 @@ class TestMain:
     def test_main_requires_pr_number(self, check_mod) -> None:
         with pytest.raises(SystemExit):
             check_mod.main([])
+
+
+class TestCheckRunVerdict:
+    """Acceptance #1: a self-healed PR -- a stale FAILURE check run followed by
+    a later SUCCESS on the SAME head SHA -- must not read gate-red.
+
+    bot-review-gate triggers on every pull_request / pull_request_review event,
+    and GitHub keeps a separate "Bot review gate" check run for each workflow
+    run on the same SHA. mergeStateStatus keys off ANY failing check run, so a
+    stale FAILURE left behind by a self-heal pins the PR on UNSTABLE forever.
+
+    The gate anchors its verdict to the head SHA: the LATEST COMPLETED
+    bot-review-gate check run is authoritative, so the later SUCCESS supersedes
+    the stale FAILURE. Against code without check-run anchoring this fails to
+    report the PR as green (the function does not exist, so the test errors).
+    """
+
+    HEAD_SHA = "1baa21a" + "0" * 34
+
+    @staticmethod
+    def _run(run_id, conclusion, started_at, /, *, in_progress=False):
+        return {
+            "id": run_id,
+            "name": "Bot review gate",
+            "head_sha": "1baa21a",
+            "status": "in_progress" if in_progress else "completed",
+            "conclusion": None if in_progress else conclusion,
+            "started_at": started_at,
+            "completed_at": started_at,
+        }
+
+    @staticmethod
+    def _mock_list(check_runs):
+        def side_effect(url, token=None):
+            return [{"total_count": len(check_runs), "check_runs": check_runs}]
+        return side_effect
+
+    def test_stale_failure_then_success_is_not_red(self, check_mod) -> None:
+        # The #2493 condition: a 10-day-old FAILURE and three SUCCESS runs, all
+        # on the same head SHA. The latest completed run is success, so the
+        # self-heal must read green.
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "success", "2026-08-27T12:08:17Z"),
+            self._run(33070472412, "success", "2026-08-27T12:08:18Z"),
+            self._run(32072071321, "success", "2026-08-27T12:08:20Z"),
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 0
+        assert "success" in message
+
+    def test_only_stale_failure_is_red(self, check_mod) -> None:
+        runs = [self._run(32071499652, "failure", "2026-08-17T21:30:58Z")]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 1
+        assert "failure" in message
+
+    def test_latest_is_failure_even_with_older_success(self, check_mod) -> None:
+        # A genuine failure that self-heals LATER is green; a success that is
+        # then re-failed by a NEW stub is red. Latest wins.
+        runs = [
+            self._run(32071499652, "success", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "failure", "2026-08-27T12:08:17Z"),
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 1
+        assert "failure" in message
+
+    def test_in_progress_latest_does_not_pretend_self_heal(self, check_mod) -> None:
+        # An unsettled (in-progress) latest run must not by itself clear a stale
+        # failure: latest_check_run_conclusion trusts only completed runs, so a
+        # 'latest comment' never decides the verdict mid-run.
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "success", "2026-08-27T12:08:17Z", in_progress=True),
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 1
+        assert "failure" in message
+
+    def test_no_check_run_is_not_red(self, check_mod) -> None:
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list([])):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 0
+        assert "no bot-review-gate check run" in message.lower() or "none" in message.lower()
+
+    def test_api_failure_returns_error(self, check_mod) -> None:
+        with patch.object(check_mod, "_api_get", return_value=None):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 2
+        assert "error" in message.lower()
+
+    def test_latest_check_run_conclusion_picks_latest_completed(self, check_mod) -> None:
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "success", "2026-08-27T12:08:17Z"),
+        ]
+        assert check_mod.latest_check_run_conclusion(runs) == "success"
+
+    def test_latest_check_run_conclusion_none_when_no_completed(self, check_mod) -> None:
+        runs = [self._run(1, "success", "2026-08-27T12:08:17Z", in_progress=True)]
+        assert check_mod.latest_check_run_conclusion(runs) is None
+
+    def test_filters_to_bot_review_gate_runs_only(self, check_mod) -> None:
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            {"id": 9, "name": "CodeRabbit", "status": "completed", "conclusion": "success",
+             "started_at": "2026-08-28T00:00:00Z", "completed_at": "2026-08-28T00:00:00Z"},
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, _ = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        # The foreign "CodeRabbit" check run must not decide the verdict; only
+        # the stale bot-review-gate failure remains, so it stays red.
+        assert exit_code == 1
+
+
+class TestReconcileCheckRun:
+    """The #2493 fix in the write path: the self-heal run UPDATES the stale
+    FAILURE check run on the head SHA instead of letting it coexist with the
+    new SUCCESS (which pins mergeStateStatus on UNSTABLE)."""
+
+    HEAD_SHA = "1baa21a" + "0" * 34
+
+    @staticmethod
+    def _run(run_id, conclusion, started_at):
+        return {
+            "id": run_id,
+            "name": "Bot review gate",
+            "head_sha": "1baa21a",
+            "status": "completed",
+            "conclusion": conclusion,
+            "started_at": started_at,
+            "completed_at": started_at,
+        }
+
+    def test_patches_stale_failure_to_success(self, check_mod) -> None:
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "success", "2026-08-27T12:08:17Z"),
+        ]
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 2, "check_runs": runs}]), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            result = check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        assert result is not None
+        # Only the stale failure (== target differs) is patched; the already-
+        # success run is left alone (idempotent).
+        assert mutate.call_count == 1
+        call = mutate.call_args
+        assert call.kwargs.get("method") == "PATCH"
+        assert "32071499652" in call.args[0]
+        assert call.args[1]["conclusion"] == "success"
+        assert call.args[1]["status"] == "completed"
+
+    def test_idempotent_when_all_match(self, check_mod) -> None:
+        runs = [self._run(33070472073, "success", "2026-08-27T12:08:17Z")]
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 1, "check_runs": runs}]), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        assert mutate.call_count == 0
+
+    def test_creates_when_absent(self, check_mod) -> None:
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 0, "check_runs": []}]), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        assert mutate.call_count == 1
+        call = mutate.call_args
+        assert call.kwargs.get("method") == "POST"
+        assert call.args[1]["name"] == "Bot review gate"
+        assert call.args[1]["head_sha"] == self.HEAD_SHA
+        assert call.args[1]["conclusion"] == "success"
+
+    def test_skips_in_progress_run(self, check_mod) -> None:
+        runs = [
+            {"id": 1, "name": "Bot review gate", "head_sha": self.HEAD_SHA,
+             "status": "in_progress", "conclusion": None,
+             "started_at": "2026-08-27T12:08:17Z", "completed_at": None},
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+        ]
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 2, "check_runs": runs}]), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        # Only the completed stale failure is patched; the in-progress run is
+        # left for the job's exit code to settle.
+        assert mutate.call_count == 1
+        assert "32071499652" in mutate.call_args.args[0]
+
+    def test_returns_none_on_api_failure(self, check_mod) -> None:
+        with patch.object(check_mod, "_api_get", return_value=None), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            result = check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        assert result is None
+        assert mutate.call_count == 0
+
+    def test_reconciles_all_stale_runs(self, check_mod) -> None:
+        # Multiple stale FAILURE runs on the SHA all get updated so none is left
+        # behind to pin mergeStateStatus on UNSTABLE.
+        runs = [
+            self._run(32071499652, "failure", "2026-08-17T21:30:58Z"),
+            self._run(33070472073, "failure", "2026-08-27T12:08:17Z"),
+        ]
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 2, "check_runs": runs}]), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            check_mod.reconcile_head_sha_check_run("jaylfc", "taOS", self.HEAD_SHA, "success")
+        assert mutate.call_count == 2
+        patched_ids = {call.args[0] for call in mutate.call_args_list}
+        assert all("32071499652" in u or "33070472073" in u for u in patched_ids)
+
+
+class TestDetectorIsolation:
+    """Acceptance #2: each fake-green detector is non-vacuous in isolation, so
+    neutering one cannot hide behind another. The 2026-08-16 audit measured
+    that neutering both halves at once read green at 43/43 with an untested
+    half masking the gap -- these tests prove each half stands alone.
+
+    Each body below is matched by EXACTLY one detector. Neutering that detector
+    loses protection for its body but leaves the other detectors' bodies caught,
+    so no single neuter can stay green by leaning on a different detector."""
+
+    RL_BODY = "Review rate limited. Please try again later."
+
+    def test_rate_limit_body_rejected(self, check_mod) -> None:
+        item = check_mod.CRItem(id=1, body=self.RL_BODY, is_review=True, review_state="APPROVED")
+        assert not check_mod.is_real_item(item)
+
+    def test_neutering_rate_limit_loses_only_its_protection(self, check_mod) -> None:
+        with patch.object(check_mod, "is_rate_limit_stub", return_value=False):
+            rl = check_mod.CRItem(id=1, body=self.RL_BODY, is_review=True, review_state="APPROVED")
+            assert check_mod.is_real_item(rl) is True  # protection lost
+            ack = check_mod.CRItem(id=2, body=ACK_BODY, is_review=True, review_state="APPROVED")
+            assert not check_mod.is_real_item(ack)  # acknowledgement still caught
+
+    def test_acknowledgement_body_rejected(self, check_mod) -> None:
+        item = check_mod.CRItem(id=1, body=ACK_BODY, is_review=True, review_state="APPROVED")
+        assert not check_mod.is_real_item(item)
+
+    def test_neutering_acknowledgement_loses_only_its_protection(self, check_mod) -> None:
+        with patch.object(check_mod, "is_coderabbit_acknowledgement", return_value=False):
+            ack = check_mod.CRItem(id=1, body=ACK_BODY, is_review=True, review_state="APPROVED")
+            assert check_mod.is_real_item(ack) is True  # protection lost
+            summary = check_mod.CRItem(id=2, body=SUMMARY_BODY, is_review=True, review_state="APPROVED")
+            assert not check_mod.is_real_item(summary)  # summary still caught
+
+    def test_auto_summary_body_rejected(self, check_mod) -> None:
+        item = check_mod.CRItem(id=1, body=SUMMARY_BODY, is_review=True, review_state="APPROVED")
+        assert not check_mod.is_real_item(item)
+
+    def test_neutering_auto_summary_loses_only_its_protection(self, check_mod) -> None:
+        with patch.object(check_mod, "is_coderabbit_auto_summary", return_value=False):
+            summary = check_mod.CRItem(id=1, body=SUMMARY_BODY, is_review=True, review_state="APPROVED")
+            assert check_mod.is_real_item(summary) is True  # protection lost
+            ack = check_mod.CRItem(id=2, body=ACK_BODY, is_review=True, review_state="APPROVED")
+            assert not check_mod.is_real_item(ack)  # acknowledgement still caught
+
+    def test_neutering_every_detector_loses_every_protection(self, check_mod) -> None:
+        """The trap the audit caught, reproduced: neutering ALL stub detectors
+        must let EVERY stub kind through (green), not stay red on one because an
+        untested detector was left on. Each stub must flip independently."""
+        with patch.object(check_mod, "is_rate_limit_stub", return_value=False), \
+             patch.object(check_mod, "is_coderabbit_acknowledgement", return_value=False), \
+             patch.object(check_mod, "is_coderabbit_auto_summary", return_value=False):
+            rl = check_mod.CRItem(id=1, body=self.RL_BODY, is_review=True, review_state="APPROVED")
+            ack = check_mod.CRItem(id=2, body=ACK_BODY, is_review=True, review_state="APPROVED")
+            summary = check_mod.CRItem(id=3, body=SUMMARY_BODY, is_review=True, review_state="APPROVED")
+            assert check_mod.is_real_item(rl) is True
+            assert check_mod.is_real_item(ack) is True
+            assert check_mod.is_real_item(summary) is True
+
+
+class TestTrueGateFailure:
+    """Acceptance #3: a TRUE gate failure (#2554 -- CodeRabbit scaffolding only,
+    no review content) must STILL be reported red. The fix clears stale red by
+    SUPERSISING a later verdict, never by weakening the gate, so a real
+    failure that never self-heals stays red on the head SHA."""
+
+    def _pr2554_items(self, check_mod):
+        """#2554 condition: the only CodeRabbit output is auto-generated
+        scaffolding (acknowledgement + auto-summary), no review content."""
+        return [
+            check_mod.CRItem(id=1, body=ACK_BODY, is_review=False),
+            check_mod.CRItem(id=2, body=SUMMARY_BODY, is_review=False),
+        ]
+
+    def test_pr2554_scaffolding_only_is_red(self, check_mod) -> None:
+        exit_code, message = check_mod.classify(self._pr2554_items(check_mod))
+        assert exit_code == 1
+        assert "FAIL" in message
+        assert "scaffolding" in message
+
+    def test_pr2554_check_run_stays_red_without_self_heal(self, check_mod) -> None:
+        # #2554 never self-heals: its only bot-review-gate check run is a
+        # FAILURE (scaffolding-only verdict), so latest-wins keeps it red.
+        head = "deadbeef" + "0" * 32
+        runs = [
+            {"id": 1, "name": "Bot review gate", "head_sha": head,
+             "status": "completed", "conclusion": "failure",
+             "started_at": "2026-08-27T12:08:17Z", "completed_at": "2026-08-27T12:08:18Z"},
+        ]
+        with patch.object(check_mod, "_api_get", return_value=[{"total_count": 1, "check_runs": runs}]):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", head)
+        assert exit_code == 1
+        assert "failure" in message
+
+    def test_pr2554_review_and_check_run_both_red(self, check_mod) -> None:
+        """The gate's two verdict surfaces agree on #2554: the review detection
+        is red (scaffolding only) and the latest check run is red (no self-heal).
+        A fix that clears one by weakening the other is a regression."""
+        with patch.object(check_mod, "collect_coderabbit_items",
+                          return_value=self._pr2554_items(check_mod)):
+            exit_code, _ = check_mod.check_bot_review("jaylfc", "taOS", 2554,
+                                                      token="t")
+        # Review-detection surface on #2554: scaffolding-only, must be red.
+        assert exit_code == 1
+        ec2, msg2 = check_mod.classify(self._pr2554_items(check_mod))
+        assert ec2 == 1
+        assert "FAIL" in msg2

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -525,10 +525,10 @@ class TestCheckRunVerdict:
     HEAD_SHA = "1baa21a" + "0" * 34
 
     @staticmethod
-    def _run(run_id, conclusion, started_at, /, *, in_progress=False):
+    def _run(run_id, conclusion, started_at, /, *, in_progress=False, name=None):
         return {
             "id": run_id,
-            "name": "Bot review gate",
+            "name": name or "Bot review gate",
             "head_sha": "1baa21a",
             "status": "in_progress" if in_progress else "completed",
             "conclusion": None if in_progress else conclusion,
@@ -623,6 +623,37 @@ class TestCheckRunVerdict:
         # The foreign "CodeRabbit" check run must not decide the verdict; only
         # the stale bot-review-gate failure remains, so it stays red.
         assert exit_code == 1
+
+    def test_stale_failure_matched_by_job_id(self, check_mod) -> None:
+        # Acceptance (b): the run that actually pins a self-healed PR on
+        # UNSTABLE is the GitHub Actions JOB check run, named after the job id
+        # ("bot-review-gate"), not the workflow display name. It must pin red.
+        # On the original line this FAILS: list_check_runs narrowed its filter
+        # to the display name only and dropped the bot-review-gate run, so the
+        # verdict read an empty head SHA and reported pass. It must go red on
+        # today's code and green once both names are matched.
+        # Fixture mirrors the live #2565 evidence (run 98668626832).
+        runs = [
+            self._run(98668626832, "failure", "2026-08-27T20:52:03Z", name="bot-review-gate"),
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 1
+        assert "failure" in message
+
+    def test_stale_failure_matched_by_display_name(self, check_mod) -> None:
+        # CONTROL for the job-id case above. The display-name run must still
+        # be matched. A fix that SWAPS the filter from the display name to the
+        # job id -- rather than covering BOTH -- is caught here: this case
+        # would go red against such a swap, so the two cases together pin
+        # "cover both names" and neither name alone is sufficient.
+        runs = [
+            self._run(98668626832, "failure", "2026-08-27T20:52:03Z", name="Bot review gate"),
+        ]
+        with patch.object(check_mod, "_api_get", side_effect=self._mock_list(runs)):
+            exit_code, message = check_mod.check_run_verdict("jaylfc", "taOS", self.HEAD_SHA)
+        assert exit_code == 1
+        assert "failure" in message
 
 
 class TestReconcileCheckRun:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2573: bot-review-gate filters the workflow DISPLAY name while the job-named check run is the one pinning UNSTABLE, so all 9 new tests are blind to the defect

Autonomous build of board card tsk-4rcgxo.

REVISION: built on `exec/tsk-n6e3yz` (cut at `adcbb96db16ff3e5523290a0c7e8b1d22cd2a8e6`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

PR #2573 is lead-blocked (comment 5451423577): list_check_runs narrowed its
name filter to CHECK_RUN_NAME ("Bot review gate") and dropped the GitHub
Actions job check run named "bot-review-gate" (the job id). That is the run
mergeStateStatus keys off to pin a self-healed PR on UNSTABLE, so the read
path never saw the run that causes the symptom the PR exists to fix. The
fixture that reproduces it -- a stale "bot-review-gate" failure on the head
SHA -- never entered the suite, so all green tests were blind to the defect.

- Widen the read filter to CHECK_RUN_NAMES covering both the display name and
  the job id, and update the list_check_runs docstring to match.
- Wire the previously-uncalled check_run_verdict into main() as the head-SHA
  read side of the #2493 reconcile, so a stale FAILURE that survived a
  rejected PATCH is detected instead of read green.
- Add test_stale_failure_matched_by_job_id (bot-review-gate fixture that
  fails on the BASE line) and test_stale_failure_matched_by_display_name as a
  control, so a fix that swaps one name for the other is caught rather than
  covering both.

check_run_verdict is wired (not deleted): per the changelog fragment, it is
now the production read site for the head-SHA anchoring.

Proof:
- uv run pytest tests/scripts/test_check_bot_review.py -q -- 79 passed
- test_stale_failure_matched_by_job_id fails on BASE (assert 0 == 1: the
  bot-review-gate run is filtered out and check_run_verdict reads an empty
  head SHA as pass) and passes with the fix; the display-name control passes
  on both, so a name-swap regression is caught.

Files:
 .github/workflows/bot-review-gate.yml              |  11 +-
 ...4rcgxo-bot-review-gate-check-run-name-filter.md |  11 +
 .../tsk-n6e3yz-check-bot-review-gate-head-sha.md   |  15 +
 scripts/check_bot_review.py                        | 292 ++++++++++++++++-
 tests/scripts/test_check_bot_review.py             | 350 +++++++++++++++++++++
 5 files changed, 673 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot-review gate reliability by anchoring results to the pull request’s latest commit.
  * Prevented stale failures from keeping a pull request in an unstable merge state after a successful recheck.
  * Improved detection of bot-review results across supported check-run formats.
  * Preserved accurate failures for genuine review-gate issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->