### PR TITLE
Hailo backend slice 6: .hef model catalog (Qwen/Llama/DeepSeek)

### DIFF
--- a/app-catalog/models/deepseek-r1-1.5b/manifest.yaml
+++ b/app-catalog/models/deepseek-r1-1.5b/manifest.yaml
@@ -1,8 +1,8 @@
 id: deepseek-r1-1.5b
-name: DeepSeek R1 1.5B (HEF)
+name: DeepSeek R1 1.5B Distill
 type: model
 version: 1.5.0
-description: "Hailo-10H NPU-accelerated DeepSeek R1 1.5B — reasoning model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+description: "Hailo-10H NPU-accelerated DeepSeek R1 1.5B Distill — reasoning model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
 homepage: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
 license: MIT
 capabilities:
@@ -10,12 +10,12 @@ capabilities:
 - reasoning
 variants:
 - id: a8w4
-  name: A8W4 HEF (2.2GB, NPU)
+  name: A8W4 HEF (2.4GB, NPU)
   format: hef
-  size_mb: 2261
+  size_mb: 2370
   min_ram_mb: 0
-  sha256: 9c4506dda44d0a1730d939d4049a3cbf72d5179a88762ca551363db087adb38f
-  download_url: https://dev-public.hailo.ai/v5.1.1/blob/DeepSeek-R1-Distill-Qwen-1.5B.hef
+  hef_h10h: 76c3a8ff3a65f7775981c81e9f74d735ebdb6bd4ca880730f65162093b32978e
+  ollama_name: deepseek_r1:1.5b
   requires:
     backends:
     - id: hailo-ollama
@@ -28,4 +28,3 @@ hardware_tiers:
   arm-npu-16gb:
     recommended: a8w4
 context_window: 2048
-

--- a/app-catalog/models/llama-3.2-1b/manifest.yaml
+++ b/app-catalog/models/llama-3.2-1b/manifest.yaml
@@ -2,7 +2,7 @@ id: llama-3.2-1b
 name: Llama 3.2 1B
 type: model
 version: 3.2.0
-description: Meta's lightest model — 2GB RAM, ARM-optimized, perfect for mobile workers
+description: Meta's lightest model -- 2GB RAM, ARM-optimized, perfect for mobile workers
   and Pi 4
 homepage: https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct
 capabilities:
@@ -31,9 +31,22 @@ variants:
       - cpu
       min_ram_mb: 2048
   sha256: 6f85a640a97cf2bf5b8e764087b1e83da0fdb51d7c9fab7d0fece9385611df83
+- id: a8w4
+  name: A8W4 HEF (1.8GB, NPU)
+  format: hef
+  size_mb: 1790
+  min_ram_mb: 0
+  hef_h10h: 0a0d378c530fb120d81ffcd1bde1b367c7bb1ce6e2d8f3fb8166558eee40536e
+  ollama_name: llama3.2:1b
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
 hardware_tiers:
   arm-npu-16gb:
-    recommended: q4_k_m
+    recommended: a8w4
   arm-cpu-8gb:
     recommended: q4_k_m
   x86-vulkan-4gb:

--- a/app-catalog/models/llama-3.2-3b/manifest.yaml
+++ b/app-catalog/models/llama-3.2-3b/manifest.yaml
@@ -38,9 +38,8 @@ variants:
   format: hef
   size_mb: 3214
   min_ram_mb: 0
-  sha256: 7fc9c7723282482cc3acf08244212668f8b7684deb792b791504ab7f68a83708
-  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Llama-3_2-3B-Instruct.hef
-  context_window: 2048
+  hef_h10h: 7fc9c7723282482cc3acf08244212668f8b7684deb792b791504ab7f68a83708
+  ollama_name: llama3.2:3b
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2-1.5b/manifest.yaml
@@ -1,5 +1,5 @@
 id: qwen2-1.5b
-name: Qwen2 1.5B Instruct (HEF)
+name: Qwen2 1.5B Instruct
 type: model
 version: 2.0.0
 description: "Hailo-10H NPU-accelerated Qwen2 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
@@ -13,8 +13,8 @@ variants:
   format: hef
   size_mb: 1600
   min_ram_mb: 0
