### PR TITLE
fix-forward #2613: complete the ingest queue view -- GET /api/library/jobs and the retry route still do not exist

### DIFF
--- a/changelog.d/tsk-bpgu4q-ingest-queue-view.md
+++ b/changelog.d/tsk-bpgu4q-ingest-queue-view.md
@@ -1,0 +1,3 @@
+### Added
+
+- Library app ingest queue view: a pane listing active and failed pipeline jobs with stage, error text, and a per-job retry action. Polls the jobs endpoint every 3s while jobs are active and stops once the queue is idle (retry POST mocked until #2058).

--- a/changelog.d/tsk-prbxsm-fix-ingest-queue-404.md
+++ b/changelog.d/tsk-prbxsm-fix-ingest-queue-404.md
@@ -1,0 +1,2 @@
+### Fixed
+- Ingest queue view now shows a distinct "Queue unavailable" state when the jobs endpoint is unreachable, instead of silently rendering the idle "No active or failed jobs" message.

--- a/changelog.d/tsk-sradu2-ingest-queue-routes.md
+++ b/changelog.d/tsk-sradu2-ingest-queue-routes.md
@@ -1,0 +1,3 @@
+### Added
+- GET /api/library/jobs returns the cross-item ingest job list, honouring ?state= and ?limit=.
+- POST /api/library/jobs/{id}/retry re-queues a job in error state and returns 404 for unknown ids or 409 for non-error jobs.

--- a/desktop/src/apps/LibraryApp.queue.test.tsx
+++ b/desktop/src/apps/LibraryApp.queue.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { LibraryApp } from "./LibraryApp";
+import type { LibraryJob } from "../lib/library";
+
+const MOCK_KNOWLEDGE_ITEMS = [
+  {
+    id: "lib-item-1",
+    title: "YouTube Video",
+    source_type: "youtube",
+    source_url: "https://youtube.com/watch?v=1",
+    source_id: "yt-1",
+    author: "YT Author",
+    summary: "",
+    content: "",
+    media_path: null,
+    thumbnail: null,
+    categories: [],
+    tags: [],
+    metadata: {},
+    status: "ready",
+    monitor: { current_interval: 0, frequency: 0, decay_rate: 0, pinned: false, last_poll: null, last_hash: "" },
+    created_at: 1700007200,
+    updated_at: 1700007200,
+  },
+];
+
+const MOCK_JOBS: LibraryJob[] = [
+  {
+    id: "job-active-1",
+    item_id: "lib-item-1",
+    stage: "metadata",
+    state: "processing",
+    error: "",
+    created_at: 1700007200,
+    updated_at: 1700007200,
+  },
+  {
+    id: "job-failed-1",
+    item_id: "lib-item-1",
+    stage: "transcript",
+    state: "error",
+    error: "Subtitles not available on video",
+    created_at: 1700007100,
+    updated_at: 1700007100,
+  },
+];
+
+function jsonResponse(obj: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: new Map([["content-type", "application/json"]]),
+    json: () => Promise.resolve(obj),
+  } as Response);
+}
+
+function makeFetchMock(getJobs: () => LibraryJob[]) {
+  const retryJobs: string[] = [];
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/library/jobs" && method === "GET") {
+      return jsonResponse({ jobs: getJobs() });
+    }
+    if (method === "POST" && /^\/api\/library\/jobs\/[^/]+\/retry$/.test(url)) {
+      const jobId = url.split("/")[4];
+      retryJobs.push(jobId);
+      return jsonResponse({ status: "retried", job_id: jobId });
+    }
+
+    if (url.startsWith("/api/knowledge/items")) {
+      return jsonResponse({ items: MOCK_KNOWLEDGE_ITEMS, count: MOCK_KNOWLEDGE_ITEMS.length });
+    }
+    if (url === "/api/agents") {
+      return jsonResponse([]);
+    }
+    if (url === "/api/knowledge/subscriptions") {
+      return jsonResponse({ subscriptions: [] });
+    }
+    if (url === "/api/knowledge/rules") {
+      return jsonResponse({ rules: [] });
+    }
+
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      headers: new Map([["content-type", "application/json"]]),
+      json: () => Promise.resolve({}),
+    } as Response);
+  });
+  return { fetchMock, getRetryJobs: () => retryJobs };
+}
+
+describe("LibraryApp queue view", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the queue header and lists jobs with stage and error text", async () => {
+    const { fetchMock } = makeFetchMock(() => MOCK_JOBS);
+    vi.stubGlobal("fetch", fetchMock);
+    render(<LibraryApp windowId="test-win" />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+
+    await waitFor(() => screen.getByText("Ingest Queue"), { timeout: 5000 });
+    expect(screen.getByText("Ingest Queue")).toBeInTheDocument();
+
+    // Stage column renders the job's stage
+    expect(screen.getByText("metadata")).toBeInTheDocument();
+    expect(screen.getByText("transcript")).toBeInTheDocument();
+
+    // State badges
+    expect(screen.getByText("processing")).toBeInTheDocument();
+    expect(screen.getByText("error")).toBeInTheDocument();
+
+    // Error text is surfaced for failed jobs
+    expect(screen.getByText("Subtitles not available on video")).toBeInTheDocument();
+  });
+
+  it("POSTs to retry a failed job when its retry button is clicked", async () => {
+    const { fetchMock, getRetryJobs } = makeFetchMock(() => MOCK_JOBS);
+    vi.stubGlobal("fetch", fetchMock);
+    render(<LibraryApp windowId="test-win" />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+
+    await waitFor(() => screen.getByRole("button", { name: "Retry job job-failed-1" }), { timeout: 5000 });
+    fireEvent.click(screen.getByRole("button", { name: "Retry job job-failed-1" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/library/jobs/job-failed-1/retry",
+        expect.objectContaining({ method: "POST" }),
+      );
+    }, { timeout: 5000 });
+    expect(getRetryJobs()).toEqual(["job-failed-1"]);
+  });
+
+  it("does not show a retry button for active jobs", async () => {
+    const { fetchMock } = makeFetchMock(() => MOCK_JOBS);
+    vi.stubGlobal("fetch", fetchMock);
+    render(<LibraryApp windowId="test-win" />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+
+    await waitFor(() => screen.getByText("Ingest Queue"), { timeout: 5000 });
+    expect(screen.queryByRole("button", { name: /Retry job job-active-1/ })).toBeNull();
+    expect(screen.getByRole("button", { name: "Retry job job-failed-1" })).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the queue has no active or failed jobs", async () => {
+    const { fetchMock } = makeFetchMock(() => []);
+    vi.stubGlobal("fetch", fetchMock);
+    render(<LibraryApp windowId="test-win" />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+
+    await waitFor(() => screen.getByText("No active or failed jobs"), { timeout: 5000 });
+  });
+});
+
+describe("LibraryApp queue polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const countJobFetches = (fetchMock: ReturnType<typeof vi.fn>) =>
+    fetchMock.mock.calls.filter((c) => String(c[0]) === "/api/library/jobs").length;
+
+  async function activateQueue(fetchMock: ReturnType<typeof makeFetchMock>["fetchMock"]) {
+    render(<LibraryApp windowId="test-win" />);
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+    // Flush mount effects + the initial queue fetch + interval arming.
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(0);
+    return fetchMock;
+  }
+
+  it("starts polling every 3s while jobs are active", async () => {
+    const activeJobs: LibraryJob[] = [
+      {
+        id: "job-active-1",
+        item_id: "lib-item-1",
+        stage: "metadata",
+        state: "processing",
+        error: "",
+        created_at: 1700007200,
+        updated_at: 1700007200,
+      },
+    ];
+    const { fetchMock } = makeFetchMock(() => activeJobs);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await activateQueue(fetchMock);
+
+    expect(countJobFetches(fetchMock)).toBeGreaterThanOrEqual(1);
+    const before = countJobFetches(fetchMock);
+
+    // A poll tick fires at the 3s interval and refetches.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(countJobFetches(fetchMock)).toBeGreaterThanOrEqual(before + 1);
+
+    // Another tick fires at the next 3s interval — polling continues while active.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(countJobFetches(fetchMock)).toBeGreaterThanOrEqual(before + 2);
+  });
+
+  it("stops polling once the queue goes idle", async () => {
+    let currentJobs: LibraryJob[] = [
+      {
+        id: "job-active-1",
+        item_id: "lib-item-1",
+        stage: "metadata",
+        state: "queued",
+        error: "",
+        created_at: 1700007200,
+        updated_at: 1700007200,
+      },
+    ];
+    const { fetchMock } = makeFetchMock(() => currentJobs);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await activateQueue(fetchMock);
+
+    // Let it poll a couple of times while still active.
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+    const activeCount = countJobFetches(fetchMock);
+    expect(activeCount).toBeGreaterThanOrEqual(1);
+
+    // Queue drains to idle (no queued/processing jobs) on the next poll.
+    currentJobs = [];
+
+    await vi.advanceTimersByTimeAsync(3000);
+    const afterIdle = countJobFetches(fetchMock);
+    expect(afterIdle).toBeGreaterThanOrEqual(activeCount + 1);
+
+    // No further refetches once idle — polling stopped.
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(countJobFetches(fetchMock)).toBe(afterIdle);
+  });
+
+  it("does not start polling when there are no active jobs", async () => {
+    const idleJobs: LibraryJob[] = [
+      {
+        id: "job-failed-1",
+        item_id: "lib-item-1",
+        stage: "transcript",
+        state: "error",
+        error: "boom",
+        created_at: 1700007100,
+        updated_at: 1700007100,
+      },
+    ];
+    const { fetchMock } = makeFetchMock(() => idleJobs);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await activateQueue(fetchMock);
+
+    await vi.advanceTimersByTimeAsync(0);
+    const initial = countJobFetches(fetchMock);
+    expect(initial).toBeGreaterThanOrEqual(1); // initial load happens
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+    // No poll ticks fire when there are no active jobs.
+    expect(countJobFetches(fetchMock)).toBe(initial);
+  });
+});

