### PR TITLE
fleet_health BOARD STRANGLED is a false alarm that recommends a destructive prune

### DIFF
--- a/changelog.d/tsk-bvpjun-fleet-health-probe.md
+++ b/changelog.d/tsk-bvpjun-fleet-health-probe.md
@@ -1,0 +1,2 @@
+### Fixed
+- `fleet_health.sh` BOARD STRANGLED probe now captures `next_card.py`'s exit code and stderr instead of discarding them; probe failures and timeouts are reported as `probe failed:` and no longer recommend pruning. The alarm requires corroboration across two consecutive empty probes and is suppressed when the claimable count is falling.

--- a/tests/test_fleet_health_strangled.py
+++ b/tests/test_fleet_health_strangled.py
@@ -1,0 +1,167 @@
+"""Tests for fleet_health.sh BOARD STRANGLED probe.
+
+Verifies the fix for tsk-bvpjun:
+  - probe failure is distinguished from a genuine empty offer
+  - alarm requires corroboration across 2 consecutive runs
+  - alarm is suppressed when claimable count is FALLING
+  - prune advice is dropped from the message
+"""
+
+import os
+import subprocess
+import tempfile
+
+FLEET_HEALTH = os.path.expanduser("~/.taos-team/fleet_health.sh")
+_STATE_FALLBACK = "/tmp/fleet_health_strangled_state"
+
+
+def _write_mock_taos_team(team_dir, claimable_count):
+    with open(os.path.join(team_dir, "taos_team.py"), "w") as f:
+        f.write(
+            "import os\n"
+            "PROJECT = os.environ.get('TAOS_PROJECTS', 'prj-test').split(',')[0]\n"
+            "CFG = {'TAOS_PROJECT': PROJECT}\n"
+            "API = 'http://mock'\n"
+            "def login(): pass\n"
+            "def _req(base, path, payload=None, method=None):\n"
+            "    if '/tasks' in path:\n"
+            "        count = int(os.environ.get('MOCK_CLAIMABLE', '0'))\n"
+            "        return {'items': [\n"
+            "            {'id': f'tsk-{i}', 'status': 'open', 'claimer_id': None,\n"
+            "             'labels': ['claimable'], 'priority': 5, 'assignee_id': '', 'body': ''}\n"
+            "            for i in range(count)\n"
+            "        ]}\n"
+            "    return {}\n"
+        )
+
+
+def _write_mock_next_card(team_dir, empty=True, rc=0):
+    with open(os.path.join(team_dir, "next_card.py"), "w") as f:
+        f.write(
+            "#!/usr/bin/env python3\n"
+            "import sys, os\n"
+            f"rc = {rc}\n"
+            "if rc != 0:\n"
+            "    sys.stderr.write('mock next_card error')\n"
+            "    sys.exit(rc)\n"
+        )
+        if empty:
+            f.write("print('')\n")
+        else:
+            f.write("print('tsk-mock')\n")
+
+
+def _setup_env(tmp_dir, *, claimable=0, next_empty=True, next_rc=0, clean_state=True):
+    team_dir = os.path.join(tmp_dir, ".taos-team")
+    os.makedirs(team_dir, exist_ok=True)
+
+    with open(os.path.join(team_dir, "fleet_pr_lib.sh"), "w") as f:
+        f.write("#!/bin/bash\nFLEET_MAX_OPEN_PRS=20\nFLEET_LANE_REPOS='jaylfc/taOS'\n")
+
+    with open(os.path.join(team_dir, "lane-hy3.cred"), "w") as f:
+        f.write("TAOS_API=http://mock\nTAOS_TOKEN=mock-token\nTAOS_CANONICAL=mock-canonical\nTAOS_PROJECT=prj-test\n")
+
+    with open(os.path.join(team_dir, "quarantine.txt"), "w") as f:
+        f.write("")
+
+    with open(os.path.join(team_dir, "lead-hold.txt"), "w") as f:
+        f.write("")
+
+    _write_mock_taos_team(team_dir, claimable)
+    _write_mock_next_card(team_dir, empty=next_empty, rc=next_rc)
+
+    bin_dir = os.path.join(tmp_dir, "bin")
+    os.makedirs(bin_dir, exist_ok=True)
+
+    with open(os.path.join(bin_dir, "pgrep"), "w") as f:
+        f.write("#!/bin/bash\nif [ \"$1\" = '-cf' ]; then echo '1'; exit 0; fi\nexec /usr/bin/pgrep \"$@\"\n")
+    os.chmod(os.path.join(bin_dir, "pgrep"), 0o755)
+
+    with open(os.path.join(bin_dir, "gh"), "w") as f:
+        f.write("#!/bin/bash\necho '[]'\nexit 0\n")
+    os.chmod(os.path.join(bin_dir, "gh"), 0o755)
+
+    env = os.environ.copy()
+    env["HOME"] = tmp_dir
+    env["TMPDIR"] = tmp_dir
+    env["PATH"] = bin_dir + ":" + env.get("PATH", "")
+    env["MOCK_CLAIMABLE"] = str(claimable)
+
+    if clean_state:
+        state = os.path.join(tmp_dir, "fleet_health_strangled_state")
+        if os.path.exists(state):
+            os.remove(state)
+        if os.path.exists(_STATE_FALLBACK):
+            os.remove(_STATE_FALLBACK)
+
+    return env
+
+
+def _run(env):
+    return subprocess.run(
+        ["bash", FLEET_HEALTH],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_strangled_alarm_fires_after_two_consecutive_empty_probes():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, clean_state=True)
+        r1 = _run(env)
+        assert "BOARD STRANGLED - " not in r1.stdout
+        assert "Prune the quarantine" not in r1.stdout
+
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, clean_state=False)
+        r2 = _run(env)
+        assert "BOARD STRANGLED - " in r2.stdout
+        assert "Prune the quarantine" not in r2.stdout
+
+
+def test_single_empty_probe_does_not_alarm_without_corroboration():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, clean_state=True)
+        r = _run(env)
+        assert "BOARD STRANGLED - " not in r.stdout
+
+
+def test_probe_failure_reports_error_and_does_not_alarm():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=5, next_empty=False, next_rc=1, clean_state=True)
+        r = _run(env)
+        assert "BOARD STRANGLED - " not in r.stdout
+        assert "probe failed" in r.stdout
+        assert "rc=1" in r.stdout
+        assert "Prune the quarantine" not in r.stdout
+
+
+def test_next_card_timeout_reports_error_and_does_not_alarm():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, next_rc=124, clean_state=True)
+        r = _run(env)
+        assert "BOARD STRANGLED - " not in r.stdout
+        assert "probe failed" in r.stdout
+        assert "Prune the quarantine" not in r.stdout
+
+
+def test_falling_claimable_count_suppresses_alarm():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, clean_state=True)
+        _run(env)
+
+        env = _setup_env(tmp_dir, claimable=3, next_empty=True, clean_state=False)
+        r = _run(env)
+        assert "BOARD STRANGLED - " not in r.stdout
+
+
+def test_rising_claimable_count_allows_alarm_after_corroboration():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        env = _setup_env(tmp_dir, claimable=3, next_empty=True, clean_state=True)
+        _run(env)
+
+        env = _setup_env(tmp_dir, claimable=5, next_empty=True, clean_state=False)
+        r = _run(env)
+        assert "BOARD STRANGLED - " in r.stdout
+        assert "Prune the quarantine" not in r.stdout


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fleet_health BOARD STRANGLED is a false alarm that recommends a destructive prune

