### PR TITLE
NotificationsPanel duplicates its header block across three render branches

### DIFF
--- a/changelog.d/tsk-2vifch-notifications-panel-header-dedupe.md
+++ b/changelog.d/tsk-2vifch-notifications-panel-header-dedupe.md
@@ -1,0 +1,2 @@
+### Fixed
+- The Notifications settings panel no longer duplicates its `<section>`/`<h2>`/description chrome across the loading, error, and loaded render branches; the chrome now lives in a single return, and the loading state's heading spacing unifies with the error and loaded states (the loader was the `mb-5` outlier).

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.test.tsx
@@ -59,6 +59,10 @@ describe("NotificationsPanel", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Failed to save (500)",
     );
+    // A save-time error keeps the loaded list: Retry belongs to the
+    // could-not-load branch only, so it must not appear beside the toggles.
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    expect(screen.getByText("Worker joined")).toBeInTheDocument();
   });
 
   it("shows loading state while genuinely pending", async () => {

--- a/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/NotificationsPanel.tsx
@@ -70,76 +70,60 @@ export function NotificationsPanel() {
     }
   };
 
-  if (!loaded) {
-    return (
-      <section aria-label="Notification settings">
-        <h2 className="text-lg font-semibold mb-5">Notifications</h2>
-        <p className="text-sm text-shell-text-tertiary">Loading...</p>
-      </section>
-    );
-  }
-
-  if (!prefs) {
-    return (
-      <section aria-label="Notification settings">
-        <h2 className="text-lg font-semibold mb-2">Notifications</h2>
-        <p className="text-sm text-shell-text-tertiary mb-5">
-          Choose which notification types to receive. Disabled types are suppressed
-          everywhere -- no in-app notification, no web push.
-        </p>
-
-        {error && (
-          <>
-            <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
-              {error}
-            </p>
-            <Button variant="outline" size="sm" onClick={loadPrefs}>
-              Retry
-            </Button>
-          </>
-        )}
-      </section>
-    );
-  }
-
   return (
     <section aria-label="Notification settings">
       <h2 className="text-lg font-semibold mb-2">Notifications</h2>
-      <p className="text-sm text-shell-text-tertiary mb-5">
-        Choose which notification types to receive. Disabled types are suppressed
-        everywhere -- no in-app notification, no web push.
-      </p>
 
-      {error && (
-        <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
-          {error}
-        </p>
+      {!loaded ? (
+        <p className="text-sm text-shell-text-tertiary">Loading...</p>
+      ) : (
+        <>
+          <p className="text-sm text-shell-text-tertiary mb-5">
+            Choose which notification types to receive. Disabled types are suppressed
+            everywhere -- no in-app notification, no web push.
+          </p>
+
+          {error && (
+            <>
+              <p role="alert" className="mb-3 text-xs text-amber-400 flex items-center gap-1.5">
+                {error}
+              </p>
+              {!prefs && (
+                <Button variant="outline" size="sm" onClick={loadPrefs}>
+                  Retry
+                </Button>
+              )}
+            </>
+          )}
+
+          {prefs && (
+            <div className="space-y-2">
+              {NOTIF_TYPES.map((item) => {
+                const pref = prefs.find((p) => p.event_type === item.type);
+                const checked = pref ? !pref.muted : true;
+                const id = `notif-${item.type}`;
+                return (
+                  <Card key={item.type} className="p-4 flex items-center justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <Label htmlFor={id} className="text-sm font-medium text-shell-text">
+                        {item.label}
+                      </Label>
+                      <p className="text-xs text-shell-text-tertiary mt-0.5">{item.desc}</p>
+                    </div>
+                    <Switch
+                      id={id}
+                      checked={checked}
+                      onCheckedChange={(v) => toggle(item.type, !v)}
+                      disabled={saving === item.type}
+                      aria-label={`${item.label} notifications`}
+                    />
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
-
-      <div className="space-y-2">
-        {NOTIF_TYPES.map((item) => {
-          const pref = prefs.find((p) => p.event_type === item.type);
-          const checked = pref ? !pref.muted : true;
-          const id = `notif-${item.type}`;
-          return (
-            <Card key={item.type} className="p-4 flex items-center justify-between gap-3">
-              <div className="flex-1 min-w-0">
-                <Label htmlFor={id} className="text-sm font-medium text-shell-text">
-                  {item.label}
-                </Label>
-                <p className="text-xs text-shell-text-tertiary mt-0.5">{item.desc}</p>
-              </div>
-              <Switch
-                id={id}
-                checked={checked}
-                onCheckedChange={(v) => toggle(item.type, !v)}
-                disabled={saving === item.type}
-                aria-label={`${item.label} notifications`}
-              />
-            </Card>
-          );
-        })}
-      </div>
     </section>
   );
 }


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): NotificationsPanel duplicates its header block across three render branches

Autonomous build of board card tsk-2vifch.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

NotificationsPanel returned from three places (loading, error, loaded),
each repeating the <section aria-label="Notification settings"> +
<h2>Notifications</h2> + description paragraph. The copies had already
drifted: the loading branch used mb-5 on the h2 while error and loaded
used mb-2.

Hoist the chrome into a single return with conditional inner content so
the section, heading, description, and error paragraph each exist once.
The aria-label stays on the outer section in every state.

Spacing decision (deliberate, not accidental): all three states now
share mb-2 on the h2. The loading state was the outlier (it used mb-5);
it is now mb-2 to match the error and loaded states. The description
paragraph keeps its mb-5, unchanged and already consistent across the
error and loaded states.

Tests: existing NotificationsPanel suite passes unchanged, 7/7.

Proofs:
- grep -c 'Notification settings' NotificationsPanel.tsx == 1
- npx vitest run .../NotificationsPanel.test.tsx -> 7 passed

Files:
 ...tsk-2vifch-notifications-panel-header-dedupe.md |   2 +
 .../src/apps/SettingsApp/NotificationsPanel.tsx    | 114 +++++++++------------
 2 files changed, 51 insertions(+), 65 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Notifications settings panel so its heading and description remain consistent across loading, error, and loaded states.
  * Prevented duplicate panel header content from appearing.
  * Ensured notification options remain visible when saving a toggle fails, without displaying an unnecessary Retry button.
  * Aligned loading-state spacing with other panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->