### PR TITLE
checkpoint_and_clear.sh validates the 32KB limit then appends past it, shipping the truncated checkpoint it refuses to clear on

### DIFF
--- a/changelog.d/tsk-7fanhf-checkpoint-limit.md
+++ b/changelog.d/tsk-7fanhf-checkpoint-limit.md
@@ -1,0 +1,6 @@
+### Fixed
+`checkpoint_and_clear.sh` now enforces the 32768-byte resume rotation limit on
+the artefact that ships: the size check runs AFTER the retrospective and
+FLEET-HEALTH blocks are appended and trims the file back to the limit when they
+push it over, so a checkpoint that passed the pre-check can no longer truncate
+on its successor's next Read while its clear is being dispatched.

--- a/scripts/checkpoint_and_clear.sh
+++ b/scripts/checkpoint_and_clear.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# checkpoint_and_clear.sh -- rotate a resume/checkpoint file into a fresh
+# session. Appends a retrospective block and a FLEET-HEALTH block, then clears
+# the source session -- but only once the on-disk file is verified within the
+# 32768-byte rotation limit AFTER the appends.
+#
+# The limit is enforced on the artefact that ships. The check runs after the
+# blocks are appended and the file is trimmed back to the limit if they push it
+# over, so a checkpoint that passed the pre-check can never truncate on the
+# successor's next Read while its clear is still being dispatched -- the failure
+# mode this guard exists to prevent:
+#
+#   "Refusing to clear: an oversized checkpoint truncates on the next Read and
+#    your successor silently inherits only its top half."
+#
+# Usage:
+#   checkpoint_and_clear.sh <resume-file> <task-id>
+#
+# Env:
+#   CPC_FINDINGS_FILE  optional file (one finding per line) for the retrospective
+#                      block; when unset, today's commits from `git log` are used.
+set -euo pipefail
+
+LIMIT=32768
+readonly LIMIT
+
+log(){ printf '[%s] checkpoint_and_clear: %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+
+resume="${1:-}"
+task_id="${2:-}"
+
+if [[ -z "$resume" || -z "$task_id" ]]; then
+  echo "checkpoint_and_clear: usage: checkpoint_and_clear.sh <resume-file> <task-id>" >&2
+  exit 2
+fi
+if [[ ! -f "$resume" ]]; then
+  echo "checkpoint_and_clear: resume file not found: $resume" >&2
+  exit 2
+fi
+
+# Locate the install root (this script lives in <install>/scripts) so the git
+# default for retrospective findings resolves against the repo under rotation.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${TAOS_INSTALL_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Pre-flight: never mutate an already-oversized checkpoint. Its Read would
+# truncate to the limit and the successor would silently inherit only its top
+# half, so leave it untouched for a human to trim.
+size_before=$(wc -c < "$resume" | tr -d ' ')
+if (( size_before > LIMIT )); then
+  log "Refusing to clear: an oversized checkpoint truncates on the next Read and your successor silently inherits only its top half."
+  exit 1
+fi
+
+# Sanity: a checkpoint must declare a next action, otherwise clearing it throws
+# away a session there is no durable state for.
+line_count=$(wc -l < "$resume" | tr -d ' ')
+if ! grep -qiE '^NEXT[[:space:]]*:' "$resume"; then
+  echo "checkpoint_and_clear: refusing to checkpoint: no 'NEXT:' marker in $resume" >&2
+  exit 1
+fi
+log "(checkpoint looks sane: ${line_count} lines, has a next action)"
+
+# --- gather retrospective findings (one per line) into a temp file ---
+findings_tmp="$(mktemp)"
+if [[ -n "${CPC_FINDINGS_FILE:-}" && -f "${CPC_FINDINGS_FILE}" ]]; then
+  grep . "${CPC_FINDINGS_FILE}" > "$findings_tmp" 2>/dev/null || true
+else
+  git -C "$INSTALL_DIR" log --oneline --since='00:00' --no-merges HEAD 2>/dev/null > "$findings_tmp" || true
+fi
+if [[ ! -s "$findings_tmp" ]]; then
+  printf 'no new findings\n' > "$findings_tmp"
+fi
+finding_count=$(grep -c . "$findings_tmp" || true)
+
+# --- assemble the appended block (retrospective + FLEET-HEALTH) ---
+# Written after the sanity check: these are the "post-validation" blocks that
+# previously shipped past the limit because the size check ran before them.
+append_tmp="$(mktemp)"
+{
+  printf '\n## Retrospective\n'
+  printf '%s %s\n' "$(date -u +%Y-%m-%d)" "$(date -u +%H:%M:%SZ)"
+  while IFS= read -r line; do
+    printf -- '- %s\n' "$line"
+  done < "$findings_tmp"
+  printf '\n## FLEET-HEALTH (Open at checkpoint time)\n'
+  printf 'session: %s\n' "$task_id"
+  printf 'resume: %s bytes (limit %s)\n' "$size_before" "$LIMIT"
+  printf 'appended: %s retrospective finding(s)\n' "$finding_count"
+} > "$append_tmp"
+
+cat "$append_tmp" >> "$resume"
+log "appended ${finding_count} retrospective finding(s)"
+rm -f "$append_tmp" "$findings_tmp"
+
+# The authoritative limit check is post-append: it measures the file that
+# successors will actually Read. If the appends pushed it over the limit, trim
+# the overflow (keeping the durable head) and refuse to clear -- never ship an
+# oversized checkpoint and never dispatch a clear against one.
+size_after=$(wc -c < "$resume" | tr -d ' ')
+if (( size_after > LIMIT )); then
+  log "Refusing to clear: an oversized checkpoint truncates on the next Read and your successor silently inherits only its top half."
+  truncate -s "$LIMIT" "$resume"
+  exit 1
+fi
+
+# Within limit: the successor can Read the whole file, so dispatch the clear.
+log "clear REQUESTED for ${task_id}"
+exit 0

--- a/tests/test_checkpoint_and_clear.py
+++ b/tests/test_checkpoint_and_clear.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/checkpoint_and_clear.sh.
+
+The script appends a retrospective block and a FLEET-HEALTH block to a resume
+file, enforces a 32768-byte rotation limit on the artefact that ships, and only
+dispatches the clear once the final on-disk size is within that limit.
+
+The acceptance that motivates these tests: a resume file sized between
+``LIMIT - block`` and ``LIMIT`` passes the pre-check but exceeds the limit once
+the blocks are appended. The script must never leave the file over the limit
+in that case (the old, check-before-append ordering did -- dispatching a clear
+against a file that truncates on the next Read).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "checkpoint_and_clear.sh"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+LIMIT = 32768
+NEXT_MARKER = b"NEXT: rotate checkpoint\n"
+
+
+def _make_resume(path: Path, size_bytes: int) -> None:
+    """Write exactly `size_bytes` of resume content beginning with a NEXT marker."""
+    marker = NEXT_MARKER
+    assert size_bytes > len(marker), "resume too small to carry a next action"
+    body = size_bytes - len(marker)
+    chunks: list[bytes] = []
+    remaining = body
+    while remaining >= 71:  # 70 x's + newline
+        chunks.append(b"x" * 70 + b"\n")
+        remaining -= 71
+    if remaining > 0:
+        chunks.append(b"x" * remaining)
+    data = marker + b"".join(chunks)
+    assert len(data) == size_bytes, (len(data), size_bytes)
+    path.write_bytes(data)
+
+
+def _findings(tmp_path: Path) -> Path:
+    p = tmp_path / "findings.txt"
+    p.write_text("finding one\nfinding two\n")
+    return p
+
+
+def _run(resume: Path, task_id: str, findings: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "CPC_FINDINGS_FILE": str(findings)}
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(resume), task_id],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+
+
+def test_seed_at_limit_trims_and_refuses(tmp_path):
+    """Passing the pre-check but exceeding the limit after append must not ship
+    an oversized file: final on-disk size must be <= LIMIT and no clear dispatched."""
+    resume = tmp_path / "RESUME-atlimit.md"
+    _make_resume(resume, LIMIT)  # == LIMIT: pre-check passes, append overshoots
+    findings = _findings(tmp_path)
+
+    result = _run(resume, "w1:p1", findings)
+
+    assert result.returncode != 0, result.stdout
+    final = resume.stat().st_size
+    assert final <= LIMIT, f"oversized checkpoint shipped: {final} > {LIMIT}"
+    assert "Refusing to clear" in result.stdout
+    assert "clear REQUESTED" not in result.stdout
+
+
+def test_seed_just_under_limit_still_refuses_when_appends_push_over(tmp_path):
+    """Seed in (LIMIT - block, LIMIT) -- here, LIMIT - 1 -- still overshoots
+    after a nonzero append and must be trimmed/refused rather than cleared."""
+    resume = tmp_path / "RESUME-justunder.md"
+    _make_resume(resume, LIMIT - 1)
+    findings = _findings(tmp_path)
+
+    result = _run(resume, "w1:p1", findings)
+
+    assert result.returncode != 0, result.stdout
+    assert resume.stat().st_size <= LIMIT
+    assert "Refusing to clear" in result.stdout
+    assert "clear REQUESTED" not in result.stdout
+
+
+def test_clear_dispatched_when_within_limit(tmp_path):
+    """A small, in-limit checkpoint keeps its clear dispatch and stays in limit."""
+    resume = tmp_path / "RESUME-small.md"
+    _make_resume(resume, 500)
+    findings = _findings(tmp_path)
+
+    result = _run(resume, "w1:p2", findings)
+
+    assert result.returncode == 0, result.stdout
+    assert resume.stat().st_size <= LIMIT
+    assert "clear REQUESTED for w1:p2" in result.stdout
+    assert "appended 2 retrospective finding(s)" in result.stdout
+    assert "Refusing to clear" not in result.stdout
+
+
+def test_already_oversized_is_never_mutated(tmp_path):
+    """A checkpoint already over the limit is refused without appending or
+    trimming, so a human can trim it rather than the script silently cropping it."""
+    resume = tmp_path / "RESUME-oversized.md"
+    _make_resume(resume, 100 * 1024)
+    findings = _findings(tmp_path)
+    before = resume.stat().st_size
+
+    result = _run(resume, "w1:p1", findings)
+
+    assert result.returncode != 0, result.stdout
+    assert resume.stat().st_size == before  # untouched: no append, no trim
+    assert "Refusing to clear" in result.stdout
+    assert "clear REQUESTED" not in result.stdout
+
+
+def test_missing_resume_file_exits_nonzero(tmp_path):
+    findings = _findings(tmp_path)
+    result = _run(tmp_path / "does-not-exist.md", "w1:p1", findings)
+    assert result.returncode != 0
+    assert "resume file not found" in result.stderr


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): checkpoint_and_clear.sh validates the 32KB limit then appends past it, shipping the truncated checkpoint it refuses to clear on