Autonomous build of board card tsk-bvpjun.

- Capture next_card.py rc and stderr instead of discarding them
- Report probe failed: rc=N stderr=... for nonzero rc or timeout
- Require 2 consecutive empty probes before alarming
- Suppress alarm when claimable count is falling
- Drop unconditional prune advice from BOARD STRANGLED message

Tests in tests/test_fleet_health_strangled.py verify:
- Red: genuinely strangled board alarms after corroboration
- Red: probe failure reports error and does not alarm
- Red: next_card timeout reports error and does not alarm
- Red: falling claimable count suppresses alarm
- Control: rising claimable count allows alarm after corroboration
- Control: single empty probe does not alarm without corroboration

Files:
 changelog.d/tsk-bvpjun-fleet-health-probe.md |   2 +
 tests/test_fleet_health_strangled.py         | 167 +++++++++++++++++++++++++++
 2 files changed, 169 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fleet health reporting by displaying probe failures and timeouts clearly.
  - Reduced false alarms by requiring two consecutive empty probes before alerting.
  - Suppressed alerts when the claimable item count is decreasing.
  - Removed outdated “Prune the quarantine” guidance from probe alerts.
  - Alerts now trigger when the claimable count rises after confirmed empty probes.

- **Tests**
  - Added coverage for probe failures, timeouts, alert confirmation, and changing claimable counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->