### PR TITLE
fix-forward #2592: the wake budget fails OPEN on a damaged wake_budget.json, so enforcement silently ceases fleet-wide

### DIFF
--- a/changelog.d/tsk-egxlga-wake-budget-fixes.md
+++ b/changelog.d/tsk-egxlga-wake-budget-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Wake-budget reporting now passes the agent's bound `project_id` instead of `None`, so per-project consumption is measured against the same state key that enforcement writes.
+- Observatory `/api/observatory/wake-budget` now returns rows for agents with `status: "running"` (the only status the heartbeat wakes), instead of silently returning an empty list.
+- Removed the unused `mention_cap` / `mention_count` half of the wake-budget module, which had zero production callers and structurally always reported zero mentions.

--- a/changelog.d/tsk-hw6jyp-wake-budget-fixes.md
+++ b/changelog.d/tsk-hw6jyp-wake-budget-fixes.md
@@ -1,0 +1,4 @@
+### Fixed
+- Wake-budget enforcement no longer fails open on a damaged `wake_budget.json`: an absent file is treated as a fresh state, while a present-but-unreadable or unparseable file makes `can_wake` return False (fail closed) and surfaces the corruption in the log instead of silently restoring a full budget fleet-wide.
+- `record_scheduled_wake` in the heartbeat loop is now called before the debounce stamp and outside the per-agent `try/except`, so a persistence failure propagates to the sweep-level handler rather than silencing the agent for the cooldown on an uncharged wake.
+- `AppConfig.wake_budget` nested mappings (`per_agent`, `per_project`) are deep-copied per instance at both construction sites, preventing cross-instance and `DEFAULT_CONFIG` leakage.

--- a/changelog.d/tsk-kj3hc2-wake-budget.md
+++ b/changelog.d/tsk-kj3hc2-wake-budget.md
@@ -1,0 +1,2 @@
+### Added
+- Wake-budget config: per-agent and per-project scheduled-wake overrides with a global default of 2/day, OS-enforced by the heartbeat loop and surfaced in Observatory and agent settings. Mention wakes bypass the schedule and are counted separately.

--- a/changelog.d/tsk-kj3hc2-wake-budget.md
+++ b/changelog.d/tsk-kj3hc2-wake-budget.md
@@ -1,2 +1,2 @@
 ### Added
-- Wake-budget config: per-agent and per-project scheduled-wake overrides with a global default of 2/day, OS-enforced by the heartbeat loop and surfaced in Observatory and agent settings. Mention wakes bypass the schedule and are counted separately.
+- Wake-budget config: per-agent and per-project scheduled-wake overrides with a global default of 2/day, OS-enforced by the heartbeat loop and surfaced in Observatory and agent settings.

--- a/changelog.d/tsk-we2gyt-heartbeat-data-dir-guard.md
+++ b/changelog.d/tsk-we2gyt-heartbeat-data-dir-guard.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The agent heartbeat no longer silently swallows a missing `data_dir`: the wake-budget guard now lives at tick entry, so a missing `data_dir` fails loudly at the tick/sweep level instead of being caught by the per-agent `except` and leaving every agent silently unwakeable.

--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -29,3 +29,13 @@ agents: []
 metrics:
   poll_interval: 30
   retention_days: 30
+
+# Wake budget controls how many scheduled checks an agent may receive per day.
+# Most specific wins: per-project overrides apply to project-bound agents,
+# then per-agent overrides, then the global default. Mention wakes bypass
+# the scheduled budget but are counted for observability.
+wake_budget:
+  global_default: 2        # fleet default (rule 6): 2 scheduled checks/day
+  per_agent: {}            # agent id -> override
+  per_project: {}          # project id -> override
+  mention_cap: {}          # agent id -> daily mention cap; null/absent = uncapped

--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -32,10 +32,8 @@ metrics:
 
 # Wake budget controls how many scheduled checks an agent may receive per day.
 # Most specific wins: per-project overrides apply to project-bound agents,
-# then per-agent overrides, then the global default. Mention wakes bypass
-# the scheduled budget but are counted for observability.
+# then per-agent overrides, then the global default.
 wake_budget:
   global_default: 2        # fleet default (rule 6): 2 scheduled checks/day
   per_agent: {}            # agent id -> override
   per_project: {}          # project id -> override
-  mention_cap: {}          # agent id -> daily mention cap; null/absent = uncapped

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -384,10 +384,10 @@ The registry-JWT surface, by scope:
   (`_is_agent_decisions_path` in `tinyagentos/auth_middleware.py`).
 - **observatory_control**: the Observatory fleet dials.
   `GET|POST /api/observatory/pause`, `GET|POST /api/observatory/throttle`,
-  `GET|POST /api/observatory/approval-mode`, and `GET /api/observatory/fleet`
-  (read-only, there is no POST). Writes require a global (null-project) grant;
-  reads admit any active grant. Admin session and local token are always
-  allowed.
+  `GET|POST /api/observatory/approval-mode`, `GET /api/observatory/fleet`,
+  and `GET /api/observatory/wake-budget` (read-only). Writes require a global
+  (null-project) grant; reads admit any active grant. Admin session and local
+  token are always allowed.
 - **a2a_receive**: the bus READ routes only -- `GET /api/a2a/bus/channels`,
   `GET /api/a2a/bus/messages`, `GET /api/a2a/bus/stream`.
   **a2a_send**: `POST /api/a2a/bus/send` only, which forces `from` to the

--- a/docs/design/wake-budget.md
+++ b/docs/design/wake-budget.md
@@ -21,8 +21,6 @@ wake_budget:
     "agent-42": 5
   per_project:               # project id -> override for project-bound agents
     "proj-abc": 1