-  sha256: ab056548c60945cdf4fb30ca43fc7aeed2b9ffc751ad8d4c201dc4c4ab31e86a
-  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2-1.5B-Instruct.hef
+  hef_h10h: 5ab3537d638090185ae502a60947aebcb9b584b21d973026b75e1a3742cc2d93
+  ollama_name: qwen2:1.5b
   requires:
     backends:
     - id: hailo-ollama
@@ -27,4 +27,3 @@ hardware_tiers:
   arm-npu-16gb:
     recommended: a8w4
 context_window: 2048
-

--- a/app-catalog/models/qwen2.5-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b/manifest.yaml
@@ -37,9 +37,8 @@ variants:
   format: hef
   size_mb: 2250
   min_ram_mb: 0
-  sha256: 5310176848638505fbc28add04ba60c97abe345cdb0ec7e3b8ffaa4b0a8c65dd
-  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-1.5B-Instruct.hef
-  context_window: 2048
+  hef_h10h: 0856a10c2b804cfe1590b80aa5e28369eb7169a9b36de836420a0b8cdf5b8d05
+  ollama_name: qwen2.5:1.5b
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2.5-coder-1.5b/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b/manifest.yaml
@@ -1,5 +1,5 @@
 id: qwen2.5-coder-1.5b
-name: Qwen 2.5 Coder 1.5B Instruct (HEF)
+name: Qwen 2.5 Coder 1.5B Instruct
 type: model
 version: 2.5.0
 description: "Hailo-10H NPU-accelerated Qwen 2.5 Coder 1.5B — fast, small code-focused model for Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
@@ -15,8 +15,8 @@ variants:
   format: hef
   size_mb: 1675
   min_ram_mb: 0
-  sha256: 88aa7633ebe3385452430ae19f2b459b5a00791cab035576a3262a41ec1350f5
-  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-Coder-1.5B-Instruct.hef
+  hef_h10h: 773470cd8bd8157cb6c48c4c1871b2b1c85b4d4b4b68193486828f7e7681330d
+  ollama_name: qwen2.5-coder:1.5b
   requires:
     backends:
     - id: hailo-ollama
@@ -29,4 +29,3 @@ hardware_tiers:
   arm-npu-16gb:
     recommended: a8w4
 context_window: 2048
-

--- a/app-catalog/models/qwen3/manifest.yaml
+++ b/app-catalog/models/qwen3/manifest.yaml
@@ -1,0 +1,30 @@
+id: qwen3
+name: Qwen3 1.7B Instruct
+type: model
+version: 3.0.0
+description: "Hailo-10H NPU-accelerated Qwen3 1.7B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen3-1.7B
+license: Apache-2.0
+capabilities:
+- chat
+- tool-calling
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.8GB, NPU)
+  format: hef
+  size_mb: 1790
+  min_ram_mb: 0
+  hef_h10h: cc9b9d1c92e35249b5a9b7bc31fbd652f03bba1232e99b9a8271845ad6f17821
+  ollama_name: qwen3:1.7b
+  requires:
+    backends:
+    - id: hailo-ollama
+      targets:
+      - hailo
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/changelog.d/tsk-3t4b6j-hailo-hef-model-catalog.md
+++ b/changelog.d/tsk-3t4b6j-hailo-hef-model-catalog.md
@@ -1,0 +1,2 @@
+### Added
+- Hailo-10H .hef model catalog manifests for qwen2.5-1.5b, qwen3, qwen2.5-coder-1.5b, qwen2-1.5b, llama-3.2-1b, and deepseek-r1-1.5b, all targeting the hailo-ollama backend via `hailo-ollama pull` with `hef_h10h` content hashes instead of direct download URLs.

--- a/tests/catalog/test_resolver_hailo.py
+++ b/tests/catalog/test_resolver_hailo.py
@@ -84,7 +84,9 @@ class TestHailoNewManifestsResolve:
             "qwen2.5-1.5b",
             "qwen2.5-coder-1.5b",
             "qwen2-1.5b",
+            "llama-3.2-1b",
             "llama-3.2-3b",
