### PR TITLE
fix-forward #2614: valid, absent and garbage credentials are byte-identical on an unknown route

### DIFF
--- a/changelog.d/tsk-hbzm7l-fix-route-enumeration.md
+++ b/changelog.d/tsk-hbzm7l-fix-route-enumeration.md
@@ -1,0 +1,2 @@
+### Fixed
+- Auth middleware now returns 404 for authenticated callers on unknown routes instead of 401. This fixes a bug where a wrong URL was indistinguishable from dead credentials. The auth middleware runs before routing, so previously routing failures were reported as auth failures. The fix allows validated credentials to continue to routing where unknown routes return 404, while unauthenticated callers still get 401 for anti-enumeration (issue #tsk-hbzm7l).

--- a/changelog.d/tsk-vylg2y-registry-jwt-unknown-route-404.md
+++ b/changelog.d/tsk-vylg2y-registry-jwt-unknown-route-404.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Auth middleware now returns 404 (not 401) for a valid registry JWT presented against a route that is not in the closed agent-token allowlist. This makes a wrong URL distinguishable from dead credentials while keeping the allowlist closed and preserving the anonymous 401.

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 from fastapi.responses import JSONResponse
 from starlette.responses import RedirectResponse
 
@@ -703,3 +705,127 @@ class TestDeviceBearerPassthroughBoundary:
         assert _is_device_bearer_path("POST", "/api/decisions/a/b/answer") is False
         assert _is_device_bearer_path("GET", "/api/settings") is False
         assert _is_device_bearer_path("POST", "/api/projects") is False
+
+
+def _registry_keypair() -> tuple[bytes, bytes]:
+    """Return (private_pem, public_pem) for a fresh Ed25519 keypair."""
+    private = Ed25519PrivateKey.generate()
+    private_pem = private.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=NoEncryption(),
+    )
+    public_pem = private.public_key().public_bytes(
+        encoding=Encoding.PEM,
+        format=PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _signed_registry_token(private_pem: bytes) -> str:
+    """Mint a registry JWT signed by *private_pem*."""
+    from tinyagentos.agent_registry_store import mint_registry_token
+    return mint_registry_token(
+        canonical_id="test-agent",
+        private_key_pem=private_pem,
+        user_id="",
+        framework="test",
+        project_id=None,
+    )
+
+
+class TestRegistryJwtUnknownRouteDispatch:
+    """Four assertions from tsk-vylg2y: valid cred, absent cred, garbage cred,
+    and skeleton-key control on an unlisted route that does exist."""
+
+    UNKNOWN_PATH = "/api/nonexistent/unknown-route"
+
+    def _app_state(self, *, public_pem: bytes | None = None) -> MagicMock:
+        state = MagicMock()
+        if public_pem is not None:
+            state.agent_registry_keypair = (b"private", public_pem)
+        else:
+            state.agent_registry_keypair = None
+        return state
+
+    @pytest.mark.asyncio
+    async def test_valid_registry_jwt_unknown_path_returns_404(self):
+        """RED: a real credential on an unlisted route must return 404 from
+        the middleware directly -- routing must NOT be reached."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": f"Bearer {token}"},
+        )
+        req.app.state = self._app_state(public_pem=public_pem)
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 404
+        assert resp.body == b'{"error":"Not Found"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_credential_unknown_path_returns_401(self):
+        """Control B: no credential on the same unknown path still returns
+        401.  A blanket 404 from the middleware would fail this test."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(path=self.UNKNOWN_PATH)
+        req.app.state = self._app_state()
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_garbage_bearer_unknown_path_returns_401(self):
+        """Control C: a forged/garbage bearer on the same unknown path still
+        returns 401.  Verifies the fix keys off a real credential, not merely
+        the presence of an Authorization header."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": "Bearer garbage-not-a-jwt"},
+        )
+        req.app.state = self._app_state()
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skeleton_key_registry_jwt_existing_non_allowlisted_route(self):
+        """Skeleton-key control: a valid registry JWT on a route that exists
+        but is NOT in the agent-token allowlist must NOT be routed.  The
+        handler must never run -- call_next must not be awaited.  A fix that
+        calls call_next for the 404 would fail here."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path="/api/system",  # exists but is NOT an _AGENT_TOKEN_PATHS entry
+            headers={"authorization": f"Bearer {token}"},
+        )
+        req.app.state = self._app_state(public_pem=public_pem)
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"system": "ok"}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 404
+        assert resp.body == b'{"error":"Not Found"}'
+        call_next.assert_not_awaited()

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -554,6 +554,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.user_id = None
                     request.state.is_admin = False
                     request.state.via = "local_token"
