### PR TITLE
fix-forward #2570: _cap_context_snapshot slices serialized JSON then reparses it, so every oversized snapshot collapses to a bare _truncated marker (60119 bytes in, 68 out)

### DIFF
--- a/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
+++ b/changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resume notes no longer lose their entire `context_snapshot` when it exceeds the limit: `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` now drops the largest fields until the serialized form fits within 32768 bytes, preserving valid JSON and smaller keys such as `agent_id`, and records the dropped fields in a `_dropped` marker alongside `_truncated`.

--- a/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
+++ b/changelog.d/tsk-kkxn6f-resume-context-snapshot-cap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Resume notes no longer carry an unbounded `context_snapshot` to `POST /resume`: `_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates it to a 32768-byte suffix with a `_truncated` marker, so an oversized transcript no longer saturates the woken agent's input window and restarts into the same overflow.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -117,10 +117,12 @@ without limit if the agent dumps its transcript or memory into it. An oversized
 snapshot saturates the framework's input window at wake, so the agent restarts
 into the same overflow every time and the recovery note is never consumed.
 
-`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
-snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
-posted. Do not bypass it: any code that writes a resume note by hand must still
-route it through that guard, lest a 32 KB transcript become a 32 KB failure.
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` drops the largest
+fields from the snapshot until its serialized form fits within 32768 bytes, then
+adds a `_truncated` marker and a `_dropped` list naming the removed keys. The
+result is always valid JSON and preserves as much of the remaining structure as
+possible. Do not bypass it: any code that writes a resume note by hand must still
+route it through that guard, lest an unbounded transcript become a 32 KB failure.
 
 ## Credentials, grants and the things that bite
 

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -110,6 +110,18 @@ reach it, and write your pid to a pidfile. Under a systemd unit, `systemctl
 --user show -p MainPID` is authoritative; a startup-only pidfile can lie between
 restarts if a second instance started last.
 
+## Resume notes: context snapshot must be bounded
+
+A resume note's `context_snapshot` is carried through `POST /resume` and can grow
+without limit if the agent dumps its transcript or memory into it. An oversized
+snapshot saturates the framework's input window at wake, so the agent restarts
+into the same overflow every time and the recovery note is never consumed.
+
+`_cap_context_snapshot()` in `tinyagentos/restart_orchestrator.py` truncates the
+snapshot to a 32768-byte suffix (with a `_truncated` marker) before the note is
+posted. Do not bypass it: any code that writes a resume note by hand must still
+route it through that guard, lest a 32 KB transcript become a 32 KB failure.
+
 ## Credentials, grants and the things that bite
 
 **Your token is shown once and cannot be recovered.** Not by you, not by the

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -156,3 +156,72 @@ class TestResumeAgentsFromNotes:
 
         state.notifications.add.assert_not_awaited()
         assert not state._background_tasks
+
+
+class TestCapContextSnapshot:
+    def test_leaves_small_snapshot_untouched(self):
+        note = {"context_snapshot": {"key": "value"}}
+        ro._cap_context_snapshot(note)
+        assert note["context_snapshot"] == {"key": "value"}
+
+    def test_truncates_oversized_snapshot(self):
+        big = {f"field_{i}": "x" * 200 for i in range(500)}
+        note = {"context_snapshot": big}
+        original_size = len(json.dumps(big, separators=(",", ":")))
+        assert original_size > ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        ro._cap_context_snapshot(note)
+        capped_size = len(json.dumps(note["context_snapshot"], separators=(",", ":")))
+        assert capped_size <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert note["context_snapshot"] is not big
+
+    def test_empty_snapshot_is_noop(self):
+        for val in [{}, None, "", "str"]:
+            note = {"context_snapshot": val}
+            ro._cap_context_snapshot(note)
+            assert note["context_snapshot"] == val
+
+    def test_missing_snapshot_is_noop(self):
+        note = {"reason": "pause"}
+        ro._cap_context_snapshot(note)
+        assert "context_snapshot" not in note
+
+
+class TestResumeRetryLoopCapsSnapshot:
+    @pytest.mark.asyncio
+    async def test_retry_loop_caps_oversized_snapshot(self, tmp_path, monkeypatch):
+        """When the first resume attempt fails (agent slow to boot), the
+        retry loop re-loads the note from disk and posts it again. The
+        context_snapshot must still be capped on every retry, not only on
+        the initial attempt."""
+        agent = {"name": "slow", "host": "10.0.0.7", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "slow"
+        note_dir.mkdir(parents=True)
+        big_snapshot = {f"field_{i}": "x" * 200 for i in range(500)}
+        (note_dir / "resume_note.json").write_text(
+            json.dumps({"reason": "pause", "context_snapshot": big_snapshot})
+        )
+
+        posted_notes = []
+        attempts = {"n": 0}
+
+        async def flaky_post(host, port, note):
+            attempts["n"] += 1
+            posted_notes.append(dict(note))
+            return attempts["n"] >= 2
+
+        monkeypatch.setattr(ro, "_post_resume", flaky_post)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 5)
+
+        await ro.resume_agents_from_notes(state)
+
+        for task in list(state._background_tasks):
+            await task
+
+        assert attempts["n"] == 2
+        for posted in posted_notes:
+            encoded = json.dumps(
+                posted["context_snapshot"], separators=(",", ":")
+            )
+            assert len(encoded) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -164,6 +164,18 @@ class TestCapContextSnapshot:
         ro._cap_context_snapshot(note)
         assert note["context_snapshot"] == {"key": "value"}
 
+    def test_oversized_snapshot_keeps_required_fields(self):
+        big = {"agent_id": "a1", "user_msg": "x" * 20000, "extra": "y" * 20000}
+        note = {"context_snapshot": big}
+        ro._cap_context_snapshot(note)
+        capped = note["context_snapshot"]
+        assert "agent_id" in capped
+        assert capped["agent_id"] == "a1"
+        assert json.dumps(capped, separators=(",", ":"))  # valid JSON
+        assert len(json.dumps(capped, separators=(",", ":"))) <= ro._MAX_CONTEXT_SNAPSHOT_BYTES
+        assert capped.get("_truncated") is True
+        assert "_dropped" in capped
+
     def test_truncates_oversized_snapshot(self):
         big = {f"field_{i}": "x" * 200 for i in range(500)}
         note = {"context_snapshot": big}

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -256,6 +256,28 @@ async def apply_pending_restart_check(app_state) -> None:
 _RESUME_RETRY_INTERVAL_S = 30
 _RESUME_RETRY_WINDOW_S = 600
 
+_MAX_CONTEXT_SNAPSHOT_BYTES = 32768
+
+
+def _cap_context_snapshot(note: dict) -> None:
+    snapshot = note.get("context_snapshot")
+    if not isinstance(snapshot, dict) or not snapshot:
+        return
+    encoded = json.dumps(snapshot, separators=(",", ":"))
+    if len(encoded) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+        return
+    overflow = len(encoded) - _MAX_CONTEXT_SNAPSHOT_BYTES
+    logger.warning(
+        "resume note context_snapshot capped: %d bytes over limit (%d bytes total)",
+        overflow,
+        len(encoded),
+    )
+    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
+    try:
+        note["context_snapshot"] = json.loads(kept)
+    except json.JSONDecodeError:
+        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+
 
 def _load_or_synthesize_note(note_path: Path) -> dict:
     if note_path.exists():
@@ -350,6 +372,7 @@ async def resume_agents_from_notes(app_state) -> None:
             continue
 
         note = _load_or_synthesize_note(note_path)
+        _cap_context_snapshot(note)
         if await _post_resume(host, port, note):
             finalize.append((agent, note_path))
             resumed.append(name)
@@ -438,6 +461,7 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
                     continue
                 note_path = data_dir / "agent-memory" / name / "resume_note.json"
                 note = _load_or_synthesize_note(note_path)
+                _cap_context_snapshot(note)
                 if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
                     # Per-agent config write is fine here: retry successes are
                     # rare, isolated events (one agent per 30s tick at worst),

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -272,11 +272,40 @@ def _cap_context_snapshot(note: dict) -> None:
         overflow,
         len(encoded),
     )
-    kept = encoded[-_MAX_CONTEXT_SNAPSHOT_BYTES:]
-    try:
-        note["context_snapshot"] = json.loads(kept)
-    except json.JSONDecodeError:
-        note["context_snapshot"] = {"_truncated": "snapshot exceeded context window; remainder dropped"}
+    snapshot_copy = dict(snapshot)
+    fields = sorted(
+        snapshot_copy.items(),
+        key=lambda kv: len(json.dumps(kv[0], separators=(",", ":")))
+        + len(json.dumps(kv[1], separators=(",", ":")))
+        + 1,
+        reverse=True,
+    )
+    dropped = []
+    for key, _ in fields:
+        del snapshot_copy[key]
+        dropped.append(key)
+        encoded = json.dumps(snapshot_copy, separators=(",", ":"))
+        if len(encoded) <= _MAX_CONTEXT_SNAPSHOT_BYTES:
+            break
+    if dropped:
+        snapshot_copy["_truncated"] = True
+        snapshot_copy["_dropped"] = dropped
+        encoded = json.dumps(snapshot_copy, separators=(",", ":"))
+        while len(encoded) > _MAX_CONTEXT_SNAPSHOT_BYTES and len(snapshot_copy) > 1:
+            remaining = [k for k in snapshot_copy if k not in ("_truncated", "_dropped")]
+            if not remaining:
+                break
+            smallest = min(
+                remaining,
+                key=lambda k: len(json.dumps(k, separators=(",", ":")))
+                + len(json.dumps(snapshot_copy[k], separators=(",", ":")))
+                + 1,
+            )
+            del snapshot_copy[smallest]
+            dropped.append(smallest)
+            snapshot_copy["_dropped"] = dropped
+            encoded = json.dumps(snapshot_copy, separators=(",", ":"))
+    note["context_snapshot"] = snapshot_copy
 
 
 def _load_or_synthesize_note(note_path: Path) -> dict:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2570: _cap_context_snapshot slices serialized JSON then reparses it, so every oversized snapshot collapses to a bare _truncated marker (60119 bytes in, 68 out)

Autonomous build of board card tsk-ekc4ct.

REVISION: built on `exec/tsk-kkxn6f` (cut at `b4f1742d8b38b7f5d277e33720b32b8f99711299`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

_cap_context_snapshot() previously sliced the JSON-encoded snapshot to the
byte limit and reparsed the slice, which is almost never valid JSON, so every
oversized snapshot collapsed to a bare _truncated marker with zero fields
preserved. The fix drops fields largest-first until the serialized form fits,
preserving valid JSON and smaller keys such as agent_id, and records dropped
fields in a _dropped list. Tests now assert required keys survive and the
result is valid JSON, not just size. Docs updated to describe the new behavior.

Files:
 changelog.d/tsk-ekc4ct-fix-context-snapshot-cap.md |  3 +
 .../tsk-kkxn6f-resume-context-snapshot-cap.md      |  3 +
 docs/agent-coordination.md                         | 14 ++++
 tests/test_restart_orchestrator_resume.py          | 81 ++++++++++++++++++++++
 tinyagentos/restart_orchestrator.py                | 53 ++++++++++++++
 5 files changed, 154 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resume notes now cap oversized context snapshots at 32 KiB.
  * Large fields are removed as needed, while truncation and dropped-field details are recorded.
  * Snapshot limits are enforced during initial resume attempts and retries, preventing repeated input overflow.

* **Documentation**
  * Added guidance explaining context snapshot limits and safe resume-note handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->