### PR TITLE
fix-forward #2618: workflow_dispatch checks out the DEFAULT branch, so the gate judges a PR with the wrong checker

### DIFF
--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -38,6 +38,12 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
     branches: [master, dev]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to inspect for gate-integrity violations"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -70,7 +76,7 @@ jobs:
         # blip never reads as green -- see check_gate_integrity.EXIT_ERROR.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
         run: |
           set -euo pipefail
           python scripts/check_gate_integrity.py "$PR_NUMBER"

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -59,12 +59,20 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      - name: Resolve PR base ref for workflow_dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          base=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.inputs.pr_number }} --jq .base.ref)
+          echo "BASE_REF=$base" >> $GITHUB_ENV
+
       # On `pull_request_target` checkout defaults to the base branch,
       # not the merge ref. Pinning `ref` to base_ref guarantees
       # the base-ref checker (and this workflow) execute from base.
+      # For workflow_dispatch, the step above sets BASE_REF to the PR's actual
+      # base branch; for pull_request_target, github.base_ref is used below.
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ env.BASE_REF || github.base_ref }}
           fetch-depth: 1
 
       - uses: actions/setup-python@v7

--- a/changelog.d/tsk-fawr2n-gate-integrity-paginate-and-self-protect.md
+++ b/changelog.d/tsk-fawr2n-gate-integrity-paginate-and-self-protect.md
@@ -1,0 +1,10 @@
+### Added
+
+- `workflow_dispatch` trigger on `gate-integrity.yml` with a `pr_number` input, enabling manual red-in-CI proof runs against any target PR without requiring a push to the branch.
+
+### Fixed
+
+- **`.github/` full-tree protection**: `PROTECTED_PREFIXES` now covers the entire `.github/` tree (workflows, composite actions, `.github/scripts/`, Dependabot config, etc.) instead of only `.github/workflows/` and `.github/scripts/` subdirectories. Over-inclusion is safe because the `gate-integrity-allow` label provides an explicit human-set waiver for intentional changes.
+- **`per_page=100` pagination on `/files`**: `collect_pr_files` now requests 100 records per page from the GitHub `/pulls/{n}/files` endpoint and `_api_get` already follows `Link: rel="next"` headers until exhausted. A 150-file PR now enumerates all records across two pages.
+- **Fail-closed on enumeration mismatch**: the existing `record_count != changed_files` check (EXIT_ERROR) now also catches truncated multi-page listings where `_api_get` stopped following the Link chain.
+- **`scripts/check_*.py` nested coverage**: `is_protected` matches `scripts/check_*.py` at any depth under `scripts/` (e.g. `scripts/platform/check_foo.py`), auto-covering future gate checkers including `check_gate_integrity.py` itself.

--- a/changelog.d/tsk-ti4k5d-fix-forward-workflow_dispatch-base-ref.md
+++ b/changelog.d/tsk-ti4k5d-fix-forward-workflow_dispatch-base-ref.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `gate-integrity.yml`: On `workflow_dispatch`, resolve the PR base ref via `gh api` instead of relying on `github.base_ref` (empty for dispatch), so the checkout targets the PR's actual base branch rather than the default branch

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -162,6 +162,26 @@ helper rather than parsing inline - it follows the module's existing
   edge-case correctness problem) before merging. Style and preference nits can
   be deferred or taken in a follow-up.
 
+### Gate-integrity-allow label for CI/gate changes
+
+The `gate-integrity` required check (`.github/workflows/gate-integrity.yml`) runs
+on `pull_request_target` from the base branch and inspects the PR diff via the
+GitHub API only. It blocks any PR that touches protected paths under `.github/`
+or `scripts/check_*.py` unless the PR carries the `gate-integrity-allow` label.
+
+This label must be set manually by the lead after a human review of the gate
+change. Legitimate changes that touch these paths and need the label include:
+
+- Editing `.github/workflows/*.yml` to fix or extend a required check
+- Editing `scripts/check_*.py` (any gate checker, including nested ones)
+- Editing `.github/actions/**` (composite actions used by workflows)
+- Editing `.github/scripts/**` (gate scripts collocated under `.github`)
+
+The label is the explicit human-set waiver: automation must never apply it, and
+a PR without it that touches a protected path fails the gate. When reviewing a PR
+that legitimately changes these files, apply `gate-integrity-allow` after
+confirming the change is intentional and reviewed.
+
 ## Spend model tokens on judgement, not on waiting
 
 An agent working this repo pays for every turn it takes. Reserve those turns for

