### PR TITLE
fix-forward #2582: _cap_context_snapshot reintroduces #2570's collapse and breaches its own cap when field names are long

### DIFF
--- a/changelog.d/tsk-7sq5eh-fix-context-snapshot-cap.md
+++ b/changelog.d/tsk-7sq5eh-fix-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` size-budgets the `_truncated` marker so it cannot itself breach the 32768-byte cap, appends every later removal to the dropped count so the marker stays accurate, and never returns a snapshot over the limit.

--- a/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
+++ b/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` no longer collapses oversized snapshots to an empty `_truncated` marker: it now drops the largest fields first until the serialized form fits within 32768 bytes, preserving smaller fields and recording the dropped field names in the marker.

--- a/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
+++ b/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Resume notes no longer carry an unbounded `context_snapshot` to `POST /resume`: `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates it to a 32768-byte suffix with a `_truncated` marker, so an oversized transcript no longer saturates the woken agent's input window and restarts into the same overflow.
+- `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` drops the largest fields first until the serialized form fits within 32768 bytes, preserving smaller fields and recording the dropped field names in a `_truncated` marker.

--- a/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
+++ b/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resume notes no longer carry an unbounded `context_snapshot` to `POST /resume`: `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates it to a 32768-byte suffix with a `_truncated` marker, so an oversized transcript no longer saturates the woken agent's input window and restarts into the same overflow.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -117,9 +117,10 @@ without limit if the agent dumps its transcript or memory into it. An oversized
 snapshot saturates the framework's input window at wake, so the agent restarts
 into the same overflow every time and the recovery note is never consumed.
 
-`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
-snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
-posted. Do not bypass it: any code that writes a resume note by hand must still
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` caps the
+snapshot by dropping the largest fields first until the serialized form fits
+within 32768 bytes, then records the dropped field names in a `_truncated`
+marker. Do not bypass it: any code that writes a resume note by hand must still
 route it through that guard, lest a 32 KB transcript become a 32 KB failure.
 
 ## Credentials, grants and the things that bite

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -110,6 +110,18 @@ reach it, and write your pid to a pidfile. Under a systemd unit, `systemctl
 --user show -p MainPID` is authoritative; a startup-only pidfile can lie between
 restarts if a second instance started last.
 
+## Resume notes: context snapshot must be bounded
+
+A resume note's `context_snapshot` is carried through `POST /resume` and can grow
+without limit if the agent dumps its transcript or memory into it. An oversized
+snapshot saturates the framework's input window at wake, so the agent restarts
+into the same overflow every time and the recovery note is never consumed.
+
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
+snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
+posted. Do not bypass it: any code that writes a resume note by hand must still
+route it through that guard, lest a 32 KB transcript become a 32 KB failure.
+
 ## Credentials, grants and the things that bite
 
 **Your token is shown once and cannot be recovered.** Not by you, not by the

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -170,9 +170,30 @@ class TestCapContextSnapshot:
         original_size = len(json.dumps(big, separators=(",", ":")))
         assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
         ro._cap_context_snapshot(note)
-        capped_size = len(json.dumps(note["context_snapshot"], separators=(",", ":")))
+        capped = note["context_snapshot"]
+        capped_size = len(json.dumps(capped, separators=(",", ":")))
         assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
-        assert note["context_snapshot"] is not big
+        assert capped is not big
+        assert "_truncated" in capped
+        assert isinstance(capped["_truncated"], dict)
+        assert "dropped_fields" in capped["_truncated"]
+
+    def test_oversized_snapshot_keeps_required_fields(self):
+        snapshot = {
+            "agent_id": "a" * 100,
+            "session_id": "b" * 100,
+            "transcript": "x" * 60000,
+            "memory": "y" * 1000,
+        }
+        note = {"context_snapshot": snapshot}
+        ro._cap_context_snapshot(note)
+        capped = note["context_snapshot"]
+        assert "agent_id" in capped
+        assert "session_id" in capped
+        json.dumps(capped)
+        assert len(json.dumps(capped, separators=(",", ":"))) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert "transcript" not in capped
+        assert capped["_truncated"]["dropped_fields"][0] == "transcript"
 
     def test_empty_snapshot_is_noop(self):
         for val in [{}, None, "", "str"]:

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -195,6 +195,19 @@ class TestCapContextSnapshot:
         assert "transcript" not in capped
         assert capped["_truncated"]["dropped_fields"][0] == "transcript"
 
