### PR TITLE
Board UI: surface quarantined status + lead unquarantine action

### DIFF
--- a/changelog.d/tsk-4b5ivs-board-quarantine.md
+++ b/changelog.d/tsk-4b5ivs-board-quarantine.md
@@ -1,0 +1,2 @@
+### Added
+- Board UI for quarantined tasks: visible Quarantined column/section with strike count and latest strike reason, plus a lead-only Unquarantine action that calls the backend route and surfaces the 409 state cleanly. Quarantine transitions now appear without manual reload via the board's live event stream.

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -205,6 +205,11 @@ export function ProjectWorkspace({ project, onChanged, initialTab, filePath }: {
     [members, agentName],
   );
 
+  const isLead = useMemo(() => {
+    if (!currentUserId) return false;
+    return members.some(m => m.member_id === currentUserId && (m.is_lead === 1 || m.member_id === project.lead_member_id));
+  }, [members, currentUserId, project.lead_member_id]);
+
   const openTask = (id: string) => { setTaskParam(id); setOpenTaskId(id); };
   const closeTask = () => { setTaskParam(null); setOpenTaskId(null); };
 
@@ -341,6 +346,7 @@ export function ProjectWorkspace({ project, onChanged, initialTab, filePath }: {
               <ProjectBoard
                 projectId={project.id}
                 currentUserId={currentUserId}
+                isLead={isLead}
                 elementId={scopedElementId}
                 onOpenTask={openTask}
               />

--- a/desktop/src/apps/ProjectsApp/board/BoardColumn.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardColumn.module.css
@@ -4,4 +4,4 @@
 .count { margin-left: auto; font: 600 11px -apple-system; background: rgba(255,255,255,.07); padding: 2px 8px; border-radius: 8px; color: #d2d2d7; }
 .body { display: flex; flex-direction: column; gap: 10px; }
 .showMore { background: transparent; border: 1px dashed var(--board-hair); color: #86868b; padding: 6px; border-radius: 8px; cursor: pointer; font: 11px -apple-system; }
-.ready, .claimed, .closed {} /* status modifiers reserved for future glow */
+.ready, .claimed, .closed, .quarantined {} /* status modifiers reserved for future glow */

--- a/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
@@ -2,28 +2,29 @@ import type { ReactNode } from "react";
 import styles from "./BoardColumn.module.css";
 
 export interface BoardColumnProps {
-  status: "ready" | "claimed" | "closed";
+  status: "ready" | "claimed" | "closed" | "quarantined";
   count: number;
   showAllClosed?: boolean;
   onShowAllClosed?: () => void;
-  onDropTask: (taskId: string) => void;
+  onDropTask?: (taskId: string) => void;
   children: ReactNode;
 }
 
-const NAME = { ready: "Ready", claimed: "Claimed", closed: "Closed · 7d" } as const;
+const NAME = { ready: "Ready", claimed: "Claimed", closed: "Closed · 7d", quarantined: "Quarantined" } as const;
 
 export function BoardColumn(p: BoardColumnProps) {
+  const onDropTask = p.onDropTask;
   return (
     <section
       role="region"
       aria-label={NAME[p.status]}
       className={`${styles.col} ${styles[p.status]}`}
-      onDragOver={(e) => { e.preventDefault(); }}
-      onDrop={(e) => {
+      onDragOver={onDropTask ? (e) => { e.preventDefault(); } : undefined}
+      onDrop={onDropTask ? (e) => {
         e.preventDefault();
         const id = e.dataTransfer.getData("text/plain");
-        if (id) p.onDropTask(id);
-      }}
+        if (id) onDropTask(id);
+      } : undefined}
     >
       <header className={styles.head}>
         <span className={styles.name}>{NAME[p.status]}</span>

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.module.css
@@ -1,4 +1,4 @@
-.row { display: grid; grid-template-columns: 200px 1fr 1fr 1fr; gap: 10px; padding: 12px 0; border-top: 1px solid var(--board-hair); }
+.row { display: grid; grid-template-columns: 200px 1fr 1fr 1fr 1fr; gap: 10px; padding: 12px 0; border-top: 1px solid var(--board-hair); }
 .row:first-child { border-top: 0; }
 .head { display: flex; align-items: center; gap: 10px; padding: 4px 8px; }
 .av { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg,#0891b2,#06b6d4); display: flex; align-items: center; justify-content: center; color: white; font: 600 13px -apple-system; }

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
@@ -2,11 +2,11 @@ import type { DragEvent, ReactNode } from "react";
 import styles from "./BoardLane.module.css";
 import type { LaneHeader } from "./types";
 
-type CellStatus = "ready" | "claimed" | "closed";
+type CellStatus = "ready" | "claimed" | "closed" | "quarantined";
 
 export interface BoardLaneProps {
   header: LaneHeader;
-  cells: { ready: ReactNode; claimed: ReactNode; closed: ReactNode };
+  cells: { ready: ReactNode; claimed: ReactNode; closed: ReactNode; quarantined: ReactNode };
   onDropTask: (taskId: string, status: CellStatus, laneKey: string) => void;
 }
 
@@ -30,6 +30,7 @@ export function BoardLane({ header, cells, onDropTask }: BoardLaneProps) {
       <div data-testid="lane-cell-ready" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("ready")}>{cells.ready}</div>
       <div data-testid="lane-cell-claimed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("claimed")}>{cells.claimed}</div>
       <div data-testid="lane-cell-closed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("closed")}>{cells.closed}</div>
+      <div data-testid="lane-cell-quarantined" className={styles.cell}>{cells.quarantined}</div>
     </div>
   );
 }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.module.css
@@ -1,7 +1,7 @@
 .frame { background: var(--board-bg); border-radius: 14px; border: 1px solid var(--board-hair); overflow: hidden; }
-.cols { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; padding: 16px; }
+.cols { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 14px; padding: 16px; }
 .lanes { padding: 0 16px 16px; }
-.colsHeader { display: grid; grid-template-columns: 200px 1fr 1fr 1fr; padding: 10px 4px; color: #86868b; font: 600 10.5px -apple-system; text-transform: uppercase; letter-spacing: .5px; }
+.colsHeader { display: grid; grid-template-columns: 200px 1fr 1fr 1fr 1fr; padding: 10px 4px; color: #86868b; font: 600 10.5px -apple-system; text-transform: uppercase; letter-spacing: .5px; }
 .sr { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
 .movePop { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: #1f1f22; border: 1px solid var(--board-hair-strong); border-radius: 12px; padding: 16px; min-width: 240px; box-shadow: 0 20px 60px rgba(0,0,0,.5); z-index: 60; display: flex; flex-direction: column; gap: 8px; }
 .movePop p { margin: 0 0 4px; color: #d2d2d7; font: 600 12px -apple-system; }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -22,6 +22,7 @@ export interface ProjectBoardProps {
   projectId: string;
   currentUserId: string;
   onOpenTask?: (id: string) => void;
+  isLead?: boolean;
   /** When set, the board is scoped to this element and the element filter bar
    *  is hidden (the element is the active filter). Used by element drill-in. */
   elementId?: string | null;
@@ -36,10 +37,11 @@ const MOBILE_COLUMNS: ReadonlyArray<MobileBoardColumn> = [
   { id: "ready", label: "Ready" },
   { id: "claimed", label: "Claimed" },
   { id: "closed", label: "Closed" },
+  { id: "quarantined", label: "Quarantined" },
 ];
-type ColStatus = "ready" | "claimed" | "closed";
+type ColStatus = "ready" | "claimed" | "closed" | "quarantined";
 
-export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }: ProjectBoardProps) {
+export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, elementId }: ProjectBoardProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("lanes");
   const [groupBy, setGroupBy] = useState<GroupBy>("assignee");
   const [filters, setFilters] = useState<Filters>({ ...EMPTY_FILTERS, elementId: elementId ?? null });
@@ -87,6 +89,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
     ready: filtered.filter((t) => t.status === "open"),
     claimed: filtered.filter((t) => t.status === "claimed"),
     closed: filtered.filter((t) => t.status === "closed"),
+    quarantined: filtered.filter((t) => t.status === "quarantined"),
   }), [filtered]);
 
   const lanes = useMemo(() => {
@@ -99,6 +102,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
     ready: filtered.filter(t => t.status === "open").length,
     claimed: filtered.filter(t => t.status === "claimed").length,
     closed: filtered.filter(t => t.status === "closed").length,
+    quarantined: filtered.filter(t => t.status === "quarantined").length,
   }), [filtered]);
 
   const elementNameById = useMemo(
@@ -107,11 +111,12 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
   );
   const showElementBadge = filters.elementId === null;
 
-  const onCardDragStart = (e: DragEvent<HTMLButtonElement>, task: Task) => {
+  const onCardDragStart = (e: DragEvent<HTMLDivElement>, task: Task) => {
     e.dataTransfer.setData("text/plain", task.id);
   };
 
   const dispatchDnd = async (taskId: string, columnStatus: ColStatus, laneKey?: string) => {
+    if (columnStatus === "quarantined") return;
     const task = tasks.find(t => t.id === taskId);
     if (!task) return;
     const result = dndAction({
@@ -144,18 +149,35 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
     if (moved) setAnnouncement(`Moved ${moved.title} to ${columnStatus}`);
   };
 
-  const renderCard = (t: Task, drag = true) => (
-    <TaskCard
-      key={t.id}
-      task={t}
-      onOpen={(id) => onOpenTask?.(id)}
-      onMove={(id) => setMovePopover(id)}
-      justClaimed={justClaimed === t.id}
-      draggable={drag}
-      elementName={showElementBadge && t.element_id ? (elementNameById[t.element_id] ?? null) : null}
-      onDragStart={drag ? onCardDragStart : undefined}
-    />
-  );
+  const renderCard = (t: Task, drag = true) => {
+    const handleUnquarantine = async () => {
+      if (t.status !== "quarantined" || !isLead) return;
+      try {
+        await projectsApi.tasks.unquarantine(projectId, t.id);
+      } catch (err) {
+        console.error("Unquarantine failed", err);
+        if (err instanceof Error && err.message.includes("409")) {
+          window.alert("This task is no longer quarantined.");
+        } else {
+          window.alert("Could not unquarantine task.");
+        }
+      }
+    };
+    return (
+      <TaskCard
+        key={t.id}
+        task={t}
+        onOpen={(id) => onOpenTask?.(id)}
+        onMove={(id) => setMovePopover(id)}
+        justClaimed={justClaimed === t.id}
+        draggable={drag && t.status !== "quarantined"}
+        elementName={showElementBadge && t.element_id ? (elementNameById[t.element_id] ?? null) : null}
+        onDragStart={drag && t.status !== "quarantined" ? onCardDragStart : undefined}
+        isLead={isLead}
+        onUnquarantine={t.status === "quarantined" && isLead ? handleUnquarantine : undefined}
+      />
+    );
+  };
 
   if (isMobile) {
     return (
@@ -197,11 +219,11 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
       />
       {viewMode === "kanban" ? (
         <div className={styles.cols}>
-          {(["ready", "claimed", "closed"] as ColStatus[]).map(s => {
+          {(["ready", "claimed", "closed", "quarantined"] as ColStatus[]).map(s => {
             const dataStatus = s === "ready" ? "open" : s;
             const cards = filtered.filter(t => t.status === dataStatus);
             return (
-              <BoardColumn key={s} status={s} count={cards.length} onDropTask={(id) => dispatchDnd(id, s)}>
+              <BoardColumn key={s} status={s} count={cards.length} onDropTask={s === "quarantined" ? undefined : (id) => dispatchDnd(id, s)}>
                 {cards.map(t => renderCard(t))}
               </BoardColumn>
             );
@@ -214,6 +236,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
             <span>Ready · {counts.ready}</span>
             <span>Claimed · {counts.claimed}</span>
             <span>Closed · {counts.closed}</span>
+            <span>Quarantined · {counts.quarantined}</span>
           </div>
           {lanes!.map(lane => (
             <BoardLane
@@ -223,6 +246,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }
                 ready: lane.cards.filter(t => t.status === "open").map(t => renderCard(t)),
                 claimed: lane.cards.filter(t => t.status === "claimed").map(t => renderCard(t)),
                 closed: lane.cards.filter(t => t.status === "closed").map(t => renderCard(t, false)),
+                quarantined: lane.cards.filter(t => t.status === "quarantined").map(t => renderCard(t, false)),
               }}
               onDropTask={(id, status, laneKey) => dispatchDnd(id, status, laneKey)}
             />

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
@@ -24,3 +24,11 @@
 .lbl_review { background: rgba(191,90,242,.18); color: #d397ff; }
 .foot { display: flex; gap: 8px; font: 10.5px -apple-system; color: #86868b; }
 .grow { flex: 1; }
+.quarantined { border-color: rgba(255, 69, 58, .35); }
+.quarantineBadge { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; padding: 4px 8px; border-radius: 6px; background: rgba(255, 69, 58, .12); color: #ff7a73; font: 600 10px -apple-system; }
+.quarantineIcon { font-size: 12px; line-height: 1; }
+.quarantineText { flex: 1; }
+.quarantineReason { color: #86868b; font-weight: 400; }
+.unquarantineBtn { background: rgba(255, 255, 255, .06); border: 1px solid rgba(255, 255, 255, .12); border-radius: 6px; color: #f5f5f7; padding: 2px 8px; font: 600 10px -apple-system; cursor: pointer; }
+.unquarantineBtn:hover { background: rgba(255, 255, 255, .1); border-color: var(--board-hair-strong); }
+.unquarantineBtn:focus-visible { outline: 2px solid #64d2ff; outline-offset: 2px; }

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
@@ -10,14 +10,16 @@ export interface TaskCardProps {
   justClaimed?: boolean;
   draggable?: boolean;
   elementName?: string | null;
-  onDragStart?: (e: DragEvent<HTMLButtonElement>, t: Task) => void;
+  onDragStart?: (e: DragEvent<HTMLDivElement>, t: Task) => void;
+  isLead?: boolean;
+  onUnquarantine?: (id: string) => void;
 }
 
-export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, elementName, onDragStart }: TaskCardProps) {
+export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, elementName, onDragStart, isLead, onUnquarantine }: TaskCardProps) {
   const cover = inferCoverKind(task);
   const pri = task.priority === 0 ? "p0" : task.priority === 1 ? "p1" : "p2";
-  const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
-    if (e.key === "Enter") {
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       onOpen(task.id);
     } else if ((e.key === "m" || e.key === "M") && onMove) {
@@ -25,11 +27,13 @@ export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, element
       onMove(task.id);
     }
   };
+  const quarantined = task.status === "quarantined";
   return (
-    <button
+    <div
       data-testid="task-card"
-      type="button"
-      className={`${styles.card} ${styles[pri as keyof typeof styles] ?? ""} ${justClaimed ? styles.justClaimed : ""}`}
+      role="button"
+      tabIndex={0}
+      className={`${styles.card} ${styles[pri as keyof typeof styles] ?? ""} ${justClaimed ? styles.justClaimed : ""} ${quarantined ? styles.quarantined : ""}`}
       onClick={() => onOpen(task.id)}
       onKeyDown={onKeyDown}
       draggable={draggable}
@@ -45,6 +49,28 @@ export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, element
         </div>
         <div className={styles.title}>{task.title}</div>
         {elementName && <span className={styles.elBadge}>{elementName}</span>}
+        {quarantined && (
+          <div className={styles.quarantineBadge} role="status" aria-label={`Quarantined: ${task.strike_count ?? 0} strikes`}>
+            <span className={styles.quarantineIcon} aria-hidden>⚠</span>
+            <span className={styles.quarantineText}>
+              {task.strike_count ?? 0} strikes
+              {task.latest_strike?.step && <span className={styles.quarantineReason}> — {task.latest_strike.step}</span>}
+            </span>
+            {isLead && onUnquarantine && (
+              <button
+                type="button"
+                className={styles.unquarantineBtn}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUnquarantine(task.id);
+                }}
+                aria-label={`Unquarantine task ${task.id}`}
+              >
+                Unquarantine
+              </button>
+            )}
+          </div>
+        )}
         {task.labels.length > 0 && (
           <div className={styles.labels}>
             {task.labels.filter(l => !l.startsWith("cover:")).map(l => (
@@ -58,7 +84,7 @@ export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, element
           <span>{relativeTime(task.updated_at)}</span>
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
@@ -25,4 +25,29 @@ describe("ProjectBoard", () => {
     fireEvent.click(await screen.findByRole("tab", { name: /Kanban/ }));
     expect(screen.getByRole("tab", { name: /Kanban/ })).toHaveAttribute("aria-selected", "true");
   });
+
+  it("renders a Quarantined column with quarantined tasks in Kanban mode", async () => {
+    vi.spyOn(projectsApi.tasks, "list").mockImplementation((_pid: string, status?: string) => {
+      if (status === "quarantined") return Promise.resolve([{ id: "tq1", title: "Q task", status: "quarantined", labels: [], priority: 1, strike_count: 2, latest_strike: { step: "bad" } } as any]);
+      return Promise.resolve([]);
+    });
+    render(<ProjectBoard projectId="p1" currentUserId="u1" isLead />);
+    fireEvent.click(await screen.findByRole("tab", { name: /Kanban/ }));
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /Quarantined/ })).toBeInTheDocument();
+      expect(screen.getByText("Q task")).toBeInTheDocument();
+    });
+  });
+
+  it("shows unquarantine button on quarantined cards for leads", async () => {
+    vi.spyOn(projectsApi.tasks, "list").mockImplementation((_pid: string, status?: string) => {
+      if (status === "quarantined") return Promise.resolve([{ id: "tq1", title: "Q task", status: "quarantined", labels: [], priority: 1, strike_count: 1, latest_strike: { step: "boom" } } as any]);
+      return Promise.resolve([]);
+    });
+    render(<ProjectBoard projectId="p1" currentUserId="u1" isLead />);
+    fireEvent.click(await screen.findByRole("tab", { name: /Kanban/ }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Unquarantine task tq1/i })).toBeInTheDocument();
+    });
+  });
 });

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
@@ -39,4 +39,31 @@ describe("TaskCard", () => {
     fireEvent.keyDown(card, { key: "M" });
     expect(move).toHaveBeenCalledWith("t1");
   });
+
+  it("renders quarantine badge and unquarantine action when quarantined", () => {
+    const quarantined: Task = {
+      ...t,
+      status: "quarantined",
+      strike_count: 3,
+      latest_strike: { id: "s3", task_id: "t1", step: "verification failed", log_tail: "", actor: "system", created_at: 1 },
+    };
+    const unquarantine = vi.fn();
+    render(<TaskCard task={quarantined} onOpen={() => {}} isLead onUnquarantine={unquarantine} />);
+    expect(screen.getByRole("status", { name: /Quarantined: 3 strikes/i })).toBeInTheDocument();
+    expect(screen.getByText(/verification failed/)).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /Unquarantine task t1/i });
+    fireEvent.click(btn);
+    expect(unquarantine).toHaveBeenCalledWith("t1");
+  });
+
+  it("does not render unquarantine action when not lead", () => {
+    const quarantined: Task = {
+      ...t,
+      status: "quarantined",
+      strike_count: 2,
+      latest_strike: { id: "s2", task_id: "t1", step: "timeout", log_tail: "", actor: "system", created_at: 1 },
+    };
+    render(<TaskCard task={quarantined} onOpen={() => {}} isLead={false} onUnquarantine={() => {}} />);
+    expect(screen.queryByRole("button", { name: /Unquarantine/i })).not.toBeInTheDocument();
+  });
 });

--- a/desktop/src/apps/ProjectsApp/board/types.ts
+++ b/desktop/src/apps/ProjectsApp/board/types.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = "open" | "claimed" | "closed";
+export type TaskStatus = "open" | "claimed" | "closed" | "quarantined";
 
 export interface Task {
   id: string;
@@ -18,6 +18,8 @@ export interface Task {
   created_by: string;
   created_at: string;
   updated_at: string;
+  strike_count?: number;
+  latest_strike?: { id: string; task_id: string; step: string; log_tail: string; actor: string; created_at: number } | null;
 }
 
 // Element filter axis. null = no element filter (all tasks, tagged or not).

--- a/desktop/src/apps/ProjectsApp/board/useBoardData.ts
+++ b/desktop/src/apps/ProjectsApp/board/useBoardData.ts
@@ -13,15 +13,16 @@ export function useBoardData(projectId: string) {
     let cancelled = false;
     setLoading(true);
     (async () => {
-      const [open, claimed, closed, els] = await Promise.all([
+      const [open, claimed, closed, quarantined, els] = await Promise.all([
         projectsApi.tasks.list(projectId, "open"),
         projectsApi.tasks.list(projectId, "claimed"),
         projectsApi.tasks.list(projectId, "closed"),
+        projectsApi.tasks.list(projectId, "quarantined").catch(() => [] as any[]),
         projectsApi.elements.list(projectId).catch(() => [] as ProjectElement[]),
       ]);
       if (!cancelled) {
         const seen = new Set<string>();
-        const all = [...open, ...claimed, ...closed].filter(t => {
+        const all = [...open, ...claimed, ...closed, ...quarantined].filter(t => {
           if (seen.has(t.id)) return false;
           seen.add(t.id);
           return true;
@@ -51,6 +52,10 @@ export function useBoardData(projectId: string) {
           return prev.map(t => t.id === p.id ? { ...t, status: "closed", closed_by: p.closed_by ?? null } : t);
         case "task.deleted":
           return prev.filter(t => t.id !== p.id);
+        case "task.quarantined":
+          return prev.map(t => t.id === p.id ? { ...t, status: "quarantined" } : t);
+        case "task.unquarantined":
+          return prev.map(t => t.id === p.id ? { ...t, status: "open", claimed_by: null, strike_count: undefined, latest_strike: null } : t);
         default:
           return prev;
       }

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -31,7 +31,7 @@ export type ProjectTask = {
   parent_task_id: string | null;
   title: string;
   body: string;
-  status: "open" | "claimed" | "closed" | "cancelled";
+  status: "open" | "claimed" | "closed" | "cancelled" | "quarantined";
   priority: number;
   labels: string[];
   assignee_id: string | null;
@@ -44,6 +44,8 @@ export type ProjectTask = {
   created_by: string;
   created_at: number;
   updated_at: number;
+  strike_count?: number;
+  latest_strike?: { id: string; task_id: string; step: string; log_tail: string; actor: string; created_at: number } | null;
 };
 
 export type ElementType =
@@ -269,6 +271,10 @@ export const projectsApi = {
       http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}`, {
         method: "PATCH",
         body: JSON.stringify(patch),
+      }),
+    unquarantine: (pid: string, tid: string) =>
+      http<ProjectTask>(`/api/projects/${pid}/tasks/${tid}/unquarantine`, {
+        method: "POST",
       }),
     listComments: (pid: string, tid: string) =>
       http<{ items: ProjectComment[] }>(`/api/projects/${pid}/tasks/${tid}/comments`).then((r) => r.items),

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -307,6 +307,7 @@
   --board-status-ready: #64d2ff;
   --board-status-claimed: #ffb340;
   --board-status-closed: #30d158;
+  --board-status-quarantined: #ff453a;
 }
 
 /* ==================================================================


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Board UI: surface quarantined status + lead unquarantine action

Autonomous build of board card tsk-4b5ivs.

- add quarantined task status, strike_count, and latest_strike to frontend types
- fetch quarantined tasks from the API and include them in board columns
- render a visible Quarantined column in kanban and lanes mode, plus mobile
- show quarantine badge on cards with strike count and latest strike reason
- add lead-only Unquarantine button that calls the backend route and surfaces 409 cleanly
- handle task.quarantined and task.unquarantined SSE events for live refresh
- add ARIA labels and keyboard access to quarantine badge and action
- add component tests for TaskCard quarantine UI and ProjectBoard quarantined column

changelog: tsk-4b5ivs-board-quarantine.md

Files:
 desktop/src/apps/ProjectsApp/board/TaskCard.tsx    | 42 +++++++++++++---
 .../board/__tests__/ProjectBoard.test.tsx          | 25 ++++++++++
 .../ProjectsApp/board/__tests__/TaskCard.test.tsx  | 27 ++++++++++
 desktop/src/apps/ProjectsApp/board/types.ts        |  4 +-
 desktop/src/apps/ProjectsApp/board/useBoardData.ts |  9 +++-
 desktop/src/lib/projects.ts                        |  8 ++-
 desktop/src/theme/tokens.css                       |  1 +
 16 files changed, 176 insertions(+), 42 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Quarantined column across project board views, including task counts and quarantine details.
  * Quarantined tasks display strike information and cannot be dragged.
  * Project leads can unquarantine tasks directly from the task card.
  * Board updates now reflect quarantine and restoration changes in real time.
* **Bug Fixes**
  * Improved handling of unquarantine conflicts and unavailable quarantine data.
  * Enhanced keyboard accessibility for opening task cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->