--- a/scripts/check_gate_integrity.py
+++ b/scripts/check_gate_integrity.py
@@ -32,9 +32,10 @@ file that drives it, which is why #1 is still required. This guard covers
 both, so #2 is redundant for the covered surface.
 
 Protected paths (the minimal gate surface a lane could corrupt):
-  - `.github/workflows/`        the required-check workflow YAML itself
-  - `.github/scripts/`          gate checkers collocated under `.github`
-  - `scripts/check_*.py`        every repo gate checker lives here by convention
+  - `.github/`                  the entire .github tree (workflows, composite
+                                actions, scripts, Dependabot config, etc.)
+  - `scripts/check_*.py`        every repo gate checker under scripts/ (flat
+                                or nested; auto-covers future gate checkers)
   - `docs/doc-gate.toml`        the doc-gate's rule DATA (a gate input, not code)
   - `pyproject.toml`            tool/test configuration the gates execute under
   - `tests/conftest.py`         fixture root every gate-adjacent test imports
@@ -69,8 +70,7 @@ DEFAULT_ALLOW_LABEL = "gate-integrity-allow"
 # silence or subvert a required check, so such edits are blocked unless the
 # allow label is set.
 PROTECTED_PREFIXES: tuple[str, ...] = (
-    ".github/workflows/",
-    ".github/scripts/",
+    ".github/",
     "docs/doc-gate.toml",
     "pyproject.toml",
     "tests/conftest.py",
@@ -150,14 +150,7 @@ def is_protected(path: str) -> bool:
     for prefix in PROTECTED_PREFIXES:
         if norm.startswith(prefix):
             return True
-    if (
-        norm.startswith(GATE_SCRIPT_PREFIX)
-        and norm.endswith(GATE_SCRIPT_SUFFIX)
-        and norm.count("/") == 1
-    ):
-        # `scripts/check_<x>.py` directly under scripts/ only; a nested file
-        # like scripts/platform/check_foo.py is not matched by the flat
-        # `scripts/check_*.py` convention.
+    if norm.startswith("scripts/") and "/check_" in norm and norm.endswith(GATE_SCRIPT_SUFFIX):
         return True
     return False
 
@@ -172,7 +165,7 @@ def collect_pr_files(
     truncation check must compare records against `changed_files`, or every
     rename would read as a truncated listing. None on infrastructure
     failure."""
-    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}/files", token)
+    data = _api_get(f"{API}/repos/{owner}/{repo}/pulls/{pr_number}/files?per_page=100", token)
     if data is None:
         return None
     records = [f for f in data if isinstance(f, dict)]
@@ -222,7 +215,7 @@ def classify(
         return CheckResult(
             EXIT_OK,
             "gate-integrity: PASS -- PR touches no protected gate paths "
-            f"({', '.join(PROTECTED_PREFIXES)} or {GATE_SCRIPT_PREFIX}*{GATE_SCRIPT_SUFFIX})",
+            f"({', '.join(PROTECTED_PREFIXES)} or scripts/check_*.py)",
         )
     if allow_label in label_set:
         return CheckResult(

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -23,6 +23,7 @@ closed).
 """
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -52,15 +53,19 @@ def _pr_payload(label_names: list[str], changed_files: int) -> list[dict]:
     }]
 
 
-def _api_get_routing(files: list[str], labels: list[str]):
-    """Build a side_effect that routes files vs PR-object requests by URL."""
+def _api_get_routing(files: list[str], labels: list[str], changed_files: int | None = None):
+    """Build a side_effect that routes files vs PR-object requests by URL.
+
+    `changed_files` defaults to len(files) because a flat list of N paths
+    corresponds to N /files records. Tests with renames override it explicitly
+    since one rename record expands to two paths.
+    """
+    _changed = changed_files if changed_files is not None else len(files)
 
     def _fake(url: str, token: str | None = None, **_: object) -> list:
-        if url.endswith("/files"):
+        if "/files" in url:
             return _files_payload(files)
-        # single-object /pulls/{n} endpoint; changed_files agrees with the
-        # /files listing unless a test overrides the payload deliberately.
-        return _pr_payload(labels, changed_files=len(files))
+        return _pr_payload(labels, changed_files=_changed)
 
     return _fake
 
@@ -81,6 +86,9 @@ class TestIsProtected:
             ".github/workflows/deleted-symbols-gate.yml",
             ".github/workflows/gate-integrity.yml",
             ".github/scripts/check_all_skip.py",
+            ".github/dependabot.yml",
+            ".github/FUNDING.yml",
+            ".github/actions/build.yml",
             "docs/doc-gate.toml",
             "pyproject.toml",
             "tests/conftest.py",
@@ -103,6 +111,7 @@ class TestIsProtected:
             "scripts/check_retrofit_migrations.py",
             "scripts/check_evil_merge.py",
             "scripts/check_gate_integrity.py",
+            "scripts/platform/check_foo.py",
         ],
     )
     def test_gate_checker_scripts_are_protected(self, path: str) -> None:
@@ -118,15 +127,9 @@ class TestIsProtected:
             "data/hub/identity.json",
             "scripts/audit-forks.py",
             "scripts/audit-manifests.py",
-            # .github config that is not a workflow or gate script is not blocked
-            ".github/dependabot.yml",
-            ".github/FUNDING.yml",
             ".coderabbit.yaml",
             "docs/something.md",
             "changelog.d/foo.md",
-            # a check_*.py nested in a subdir is NOT matched by the single
-            # scripts/check_*.py convention the guard enforces
-            "scripts/platform/check_foo.py",
         ],
     )
     def test_non_gate_paths_are_not_protected(self, path: str) -> None:
@@ -252,7 +255,7 @@ class TestCheckGateIntegrity:
         # stops. A listing shorter than the PR's own changed_files count means
         # the gate cannot see the whole diff -> EXIT_ERROR, never a pass.
         def _fake(url: str, token: str | None = None, **_: object) -> list:
-            if url.endswith("/files"):
+            if "/files" in url:
                 return _files_payload(["README.md", "docs/a.md"])
             return _pr_payload([], changed_files=5)
 
@@ -261,13 +264,58 @@ class TestCheckGateIntegrity:
         assert code == cgi.EXIT_ERROR
         assert "truncated" in message
 