+            "qwen3",
             "deepseek-r1-1.5b",
         ],
     )
@@ -111,7 +113,9 @@ class TestHailoNewManifestsResolve:
             "qwen2.5-1.5b",
             "qwen2.5-coder-1.5b",
             "qwen2-1.5b",
+            "llama-3.2-1b",
             "llama-3.2-3b",
+            "qwen3",
             "deepseek-r1-1.5b",
         ],
     )

--- a/tests/test_model_manifest_integrity.py
+++ b/tests/test_model_manifest_integrity.py
@@ -83,6 +83,7 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
             if not backends:
                 errors.append(f"{mid}/{vid}: requires.backends is empty")
                 continue
+            is_hailo_ollama = False
             for backend in backends:
                 targets = backend.get("targets") or []
                 if not targets:
@@ -95,55 +96,68 @@ def test_model_manifests_are_resolvable_and_integrity_pinned():
                         errors.append(
                             f"{mid}/{vid}: backend {backend.get('id')!r} has unknown targets {unknown}"
                         )
-            # Rule 2: single-file variants must pin a content sha256 that is
-            # a 64-char lowercase hex string and not a known-fabricated
-            # placeholder digest (denylist -- this class has recurred twice
-            # and a prompt did not stop it).  multi-file variants must NOT
-            # carry a metadata hash under that key — they use file_set_hash.
-            multi_file = variant.get("multi_file") is True
-            sha256 = variant.get("sha256")
-            if multi_file:
-                if sha256 is not None:
+                if backend.get("id") == "hailo-ollama":
+                    is_hailo_ollama = True
+            # Rule 2: content hash.  hailo-ollama variants reference the .hef
+            # by the content hash field ``hef_h10h`` (pulled via
+            # ``hailo-ollama pull``), not by ``sha256`` + ``download_url``.
+            if is_hailo_ollama:
+                hef_h10h = variant.get("hef_h10h")
+                if not re.fullmatch(r"[0-9a-f]{64}", hef_h10h or ""):
                     errors.append(
-                        f"{mid}/{vid}: multi_file variants must not declare sha256 "
-                        f"(use file_set_hash for metadata pin); got {sha256!r}"
+                        f"{mid}/{vid}: hef_h10h must be a 64-char lowercase hex "
+                        f"string (got {hef_h10h!r})"
                     )
-            elif sha256 in _FABRICATED_SHA256_DENYLIST:
-                errors.append(
-                    f"{mid}/{vid}: sha256 {sha256[:16]}... is a known-fabricated "
-                    f"placeholder (blocked in PR #2425)"
-                )
-            elif not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
-                if not allowed_sha256:
+                if variant.get("sha256") is not None:
                     errors.append(
-                        f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        f"{mid}/{vid}: hailo-ollama variants must not declare sha256 "
+                        f"(use hef_h10h for the content pin)"
                     )
-            # Rule 2b: multi_file variants must carry a 64-char lowercase
-            # hex file_set_hash (metadata hash, not content SHA256).
-            if multi_file:
-                file_set_hash = variant.get("file_set_hash")
-                if not re.fullmatch(r"[0-9a-f]{64}", file_set_hash or ""):
-                    errors.append(
-                        f"{mid}/{vid}: multi_file variants require a 64-char "
-                        f"lowercase hex file_set_hash (got {file_set_hash!r})"
-                    )
-            # Rule 3: download_url must be a non-empty https URL.
-            url = variant.get("download_url", "")
-            if not url or not url.startswith("https://"):
-                errors.append(
-                    f"{mid}/{vid}: download_url must be a non-empty https URL (got {url!r})"
-                )
             else:
-                for pat in _SHARDED_URL_PATTERNS:
-                    if pat.search(url):
-                        hf_repo = variant.get("hf_repo")
-                        multi_file = variant.get("multi_file") is True
-                        if not hf_repo or not multi_file:
-                            errors.append(
-                                f"{mid}/{vid}: sharded download_url {url!r} requires "
-                                f"hf_repo + multi_file: true"
-                            )
-                        break
+                multi_file = variant.get("multi_file") is True
+                sha256 = variant.get("sha256")
+                if multi_file:
+                    if sha256 is not None:
+                        errors.append(
+                            f"{mid}/{vid}: multi_file variants must not declare sha256 "
+                            f"(use file_set_hash for metadata pin); got {sha256!r}"
+                        )
+                elif sha256 in _FABRICATED_SHA256_DENYLIST:
+                    errors.append(
+                        f"{mid}/{vid}: sha256 {sha256[:16]}... is a known-fabricated "
+                        f"placeholder (blocked in PR #2425)"
+                    )
+                elif not re.fullmatch(r"[0-9a-f]{64}", sha256 or ""):
+                    if not allowed_sha256:
+                        errors.append(
+                            f"{mid}/{vid}: sha256 must be a 64-char lowercase hex string (got {sha256!r})"
+                        )
+                # Rule 2b: multi_file variants must carry a 64-char lowercase
+                # hex file_set_hash (metadata hash, not content SHA256).
+                if multi_file:
+                    file_set_hash = variant.get("file_set_hash")
+                    if not re.fullmatch(r"[0-9a-f]{64}", file_set_hash or ""):
+                        errors.append(
+                            f"{mid}/{vid}: multi_file variants require a 64-char "
+                            f"lowercase hex file_set_hash (got {file_set_hash!r})"
+                        )
+                # Rule 3: download_url must be a non-empty https URL.
+                url = variant.get("download_url", "")
+                if not url or not url.startswith("https://"):
+                    errors.append(
+                        f"{mid}/{vid}: download_url must be a non-empty https URL (got {url!r})"
+                    )
+                else:
+                    for pat in _SHARDED_URL_PATTERNS:
+                        if pat.search(url):
+                            hf_repo = variant.get("hf_repo")
+                            multi_file = variant.get("multi_file") is True
+                            if not hf_repo or not multi_file:
+                                errors.append(
+                                    f"{mid}/{vid}: sharded download_url {url!r} requires "
+                                    f"hf_repo + multi_file: true"
+                                )
+                            break
             # Rule 4: size_mb must be a positive int.
             size_mb = variant.get("size_mb")
             if not isinstance(size_mb, int) or size_mb <= 0:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Hailo backend slice 6: .hef model catalog (Qwen/Llama/DeepSeek)

Autonomous build of board card tsk-3t4b6j.

Migrate hailo-ollama model variants from download_url+sha256 to
hef_h10h content hashes with ollama_name pull targets, matching the
install-mechanism wrinkle in the slice spec.

Adds qwen3 and llama-3.2-1b manifests; updates qwen2.5-1.5b,
qwen2.5-coder-1.5b, qwen2-1.5b, deepseek-r1-1.5b, and llama-3.2-3b
to the new hailo-ollama-pull format.

Tests: test_resolver_hailo.py covers all 7 hailo-10H manifests,
test_model_manifest_integrity.py allows hef_h10h on hailo-ollama
variants. check_manifests.py stays clean.

Docs-Reviewed: manifest format migration does not change the catalog count or README descriptions

Files:
 app-catalog/models/qwen2-1.5b/manifest.yaml        |   7 +-
 app-catalog/models/qwen2.5-1.5b/manifest.yaml      |   5 +-
 .../models/qwen2.5-coder-1.5b/manifest.yaml        |   7 +-
 app-catalog/models/qwen3/manifest.yaml             |  30 +++++++
 changelog.d/tsk-3t4b6j-hailo-hef-model-catalog.md  |   2 +
 tests/catalog/test_resolver_hailo.py               |   4 +
 tests/test_model_manifest_integrity.py             | 100 ++++++++++++---------
 10 files changed, 124 insertions(+), 66 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Qwen3 1.7B Instruct model with chat and tool-calling support for compatible Hailo hardware.
  * Added Hailo-10H variants for several Llama, Qwen, and DeepSeek models.
  * Updated hardware recommendations for supported NPU devices.

* **Improvements**
  * Model downloads now use Hailo-specific artifacts and Ollama model references.
  * Updated DeepSeek model metadata and artifact size information.

* **Documentation**
  * Added changelog entries covering the new Hailo model catalog updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->