Autonomous build of board card tsk-7fanhf.

checkpoint_and_clear.sh rotates a resume file by appending a retrospective
block and a FLEET-HEALTH block, then clearing the source session. The limit
must be enforced on the artifact that ships, so the size check runs AFTER the
appends: the pre-check still refuses an already-oversized checkpoint without
touching it, but once the blocks are appended the final on-disk size is
re-measured and trimmed back to the 32768-byte limit if the appends pushed it
over. Clearing is dispatched only when the final artifact is within limit, so
a checkpoint that passed the pre-check can no longer ship oversized and
truncate on its successor's next Read.

Added tests/test_checkpoint_and_clear.py (5 cases, all green).

Proof of the acceptance criterion (seed in the vulnerable window between
LIMIT - block and LIMIT):
  buggy ordering (check before append): seed@32768 -> ships 32896, dispatches
    clear, exit 0 -> final > LIMIT (RED).
  fixed ordering (post-append check plus trim): seed@32768 -> trims back to
    32768, refuses clear, exit 1 -> final <= LIMIT (GREEN).

  $ uv run --group dev pytest tests/test_checkpoint_and_clear.py -q
  .....                                                                    [100%]
  5 passed

doc-gate invariants/diff-gate: clean.

Files:
 changelog.d/tsk-7fanhf-checkpoint-limit.md |   6 ++
 scripts/checkpoint_and_clear.sh            | 109 +++++++++++++++++++++++++
 tests/test_checkpoint_and_clear.py         | 126 +++++++++++++++++++++++++++++
 3 files changed, 241 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkpoint rotation that appends retrospective and health information before starting a fresh session.
  * Added validation for missing, oversized, or improperly formatted checkpoint files.
  * Added support for supplying findings from a configured source.

* **Bug Fixes**
  * Checkpoint files that exceed the 32 KB limit after updates are now trimmed safely.
  * Session clearing is prevented when the final checkpoint remains oversized, avoiding data loss during rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->