+    def test_150_file_paginates_fully(self) -> None:
+        # With per_page=100 the /files endpoint returns up to 100 records per
+        # page; a 150-file PR needs two pages. The Link header on page 1 points
+        # to page 2; the guard must follow it and collect all 150 before
+        # comparing to changed_files.
+        page1_files = [{"filename": f"src/file_{i:03d}.py"} for i in range(100)]
+        page2_files = [{"filename": f"src/file_{i:03d}.py"} for i in range(100, 150)]
+        next_url = (
+            "https://api.github.com/repos/jaylfc/taOS/pulls/42/files"
+            "?per_page=100&page=2"
+        )
+        link_hdr = f'<{next_url}>; rel="next"'
+        pr_url = "https://api.github.com/repos/jaylfc/taOS/pulls/42"
+
+        import http.client
+        import io
+        import urllib.response as _ur
+
+        def _make_response(body: list[dict], link: str = "") -> _ur.addinfourl:
+            return _ur.addinfourl(
+                io.BytesIO(json.dumps(body).encode()),
+                {"Link": link} if link else {},
+                "https://api.github.com",
+                200,
+            )
+
+        call_count = 0
+
+        def _fake_urlopen(req, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            url = req.full_url if hasattr(req, "full_url") else req
+            if url == pr_url:
+                return _make_response([{
+                    "labels": [],
+                    "changed_files": 150,
+                }])
+            if "page=2" in str(url):
+                return _make_response(page2_files)
+            return _make_response(page1_files, link_hdr)
+
+        with patch("check_gate_integrity.urllib.request.urlopen", side_effect=_fake_urlopen):
+            code, message = cgi.check_gate_integrity("jaylfc", "taOS", 42)
+        assert code == cgi.EXIT_OK, f"expected PASS, got: {message}"
+
     def test_rename_out_of_protected_path_fails_without_label(self) -> None:
         # A rename edits BOTH paths: renaming a workflow out of
         # .github/workflows/ disables it, yet /files reports only the new
         # filename at top level and carries the old one in
         # previous_filename. The protected old side must still be classified.
         def _fake(url: str, token: str | None = None, **_: object) -> list:
-            if url.endswith("/files"):
+            if "/files" in url:
                 return [{
                     "filename": "docs/archived-gate.yml",
                     "previous_filename": ".github/workflows/doc-gate.yml",
@@ -286,7 +334,7 @@ class TestCheckGateIntegrity:
         # renamed record with changed_files=1 is a complete listing, not a
         # truncated one.
         def _fake(url: str, token: str | None = None, **_: object) -> list:
-            if url.endswith("/files"):
+            if "/files" in url:
                 return [{
                     "filename": "docs/b.md",
                     "previous_filename": "docs/a.md",
@@ -302,7 +350,7 @@ class TestCheckGateIntegrity:
         # Without the changed_files field truncation is undetectable; treat
         # the payload as cannot-see rather than assuming the listing is whole.
         def _fake(url: str, token: str | None = None, **_: object) -> list:
-            if url.endswith("/files"):
+            if "/files" in url:
                 return _files_payload(["README.md"])
             return [{"labels": []}]
 
@@ -330,8 +378,8 @@ class TestCheckGateIntegrity:
         with patch("check_gate_integrity._api_get", side_effect=_spy):
             code, _ = cgi.check_gate_integrity("jaylfc", "taOS", 42)
         assert code == cgi.EXIT_OK
-        assert any(u.endswith("/files") for u in captured)
-        assert any(u.endswith("/pulls/42") for u in captured)
+        assert any("/files" in u for u in captured)
+        assert any("/pulls/42" in u for u in captured)
 
 
 class TestMainTokenEnvPropagation:
@@ -343,7 +391,7 @@ class TestMainTokenEnvPropagation:
 
         def fake_api_get(url, token=None, **_):
             captured["token"] = token
-            if url.endswith("/files"):
+            if "/files" in url:
                 return []
             return _pr_payload([], changed_files=0)
 

--- a/tests/test_check_gate_integrity.py
+++ b/tests/test_check_gate_integrity.py
@@ -278,7 +278,6 @@ class TestCheckGateIntegrity:
         link_hdr = f'<{next_url}>; rel="next"'
         pr_url = "https://api.github.com/repos/jaylfc/taOS/pulls/42"
 
-        import http.client
         import io
         import urllib.response as _ur
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2618: workflow_dispatch checks out the DEFAULT branch, so the gate judges a PR with the wrong checker

Autonomous build of board card tsk-ti4k5d.

REVISION: built on `exec/tsk-fawr2n` (cut at `92d492f6bf6947d8a055ec943af1d41b5db589a8`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

- On workflow_dispatch, query gh api for PR's .base.ref and set BASE_REF env
- Checkout uses env.BASE_REF || github.base_ref so pull_request_target path is unaffected
- Kept all 65 tests green, test_150_file_paginates_fully remains mutation-capable
- Removed unused http.client import from test_150_file_paginates_fully

Files:
 .github/workflows/gate-integrity.yml               | 18 ++++-
 ...r2n-gate-integrity-paginate-and-self-protect.md | 10 +++
 ...i4k5d-fix-forward-workflow_dispatch-base-ref.md |  3 +
 docs/agent-coordination.md                         | 20 +++++
 scripts/check_gate_integrity.py                    | 23 ++----
 tests/test_check_gate_integrity.py                 | 85 +++++++++++++++++-----
 6 files changed, 123 insertions(+), 36 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual integrity-check runs by specifying a pull request number.
  * Integrity checks now review all protected configuration paths and nested checker scripts.
  * Large pull requests are fully reviewed through paginated file listings.

* **Bug Fixes**
  * Manual checks now target the pull request’s actual base branch.
  * Checks fail safely when file listings are incomplete.

* **Documentation**
  * Documented labeling requirements for approved protected-path changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->