### PR TITLE
Flaky test: test_queue_position_global_for_loads settles on t1 but asserts t2/t3 (pre-existing on dev)

### DIFF
--- a/changelog.d/tsk-4k7i4j-fix-queue-settle-predicate.md
+++ b/changelog.d/tsk-4k7i4j-fix-queue-settle-predicate.md
@@ -1,0 +1,2 @@
+### Fixed
+- `test_queue_position_global_for_loads` and `test_queue_position_per_model_for_inference` in `tests/test_gpu_arbiter_queue_ops.py` settled on a single task before asserting queue positions for all submitted tasks, racing the event loop when later coroutines had not yet enqueued. The settle predicates now wait for every asserted task_id to be non-None, eliminating the flaky `assert queue_position(t2.id) == 2` (None vs int) failure (#tsk-4k7i4j).

--- a/tests/test_gpu_arbiter_queue_ops.py
+++ b/tests/test_gpu_arbiter_queue_ops.py
@@ -47,7 +47,7 @@ async def test_queue_position_global_for_loads():
         t2, required_vram_mb=1024, op="load", model="b", backend_name="b1"))
     f3 = asyncio.ensure_future(arbiter.submit_gpu(
         t3, required_vram_mb=1024, op="load", model="c", backend_name="b1"))
-    await _settle(lambda: arbiter.queue_position(t1.id) is not None)
+    await _settle(lambda: all(arbiter.queue_position(t.id) is not None for t in (t1, t2, t3)))
     assert arbiter.queue_position(t1.id) == 1
     assert arbiter.queue_position(t2.id) == 2
     assert arbiter.queue_position(t3.id) == 3
@@ -62,7 +62,7 @@ async def test_queue_position_per_model_for_inference():
     fs = [asyncio.ensure_future(arbiter.submit_gpu(
               t, required_vram_mb=1024, op="inference", model=m, backend_name="b1"))
           for t, m in ((ta, "m-a"), (tb, "m-b"), (ta2, "m-a"))]
-    await _settle(lambda: arbiter.queue_position(ta.id) is not None)
+    await _settle(lambda: all(arbiter.queue_position(t.id) is not None for t in (ta, tb, ta2)))
     assert arbiter.queue_position(ta.id) == 1
     assert arbiter.queue_position(tb.id) == 1   # only m-b entries count
     assert arbiter.queue_position(ta2.id) == 2  # behind ta on m-a


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Flaky test: test_queue_position_global_for_loads settles on t1 but asserts t2/t3 (pre-existing on dev)

Autonomous build of board card tsk-4k7i4j.

Two gpu_arbiter queue-op tests settled on a single task_id before asserting
positions for every submitted task, racing the event loop when later
coroutines had not yet entered _queued_entries:

  - test_queue_position_global_for_loads: settled on t1, asserted t1/t2/t3
  - test_queue_position_per_model_for_inference: settled on ta,
    asserted ta/tb/ta2

Settle predicates now wait for all three task_ids to be non-None.

Audit scope: every _settle call in tests/test_gpu_arbiter_queue_ops.py
(the only file that defines _settle) was reviewed, and the other
gpu_arbiter test files (test_gpu_arbiter_894.py, test_gpu_arbiter_toctou.py,
test_gpu_arbiter_wakeup.py) were confirmed to not use _settle. The
remaining _settle calls (lines 79, 98, 121) each settle on the single
task that follows in their asserts, so they are unaffected.

Deterministic red (not statistical): a forced scheduling order that
patches _reserve_and_check so t2/t3 delay 0.2 s past t1 makes the OLD
settle predicate return after observing only t1 (pos=1) while
queue_position(t2) and queue_position(t3) are still None, so the assert
queue_position(t2.id) == 2 sees None. With the NEW predicate (all three),
settle blocks until all are queued and the asserts hold with positions
1/2/3. 40 repeated runs of both fixed tests: 0 failures.

Files:
 changelog.d/tsk-4k7i4j-fix-queue-settle-predicate.md | 2 ++
 tests/test_gpu_arbiter_queue_ops.py                  | 4 ++--
 2 files changed, 4 insertions(+), 2 deletions(-)