+                # We have validated the credential, so continue to routing
+                # Let unknown paths return 404 and known paths proceed normally
+                # This allows routing to distinguish between valid credentials
+                # and invalid ones, fixing the bug where unknown routes returned
+                # 401 for valid tokens.
                 return await call_next(request)
 
         # Agent-token endpoints (registry feeds + A2A bus proxy + project kanban)

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import HTMLResponse, RedirectResponse
 
+from tinyagentos.agent_registry_store import verify_registry_token
 from tinyagentos.auth import AuthStoreCorruptError
 from tinyagentos.device_store import DEVICE_TOKEN_PREFIX
 
@@ -282,6 +283,23 @@ def _is_agent_scope_request_path(method: str, path: str) -> bool:
     route verifies the JWT identity == canonical_id; approve/deny are excluded
     (extra path segments) and stay owner/admin session-only."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_SCOPE_REQUEST_ROUTES)
+
+
+def _looks_like_registry_jwt(token: str, public_key_pem: bytes) -> bool:
+    """Return True if *token* has a valid EdDSA signature against *public_key_pem*.
+
+    Verifies SIGNATURE ONLY -- no scope-grant check, no project binding, no
+    registry lookup. The result is used solely to distinguish a real credential
+    (404 for an unlisted route) from an anonymous or forged one (401), so a
+    wrong URL cannot be confused with dead credentials.
+    """
+    try:
+        verify_registry_token(token, public_key_pem)
+    except (ValueError, Exception):
+        return False
+    return True
+
+
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -639,5 +657,26 @@ class AuthMiddleware(BaseHTTPMiddleware):
         if "text/html" in accept:
             next_param = f"?next={path}" if path != "/" else ""
             return RedirectResponse(f"/auth/login{next_param}", status_code=303)
+
+        # A registry JWT presented for an unlisted route is a real credential
+        # pointing at the wrong URL.  Returning 404 here (without calling
+        # call_next) keeps the agent-token allowlist closed -- routing is never
+        # reached, so a registry JWT cannot authenticate any other route -- and
+        # gives the caller a response that is distinguishable from dead
+        # credentials (which still get 401).  The anonymous caller (no header,
+        # no session cookie) still falls through to 401 below.
+        if auth_header.lower().startswith("bearer "):
+            presented_bearer = auth_header[7:].strip()
+            if presented_bearer:
+                keypair = getattr(
+                    request.app.state, "agent_registry_keypair", None
+                )
+                if keypair is not None and _looks_like_registry_jwt(
+                    presented_bearer, keypair[1]
+                ):
+                    return JSONResponse(
+                        {"error": "Not Found"},
+                        status_code=404,
+                    )
 
         return JSONResponse({"error": "Authentication required"}, status_code=401)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2614: valid, absent and garbage credentials are byte-identical on an unknown route

Autonomous build of board card tsk-vylg2y.

REVISION: built on `exec/tsk-hbzm7l` (cut at `4b27a6f9b5932dc9b735f5679581d354cf27fcc2`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

A valid credential on an unlisted route previously hit the terminal 401
fallthrough in _dispatch, making a wrong URL byte-identical to dead
credentials. The fix verifies the registry JWT signature (signature only,
no scope check) when a Bearer header is present but no other credential
path matched; if the signature is valid and the route is not in the closed
agent-token allowlist the middleware returns 404 directly, keeping routing
unreached (no skeleton key) and keeping the anonymous 401 unchanged.

Four acceptance tests added: valid JWT+unknown path -> 404; no credential
-> 401; garbage bearer -> 401; valid JWT on an existing non-allowlisted
route -> 404 and call_next not awaited.

Docs-Reviewed: the agent-token route allowlist is unchanged; the new 404
response for unlisted routes is a middleware-layer anti-enumeration
enhancement, not an API surface change.

Files:
 changelog.d/tsk-hbzm7l-fix-route-enumeration.md    |   2 +
 .../tsk-vylg2y-registry-jwt-unknown-route-404.md   |   3 +
 tests/test_auth_middleware.py                      | 126 +++++++++++++++++++++
 tinyagentos/auth_middleware.py                     |  44 +++++++
 4 files changed, 175 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated requests to unknown or non-allowlisted routes now return **404 Not Found** instead of **401 Unauthorized**.
  * Requests with missing or invalid credentials continue to return **401 Unauthorized**.
  * Valid credentials still produce a direct 404 without invoking downstream route handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->