### PR TITLE
Resolve merge conflicts on PR #2070 (library: P3 heavy tier download, quality prefs, storage)

### DIFF
--- a/changelog.d/tsk-4xcxcm-library-p3-heavy-tier.md
+++ b/changelog.d/tsk-4xcxcm-library-p3-heavy-tier.md
@@ -1,0 +1,3 @@
+### Added
+
+- Library app: heavy-tier media download (yt-dlp) for YouTube URLs with quality preferences (360/480/720/1080/best), per-source auto-download rules with fnmatch matching, and storage accounting (size, kind breakdown).


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Resolve merge conflicts on PR #2070 (library: P3 heavy tier download, quality prefs, storage)

Autonomous build of board card tsk-4xcxcm.

The library feature (P1-P3: LibraryStore, ingest pipeline, processors,
collections handoff, heavy-tier download, quality preferences, storage
accounting, per-source rules) was rebased onto current dev.

Dev already incorporated the library code via prior merges (P1 via #2062,
P2 via #2177, P3 via the original #2070 merge, CivitaiProcessor via
lora-studio). The rebase applied all 7 PR commits on top of dev (617 commits
ahead of the original merge base aed3c951d) and resolved the following
conflicts:

1. tests/test_library.py (5 hunks): all about 'from unittest.mock import
   patch' inside HeavyDownloadProcessor test functions. The PR's commit
   93870c336 ('patch imports') was meant to add these. Dev already had them,
   so the resolution kept dev's version. The subsequent fix commit became a
   no-op.

2. tinyagentos/library_pipeline.py (2 hunks): HeavyDownloadProcessor
   fallback file search, dev scopes the glob to the item's video_id
   (prevents cross-attribution of concurrent downloads), the PR had a
   blanket glob. Resolution kept dev's scoped version.
   Error handling in run_heavy_pipeline, dev treats heavy download as
   optional (records failure on the heavy_download job state instead of
   flipping item to 'error'), the PR set status='error'. Resolution kept
   dev's optional-download semantics.

3. tinyagentos/routes/library.py (3 hunks): Error handling in
   _heavy_download_task, same optional-download semantics, resolution kept
   dev's version.
   HTMX rendering in list_rules and storage_usage, the PR added HTMX-aware
   responses, dev already had identical rendering (helper functions
   _render_rules_list/_render_storage_summary/_is_htmx already exist).
   Resolution kept the PR's additions (identical to dev's existing code).

Conflict resolution strategy: dev's more advanced code was preferred in all
cases, incorporating later fixes the PR's commit stack did not account for.
CivitaiProcessor was explicitly KEPT (not removed as the PR's c530df662
're-cut' commit intended) because dev's test_lora_studio.py directly imports
and exercises CivitaiProcessor (54 tests). The PR's removal was valid only
in the PR branch context where test_lora_studio.py did not exist.

Net tree delta vs dev: 0 files changed -- the library feature is already
present in dev. Changelog fragment is the only new file.

PR comment with conflict details was added to the PR via gh pr comment.

All 132 library + lora_studio tests pass (78 + 54).

Docs-Reviewed: routes/library.py is already present in dev from prior
merges and documented in docs/agent-coordination.md (line 834-836 covers
CivitaiProcessor); no doc change needed for the zero-delta rebase.

Files:
 changelog.d/tsk-4xcxcm-library-p3-heavy-tier.md | 3 +++
 1 file changed, 3 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for heavy-tier library media downloads.
  * Added YouTube quality preferences and per-source automatic download rules.
  * Added storage tracking by file size and media type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->