-  mention_cap:               # agent id -> daily mention cap; null/absent = uncapped
-    "agent-99": 10
 ```
 
 Resolution order (most specific wins):
@@ -37,9 +35,6 @@ Every resolution is logged so cost is attributable.
 - **Scheduled** -- heartbeat ticks, routine fires, external poll cadence.
   Counts against the resolved budget. OS blocks further wakes once the
   budget is exhausted and surfaces the exhaustion to the agent.
-- **Mention** -- explicit `@handle` wakes. Bypass the scheduled budget
-  entirely. Counted separately for Observatory visibility. Capped by
-  `mention_cap` when set; default is uncapped.
 
 ## OS enforcement
 
@@ -57,8 +52,7 @@ automatically by date rollover.
 - **Agent settings UI** -- `/api/taos-agent/config` includes the resolved
   wake budget for the requesting agent.
 - **Observatory** -- `/api/observatory/wake-budget` returns each agent's
-  `budget`, `consumed`, `remaining`, `next_wake_epoch`, and `mention_count`
-  for the current day.
+  `budget`, `consumed`, `remaining`, and `next_wake_epoch` for the current day.
 - **Decision** -- dec-sfdooy closed: the fleet default stays at 2/day until
   this ships; per-agent and per-project overrides are opt-in.
 

--- a/docs/design/wake-budget.md
+++ b/docs/design/wake-budget.md
@@ -1,0 +1,70 @@
+# Wake-budget config
+
+**Status:** Proposed. Implements tsk-kj3hc2.
+**Date:** 2026-08-27
+
+## Why
+
+Every scheduled wake is a paid LLM turn. A chatty channel or misconfigured
+heartbeat can exhaust a daily budget in minutes. The current heartbeat loop
+has no per-agent ceiling, and external agents set their own poll cadence.
+This design adds a single, OS-enforced budget that agents cannot override.
+
+## Config model
+
+A new top-level `wake_budget` block in `config.yaml`:
+
+```yaml
+wake_budget:
+  global_default: 2          # scheduled checks per day (rule 6 fleet default)
+  per_agent:                 # agent id -> override
+    "agent-42": 5
+  per_project:               # project id -> override for project-bound agents
+    "proj-abc": 1
+  mention_cap:               # agent id -> daily mention cap; null/absent = uncapped
+    "agent-99": 10
+```
+
+Resolution order (most specific wins):
+1. `per_project[project_id]` when the agent is bound to that project
+2. `per_agent[agent_id]`
+3. `global_default`
+
+Every resolution is logged so cost is attributable.
+
+## Wake types
+
+- **Scheduled** -- heartbeat ticks, routine fires, external poll cadence.
+  Counts against the resolved budget. OS blocks further wakes once the
+  budget is exhausted and surfaces the exhaustion to the agent.
+- **Mention** -- explicit `@handle` wakes. Bypass the scheduled budget
+  entirely. Counted separately for Observatory visibility. Capped by
+  `mention_cap` when set; default is uncapped.
+
+## OS enforcement
+
+The wake-gate lives in `tinyagentos/wake_budget.py`. The heartbeat loop
+(`agent_heartbeat.py`) and the routine runner (`routine_runner.py`) call
+`can_wake()` before firing. An agent cannot exceed its budget by
+misconfiguring itself because the gate reads the OS config, not any
+agent-supplied value.
+
+Daily consumption is persisted in `data_dir/wake_budget.json` and reset
+automatically by date rollover.
+
+## Surfaces
+
+- **Agent settings UI** -- `/api/taos-agent/config` includes the resolved
+  wake budget for the requesting agent.
+- **Observatory** -- `/api/observatory/wake-budget` returns each agent's
+  `budget`, `consumed`, `remaining`, `next_wake_epoch`, and `mention_count`
+  for the current day.
+- **Decision** -- dec-sfdooy closed: the fleet default stays at 2/day until
+  this ships; per-agent and per-project overrides are opt-in.
+
+## Interim
+
+Rule 6 (2 scheduled checks/day, acked by website-dev + taosmd-dev on the
+bus, msgs 2029/2030) remains the fleet default. Existing configs without a
+`wake_budget` block inherit the 2/day default automatically via
+`normalize_agent`.

--- a/tests/test_agent_heartbeat.py
+++ b/tests/test_agent_heartbeat.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -43,12 +46,21 @@ def _make_state(**overrides) -> SimpleNamespace:
 
     config = overrides.get("config", SimpleNamespace(agents=[], server={"agent_heartbeat_enabled": True}))
 
+    # Wake-budget enforcement reads/writes <data_dir>/wake_budget.json, so a
+    # real writable path is needed whenever the heartbeat is enabled. Default to
+    # a fresh tempdir per state; pass data_dir=None to simulate the misconfigured
+    # (missing) state the new regression tests pin.
+    data_dir = overrides.get(
+        "data_dir", Path(tempfile.mkdtemp(prefix="taos-hb-"))
+    )
+
     state = SimpleNamespace(
         project_task_store=overrides.get("project_task_store", task_store),
         project_store=overrides.get("project_store", project_store),
         chat_channels=overrides.get("chat_channels", chat_channels),
         chat_messages=overrides.get("chat_messages", chat_messages),
         bridge_sessions=overrides.get("bridge_sessions", bridge_sessions),
+        data_dir=data_dir,
         config=config,
     )
     return state
@@ -333,3 +345,53 @@ async def test_agent_heartbeat_loop_ticks_then_sleeps(monkeypatch):
 
     state.bridge_sessions.enqueue_user_message.assert_awaited_once()
     assert sleeps == [60]
+
+
+@pytest.mark.asyncio
+async def test_missing_data_dir_fails_loudly_at_tick_entry():
+    # data_dir is REQUIRED for wake-budget enforcement (it backs
+    # wake_budget.json). A missing data_dir is a fatal misconfiguration, not a
+    # per-agent hiccup: the tick must raise LOUDLY before touching any agent,
+    # so the heartbeat "refuses to start" rather than emitting only a log line.
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config, data_dir=None)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+
+    with pytest.raises(RuntimeError, match="data_dir is required for wake-budget enforcement"):
+        await _heartbeat_tick(state)
+
+    # The failure must occur before any agent is woken -- no agent should have
+    # been enqueued a wake message.
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+    state.project_task_store.list_ready_tasks_for_assignee.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_data_dir_failure_observable_at_sweep_level(monkeypatch, caplog):
+    # The wake-budget guard must NOT live inside the per-agent try/except, because
+    # that handler swallows every exception and logs only a per-agent
+    # "tick failed for agent X" line: with data_dir absent, every agent raised
+    # there, the tick completed "normally" and the whole fleet stayed silently
+    # unwakeable. Instead the failure must surface at the TICK/sweep level --
+    # i.e. _heartbeat_tick propagates to the loop's sweep-level handler.
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config, data_dir=None)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+
+    import asyncio as _asyncio
+
+    async def _stop(seconds):
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(_asyncio, "sleep", _stop)
+    caplog.set_level(logging.ERROR, logger="tinyagentos.agent_heartbeat")
+
+    with pytest.raises(_asyncio.CancelledError):
+        await agent_heartbeat_loop(state)
+
+    messages = [record.message for record in caplog.records]
+    # The misconfiguration is surfaced as a sweep-level crash...
+    assert any("sweep iteration crashed" in m for m in messages)
+    # ...NOT silently absorbed per-agent.
+    assert not any("tick failed for agent" in m for m in messages)
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()

--- a/tests/test_agent_heartbeat.py
+++ b/tests/test_agent_heartbeat.py
@@ -395,3 +395,45 @@ async def test_missing_data_dir_failure_observable_at_sweep_level(monkeypatch, c
     # ...NOT silently absorbed per-agent.
     assert not any("tick failed for agent" in m for m in messages)
     state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_scheduled_wake_failure_propagates_and_skips_debounce(monkeypatch, caplog):
+    """record_scheduled_wake is called before the debounce stamp and OUTSIDE the
+    per-agent try/except, so a persistence failure (disk-full, permission) must
+    propagate to the sweep-level handler. The debounce entry must NOT be set,
+    or the agent is silenced for REWAKE_COOLDOWN on a wake that was never
+    charged to the budget."""
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    task = _task()
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
+
+    # Force record_scheduled_wake to fail (e.g. disk-full, permission error).
+    monkeypatch.setattr(
+        "tinyagentos.agent_heartbeat.record_scheduled_wake",
+        MagicMock(side_effect=RuntimeError("disk full")),
+    )
+
+    import asyncio as _asyncio
+
+    async def _stop(seconds):
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(_asyncio, "sleep", _stop)
+    caplog.set_level(logging.ERROR, logger="tinyagentos.agent_heartbeat")
+
+    with pytest.raises(_asyncio.CancelledError):
+        await agent_heartbeat_loop(state)
+
+    messages = [record.message for record in caplog.records]
+    # The failure must surface at sweep level...
+    assert any("sweep iteration crashed" in m for m in messages)
+    # ...NOT silently absorbed per-agent (which would also silence the agent).
+    assert not any("tick failed for agent" in m for m in messages)
+
+    # The wake DID reach the agent's queue (enqueue succeeded)...
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    # ...but the debounce entry was NOT set, so the agent is not silenced
+    # for REWAKE_COOLDOWN on an uncharged wake.
+    assert "agent-hex-1" not in state._heartbeat_last_wake

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -545,7 +545,7 @@ class TestWakeBudgetConfig:
         p = tmp_path / "config.yaml"
         cfg = AppConfig(
             config_path=p,
-            wake_budget={"global_default": 5, "per_agent": {"a1": 10}, "per_project": {"p1": 1}, "mention_cap": {"a1": 3}},
+            wake_budget={"global_default": 5, "per_agent": {"a1": 10}, "per_project": {"p1": 1}},
         )
         from tinyagentos.config import save_config, load_config
         save_config(cfg, p)
@@ -553,13 +553,12 @@ class TestWakeBudgetConfig:
         assert reloaded.wake_budget["global_default"] == 5
         assert reloaded.wake_budget["per_agent"]["a1"] == 10
         assert reloaded.wake_budget["per_project"]["p1"] == 1
-        assert reloaded.wake_budget["mention_cap"]["a1"] == 3
 
     def test_validate_valid(self, tmp_path):
         p = tmp_path / "config.yaml"
         cfg = AppConfig(
             config_path=p,
-            wake_budget={"global_default": 2, "per_agent": {"a1": 3}, "per_project": {}, "mention_cap": {}},
+            wake_budget={"global_default": 2, "per_agent": {"a1": 3}, "per_project": {}},
         )
         errors = validate_config(cfg)
         assert not any("wake_budget" in e for e in errors)
@@ -575,9 +574,3 @@ class TestWakeBudgetConfig:
         cfg = AppConfig(config_path=p, wake_budget={"per_agent": {"a1": "bad"}})
         errors = validate_config(cfg)
         assert any("per_agent" in e for e in errors)
-
-    def test_validate_rejects_non_dict_mention_cap(self, tmp_path):
-        p = tmp_path / "config.yaml"
-        cfg = AppConfig(config_path=p, wake_budget={"mention_cap": [1, 2]})
-        errors = validate_config(cfg)
-        assert any("mention_cap" in e for e in errors)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -574,3 +574,41 @@ class TestWakeBudgetConfig:
         cfg = AppConfig(config_path=p, wake_budget={"per_agent": {"a1": "bad"}})
         errors = validate_config(cfg)
         assert any("per_agent" in e for e in errors)
+
+    def test_wake_budget_nested_defaults_are_per_instance(self, tmp_path):
+        """Per-agent/per-project mappings must be deep-copied per instance so
+        mutating one AppConfig (or load_config result) cannot leak into another
+        instance, the module DEFAULT_CONFIG, or an already-created instance."""
+        from tinyagentos.config import AppConfig, DEFAULT_CONFIG, load_config
+        from tinyagentos.wake_budget import resolve_budget
+
+        earlier = AppConfig(config_path=tmp_path / "config.yaml")
+
+        a = AppConfig(config_path=tmp_path / "config.yaml")
+        assert a.wake_budget["per_agent"] is not DEFAULT_CONFIG["wake_budget"]["per_agent"]
+        assert a.wake_budget["per_project"] is not DEFAULT_CONFIG["wake_budget"]["per_project"]
+        a.wake_budget["per_agent"]["victim-agent"] = 0
+        a.wake_budget["per_project"]["victim-proj"] = 0
+
+        # A fresh instance must not inherit the mutation.
+        fresh = AppConfig(config_path=tmp_path / "config.yaml")
+        assert "victim-agent" not in fresh.wake_budget["per_agent"]
+        assert "victim-proj" not in fresh.wake_budget["per_project"]
+        assert resolve_budget("victim-agent", None, fresh) == 2
+
+        # An earlier instance must not see the mutation.
+        assert "victim-agent" not in earlier.wake_budget["per_agent"]
+        assert "victim-proj" not in earlier.wake_budget["per_project"]
+
+        # The module-level DEFAULT_CONFIG must not be mutated.
+        assert "victim-agent" not in DEFAULT_CONFIG["wake_budget"]["per_agent"]
+        assert "victim-proj" not in DEFAULT_CONFIG["wake_budget"]["per_project"]
+
+        # load_config fallback (no wake_budget in YAML) must also be isolated.
+        p = tmp_path / "config.yaml"
+        p.write_text("server:\n  host: 0.0.0.0\n  port: 6969\n")
+        cfg = load_config(p)
+        cfg.wake_budget["per_agent"]["loaded-agent"] = 0
+        fresh2 = AppConfig(config_path=tmp_path / "config.yaml")
+        assert "loaded-agent" not in fresh2.wake_budget["per_agent"]
+        assert "loaded-agent" not in DEFAULT_CONFIG["wake_budget"]["per_agent"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -531,3 +531,53 @@ class TestMemoryUrl:
 
         reloaded = load_config(p)
         assert reloaded.memory_url == "http://localhost:7900"
+
+
+class TestWakeBudgetConfig:
+    def test_defaults_when_missing(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(config_path=p)
+        assert cfg.wake_budget["global_default"] == 2
+        assert cfg.wake_budget["per_agent"] == {}
+        assert cfg.wake_budget["per_project"] == {}
+
+    def test_loads_from_yaml(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(
+            config_path=p,
+            wake_budget={"global_default": 5, "per_agent": {"a1": 10}, "per_project": {"p1": 1}, "mention_cap": {"a1": 3}},
+        )
+        from tinyagentos.config import save_config, load_config
+        save_config(cfg, p)
+        reloaded = load_config(p)
+        assert reloaded.wake_budget["global_default"] == 5
+        assert reloaded.wake_budget["per_agent"]["a1"] == 10
+        assert reloaded.wake_budget["per_project"]["p1"] == 1
+        assert reloaded.wake_budget["mention_cap"]["a1"] == 3
+
+    def test_validate_valid(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(
+            config_path=p,
+            wake_budget={"global_default": 2, "per_agent": {"a1": 3}, "per_project": {}, "mention_cap": {}},
+        )
+        errors = validate_config(cfg)
+        assert not any("wake_budget" in e for e in errors)
+
+    def test_validate_rejects_negative_global(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(config_path=p, wake_budget={"global_default": -1})
+        errors = validate_config(cfg)
+        assert any("wake_budget.global_default" in e for e in errors)
+
+    def test_validate_rejects_non_integer_per_agent(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(config_path=p, wake_budget={"per_agent": {"a1": "bad"}})
+        errors = validate_config(cfg)
+        assert any("per_agent" in e for e in errors)
+
+    def test_validate_rejects_non_dict_mention_cap(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(config_path=p, wake_budget={"mention_cap": [1, 2]})
+        errors = validate_config(cfg)
+        assert any("mention_cap" in e for e in errors)

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1829,9 +1829,43 @@ class TestAgentWakeBudget:
         assert data["budget"] == 2
         assert data["consumed"] == 0
         assert data["remaining"] == 2
-        assert data["mention_count"] == 0
         assert data["date"] == _today_str()
         assert data["next_wake_epoch"] is not None
+
+    async def test_wake_budget_reports_enforced_project_counter(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        from tinyagentos.agent_heartbeat import _heartbeat_tick
+
+        agent = next(a for a in app.state.config.agents if a["name"] == "test-agent")
+        agent["id"] = "test-agent"
+        agent["status"] = "running"
+        app.state.config.server["agent_heartbeat_enabled"] = True
+
+        project = await app.state.project_store.create_project(
+            name="proj-1", slug="proj-1", created_by="test",
+        )
+        agent["project_id"] = project["id"]
+        await app.state.project_task_store.create_task(
+            project_id=project["id"],
+            title="ready task",
+            created_by="test",
+            assignee_id="test-agent",
+        )
+
+        async def fake_wake(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(
+            "tinyagentos.agent_heartbeat._wake_agent_with_task", fake_wake
+        )
+
+        await _heartbeat_tick(app.state)
+
+        resp = await client.get("/api/agents/test-agent/wake-budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["consumed"] == 1
 
     async def test_get_wake_budget_not_found(self, client):
         resp = await client.get("/api/agents/no-such-agent/wake-budget")

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1817,3 +1817,27 @@ class TestAgentBudgetRoutes:
     async def test_reset_not_found_agent(self, client):
         resp = await client.post("/api/agents/no-such-agent/budget/reset")
         assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestAgentWakeBudget:
+    async def test_get_wake_budget_defaults(self, client):
+        resp = await client.get("/api/agents/test-agent/wake-budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent"] == "test-agent"
+        assert data["budget"] == 2
+        assert data["consumed"] == 0
+        assert data["remaining"] == 2
+        assert data["mention_count"] == 0
+        assert data["date"] == _today_str()
+        assert data["next_wake_epoch"] is not None
+
+    async def test_get_wake_budget_not_found(self, client):
+        resp = await client.get("/api/agents/no-such-agent/wake-budget")
+        assert resp.status_code == 404
+
+
+def _today_str() -> str:
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import time
 
 import pytest
 
@@ -967,3 +969,50 @@ async def test_second_answer_409_no_duplicate_event(client, monkeypatch):
         if ev.kind == "decision.answered":
             count += 1
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_dec_sfdooy_wake_budget_decision_created_and_closed(client, app):
+    """Create the dec-sfdooy decision card for wake-budget design and close it."""
+    store = app.state.decision_store
+    await store.init()
+    now = time.time()
+    await store._db.execute(
+        """INSERT INTO decisions
+           (id, from_agent, project_id, user_id, question, type, options, context,
+            priority, status, created_at, deadline, parent_decision_id,
+            checkpoint_ref, timeline_id, metadata)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)""",
+        (
+            "dec-sfdooy",
+            "@taOS-dev",
+            None,
+            "admin",
+            "Wake-budget config: per-agent + global default + per-project override, OS-enforced",
+            "approve_deny",
+            json.dumps([
+                {"label": "Approve", "value": "approve", "recommended": True, "rationale": "Matches Jay direction on dec-sfdooy"},
+                {"label": "Deny", "value": "deny"},
+            ]),
+            "Fleet default stays at 2/day until this ships. Most specific wins: per-project > per-agent > global_default. Mention wakes exempt but countable.",
+            "normal",
+            now,
+            None,
+            None,
+            None,
+            None,
+            json.dumps({"kind": "design_decision", "card": "dec-sfdooy"}),
+        ),
+    )
+    await store._db.commit()
+    decision = await store.get("dec-sfdooy")
+    assert decision is not None
+    assert decision["status"] == "pending"
+
+    updated = await store.answer("dec-sfdooy", "approve", answered_by="admin", source="in_app")
+    assert updated is not None
+    assert updated["status"] == "answered"
+    answer_value = updated["answer"]
+    if isinstance(answer_value, str):
+        answer_value = json.loads(answer_value)
+    assert answer_value["value"] == "approve"

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -620,7 +620,6 @@ class TestObservatoryWakeBudget:
             assert "budget" in row
             assert "consumed" in row
             assert "remaining" in row
-            assert "mention_count" in row
             assert "next_wake_epoch" in row
 
     async def test_fleet_wake_budget_agent_token(self, app):

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -606,3 +606,32 @@ class TestObservatoryAgentAuth:
         handles = [a["handle"] for a in agents]
         assert "@lane-a" in handles
         assert "@lane-b" not in handles
+
+
+@pytest.mark.asyncio
+class TestObservatoryWakeBudget:
+    async def test_fleet_wake_budget_admin(self, client):
+        resp = await client.get("/api/observatory/wake-budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "agents" in data
+        for row in data["agents"]:
+            assert "agent_id" in row
+            assert "budget" in row
+            assert "consumed" in row
+            assert "remaining" in row
+            assert "mention_count" in row
+            assert "next_wake_epoch" in row
+
+    async def test_fleet_wake_budget_agent_token(self, app):
+        _cid, token = await _make_obs_agent_token(app, scopes=("observatory_control",))
+        from httpx import ASGITransport, AsyncClient
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            resp = await bare.get(
+                "/api/observatory/wake-budget",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "agents" in data

--- a/tests/test_wake_budget.py
+++ b/tests/test_wake_budget.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from tinyagentos.wake_budget import (
     _coerce_budget,
     _read_state,
@@ -9,10 +11,8 @@ from tinyagentos.wake_budget import (
     get_consumption,
     get_fleet_wake_info,
     get_next_scheduled_wake,
-    record_mention_wake,
     record_scheduled_wake,
     resolve_budget,
-    resolve_mention_cap,
 )
 
 
@@ -49,24 +49,10 @@ class TestResolveBudget:
         cfg = _FakeConfig({})
         assert resolve_budget("a1", None, cfg) == 2
 
-    def test_non_integer_global_defaults_to_two(self):
+    def test_non_integer_global_default_raises(self):
         cfg = _FakeConfig({"global_default": "bad", "per_agent": {}, "per_project": {}})
-        assert resolve_budget("a1", None, cfg) == 2
-
-
-class TestResolveMentionCap:
-    def test_uncapped_by_default(self):
-        cfg = _FakeConfig({"mention_cap": {}})
-        assert resolve_mention_cap("a1", cfg) is None
-
-    def test_per_agent_cap(self):
-        cfg = _FakeConfig({"mention_cap": {"a1": 10}})
-        assert resolve_mention_cap("a1", cfg) == 10
-        assert resolve_mention_cap("a2", cfg) is None
-
-    def test_null_is_uncapped(self):
-        cfg = _FakeConfig({"mention_cap": {"a1": None}})
-        assert resolve_mention_cap("a1", cfg) is None
+        with pytest.raises(ValueError):
+            resolve_budget("a1", None, cfg)
 
 
 class TestRecordAndConsume:
@@ -75,15 +61,7 @@ class TestRecordAndConsume:
         record_scheduled_wake(data_dir, "a1", "proj-1")
         c = get_consumption(data_dir, "a1", "proj-1")
         assert c["scheduled"] == 1
-        assert c["mention"] == 0
         assert c["date"] == _today()
-
-    def test_mention_wake_increments(self, tmp_path):
-        data_dir = tmp_path
-        record_mention_wake(data_dir, "a1")
-        c = get_consumption(data_dir, "a1", None)
-        assert c["mention"] == 1
-        assert c["scheduled"] == 0
 
     def test_global_key_for_scheduled(self, tmp_path):
         data_dir = tmp_path
@@ -100,7 +78,22 @@ class TestRecordAndConsume:
         })
         c = get_consumption(data_dir, "a1", "proj-1")
         assert c["scheduled"] == 0
-        assert c["mention"] == 0
+        assert c["date"] == _today()
+
+    def test_prunes_past_dates(self, tmp_path):
+        data_dir = tmp_path
+        state_path = data_dir / "wake_budget.json"
+        _write_state(state_path, {
+            "daily": {
+                "a1:proj-1": {"1999-01-01": 5, _today(): 1},
+            },
+            "mentions": {},
+        })
+        record_scheduled_wake(data_dir, "a1", "proj-1")
+        state = _read_state(state_path)
+        agent_daily = state["daily"]["a1:proj-1"]
+        assert "1999-01-01" not in agent_daily
+        assert agent_daily[_today()] == 2
 
 
 class TestCanWake:
@@ -114,13 +107,6 @@ class TestCanWake:
         record_scheduled_wake(data_dir, "a1", None)
         cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
         assert can_wake(data_dir, "a1", "a1", None, cfg) is False
-
-    def test_mention_always_passes(self, tmp_path):
-        data_dir = tmp_path
-        record_scheduled_wake(data_dir, "a1", None)
-        record_scheduled_wake(data_dir, "a1", None)
-        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
-        assert can_wake(data_dir, "a1", "a1", None, cfg, wake_type="mention") is True
 
     def test_zero_budget_blocks(self, tmp_path):
         cfg = _FakeConfig({"global_default": 0, "per_agent": {}, "per_project": {}})
@@ -147,11 +133,11 @@ class TestNextScheduledWake:
 
 
 class TestFleetWakeInfo:
-    def test_returns_rows_for_active_agents(self, tmp_path):
+    def test_returns_rows_for_running_agents(self, tmp_path):
         cfg = _FakeConfig(
-            wake_budget={"global_default": 2, "per_agent": {}, "per_project": {}, "mention_cap": {}},
+            wake_budget={"global_default": 2, "per_agent": {}, "per_project": {}},
             agents=[
-                {"id": "a1", "name": "agent-1", "status": "active"},
+                {"id": "a1", "name": "agent-1", "status": "running"},
                 {"id": "a2", "name": "agent-2", "status": "paused"},
             ],
         )
@@ -161,3 +147,8 @@ class TestFleetWakeInfo:
         assert rows[0]["budget"] == 2
         assert rows[0]["consumed"] == 0
         assert rows[0]["remaining"] == 2
+
+
+def _today() -> str:
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")

--- a/tests/test_wake_budget.py
+++ b/tests/test_wake_budget.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from tinyagentos.wake_budget import (
     get_next_scheduled_wake,
     record_scheduled_wake,
     resolve_budget,
+    WakeBudgetStateError,
 )
 
 
@@ -74,7 +76,6 @@ class TestRecordAndConsume:
         state_path = data_dir / "wake_budget.json"
         _write_state(state_path, {
             "daily": {"a1:proj-1": {"1999-01-01": 5}},
-            "mentions": {"a1": {"1999-01-01": 3}},
         })
         c = get_consumption(data_dir, "a1", "proj-1")
         assert c["scheduled"] == 0
@@ -87,7 +88,6 @@ class TestRecordAndConsume:
             "daily": {
                 "a1:proj-1": {"1999-01-01": 5, _today(): 1},
             },
-            "mentions": {},
         })
         record_scheduled_wake(data_dir, "a1", "proj-1")
         state = _read_state(state_path)
@@ -147,6 +147,61 @@ class TestFleetWakeInfo:
         assert rows[0]["budget"] == 2
         assert rows[0]["consumed"] == 0
         assert rows[0]["remaining"] == 2
+
+
+class TestDamagedState:
+    def test_absent_file_is_fresh_state(self, tmp_path):
+        """An absent wake_budget.json is a fresh state: _read_state returns an
+        empty daily dict (no 'mentions' key) and can_wake returns True."""
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert can_wake(tmp_path, "a1", "a1", None, cfg) is True
+        state = _read_state(tmp_path / "wake_budget.json")
+        assert state == {"daily": {}}
+
+    def test_damaged_state_fails_closed(self, tmp_path):
+        """A damaged (present but unreadable/unparseable) wake_budget.json must
+        fail closed: can_wake returns False instead of silently restoring a
+        full budget. A healthy file with room still returns True as control."""
+        data_dir = tmp_path
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        path = data_dir / "wake_budget.json"
+
+        # Control: healthy file with room consumed still returns True.
+        _write_state(path, {"daily": {"a1:global": {_today(): 1}}})
+        assert can_wake(data_dir, "a1", "a1", None, cfg) is True
+
+        # Control: _read_state succeeds on a healthy file.
+        assert _read_state(path) == {"daily": {"a1:global": {_today(): 1}}}
+
+        # Damaged: zeroed file (null bytes) -> UnicodeDecodeError on read_text.
+        path.write_bytes(b"\x00\x01\x02\x00")
+        with pytest.raises(WakeBudgetStateError):
+            _read_state(path)
+        assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+
+        # Damaged: truncated JSON -> JSONDecodeError on json.loads.
+        path.write_text("{")
+        with pytest.raises(WakeBudgetStateError):
+            _read_state(path)
+        assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+
+        # Damaged: non-dict root (valid JSON but wrong shape).
+        path.write_text("[1, 2, 3]")
+        with pytest.raises(WakeBudgetStateError):
+            _read_state(path)
+        assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+
+        # Damaged: unreadable file (chmod 000) -> PermissionError on read_text.
+        # Root bypasses file permissions, so skip that sub-assertion as root.
+        path.write_text("{}")
+        os.chmod(path, 0o000)
+        try:
+            if os.geteuid() != 0:
+                with pytest.raises(WakeBudgetStateError):
+                    _read_state(path)
+                assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+        finally:
+            os.chmod(path, 0o644)
 
 
 def _today() -> str:

--- a/tests/test_wake_budget.py
+++ b/tests/test_wake_budget.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+
+from tinyagentos.wake_budget import (
+    _coerce_budget,
+    _read_state,
+    _write_state,
+    _today,
+    can_wake,
+    get_consumption,
+    get_fleet_wake_info,
+    get_next_scheduled_wake,
+    record_mention_wake,
+    record_scheduled_wake,
+    resolve_budget,
+    resolve_mention_cap,
+)
+
+
+class _FakeConfig:
+    def __init__(self, wake_budget=None, agents=None):
+        self.wake_budget = wake_budget or {}
+        self.agents = agents or []
+
+
+class TestResolveBudget:
+    def test_global_default(self):
+        cfg = _FakeConfig({"global_default": 3, "per_agent": {}, "per_project": {}})
+        assert resolve_budget("a1", None, cfg) == 3
+
+    def test_per_agent_override(self):
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {"a1": 5}, "per_project": {}})
+        assert resolve_budget("a1", None, cfg) == 5
+        assert resolve_budget("a2", None, cfg) == 2
+
+    def test_per_project_overrides_per_agent(self):
+        cfg = _FakeConfig({
+            "global_default": 2,
+            "per_agent": {"a1": 5},
+            "per_project": {"proj-1": 1},
+        })
+        assert resolve_budget("a1", "proj-1", cfg) == 1
+        assert resolve_budget("a1", "proj-2", cfg) == 5
+
+    def test_per_agent_overrides_global(self):
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {"a1": 0}, "per_project": {}})
+        assert resolve_budget("a1", None, cfg) == 0
+
+    def test_missing_config_defaults_to_two(self):
+        cfg = _FakeConfig({})
+        assert resolve_budget("a1", None, cfg) == 2
+
+    def test_non_integer_global_defaults_to_two(self):
+        cfg = _FakeConfig({"global_default": "bad", "per_agent": {}, "per_project": {}})
+        assert resolve_budget("a1", None, cfg) == 2
+
+
+class TestResolveMentionCap:
+    def test_uncapped_by_default(self):
+        cfg = _FakeConfig({"mention_cap": {}})
+        assert resolve_mention_cap("a1", cfg) is None
+
+    def test_per_agent_cap(self):
+        cfg = _FakeConfig({"mention_cap": {"a1": 10}})
+        assert resolve_mention_cap("a1", cfg) == 10
+        assert resolve_mention_cap("a2", cfg) is None
+
+    def test_null_is_uncapped(self):
+        cfg = _FakeConfig({"mention_cap": {"a1": None}})
+        assert resolve_mention_cap("a1", cfg) is None
+
+
+class TestRecordAndConsume:
+    def test_scheduled_wake_increments(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-1")
+        c = get_consumption(data_dir, "a1", "proj-1")
+        assert c["scheduled"] == 1
+        assert c["mention"] == 0
+        assert c["date"] == _today()
+
+    def test_mention_wake_increments(self, tmp_path):
+        data_dir = tmp_path
+        record_mention_wake(data_dir, "a1")
+        c = get_consumption(data_dir, "a1", None)
+        assert c["mention"] == 1
+        assert c["scheduled"] == 0
+
+    def test_global_key_for_scheduled(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", None)
+        c = get_consumption(data_dir, "a1", None)
+        assert c["scheduled"] == 1
+
+    def test_date_rollover(self, tmp_path):
+        data_dir = tmp_path
+        state_path = data_dir / "wake_budget.json"
+        _write_state(state_path, {
+            "daily": {"a1:proj-1": {"1999-01-01": 5}},
+            "mentions": {"a1": {"1999-01-01": 3}},
+        })
+        c = get_consumption(data_dir, "a1", "proj-1")
+        assert c["scheduled"] == 0
+        assert c["mention"] == 0
+
+
+class TestCanWake:
+    def test_allowed_when_under_budget(self, tmp_path):
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert can_wake(tmp_path, "a1", "a1", None, cfg) is True
+
+    def test_blocked_when_exhausted(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", None)
+        record_scheduled_wake(data_dir, "a1", None)
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+
+    def test_mention_always_passes(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", None)
+        record_scheduled_wake(data_dir, "a1", None)
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert can_wake(data_dir, "a1", "a1", None, cfg, wake_type="mention") is True
+
+    def test_zero_budget_blocks(self, tmp_path):
+        cfg = _FakeConfig({"global_default": 0, "per_agent": {}, "per_project": {}})
+        assert can_wake(tmp_path, "a1", "a1", None, cfg) is False
+
+
+class TestNextScheduledWake:
+    def test_returns_epoch_when_available(self, tmp_path):
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        nxt = get_next_scheduled_wake(tmp_path, "a1", None, cfg)
+        assert nxt is not None
+        assert nxt > 0
+
+    def test_none_when_exhausted(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", None)
+        record_scheduled_wake(data_dir, "a1", None)
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert get_next_scheduled_wake(data_dir, "a1", None, cfg) is None
+
+    def test_none_when_zero_budget(self, tmp_path):
+        cfg = _FakeConfig({"global_default": 0, "per_agent": {}, "per_project": {}})
+        assert get_next_scheduled_wake(tmp_path, "a1", None, cfg) is None
+
+
+class TestFleetWakeInfo:
+    def test_returns_rows_for_active_agents(self, tmp_path):
+        cfg = _FakeConfig(
+            wake_budget={"global_default": 2, "per_agent": {}, "per_project": {}, "mention_cap": {}},
+            agents=[
+                {"id": "a1", "name": "agent-1", "status": "active"},
+                {"id": "a2", "name": "agent-2", "status": "paused"},
+            ],
+        )
+        rows = get_fleet_wake_info(tmp_path, cfg)
+        assert len(rows) == 1
+        assert rows[0]["agent_id"] == "a1"
+        assert rows[0]["budget"] == 2
+        assert rows[0]["consumed"] == 0
+        assert rows[0]["remaining"] == 2

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -176,6 +176,7 @@ async def _heartbeat_tick(app_state) -> None:
         agent_id = agent.get("id")
         if not agent_id:
             continue
+        woke_with_task = None
         try:
             if await project_task_store.held_task(agent_id) is not None:
                 continue
@@ -203,10 +204,20 @@ async def _heartbeat_tick(app_state) -> None:
             # failed enqueue retries next tick instead of silencing the agent
             # for the whole cooldown.
             if await _wake_agent_with_task(app_state, agent, task):
-                debounce[agent_id] = (task["id"], now)
-                record_scheduled_wake(data_dir, agent_id, task.get("project_id"))
+                woke_with_task = task
         except Exception:
             logger.exception("heartbeat: tick failed for agent %s", agent.get("name"))
+            continue
+
+        if woke_with_task is not None:
+            # Record the scheduled wake BEFORE stamping the debounce, and
+            # outside the per-agent try/except above. A persistence failure
+            # (disk-full, permission error) must propagate to the sweep-level
+            # handler instead of being swallowed per-agent -- otherwise the
+            # wake was sent but never charged and the agent is silenced for
+            # REWAKE_COOLDOWN on a budget that was never consumed.
+            record_scheduled_wake(data_dir, agent_id, woke_with_task.get("project_id"))
+            debounce[agent_id] = (woke_with_task["id"], now)
 
 
 async def agent_heartbeat_loop(app_state, interval: float = HEARTBEAT_INTERVAL) -> None:

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -33,6 +33,8 @@ import logging
 import time
 import uuid
 
+from tinyagentos.wake_budget import can_wake, record_scheduled_wake
+
 logger = logging.getLogger(__name__)
 
 HEARTBEAT_INTERVAL = 60  # seconds between agent queue sweeps
@@ -156,6 +158,7 @@ async def _heartbeat_tick(app_state) -> None:
     project_task_store = app_state.project_task_store
     debounce = _debounce_map(app_state)
     now = time.time()
+    data_dir = getattr(app_state, "data_dir", None)
 
     woke_this_tick = 0
     staggered_seconds = 0.0
@@ -174,6 +177,12 @@ async def _heartbeat_tick(app_state) -> None:
             task = ready[0]
             if not _should_wake(debounce, agent_id, task["id"], now):
                 continue
+            if data_dir is not None:
+                project_id = task.get("project_id")
+                if not can_wake(
+                    data_dir, agent_id, agent.get("name", agent_id), project_id, config
+                ):
+                    continue
             # Spread successive wakes within a tick so the downstream LLM turns
             # don't all fire at one instant on a large fleet. Deterministic (not
             # random) to stay testable; only agents we actually wake sleep, so
@@ -188,6 +197,8 @@ async def _heartbeat_tick(app_state) -> None:
             # for the whole cooldown.
             if await _wake_agent_with_task(app_state, agent, task):
                 debounce[agent_id] = (task["id"], now)
+                if data_dir is not None:
+                    record_scheduled_wake(data_dir, agent_id, task.get("project_id"))
         except Exception:
             logger.exception("heartbeat: tick failed for agent %s", agent.get("name"))
 

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -177,12 +177,13 @@ async def _heartbeat_tick(app_state) -> None:
             task = ready[0]
             if not _should_wake(debounce, agent_id, task["id"], now):
                 continue
-            if data_dir is not None:
-                project_id = task.get("project_id")
-                if not can_wake(
-                    data_dir, agent_id, agent.get("name", agent_id), project_id, config
-                ):
-                    continue
+            if data_dir is None:
+                raise RuntimeError("data_dir is required for wake-budget enforcement")
+            project_id = task.get("project_id")
+            if not can_wake(
+                data_dir, agent_id, agent.get("name", agent_id), project_id, config
+            ):
+                continue
             # Spread successive wakes within a tick so the downstream LLM turns
             # don't all fire at one instant on a large fleet. Deterministic (not
             # random) to stay testable; only agents we actually wake sleep, so
@@ -197,8 +198,7 @@ async def _heartbeat_tick(app_state) -> None:
             # for the whole cooldown.
             if await _wake_agent_with_task(app_state, agent, task):
                 debounce[agent_id] = (task["id"], now)
-                if data_dir is not None:
-                    record_scheduled_wake(data_dir, agent_id, task.get("project_id"))
+                record_scheduled_wake(data_dir, agent_id, task.get("project_id"))
         except Exception:
             logger.exception("heartbeat: tick failed for agent %s", agent.get("name"))
 

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -159,6 +159,14 @@ async def _heartbeat_tick(app_state) -> None:
     debounce = _debounce_map(app_state)
     now = time.time()
     data_dir = getattr(app_state, "data_dir", None)
+    # Wake-budget enforcement needs a persistent data_dir to read/write
+    # wake_budget.json. Validate here, at the tick entry, rather than inside the
+    # per-agent try below: a missing data_dir is a fatal misconfiguration, not a
+    # per-agent hiccup, so it must surface at the tick/sweep level (propagates to
+    # the loop's sweep-level handler) instead of being silently logged per agent
+    # and leaving the whole fleet silently unwakeable.
+    if data_dir is None:
+        raise RuntimeError("data_dir is required for wake-budget enforcement")
 
     woke_this_tick = 0
     staggered_seconds = 0.0
@@ -177,8 +185,6 @@ async def _heartbeat_tick(app_state) -> None:
             task = ready[0]
             if not _should_wake(debounce, agent_id, task["id"], now):
                 continue
-            if data_dir is None:
-                raise RuntimeError("data_dir is required for wake-budget enforcement")
             project_id = task.get("project_id")
             if not can_wake(
                 data_dir, agent_id, agent.get("name", agent_id), project_id, config

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -53,6 +53,7 @@ _OBSERVATORY_PATHS = frozenset({
     "/api/observatory/throttle",
     "/api/observatory/approval-mode",
     "/api/observatory/fleet",
+    "/api/observatory/wake-budget",
 })
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -35,7 +35,7 @@ DEFAULT_CONFIG = {
     "metrics": {"poll_interval": 30, "retention_days": 30},
     "memory_url": "http://localhost:7900",
     "webhooks": [],
-    "wake_budget": {"global_default": 2, "per_agent": {}, "per_project": {}, "mention_cap": {}},
+    "wake_budget": {"global_default": 2, "per_agent": {}, "per_project": {}},
 }
 
 _config_lock = asyncio.Lock()
@@ -534,19 +534,4 @@ def validate_config(config: AppConfig) -> list[str]:
                 continue
             if n < 0:
                 errors.append(f"wake_budget.{section}[{key!r}] must be >= 0")
-    mention_cap = wb.get("mention_cap")
-    if mention_cap is not None:
-        if not isinstance(mention_cap, dict):
-            errors.append("wake_budget.mention_cap must be a mapping")
-        else:
-            for key, val in mention_cap.items():
-                if val is None:
-                    continue
-                try:
-                    n = int(val)
-                except (TypeError, ValueError):
-                    errors.append(f"wake_budget.mention_cap[{key!r}] must be an integer or null")
-                    continue
-                if n < 0:
-                    errors.append(f"wake_budget.mention_cap[{key!r}] must be >= 0")
     return errors

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = {
     "metrics": {"poll_interval": 30, "retention_days": 30},
     "memory_url": "http://localhost:7900",
     "webhooks": [],
+    "wake_budget": {"global_default": 2, "per_agent": {}, "per_project": {}, "mention_cap": {}},
 }
 
 _config_lock = asyncio.Lock()
@@ -60,6 +61,7 @@ class AppConfig:
     archived_agents: list[dict] = field(default_factory=list)
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
+    wake_budget: dict = field(default_factory=lambda: DEFAULT_CONFIG["wake_budget"].copy())
     # Locally-hosted taOSmd deployment hooks for /api/settings/update: the git
     # checkout the running service imports from, and the command that restarts
     # it (e.g. "sudo systemctl restart taosmd"). Both empty on installs where
@@ -81,6 +83,7 @@ class AppConfig:
             "qmd": self.qmd,
             "agents": self.agents,
             "metrics": self.metrics,
+            "wake_budget": self.wake_budget,
         }
         if self.webhooks:
             d["webhooks"] = self.webhooks
@@ -203,6 +206,7 @@ def load_config(path: Path) -> AppConfig:
         qmd=data.get("qmd", DEFAULT_CONFIG["qmd"].copy()),
         agents=agents,
         metrics=data.get("metrics", DEFAULT_CONFIG["metrics"].copy()),
+        wake_budget=data.get("wake_budget", DEFAULT_CONFIG["wake_budget"].copy()),
         webhooks=data.get("webhooks", []),
         archived_agents=data.get("archived_agents", []),
         archive=archive_cfg,
@@ -507,4 +511,42 @@ def validate_config(config: AppConfig) -> list[str]:
         fb = a.get("fallback_models")
         if fb is not None and not isinstance(fb, list):
             errors.append(f"agents[{i}]: fallback_models must be a list")
+    wb = config.wake_budget or {}
+    try:
+        gd = int(wb.get("global_default", 2))
+    except (TypeError, ValueError):
+        errors.append("wake_budget.global_default must be an integer")
+        gd = -1
+    if gd < 0:
+        errors.append("wake_budget.global_default must be >= 0")
+    for section in ("per_agent", "per_project"):
+        bucket = wb.get(section)
+        if bucket is None:
+            continue
+        if not isinstance(bucket, dict):
+            errors.append(f"wake_budget.{section} must be a mapping")
+            continue
+        for key, val in bucket.items():
+            try:
+                n = int(val)
+            except (TypeError, ValueError):
+                errors.append(f"wake_budget.{section}[{key!r}] must be an integer")
+                continue
+            if n < 0:
+                errors.append(f"wake_budget.{section}[{key!r}] must be >= 0")
+    mention_cap = wb.get("mention_cap")
+    if mention_cap is not None:
+        if not isinstance(mention_cap, dict):
+            errors.append("wake_budget.mention_cap must be a mapping")
+        else:
+            for key, val in mention_cap.items():
+                if val is None:
+                    continue
+                try:
+                    n = int(val)
+                except (TypeError, ValueError):
+                    errors.append(f"wake_budget.mention_cap[{key!r}] must be an integer or null")
+                    continue
+                if n < 0:
+                    errors.append(f"wake_budget.mention_cap[{key!r}] must be >= 0")
     return errors

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import os as _os
 import re
@@ -61,7 +62,7 @@ class AppConfig:
     archived_agents: list[dict] = field(default_factory=list)
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
-    wake_budget: dict = field(default_factory=lambda: DEFAULT_CONFIG["wake_budget"].copy())
+    wake_budget: dict = field(default_factory=lambda: copy.deepcopy(DEFAULT_CONFIG["wake_budget"]))
     # Locally-hosted taOSmd deployment hooks for /api/settings/update: the git
     # checkout the running service imports from, and the command that restarts
     # it (e.g. "sudo systemctl restart taosmd"). Both empty on installs where
@@ -206,7 +207,7 @@ def load_config(path: Path) -> AppConfig:
         qmd=data.get("qmd", DEFAULT_CONFIG["qmd"].copy()),
         agents=agents,
         metrics=data.get("metrics", DEFAULT_CONFIG["metrics"].copy()),
-        wake_budget=data.get("wake_budget", DEFAULT_CONFIG["wake_budget"].copy()),
+        wake_budget=copy.deepcopy(data.get("wake_budget", DEFAULT_CONFIG["wake_budget"])),
         webhooks=data.get("webhooks", []),
         archived_agents=data.get("archived_agents", []),
         archive=archive_cfg,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1645,15 +1645,15 @@ async def get_agent_wake_budget(request: Request, name: str):
         return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
     agent_id = agent.get("id") or name
     data_dir = Path(request.app.state.data_dir)
-    budget = resolve_budget(agent_id, None, config)
-    consumption = get_consumption(data_dir, agent_id, None)
-    next_wake = get_next_scheduled_wake(data_dir, agent_id, None, config)
+    project_id = agent.get("project_id")
+    budget = resolve_budget(agent_id, project_id, config)
+    consumption = get_consumption(data_dir, agent_id, project_id)
+    next_wake = get_next_scheduled_wake(data_dir, agent_id, project_id, config)
     return {
         "agent": name,
         "budget": budget,
         "consumed": consumption["scheduled"],
         "remaining": max(0, budget - consumption["scheduled"]),
-        "mention_count": consumption["mention"],
         "next_wake_epoch": next_wake,
         "date": consumption["date"],
     }

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1631,3 +1631,29 @@ async def reset_agent_budget(request: Request, name: str):
     store = _budget_store_for_request(request)
     store.reset_spend(name)
     return _budget_response(name, store.get(name))
+
+
+@router.get("/api/agents/{name}/wake-budget")
+async def get_agent_wake_budget(request: Request, name: str):
+    """Return an agent's resolved wake budget, today's consumption, and next
+    scheduled wake epoch."""
+    from pathlib import Path
+    from tinyagentos.wake_budget import resolve_budget, get_consumption, get_next_scheduled_wake
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+    agent_id = agent.get("id") or name
+    data_dir = Path(request.app.state.data_dir)
+    budget = resolve_budget(agent_id, None, config)
+    consumption = get_consumption(data_dir, agent_id, None)
+    next_wake = get_next_scheduled_wake(data_dir, agent_id, None, config)
+    return {
+        "agent": name,
+        "budget": budget,
+        "consumed": consumption["scheduled"],
+        "remaining": max(0, budget - consumption["scheduled"]),
+        "mention_count": consumption["mention"],
+        "next_wake_epoch": next_wake,
+        "date": consumption["date"],
+    }

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -456,3 +456,16 @@ async def get_fleet(request: Request):
         "status": "degraded" if stale_handles else ("active" if working_count else "idle"),
     }
     return {"agents": agents, "paused": _read_state(request), "health": health}
+
+
+@router.get("/api/observatory/wake-budget")
+async def get_wake_budget(request: Request):
+    """Per-agent wake budget, consumption, and next scheduled wake.
+
+    Admin or an agent holding ``observatory_control`` may read it.
+    """
+    await _authorize_observatory_read(request)
+    from tinyagentos.wake_budget import get_fleet_wake_info
+    data_dir = Path(request.app.state.data_dir)
+    info = get_fleet_wake_info(data_dir, request.app.state.config, request.app.state.project_store)
+    return {"agents": info}

--- a/tinyagentos/wake_budget.py
+++ b/tinyagentos/wake_budget.py
@@ -21,21 +21,40 @@ logger = logging.getLogger(__name__)
 _DEFAULT_GLOBAL = 2
 
 
+class WakeBudgetStateError(Exception):
+    """Raised when ``wake_budget.json`` exists but cannot be read or parsed.
+
+    This is distinct from a *missing* file (which is a fresh state). A
+    damaged file must fail closed -- see :func:`can_wake` -- rather than
+    silently restoring a full budget to every agent.
+    """
+
+
 def _budget_path(data_dir: Path) -> Path:
     return data_dir / "wake_budget.json"
 
 
 def _read_state(path: Path) -> dict:
+    """Read and parse the wake-budget state file.
+
+    A *missing* file is a fresh state: returns ``{"daily": {}}``.
+    A *present-but-damaged* file raises :class:`WakeBudgetStateError` so the
+    caller can fail closed instead of silently reporting zero consumption.
+    """
     if not path.exists():
-        return {"daily": {}, "mentions": {}}
+        return {"daily": {}}
     try:
         text = path.read_text(encoding="utf-8")
         data = json.loads(text)
-        if not isinstance(data, dict):
-            return {"daily": {}, "mentions": {}}
-        return data
-    except (OSError, ValueError, TypeError):
-        return {"daily": {}, "mentions": {}}
+    except (OSError, ValueError, TypeError) as e:
+        raise WakeBudgetStateError(
+            f"wake_budget.json exists but is unreadable/damaged: {e}"
+        ) from e
+    if not isinstance(data, dict):
+        raise WakeBudgetStateError(
+            f"wake_budget.json root is {type(data).__name__}, expected a JSON object"
+        )
+    return data
 
 
 def _write_state(path: Path, state: dict) -> None:
@@ -113,11 +132,22 @@ def can_wake(
     project_id: str | None,
     config: Any,
 ) -> bool:
-    """Return True when the agent may be woken for a scheduled check."""
+    """Return True when the agent may be woken for a scheduled check.
+
+    Fails closed (returns False) when the state file is damaged: a corrupted
+    ``wake_budget.json`` must not silently restore a full budget and let
+    enforcement cease fleet-wide.
+    """
     budget = resolve_budget(agent_id, project_id, config)
     if budget <= 0:
         return False
-    consumption = get_consumption(data_dir, agent_id, project_id)
+    try:
+        consumption = get_consumption(data_dir, agent_id, project_id)
+    except WakeBudgetStateError:
+        logger.exception(
+            "wake budget state damaged, refusing wake for agent %s", agent_id
+        )
+        return False
     return consumption["scheduled"] < budget
 
 

--- a/tinyagentos/wake_budget.py
+++ b/tinyagentos/wake_budget.py
@@ -1,8 +1,7 @@
 """Wake budget: OS-enforced per-agent / per-project / global daily wake limits.
 
 The scheduler and heartbeat call ``can_wake`` before firing a scheduled check.
-Mention wakes bypass the scheduled budget but are counted for Observatory
-visibility. Daily consumption is persisted in ``data_dir/wake_budget.json``
+Daily consumption is persisted in ``data_dir/wake_budget.json``
 and rolls over automatically by date.
 """
 
@@ -20,7 +19,6 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _DEFAULT_GLOBAL = 2
-_DEFAULT_MENTION_CAP = None
 
 
 def _budget_path(data_dir: Path) -> Path:
@@ -60,10 +58,7 @@ def _today() -> str:
 
 
 def _coerce_budget(v: Any) -> int:
-    try:
-        n = int(v)
-    except (TypeError, ValueError):
-        return _DEFAULT_GLOBAL
+    n = int(v)
     return max(0, n)
 
 
@@ -83,19 +78,12 @@ def resolve_budget(agent_id: str, project_id: str | None, config: Any) -> int:
     return _coerce_budget(wb.get("global_default", _DEFAULT_GLOBAL))
 
 
-def resolve_mention_cap(agent_id: str, config: Any) -> int | None:
-    """Return the daily mention cap for an agent, or None when uncapped."""
-    wb = getattr(config, "wake_budget", None) or {}
-    per_agent_caps = wb.get("mention_cap") or {}
-    if agent_id in per_agent_caps:
-        v = per_agent_caps[agent_id]
-        if v is None:
-            return None
-        return _coerce_budget(v)
-    return _DEFAULT_MENTION_CAP
-
-
 def record_scheduled_wake(data_dir: Path, agent_id: str, project_id: str | None) -> None:
+    """Record one scheduled wake for today.
+
+    The heartbeat loop is the single writer for this file. Do not call
+    concurrently from multiple processes without an external lock.
+    """
     path = _budget_path(data_dir)
     state = _read_state(path)
     today = _today()
@@ -103,16 +91,9 @@ def record_scheduled_wake(data_dir: Path, agent_id: str, project_id: str | None)
     daily = state.setdefault("daily", {})
     agent_daily = daily.setdefault(key, {})
     agent_daily[today] = int(agent_daily.get(today, 0)) + 1
-    _write_state(path, state)
-
-
-def record_mention_wake(data_dir: Path, agent_id: str) -> None:
-    path = _budget_path(data_dir)
-    state = _read_state(path)
-    today = _today()
-    mentions = state.setdefault("mentions", {})
-    agent_mentions = mentions.setdefault(agent_id, {})
-    agent_mentions[today] = int(agent_mentions.get(today, 0)) + 1
+    for k in list(agent_daily):
+        if k != today:
+            del agent_daily[k]
     _write_state(path, state)
 
 
@@ -122,8 +103,7 @@ def get_consumption(data_dir: Path, agent_id: str, project_id: str | None) -> di
     today = _today()
     key = f"{agent_id}:{project_id or 'global'}"
     scheduled = int(state.get("daily", {}).get(key, {}).get(today, 0))
-    mention = int(state.get("mentions", {}).get(agent_id, {}).get(today, 0))
-    return {"scheduled": scheduled, "mention": mention, "date": today}
+    return {"scheduled": scheduled, "date": today}
 
 
 def can_wake(
@@ -132,16 +112,8 @@ def can_wake(
     agent_name: str,
     project_id: str | None,
     config: Any,
-    wake_type: str = "scheduled",
 ) -> bool:
-    """Return True when the agent may be woken for *wake_type*.
-
-    Scheduled wakes are blocked when the resolved budget is exhausted.
-    Mention wakes always pass the gate (they bypass the schedule) but are
-    still recorded for observability.
-    """
-    if wake_type == "mention":
-        return True
+    """Return True when the agent may be woken for a scheduled check."""
     budget = resolve_budget(agent_id, project_id, config)
     if budget <= 0:
         return False
@@ -169,17 +141,18 @@ def get_next_scheduled_wake(
 
 
 def get_fleet_wake_info(data_dir: Path, config: Any, project_store: Any = None) -> list[dict]:
-    """Return wake info for every active agent in config."""
+    """Return wake info for every running agent in config."""
     rows: list[dict] = []
     agents = getattr(config, "agents", None) or []
     for agent in agents:
-        if agent.get("status") != "active":
+        if agent.get("status") != "running":
             continue
         agent_id = agent.get("id") or agent.get("name") or ""
         if not agent_id:
             continue
-        budget = resolve_budget(agent_id, None, config)
-        consumption = get_consumption(data_dir, agent_id, None)
+        project_id = agent.get("project_id")
+        budget = resolve_budget(agent_id, project_id, config)
+        consumption = get_consumption(data_dir, agent_id, project_id)
         remaining = max(0, budget - consumption["scheduled"])
         rows.append({
             "agent_id": agent_id,
@@ -187,7 +160,6 @@ def get_fleet_wake_info(data_dir: Path, config: Any, project_store: Any = None) 
             "budget": budget,
             "consumed": consumption["scheduled"],
             "remaining": remaining,
-            "mention_count": consumption["mention"],
-            "next_wake_epoch": get_next_scheduled_wake(data_dir, agent_id, None, config),
+            "next_wake_epoch": get_next_scheduled_wake(data_dir, agent_id, project_id, config),
         })
     return rows

--- a/tinyagentos/wake_budget.py
+++ b/tinyagentos/wake_budget.py
@@ -1,0 +1,193 @@
+"""Wake budget: OS-enforced per-agent / per-project / global daily wake limits.
+
+The scheduler and heartbeat call ``can_wake`` before firing a scheduled check.
+Mention wakes bypass the scheduled budget but are counted for Observatory
+visibility. Daily consumption is persisted in ``data_dir/wake_budget.json``
+and rolls over automatically by date.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_GLOBAL = 2
+_DEFAULT_MENTION_CAP = None
+
+
+def _budget_path(data_dir: Path) -> Path:
+    return data_dir / "wake_budget.json"
+
+
+def _read_state(path: Path) -> dict:
+    if not path.exists():
+        return {"daily": {}, "mentions": {}}
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            return {"daily": {}, "mentions": {}}
+        return data
+    except (OSError, ValueError, TypeError):
+        return {"daily": {}, "mentions": {}}
+
+
+def _write_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix="." + path.stem + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps(state, sort_keys=True))
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _coerce_budget(v: Any) -> int:
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return _DEFAULT_GLOBAL
+    return max(0, n)
+
+
+def resolve_budget(agent_id: str, project_id: str | None, config: Any) -> int:
+    """Resolve the scheduled wake budget for an agent.
+
+    Cascade: per-project > per-agent > global_default.
+    """
+    wb = getattr(config, "wake_budget", None) or {}
+    if project_id:
+        per_project = wb.get("per_project") or {}
+        if project_id in per_project:
+            return _coerce_budget(per_project[project_id])
+    per_agent = wb.get("per_agent") or {}
+    if agent_id in per_agent:
+        return _coerce_budget(per_agent[agent_id])
+    return _coerce_budget(wb.get("global_default", _DEFAULT_GLOBAL))
+
+
+def resolve_mention_cap(agent_id: str, config: Any) -> int | None:
+    """Return the daily mention cap for an agent, or None when uncapped."""
+    wb = getattr(config, "wake_budget", None) or {}
+    per_agent_caps = wb.get("mention_cap") or {}
+    if agent_id in per_agent_caps:
+        v = per_agent_caps[agent_id]
+        if v is None:
+            return None
+        return _coerce_budget(v)
+    return _DEFAULT_MENTION_CAP
+
+
+def record_scheduled_wake(data_dir: Path, agent_id: str, project_id: str | None) -> None:
+    path = _budget_path(data_dir)
+    state = _read_state(path)
+    today = _today()
+    key = f"{agent_id}:{project_id or 'global'}"
+    daily = state.setdefault("daily", {})
+    agent_daily = daily.setdefault(key, {})
+    agent_daily[today] = int(agent_daily.get(today, 0)) + 1
+    _write_state(path, state)
+
+
+def record_mention_wake(data_dir: Path, agent_id: str) -> None:
+    path = _budget_path(data_dir)
+    state = _read_state(path)
+    today = _today()
+    mentions = state.setdefault("mentions", {})
+    agent_mentions = mentions.setdefault(agent_id, {})
+    agent_mentions[today] = int(agent_mentions.get(today, 0)) + 1
+    _write_state(path, state)
+
+
+def get_consumption(data_dir: Path, agent_id: str, project_id: str | None) -> dict:
+    path = _budget_path(data_dir)
+    state = _read_state(path)
+    today = _today()
+    key = f"{agent_id}:{project_id or 'global'}"
+    scheduled = int(state.get("daily", {}).get(key, {}).get(today, 0))
+    mention = int(state.get("mentions", {}).get(agent_id, {}).get(today, 0))
+    return {"scheduled": scheduled, "mention": mention, "date": today}
+
+
+def can_wake(
+    data_dir: Path,
+    agent_id: str,
+    agent_name: str,
+    project_id: str | None,
+    config: Any,
+    wake_type: str = "scheduled",
+) -> bool:
+    """Return True when the agent may be woken for *wake_type*.
+
+    Scheduled wakes are blocked when the resolved budget is exhausted.
+    Mention wakes always pass the gate (they bypass the schedule) but are
+    still recorded for observability.
+    """
+    if wake_type == "mention":
+        return True
+    budget = resolve_budget(agent_id, project_id, config)
+    if budget <= 0:
+        return False
+    consumption = get_consumption(data_dir, agent_id, project_id)
+    return consumption["scheduled"] < budget
+
+
+def get_next_scheduled_wake(
+    data_dir: Path,
+    agent_id: str,
+    project_id: str | None,
+    config: Any,
+) -> float | None:
+    """Return the epoch of the next scheduled wake, or None if exhausted."""
+    budget = resolve_budget(agent_id, project_id, config)
+    if budget <= 0:
+        return None
+    consumption = get_consumption(data_dir, agent_id, project_id)
+    remaining = budget - consumption["scheduled"]
+    if remaining <= 0:
+        return None
+    now = time.time()
+    seconds_left_today = max(1, 86400 - (now % 86400))
+    return now + seconds_left_today / remaining
+
+
+def get_fleet_wake_info(data_dir: Path, config: Any, project_store: Any = None) -> list[dict]:
+    """Return wake info for every active agent in config."""
+    rows: list[dict] = []
+    agents = getattr(config, "agents", None) or []
+    for agent in agents:
+        if agent.get("status") != "active":
+            continue
+        agent_id = agent.get("id") or agent.get("name") or ""
+        if not agent_id:
+            continue
+        budget = resolve_budget(agent_id, None, config)
+        consumption = get_consumption(data_dir, agent_id, None)
+        remaining = max(0, budget - consumption["scheduled"])
+        rows.append({
+            "agent_id": agent_id,
+            "agent_name": agent.get("name", agent_id),
+            "budget": budget,
+            "consumed": consumption["scheduled"],
+            "remaining": remaining,
+            "mention_count": consumption["mention"],
+            "next_wake_epoch": get_next_scheduled_wake(data_dir, agent_id, None, config),
+        })
+    return rows


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2592: the wake budget fails OPEN on a damaged wake_budget.json, so enforcement silently ceases fleet-wide

Autonomous build of board card tsk-hw6jyp.

REVISION: built on `exec/tsk-we2gyt` (cut at `9ae910bb56571781aa430a8c060772cab68324ad`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Fix-forward for #2592. Three defects:

1. _read_state distinguishes absent (fresh state) from damaged (raises
   WakeBudgetStateError). can_wake catches it and returns False, so a
   corrupted wake_budget.json no longer silently restores a full budget.

2. record_scheduled_wake moved before the debounce stamp and outside
   the per-agent try/except in _heartbeat_tick, so a persistence failure
   propagates to the sweep-level handler instead of silencing the agent
   for REWAKE_COOLDOWN on an uncharged wake.

3. AppConfig.wake_budget nested mappings are deep-copied per instance at
   both construction sites, preventing cross-instance and DEFAULT_CONFIG
   leakage.

Also drops the dead "mentions" key from _read_state fallbacks and the
mention-wakes-counted-separately claim from the tsk-kj3hc2 fragment.

79 passed (test_wake_budget, test_config, test_agent_heartbeat) plus 7
wake-budget route/decisions tests.

Files:
 tests/test_wake_budget.py                          | 209 +++++++++++++++++++++
 tinyagentos/agent_heartbeat.py                     |  30 ++-
 tinyagentos/auth_middleware.py                     |   1 +
 tinyagentos/config.py                              |  28 +++
 tinyagentos/routes/agents.py                       |  26 +++
 tinyagentos/routes/observatory.py                  |  13 ++
 tinyagentos/wake_budget.py                         | 195 +++++++++++++++++++
 19 files changed, 911 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added daily scheduled-wake budgets with global, per-agent, and per-project limits.
  - Added agent and Observatory views showing usage, remaining allowance, and next scheduled wake.
  - Added configuration options and documented budget behavior.

- **Bug Fixes**
  - Corrected project-specific usage tracking and Observatory results for running agents.
  - Damaged budget data now blocks wakes safely and reports errors.
  - Missing data storage and persistence failures now surface instead of silently preventing wakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->