+    def test_oversized_snapshot_with_long_field_names_stays_within_cap(self):
+        snapshot = {"agent_id": "a" * 100}
+        for i in range(200):
+            snapshot[f"{'x' * 400}{i}"] = "y" * 200
+        note = {"context_snapshot": snapshot}
+        original_size = len(json.dumps(snapshot, separators=(",", ":")))
+        assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        ro._cap_context_snapshot(note)
+        capped = note["context_snapshot"]
+        capped_size = len(json.dumps(capped, separators=(",", ":")))
+        assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert "agent_id" in capped
+
     def test_empty_snapshot_is_noop(self):
         for val in [{}, None, "", "str"]:
             note = {"context_snapshot": val}

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -156,3 +156,72 @@ class TestResumeAgentsFromNotes:
 
         state.notifications.add.assert_not_awaited()
         assert not state._background_tasks
+
+
+class TestCapContextSnapshot:
+    def test_leaves_small_snapshot_untouched(self):
+        note = {"context_snapshot": {"key": "value"}}
+        ro._cap_context_snapshot(note)
+        assert note["context_snapshot"] == {"key": "value"}
+
+    def test_truncates_oversized_snapshot(self):
+        big = {f"field_{i}": "x" * 200 for i in range(500)}
+        note = {"context_snapshot": big}
+        original_size = len(json.dumps(big, separators=(",", ":")))
+        assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        ro._cap_context_snapshot(note)
+        capped_size = len(json.dumps(note["context_snapshot"], separators=(",", ":")))
+        assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert note["context_snapshot"] is not big
+
+    def test_empty_snapshot_is_noop(self):
+        for val in [{}, None, "", "str"]:
+            note = {"context_snapshot": val}
+            ro._cap_context_snapshot(note)
+            assert note["context_snapshot"] == val
+
+    def test_missing_snapshot_is_noop(self):
+        note = {"reason": "pause"}
+        ro._cap_context_snapshot(note)
+        assert "context_snapshot" not in note
+
+
+class TestResumeRetryLoopCapsSnapshot:
+    @pytest.mark.asyncio
+    async def test_retry_loop_caps_oversized_snapshot(self, tmp_path, monkeypatch):
+        """When the first resume attempt fails (agent slow to boot), the
+        retry loop re-loads the note from disk and posts it again. The
+        context_snapshot must still be capped on every retry, not only on
+        the initial attempt."""
+        agent = {"name": "slow", "host": "10.0.0.7", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "slow"
+        note_dir.mkdir(parents=True)
+        big_snapshot = {f"field_{i}": "x" * 200 for i in range(500)}
+        (note_dir / "resume_note.json").write_text(
+            json.dumps({"reason": "pause", "context_snapshot": big_snapshot})
+        )
+
+        posted_notes = []
+        attempts = {"n": 0}
+
+        async def flaky_post(host, port, note):
+            attempts["n"] += 1
+            posted_notes.append(dict(note))
+            return attempts["n"] >= 2
+
+        monkeypatch.setattr(ro, "_post_resume", flaky_post)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 5)
+
+        await ro.resume_agents_from_notes(state)
+
+        for task in list(state._background_tasks):
+            await task
+
+        assert attempts["n"] == 2
+        for posted in posted_notes:
+            encoded = json.dumps(
+                posted["context_snapshot"], separators=(",", ":")
+            )
+            assert len(encoded) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -272,11 +272,37 @@ def _cap_context_snapshot(note: dict) -> None:
         overflow,
         len(encoded),
     )