--- a/desktop/src/apps/LibraryApp.queue.test.tsx
+++ b/desktop/src/apps/LibraryApp.queue.test.tsx
@@ -161,6 +161,78 @@ describe("LibraryApp queue view", () => {
 
     await waitFor(() => screen.getByText("No active or failed jobs"), { timeout: 5000 });
   });
+
+  it("renders an unavailable state when the jobs endpoint returns 404", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url === "/api/library/jobs" && method === "GET") {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve({}),
+        } as Response);
+      }
+      if (method === "POST" && /^\/api\/library\/jobs\/[^/]+\/retry$/.test(url)) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve({}),
+        } as Response);
+      }
+
+      if (url.startsWith("/api/knowledge/items")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve({ items: [], count: 0 }),
+        } as Response);
+      }
+      if (url === "/api/agents") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      if (url === "/api/knowledge/subscriptions") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve({ subscriptions: [] }),
+        } as Response);
+      }
+      if (url === "/api/knowledge/rules") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Map([["content-type", "application/json"]]),
+          json: () => Promise.resolve({ rules: [] }),
+        } as Response);
+      }
+
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        headers: new Map([["content-type", "application/json"]]),
+        json: () => Promise.resolve({}),
+      } as Response);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    render(<LibraryApp windowId="test-win" />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "queue" }));
+
+    await waitFor(() => screen.getByText("Queue unavailable"), { timeout: 5000 });
+    expect(screen.queryByText("No active or failed jobs")).not.toBeInTheDocument();
+  });
 });
 
 describe("LibraryApp queue polling", () => {

--- a/desktop/src/apps/LibraryApp.tsx
+++ b/desktop/src/apps/LibraryApp.tsx
@@ -305,6 +305,7 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
   /* ---------- queue (ingest jobs) ---------- */
   const [jobs, setJobs] = useState<LibraryJob[]>([]);
   const [jobsLoading, setJobsLoading] = useState(false);
+  const [jobsUnavailable, setJobsUnavailable] = useState(false);
   const queuePollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const jobsLoadedRef = useRef(false);
 
@@ -423,10 +424,12 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
       const data = await listLibraryJobs();
       const next = Array.isArray(data?.jobs) ? data.jobs : [];
       setJobs(next);
+      setJobsUnavailable(false);
       jobsLoadedRef.current = true;
       return next;
     } catch {
       setJobs([]);
+      setJobsUnavailable(true);
       jobsLoadedRef.current = true;
       return [];
     } finally {
@@ -1448,12 +1451,16 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
       <div className="flex flex-col gap-2 px-4 py-3 border-b border-white/5 shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium">Ingest Queue</span>
-          <span className="text-[11px] text-shell-text-tertiary">(mock the POST until #2058)</span>
         </div>
         <div className="flex items-center gap-1.5 text-[11px] text-shell-text-tertiary">
-          {queuePolling ? (
+          {jobsUnavailable ? (
             <>
-              <span className="w-2 h-2 rounded-full bg-sky-400" aria-hidden="true" />
+              <span className="w-2 h-2 rounded-full bg-red-500" aria-hidden="true" />
+              <span>Unavailable</span>
+            </>
+          ) : queuePolling ? (
+            <>
+              <span className="w-2 h-2 rounded-full bg-accent" aria-hidden="true" />
               <span>Polling every 3s</span>
             </>
           ) : (
@@ -1467,6 +1474,11 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
       <div className="flex-1 overflow-y-auto p-3">
         {jobsLoading ? (
           <p className="text-xs text-shell-text-tertiary">Loading queue...</p>
+        ) : jobsUnavailable ? (
+          <div className="flex flex-col items-center justify-center h-full gap-3 text-shell-text-tertiary">
+            <AlertCircle size={36} className="opacity-30" />
+            <p className="text-sm">Queue unavailable</p>
+          </div>
         ) : displayableJobs.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full gap-3 text-shell-text-tertiary">
             <Clock size={36} className="opacity-30" />
@@ -1505,7 +1517,7 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
                       <Button
                         variant="outline"
                         size="sm"
-                        className="text-xs gap-1"
+                        className="text-xs gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                         onClick={() => handleRetryJob(job.id)}
                         aria-label={`Retry job ${job.id}`}
                       >

--- a/desktop/src/apps/LibraryApp.tsx
+++ b/desktop/src/apps/LibraryApp.tsx
@@ -47,6 +47,8 @@ import type {
   AgentSubscription,
   ListItemsParams,
 } from "@/lib/knowledge";
+import { listLibraryJobs, retryLibraryJob } from "@/lib/library";
+import type { LibraryJob } from "@/lib/library";
 import { useFocusTrap } from "@/hooks/use-focus-trap";
 import { useDragSource } from "@/shell/dnd/use-drag-source";
 
@@ -118,6 +120,30 @@ interface StorageViewData {
 }
 
 const STORAGE_CAP_BYTES = 50 * 1024 * 1024 * 1024;
+
+/* ------------------------------------------------------------------ */
+/*  Queue (ingest pipeline jobs)                                      */
+/* ------------------------------------------------------------------ */
+
+const POLL_INTERVAL_MS = 3000;
+const ACTIVE_JOB_STATES = new Set(["queued", "processing"]);
+const FAILED_JOB_STATE = "error";
+
+function isJobActive(state: string): boolean {
+  return ACTIVE_JOB_STATES.has(state);
+}
+
+function isJobActiveOrFailed(state: string): boolean {
+  return isJobActive(state) || state === FAILED_JOB_STATE;
+}
+
+function jobStateColor(state: string): string {
+  if (state === "queued") return "bg-blue-500/15 text-blue-400 border-blue-500/30";
+  if (state === "processing") return "bg-amber-500/15 text-amber-400 border-amber-500/30";
+  if (state === "error") return "bg-red-500/15 text-red-400 border-red-500/30";
+  if (state === "done" || state === "completed") return "bg-green-500/15 text-green-400 border-green-500/30";
+  return "bg-white/10 text-shell-text-tertiary border-white/10";
+}
 
 /* ------------------------------------------------------------------ */
 /*  Library Settings (mock contract until #2060)                       */
@@ -274,7 +300,13 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
     monitor: null,
   });
 
-  const [activeView, setActiveView] = useState<"items" | "storage" | "settings">("items");
+  const [activeView, setActiveView] = useState<"items" | "storage" | "settings" | "queue">("items");
+
+  /* ---------- queue (ingest jobs) ---------- */
+  const [jobs, setJobs] = useState<LibraryJob[]>([]);
+  const [jobsLoading, setJobsLoading] = useState(false);
+  const queuePollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const jobsLoadedRef = useRef(false);
 
   /* ---------- settings ---------- */
   const [settings, setSettings] = useState<LibrarySettings>(() => loadLibrarySettings());
@@ -379,6 +411,73 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
     const r = await listRules();
     setRules(r);
   }, []);
+
+  /* ---------- queue (ingest jobs) ---------- */
+
+  const queueActive = activeView === "queue";
+
+  const fetchJobs = useCallback(async () => {
+    const isInitial = !jobsLoadedRef.current;
+    if (isInitial) setJobsLoading(true);
+    try {
+      const data = await listLibraryJobs();
+      const next = Array.isArray(data?.jobs) ? data.jobs : [];
+      setJobs(next);
+      jobsLoadedRef.current = true;
+      return next;
+    } catch {
+      setJobs([]);
+      jobsLoadedRef.current = true;
+      return [];
+    } finally {
+      if (isInitial) setJobsLoading(false);
+    }
+  }, []);
+
+  // Poll every 3s while there are active jobs; stop once the queue is idle
+  // (no queued/processing jobs). Re-arming happens inside `tick` so the
+  // interval is created/destroyed deterministically as job state changes.
+  useEffect(() => {
+    if (!queueActive) {
+      if (queuePollRef.current) {
+        clearInterval(queuePollRef.current);
+        queuePollRef.current = null;
+      }
+      return;
+    }
+    let cancelled = false;
+
+    const tick = async () => {
+      const next = await fetchJobs();
+      if (cancelled) return;
+      const stillActive = next.some((j) => isJobActive(j.state));
+      if (stillActive && !queuePollRef.current) {
+        queuePollRef.current = setInterval(tick, POLL_INTERVAL_MS);
+      } else if (!stillActive && queuePollRef.current) {
+        clearInterval(queuePollRef.current);
+        queuePollRef.current = null;
+      }
+    };
+
+    void tick();
+    return () => {
+      cancelled = true;
+      if (queuePollRef.current) {
+        clearInterval(queuePollRef.current);
+        queuePollRef.current = null;
+      }
+    };
+  }, [queueActive, fetchJobs]);
+
+  const handleRetryJob = useCallback(
+    async (jobId: string) => {
+      const ok = await retryLibraryJob(jobId);
+      if (ok) {
+        void fetchJobs();
+      }
+    },
+    [fetchJobs],
+  );
 
   const openDetail = useCallback(
     async (item: KnowledgeItem) => {
@@ -768,7 +867,7 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
             </div>
           )}
           <div className="flex items-center gap-1 shrink-0" role="radiogroup" aria-label="View mode">
-            {(["items", "storage", "settings"] as const).map((v) => (
+            {(["items", "storage", "settings", "queue"] as const).map((v) => (
               <Button
                 key={v}
                 variant={activeView === v ? "secondary" : "ghost"}
@@ -1333,6 +1432,93 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
             </Button>
           </div>
         </section>
+      </div>
+    </main>
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Queue View UI (ingest pipeline jobs)                               */
+  /* ------------------------------------------------------------------ */
+
+  const queuePolling = queueActive && jobs.some((j) => isJobActive(j.state));
+  const displayableJobs = jobs.filter((j) => isJobActiveOrFailed(j.state));
+
+  const queueViewUI = (
+    <main className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex flex-col gap-2 px-4 py-3 border-b border-white/5 shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium">Ingest Queue</span>
+          <span className="text-[11px] text-shell-text-tertiary">(mock the POST until #2058)</span>
+        </div>
+        <div className="flex items-center gap-1.5 text-[11px] text-shell-text-tertiary">
+          {queuePolling ? (
+            <>
+              <span className="w-2 h-2 rounded-full bg-sky-400" aria-hidden="true" />
+              <span>Polling every 3s</span>
+            </>
+          ) : (
+            <>
+              <span className="w-2 h-2 rounded-full bg-shell-text-tertiary/50" aria-hidden="true" />
+              <span>Idle</span>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3">
+        {jobsLoading ? (
+          <p className="text-xs text-shell-text-tertiary">Loading queue...</p>
+        ) : displayableJobs.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full gap-3 text-shell-text-tertiary">
+            <Clock size={36} className="opacity-30" />
+            <p className="text-sm">No active or failed jobs</p>
+          </div>
+        ) : (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-shell-text-tertiary border-b border-white/5">
+                <th className="text-left pb-1.5 font-normal" scope="col">Stage</th>
+                <th className="text-left pb-1.5 font-normal" scope="col">Item</th>
+                <th className="text-left pb-1.5 font-normal" scope="col">State</th>
+                <th className="text-left pb-1.5 font-normal" scope="col">Error</th>
+                <th className="w-28 text-right pb-1.5 font-normal" scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {displayableJobs.map((job) => (
+                <tr key={job.id} className="border-t border-white/5">
+                  <td className="py-1.5 pr-2 text-shell-text-secondary font-mono">{job.stage || "—"}</td>
+                  <td className="py-1.5 pr-2 text-shell-text-tertiary truncate max-w-[140px]" title={job.item_id}>
+                    {job.item_id}
+                  </td>
+                  <td className="py-1.5 pr-2">
+                    <span
+                      className={`text-[10px] px-1.5 py-0.5 rounded border ${jobStateColor(job.state)}`}
+                    >
+                      {job.state}
+                    </span>
+                  </td>
+                  <td className="py-1.5 pr-2 text-shell-text-secondary break-words max-w-xs">
+                    {job.error || "—"}
+                  </td>
+                  <td className="py-1.5 text-right">
+                    {job.state === FAILED_JOB_STATE && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-xs gap-1"
+                        onClick={() => handleRetryJob(job.id)}
+                        aria-label={`Retry job ${job.id}`}
+                      >
+                        <RefreshCw size={11} />
+                        Retry
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </main>
   );
@@ -1924,6 +2110,8 @@ export function LibraryApp({ windowId: _windowId }: { windowId: string }) {
             </div>
           ) : activeView === "settings" ? (
             settingsViewUI
+          ) : activeView === "queue" ? (
+            queueViewUI
           ) : (
             storageViewUI
           )

--- a/desktop/src/lib/library.ts
+++ b/desktop/src/lib/library.ts
@@ -135,8 +135,8 @@ export interface ListLibraryJobsParams {
 }
 
 /** List ingest pipeline jobs (queued, processing, error, done, ...).
- *  The aggregated jobs endpoint lands in #2058; until then this resolves to an
- *  empty list when the route is unavailable.
+ *  Throws when the endpoint is unreachable so the caller can distinguish
+ *  "no jobs" from "route missing".
  */
 export async function listLibraryJobs(
   params?: ListLibraryJobsParams,
@@ -146,11 +146,17 @@ export async function listLibraryJobs(
   if (params?.limit != null) qs.set("limit", String(params.limit));
   const query = qs.toString();
   const url = `/api/library/jobs${query ? `?${query}` : ""}`;
-  const data = await fetchJson<{ jobs: LibraryJob[] }>(url, { jobs: [] });
+  const headers = new Headers();
+  headers.set("Accept", "application/json");
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`Library jobs endpoint returned ${res.status}`);
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("application/json")) throw new Error("Library jobs endpoint returned non-JSON");
+  const data = await res.json();
   return { jobs: Array.isArray(data.jobs) ? data.jobs : [] };
 }
 
-/** Retry a failed job. Mocks the POST until #2058 ships the real endpoint. */
+/** Retry a failed job. */
 export async function retryLibraryJob(jobId: string): Promise<boolean> {
   try {
     const res = await fetch(

--- a/desktop/src/lib/library.ts
+++ b/desktop/src/lib/library.ts
@@ -126,6 +126,44 @@ export async function reprocessLibraryItem(itemId: string): Promise<boolean> {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Jobs                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface ListLibraryJobsParams {
+  state?: string;
+  limit?: number;
+}
+
+/** List ingest pipeline jobs (queued, processing, error, done, ...).
+ *  The aggregated jobs endpoint lands in #2058; until then this resolves to an
+ *  empty list when the route is unavailable.
+ */
+export async function listLibraryJobs(
+  params?: ListLibraryJobsParams,
+): Promise<{ jobs: LibraryJob[] }> {
+  const qs = new URLSearchParams();
+  if (params?.state) qs.set("state", params.state);
+  if (params?.limit != null) qs.set("limit", String(params.limit));
+  const query = qs.toString();
+  const url = `/api/library/jobs${query ? `?${query}` : ""}`;
+  const data = await fetchJson<{ jobs: LibraryJob[] }>(url, { jobs: [] });
+  return { jobs: Array.isArray(data.jobs) ? data.jobs : [] };
+}
+
+/** Retry a failed job. Mocks the POST until #2058 ships the real endpoint. */
+export async function retryLibraryJob(jobId: string): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `/api/library/jobs/${encodeURIComponent(jobId)}/retry`,
+      withCsrf({ method: "POST", headers: { Accept: "application/json" } }),
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/* ------------------------------------------------------------------ */
 /*  Ingest                                                             */
 /* ------------------------------------------------------------------ */
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1086,6 +1086,73 @@ class TestLibraryRoutes:
         resp = await client.post(f"/api/library/items/{item_id}/reprocess")
         assert resp.status_code == 409
 
+    # -- Jobs endpoints --
+
+    @pytest.mark.asyncio
+    async def test_list_jobs_empty(self, client):
+        resp = await client.get("/api/library/jobs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "jobs" in data
+        assert data["jobs"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_jobs_filter_by_state(self, client, app):
+        """?state=error returns only error jobs, not jobs in other states."""
+        resp = await client.get("/api/library/jobs")
+        assert resp.status_code == 200
+        store = app.state.library_store
+        item_id = await store.create_item(kind="text", title="test")
+        error_job_id = await store.create_job(item_id, "ingest")
+        done_job_id = await store.create_job(item_id, "transcript")
+        await store.update_job(error_job_id, state="error", error="boom")
+        await store.update_job(done_job_id, state="done")
+
+        resp = await client.get("/api/library/jobs", params={"state": "error"})
+        assert resp.status_code == 200
+        data = resp.json()
+        returned_ids = {j["id"] for j in data["jobs"]}
+        assert error_job_id in returned_ids
+        assert done_job_id not in returned_ids
+
+    @pytest.mark.asyncio
+    async def test_retry_error_job(self, client, app):
+        """POST /api/library/jobs/{id}/retry re-queues an error job."""
+        resp = await client.get("/api/library/jobs")
+        assert resp.status_code == 200
+        store = app.state.library_store
+        item_id = await store.create_item(kind="text", title="test")
+        job_id = await store.create_job(item_id, "ingest")
+        await store.update_job(job_id, state="error", error="boom")
+
+        resp = await client.post(f"/api/library/jobs/{job_id}/retry")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["job_id"] == job_id
+        assert data["status"] == "queued"
+
+        job = await store.get_job(job_id)
+        assert job["state"] == "queued"
+        assert job["error"] == ""
+
+    @pytest.mark.asyncio
+    async def test_retry_unknown_job_returns_404(self, client):
+        resp = await client.post("/api/library/jobs/nonexistent/retry")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_retry_non_error_job_returns_409(self, client, app):
+        """Retrying a job that is not in error state is rejected."""
+        resp = await client.get("/api/library/jobs")
+        assert resp.status_code == 200
+        store = app.state.library_store
+        item_id = await store.create_item(kind="text", title="test")
+        job_id = await store.create_job(item_id, "ingest")
+        await store.update_job(job_id, state="done")
+
+        resp = await client.post(f"/api/library/jobs/{job_id}/retry")
+        assert resp.status_code == 409
+
 
 # ---------------------------------------------------------------------------
 # P3: LibraryStore — rules + storage accounting

--- a/tinyagentos/library_store.py
+++ b/tinyagentos/library_store.py
@@ -288,6 +288,26 @@ class LibraryStore(BaseStore):
             rows = await cursor.fetchall()
         return [dict(r) for r in rows]
 
+    async def list_jobs(
+        self, state: str | None = None, limit: int = 100,
+    ) -> list[dict]:
+        self._db.row_factory = aiosqlite.Row
+        where: list[str] = []
+        params: list = []
+        if state:
+            where.append("state = ?")
+            params.append(state)
+
+        sql = "SELECT * FROM library_jobs"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+
+        async with self._db.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+        return [dict(r) for r in rows]
+
     async def update_job(self, job_id: str, **kwargs) -> None:
         allowed = {"state", "error", "updated_at"}
         fields = [(k, v) for k, v in kwargs.items() if k in allowed]

--- a/tinyagentos/routes/library.py
+++ b/tinyagentos/routes/library.py
@@ -5,6 +5,8 @@ GET  /api/library/items   — list library items
 GET  /api/library/items/{item_id} — item detail with artifacts
 DELETE /api/library/items/{item_id} — remove item and its files
 POST /api/library/items/{item_id}/reprocess — re-run the pipeline
+GET  /api/library/jobs    — list processing jobs
+POST /api/library/jobs/{job_id}/retry — retry a failed job
 """
 
 from __future__ import annotations
@@ -333,6 +335,37 @@ async def delete_item(request: Request, item_id: str):
 
     await store.delete_item(item_id)
     return {"status": "deleted", "item_id": item_id}
+
+
+@router.get("/api/library/jobs")
+async def list_jobs(
+    request: Request,
+    state: str | None = None,
+    limit: int = 100,
+):
+    """List processing jobs, optionally filtered by state."""
+    store = await _get_library_store(request)
+    jobs = await store.list_jobs(state=state, limit=limit)
+    return {"jobs": jobs, "count": len(jobs)}
+
+
+@router.post("/api/library/jobs/{job_id}/retry")
+async def retry_job(request: Request, job_id: str):
+    """Retry a failed job. Returns 404 for unknown jobs and 409 for jobs
+    that are not in the error state."""
+    store = await _get_library_store(request)
+    job = await store.get_job(job_id)
+    if not job:
+        return JSONResponse({"error": f"Job {job_id!r} not found"}, status_code=404)
+
+    if job.get("state") != "error":
+        return JSONResponse(
+            {"error": f"Job {job_id!r} is not in error state (current: {job.get('state')})"},
+            status_code=409,
+        )
+
+    await store.update_job(job_id, state="queued", error="")
+    return {"job_id": job_id, "status": "queued"}
 
 
 @router.post("/api/library/items/{item_id}/reprocess")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2613: complete the ingest queue view -- GET /api/library/jobs and the retry route still do not exist

Autonomous build of board card tsk-sradu2.

REVISION: built on `exec/tsk-prbxsm` (cut at `97066faae67c8c4fc156a8931173588679c0a8f6`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

LibraryStore.list_jobs(state=None, limit=100) lists jobs across items
with optional state filter, newest first.

GET /api/library/jobs honours ?state= and ?limit= and returns
{"jobs": [...], "count": N}.

POST /api/library/jobs/{job_id}/retry re-queues a job in error state.
Returns 404 for unknown job ids and 409 for jobs not in error state.

Tests assert route existence against the real FastAPI app, state filter
correctness on returned ids, and that retry actually mutates job state.

Docs-Reviewed: no doc change needed, docs/agent-coordination.md has no
library routes section to update

Files:
 changelog.d/tsk-sradu2-ingest-queue-routes.md  |   3 +
 desktop/src/apps/LibraryApp.queue.test.tsx     | 352 +++++++++++++++++++++++++
 desktop/src/apps/LibraryApp.tsx                | 204 +++++++++++++-
 desktop/src/lib/library.ts                     |  44 ++++
 tests/test_library.py                          |  67 +++++
 tinyagentos/library_store.py                   |  20 ++
 tinyagentos/routes/library.py                  |  33 +++
 9 files changed, 726 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Library queue view showing active and failed ingest jobs, including stages, errors, and status.
  - Added retry actions for failed jobs.
  - Queue status refreshes automatically while processing is underway.
  - Added job-listing and retry API support.

- **Bug Fixes**
  - Added a distinct “Queue unavailable” state when job information cannot be loaded.
  - Retry operations now clearly handle unknown jobs and jobs that cannot be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->