-    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
-    try:
-        note["context_snapshot"] = json.loads(kept)
-    except json.JSONDecodeError:
-        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+    snapshot = dict(snapshot)
+    note["context_snapshot"] = snapshot
+    fields = sorted(
+        snapshot.items(),
+        key=lambda kv: len(json.dumps(kv[1], separators=(",", ":"))),
+        reverse=True,
+    )
+    dropped = []
+    for key, _value in fields:
+        if len(json.dumps(snapshot, separators=(",", ":"))) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+            break
+        dropped.append(key)
+        snapshot.pop(key)
+    _MAX_DROPPED = 100
+    reported = dropped[:_MAX_DROPPED]
+    if len(dropped) > _MAX_DROPPED:
+        reported.append(f"...and {len(dropped) - _MAX_DROPPED} more")
+    snapshot["_truncated"] = {
+        "dropped_fields": reported,
+        "reason": "snapshot exceeded context window; largest fields dropped first",
+    }
+    while len(json.dumps(snapshot, separators=(",", ":"))) > _MAX_CONTEXT_SNAPSHOT_BYTES:
+        remaining = sorted(
+            (kv for kv in snapshot.items() if kv[0] != "_truncated"),
+            key=lambda kv: len(json.dumps(kv[1], separators=(",", ":"))),
+            reverse=True,
+        )
+        if not remaining:
+            break
+        key, _value = remaining[0]
+        snapshot.pop(key)
 
 
 def _load_or_synthesize_note(note_path: Path) -> dict:

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -256,6 +256,28 @@ async def apply_pending_restart_check(app_state) -> None:
 _RESUME_RETRY_INTERVAL_S = 30
 _RESUME_RETRY_WINDOW_S = 600
 
+_MAX_CONTEXT_SNAPSHOT_BYTES = 32768
+
+
+def _cap_context_snapshot(note: dict) -> None:
+    snapshot = note.get("context_snapshot")
+    if not isinstance(snapshot, dict) or not snapshot:
+        return
+    encoded = json.dumps(snapshot, separators=(",", ":"))
+    if len(encoded) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+        return
+    overflow = len(encoded) - _MAX_CONTEXT_SNAPSHOT_BYTES
+    logger.warning(
+        "resume note context_snapshot capped: %d bytes over limit (%d bytes total)",
+        overflow,
+        len(encoded),
+    )
+    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
+    try:
+        note["context_snapshot"] = json.loads(kept)
+    except json.JSONDecodeError:
+        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+
 
 def _load_or_synthesize_note(note_path: Path) -> dict:
     if note_path.exists():
@@ -350,6 +372,7 @@ async def resume_agents_from_notes(app_state) -> None:
             continue
 
         note = _load_or_synthesize_note(note_path)
+        _cap_context_snapshot(note)
         if await _post_resume(host, port, note):
             finalize.append((agent, note_path))
             resumed.append(name)
@@ -438,6 +461,7 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
                     continue
                 note_path = data_dir / "agent-memory" / name / "resume_note.json"
                 note = _load_or_synthesize_note(note_path)
+                _cap_context_snapshot(note)
                 if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
                     # Per-agent config write is fine here: retry successes are
                     # rare, isolated events (one agent per 30s tick at worst),

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -285,14 +285,11 @@ def _cap_context_snapshot(note: dict) -> None:
             break
         dropped.append(key)
         snapshot.pop(key)
-    _MAX_DROPPED = 100
-    reported = dropped[:_MAX_DROPPED]
-    if len(dropped) > _MAX_DROPPED:
-        reported.append(f"...and {len(dropped) - _MAX_DROPPED} more")
-    snapshot["_truncated"] = {
-        "dropped_fields": reported,
-        "reason": "snapshot exceeded context window; largest fields dropped first",
-    }
+
+    snapshot["_truncated"] = _build_truncated_marker(
+        dropped, snapshot, _MAX_CONTEXT_SNAPSHOT_BYTES
+    )
+
     while len(json.dumps(snapshot, separators=(",", ":"))) > _MAX_CONTEXT_SNAPSHOT_BYTES:
         remaining = sorted(
             (kv for kv in snapshot.items() if kv[0] != "_truncated"),
@@ -300,9 +297,35 @@ def _cap_context_snapshot(note: dict) -> None:
             reverse=True,
         )
         if not remaining:
+            snapshot.pop("_truncated", None)
             break
         key, _value = remaining[0]
         snapshot.pop(key)
+        dropped.append(key)
+
+    if "_truncated" in snapshot:
+        snapshot["_truncated"] = _build_truncated_marker(
+            dropped, snapshot, _MAX_CONTEXT_SNAPSHOT_BYTES
+        )
+
+
+def _build_truncated_marker(
+    dropped: list[str], snapshot: dict, max_bytes: int
+) -> dict:
+    _MAX_DROPPED = 100
+    for n_reported in range(min(len(dropped), _MAX_DROPPED), -1, -1):
+        reported = dropped[:n_reported]
+        extra = len(dropped) - n_reported
+        marker = {
+            "dropped_fields": reported
+            + ([f"...and {extra} more"] if extra > 0 else []),
+            "reason": "snapshot exceeded context window; largest fields dropped first",
+        }
+        candidate = dict(snapshot)
+        candidate["_truncated"] = marker
+        if len(json.dumps(candidate, separators=(",", ":"))) <= max_bytes:
+            return marker
+    return {"dropped_fields": [], "reason": "snapshot exceeded context window; largest fields dropped first"}
 
 
 def _load_or_synthesize_note(note_path: Path) -> dict:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2582: _cap_context_snapshot reintroduces #2570's collapse and breaches its own cap when field names are long

Autonomous build of board card tsk-7sq5eh.

REVISION: built on `exec/tsk-ekc4ct` (cut at `9cd33e20da2232dc5daa34cdeb131fea3ec74e93`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

The _truncated marker was built from up to 100 dropped field names with no
size budget, so long field names could make the marker alone exceed
_MAX_CONTEXT_SNAPSHOT_BYTES. The trailing while loop then popped every
non-marker field and returned a marker-only snapshot that was still over
the cap, collapsing to a bare _truncated marker (#2570 regression).

Changes:
- Added _build_truncated_marker helper that reduces reported names until
  the marker fits within the remaining byte budget.
- Safety net while loop now appends later removals to dropped count.
- Rebuild marker after the safety net so the total is accurate.
- Strip the marker as a last resort if no fields remain and it still
  breaches the cap.

New test test_oversized_snapshot_with_long_field_names_stays_within_cap
uses 200 fields with 400-character names and asserts capped size <= 32768
and agent_id survives.

Proof against current exec/tsk-ekc4ct before fix:
  assert 40616 <= 32768  (failed)
  agent_id kept: False

After fix:
  13 passed in tests/test_restart_orchestrator_resume.py

Docs-Reviewed: no release-runbook or route docs changed; fix is confined to _cap_context_snapshot in restart_orchestrator.py

Files:
 changelog.d/tsk-7sq5eh-fix-context-snapshot-cap.md |   3 +
 changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md |   3 +
 .../tsk-kkxn6f-resume-context-snapshot-cap.md      |   3 +
 docs/agent-coordination.md                         |  13 +++
 tests/test_restart_orchestrator_resume.py          | 103 +++++++++++++++++++++
 tinyagentos/restart_orchestrator.py                |  73 +++++++++++++++
 6 files changed, 198 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resume context snapshots are now limited to 32 KB, preventing oversized snapshots from exceeding the available input window.
  * Large snapshots preserve smaller and required fields while identifying omitted content.
  * The size limit is re-applied when retries reload and resubmit resume information.

* **Documentation**
  * Added guidance for keeping resume context snapshots within the supported size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->