### PR TITLE
fix(desktop): invert arbitrary-value white-overlay utilities in the light theme

### DIFF
--- a/changelog.d/tsk-eqkpnt-light-theme-arbitrary-values.md
+++ b/changelog.d/tsk-eqkpnt-light-theme-arbitrary-values.md
@@ -1,0 +1,7 @@
+### Fixed
+- The light-theme compatibility layer now inverts arbitrary-value overlay
+  utilities (`bg-white/[0.04]`, `border-white/[0.06]`, and their hover
+  variants), not just the plain-fraction form (`bg-white/5`). The shared
+  primitives (card, button, tabs) and ~126 app surfaces used the
+  arbitrary-value form, which matched no attribute selector and so kept
+  additive white overlays that vanished on light backgrounds.

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -115,6 +115,31 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     }
   });
 
+  it("maps each arbitrary-value hover token to its inverted colour on :hover", () => {
+    // jsdom cannot apply :hover for getComputedStyle, so assert the exact
+    // declaration value inside the :hover rule — selector AND mapped colour —
+    // rather than only that the token's selector appears somewhere in the css.
+    // A regression that maps hover:bg-white/[0.06] to rgba(0, 0, 0, 0.05)
+    // would pass the selector-presence loop above but fail here.
+    const normalized = TOKENS_CSS.replace(/\s+/g, " ");
+    const hoverRules: Array<[string, string, string]> = [
+      ["hover:bg-white/[0.03]", "background-color", "rgba(0, 0, 0, 0.03)"],
+      ["hover:bg-white/[0.04]", "background-color", "rgba(0, 0, 0, 0.04)"],
+      ["hover:bg-white/[0.05]", "background-color", "rgba(0, 0, 0, 0.05)"],
+      ["hover:bg-white/[0.06]", "background-color", "rgba(0, 0, 0, 0.06)"],
+      ["hover:bg-white/[0.08]", "background-color", "rgba(0, 0, 0, 0.08)"],
+      ["hover:bg-white/[0.1]", "background-color", "rgba(0, 0, 0, 0.1)"],
+      ["hover:border-white/[0.06]", "border-color", "rgba(0, 0, 0, 0.06)"],
+    ];
+    for (const [token, property, value] of hoverRules) {
+      const rule = `[class~="${token}"]:hover { ${property}: ${value}; }`;
+      expect(
+        normalized,
+        `hover rule missing or mis-mapped for ${token}`,
+      ).toContain(rule);
+    }
+  });
+
   it("inverts the computed background across schemes (bg-white/[0.04])", () => {
     setScheme("dark");
     const dark = bgColor("bg-white/[0.04]");

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -12,8 +12,15 @@
 //   2. It reads tokens.css via node:fs and asserts the load actually happened —
 //      `import tokensCss from "../tokens.css"` returns an empty string under
 //      this repo's vitest config.
+//
+// A third trap is avoided by the coverage test: it DERIVES the covered overlay
+// set out of tokens.css and diffs it against what desktop/src actually uses,
+// rather than asserting against a hardcoded allowlist. An allowlist cannot fail
+// on a form it does not already enumerate, so the next new arbitrary-value
+// utility would slip past it blind; deriving the set from the source of truth
+// and scanning the real source keeps the guard honest.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 
 const TOKENS_CSS = readFileSync(
@@ -25,13 +32,37 @@ const TOKENS_CSS = readFileSync(
 // value `bg-white/[0.04]` compiles to a white-overlay rule; here we reproduce
 // that base rule (specificity (0,1,0)) so the tokens.css inversion
 // (:root[data-scheme="light"] …, specificity (0,3,0)) demonstrably overrides it
-// in light scheme and leaves it alone in dark scheme.
+// in light scheme and leaves it alone in dark scheme. The variant-prefixed and
+// divide forms get the same treatment so their inversion is asserted on
+// computed colour, not just on selector presence.
 const TAILWIND_BASE = `
 [class~="bg-white/[0.04]"] { background-color: rgba(255, 255, 255, 0.04); }
 [class~="bg-white/[0.02]"] { background-color: rgba(255, 255, 255, 0.02); }
 [class~="border-white/[0.06]"] { border-color: rgba(255, 255, 255, 0.06); }
 [class~="border-white/[0.18]"] { border-color: rgba(255, 255, 255, 0.18); }
+[class~="data-[state=active]:bg-white/[0.08]"][data-state="active"] { background-color: rgba(255, 255, 255, 0.08); }
+[class~="divide-white/[0.04]"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(255, 255, 255, 0.04); }
 `;
+
+// Walk desktop/src collecting every source module that can carry a class token,
+// skipping test files (their assertions are not rendered overlays) and the
+// node_modules/__tests__ subtrees.
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") continue;
+      out.push(...collectSourceFiles(p));
+    } else if (
+      /\.(tsx|ts|jsx|js)$/.test(entry.name) &&
+      !/\.test\.(tsx|ts|jsx|js)$/.test(entry.name)
+    ) {
+      out.push(p);
+    }
+  }
+  return out;
+}
 
 function injectCss(css: string): void {
   const style = document.createElement("style");
@@ -44,9 +75,10 @@ function setScheme(scheme: "light" | "dark" | null): void {
   else document.documentElement.setAttribute("data-scheme", scheme);
 }
 
-function bgColor(className: string): string {
+function bgColor(className: string, attrs: Record<string, string> = {}): string {
   const el = document.createElement("div");
   el.className = className;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
   document.body.appendChild(el);
   const color = window.getComputedStyle(el).backgroundColor;
   el.remove();
@@ -61,6 +93,22 @@ function borderColor(className: string): string {
   document.body.appendChild(el);
   const color = window.getComputedStyle(el).borderTopColor;
   el.remove();
+  return color;
+}
+
+// A divide utility colours the CHILD row separators, so measure the second
+// child's border-top colour, which is what `> :not([hidden]) ~ :not([hidden])`
+// targets in the emitted CSS.
+function divideColor(className: string): string {
+  const container = document.createElement("div");
+  container.className = className;
+  const first = document.createElement("div");
+  const second = document.createElement("div");
+  container.appendChild(first);
+  container.appendChild(second);
+  document.body.appendChild(container);
+  const color = window.getComputedStyle(second).borderTopColor;
+  container.remove();
   return color;
 }
 
@@ -84,35 +132,48 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     expect(TOKENS_CSS.length).toBeGreaterThan(1000);
   });
 
-  it("declares inversion rules for the arbitrary-value form", () => {
-    // Every distinct arbitrary-value overlay in the codebase must have a rule.
-    const required = [
-      "bg-white/[0.01]",
-      "bg-white/[0.02]",
-      "bg-white/[0.03]",
-      "bg-white/[0.04]",
-      "bg-white/[0.05]",
-      "bg-white/[0.06]",
-      "bg-white/[0.07]",
-      "bg-white/[0.08]",
-      "bg-white/[0.1]",
-      "border-white/[0.04]",
-      "border-white/[0.06]",
-      "border-white/[0.08]",
-      "border-white/[0.18]",
-      "hover:bg-white/[0.03]",
-      "hover:bg-white/[0.04]",
-      "hover:bg-white/[0.05]",
-      "hover:bg-white/[0.06]",
-      "hover:bg-white/[0.08]",
-      "hover:bg-white/[0.1]",
-      "hover:border-white/[0.06]",
-    ];
-    for (const token of required) {
-      expect(TOKENS_CSS, `missing inversion rule for ${token}`).toContain(
-        `[class~="${token}"]`,
-      );
+  // Trap #3: derive the covered overlay set straight out of tokens.css instead
+  // of restating it. `[class~="x"]` is the exact selector form the inversion
+  // layer uses, so every covered token — plain-fraction AND arbitrary-value —
+  // shows up here without a hand-maintained copy that can drift.
+  const COVERED_OVERLAYS = new Set(
+    Array.from(TOKENS_CSS.matchAll(/\[class~="([^"]+)"\]/g), (m) => m[1]),
+  );
+
+  it("reads a non-empty covered set out of tokens.css", () => {
+    // Guard the guard: an empty covered set would flag every overlay (noisy)
+    // and, worse, silently change what this test means.
+    expect(COVERED_OVERLAYS.size).toBeGreaterThan(10);
+    expect(COVERED_OVERLAYS.has("bg-white/[0.04]")).toBe(true);
+  });
+
+  it("declares inversion rules for every arbitrary-value white overlay used in desktop/src", () => {
+    // Scope to white overlays only: black overlays (e.g. bg-black/[0.18])
+    // already read on the light background and are deliberately not inverted.
+    const ARB_WHITE_RE =
+      /(?:^|:)(bg|text|border|ring|outline|shadow|divide|from|via|to)-white\/\[[^\]]*\]/;
+
+    const srcFiles = collectSourceFiles(resolve(process.cwd(), "src"));
+    expect(srcFiles.length).toBeGreaterThan(100);
+
+    const offenders = new Set<string>();
+    for (const file of srcFiles) {
+      const src = readFileSync(file, "utf8");
+      // Strip comments first: prose about `bg-white/[0.04]` is not a rendered
+      // overlay, and the file documents the very classes it avoids.
+      const code = src
+        .replace(/\/\*[\s\S]*?\*\//g, " ")
+        .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+      // Every whitespace/quote-delimited class token in the file, so an overlay
+      // added anywhere in the markup — including under a variant prefix like
+      // `data-[state=active]:` — is seen.
+      for (const tok of code.split(/[\s"'`{}()]+/)) {
+        if (ARB_WHITE_RE.test(tok) && !COVERED_OVERLAYS.has(tok)) {
+          offenders.add(tok);
+        }
+      }
     }
+    expect(Array.from(offenders)).toEqual([]);
   });
 
   it("maps each arbitrary-value hover token to its inverted colour on :hover", () => {
@@ -190,5 +251,35 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     for (const [className, expected] of cases) {
       expect(borderColor(className), className).toBe(expected);
     }
+  });
+
+  it("inverts the active-tab trigger only when data-state=active, and only in light scheme", () => {
+    // The class token `data-[state=active]:bg-white/[0.08]` is carried by every
+    // trigger; only the active one sets data-state="active". Dark must keep the
+    // white tint, light must flip it, and an inactive trigger must stay clear.
+    setScheme("dark");
+    const darkActive = bgColor("data-[state=active]:bg-white/[0.08]", {
+      "data-state": "active",
+    });
+    setScheme("light");
+    const lightActive = bgColor("data-[state=active]:bg-white/[0.08]", {
+      "data-state": "active",
+    });
+    const lightInactive = bgColor("data-[state=active]:bg-white/[0.08]", {
+      "data-state": "inactive",
+    });
+    expect(darkActive).toBe("rgba(255, 255, 255, 0.08)");
+    expect(lightActive).toBe("rgba(0, 0, 0, 0.08)");
+    expect(lightInactive).toBe("rgba(0, 0, 0, 0)");
+  });
+
+  it("inverts the divide row separators across schemes (divide-white/[0.04])", () => {
+    setScheme("dark");
+    const dark = divideColor("divide-white/[0.04]");
+    setScheme("light");
+    const light = divideColor("divide-white/[0.04]");
+    expect(dark).toBe("rgba(255, 255, 255, 0.04)");
+    expect(light).toBe("rgba(0, 0, 0, 0.04)");
+    expect(light).not.toBe(dark);
   });
 });

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -1,0 +1,169 @@
+// desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+//
+// Regression guard for the light-scheme gap in tokens.css. The compatibility
+// layer inverted the *plain-fraction* overlay utilities (bg-white/5, …) but
+// NOT the arbitrary-value form (bg-white/[0.04]) used by the shared primitives
+// (card, button, tabs) and ~126 app surfaces. This test proves the arbitrary
+// values now invert too.
+//
+// Two traps this test is built to avoid:
+//   1. It asserts on COMPUTED colour, never on the class name — the class is
+//      present in both schemes, so a class-name assertion could never fail.
+//   2. It reads tokens.css via node:fs and asserts the load actually happened —
+//      `import tokensCss from "../tokens.css"` returns an empty string under
+//      this repo's vitest config.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const TOKENS_CSS = readFileSync(
+  resolve(process.cwd(), "src/theme/tokens.css"),
+  "utf8",
+);
+
+// A stand-in for Tailwind's emitted utilities. In the real app the arbitrary
+// value `bg-white/[0.04]` compiles to a white-overlay rule; here we reproduce
+// that base rule (specificity (0,1,0)) so the tokens.css inversion
+// (:root[data-scheme="light"] …, specificity (0,3,0)) demonstrably overrides it
+// in light scheme and leaves it alone in dark scheme.
+const TAILWIND_BASE = `
+[class~="bg-white/[0.04]"] { background-color: rgba(255, 255, 255, 0.04); }
+[class~="bg-white/[0.02]"] { background-color: rgba(255, 255, 255, 0.02); }
+[class~="border-white/[0.06]"] { border-color: rgba(255, 255, 255, 0.06); }
+[class~="border-white/[0.18]"] { border-color: rgba(255, 255, 255, 0.18); }
+`;
+
+function injectCss(css: string): void {
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+function setScheme(scheme: "light" | "dark" | null): void {
+  if (scheme === null) document.documentElement.removeAttribute("data-scheme");
+  else document.documentElement.setAttribute("data-scheme", scheme);
+}
+
+function bgColor(className: string): string {
+  const el = document.createElement("div");
+  el.className = className;
+  document.body.appendChild(el);
+  const color = window.getComputedStyle(el).backgroundColor;
+  el.remove();
+  return color;
+}
+
+function borderColor(className: string): string {
+  const el = document.createElement("div");
+  el.className = className;
+  el.style.borderStyle = "solid";
+  el.style.borderWidth = "1px";
+  document.body.appendChild(el);
+  const color = window.getComputedStyle(el).borderTopColor;
+  el.remove();
+  return color;
+}
+
+beforeEach(() => {
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+  setScheme(null);
+  injectCss(TOKENS_CSS);
+  injectCss(TAILWIND_BASE);
+});
+
+afterEach(() => {
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+  setScheme(null);
+});
+
+describe("light-scheme arbitrary-value overlay inversion", () => {
+  it("loads tokens.css from disk (not an empty css import)", () => {
+    // Trap #2: a css raw import yields "" under vitest; node:fs must be used.
+    expect(TOKENS_CSS.length).toBeGreaterThan(1000);
+  });
+
+  it("declares inversion rules for the arbitrary-value form", () => {
+    // Every distinct arbitrary-value overlay in the codebase must have a rule.
+    const required = [
+      "bg-white/[0.01]",
+      "bg-white/[0.02]",
+      "bg-white/[0.03]",
+      "bg-white/[0.04]",
+      "bg-white/[0.05]",
+      "bg-white/[0.06]",
+      "bg-white/[0.07]",
+      "bg-white/[0.08]",
+      "bg-white/[0.1]",
+      "border-white/[0.04]",
+      "border-white/[0.06]",
+      "border-white/[0.08]",
+      "border-white/[0.18]",
+      "hover:bg-white/[0.03]",
+      "hover:bg-white/[0.04]",
+      "hover:bg-white/[0.05]",
+      "hover:bg-white/[0.06]",
+      "hover:bg-white/[0.08]",
+      "hover:bg-white/[0.1]",
+      "hover:border-white/[0.06]",
+    ];
+    for (const token of required) {
+      expect(TOKENS_CSS, `missing inversion rule for ${token}`).toContain(
+        `[class~="${token}"]`,
+      );
+    }
+  });
+
+  it("inverts the computed background across schemes (bg-white/[0.04])", () => {
+    setScheme("dark");
+    const dark = bgColor("bg-white/[0.04]");
+    setScheme("light");
+    const light = bgColor("bg-white/[0.04]");
+    // Dark keeps the additive white overlay; light flips to subtractive black.
+    expect(dark).toBe("rgba(255, 255, 255, 0.04)");
+    expect(light).toBe("rgba(0, 0, 0, 0.04)");
+    expect(light).not.toBe(dark);
+  });
+
+  it("inverts the computed border across schemes (border-white/[0.06])", () => {
+    setScheme("dark");
+    const dark = borderColor("border-white/[0.06]");
+    setScheme("light");
+    const light = borderColor("border-white/[0.06]");
+    expect(dark).toBe("rgba(255, 255, 255, 0.06)");
+    expect(light).toBe("rgba(0, 0, 0, 0.06)");
+    expect(light).not.toBe(dark);
+  });
+
+  it("inverts every arbitrary background value 1:1", () => {
+    const cases: Array<[string, string]> = [
+      ["bg-white/[0.01]", "rgba(0, 0, 0, 0.01)"],
+      ["bg-white/[0.02]", "rgba(0, 0, 0, 0.02)"],
+      ["bg-white/[0.03]", "rgba(0, 0, 0, 0.03)"],
+      ["bg-white/[0.04]", "rgba(0, 0, 0, 0.04)"],
+      ["bg-white/[0.05]", "rgba(0, 0, 0, 0.05)"],
+      ["bg-white/[0.06]", "rgba(0, 0, 0, 0.06)"],
+      ["bg-white/[0.07]", "rgba(0, 0, 0, 0.07)"],
+      ["bg-white/[0.08]", "rgba(0, 0, 0, 0.08)"],
+      ["bg-white/[0.1]", "rgba(0, 0, 0, 0.1)"],
+    ];
+    setScheme("light");
+    for (const [className, expected] of cases) {
+      expect(bgColor(className), className).toBe(expected);
+    }
+  });
+
+  it("inverts every arbitrary border value 1:1", () => {
+    const cases: Array<[string, string]> = [
+      ["border-white/[0.04]", "rgba(0, 0, 0, 0.04)"],
+      ["border-white/[0.06]", "rgba(0, 0, 0, 0.06)"],
+      ["border-white/[0.08]", "rgba(0, 0, 0, 0.08)"],
+      ["border-white/[0.18]", "rgba(0, 0, 0, 0.18)"],
+    ];
+    setScheme("light");
+    for (const [className, expected] of cases) {
+      expect(borderColor(className), className).toBe(expected);
+    }
+  });
+});

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -125,10 +125,27 @@
 :root[data-scheme="light"] [class~="bg-white/[0.08]"] { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="bg-white/[0.1]"]  { background-color: rgba(0, 0, 0, 0.1); }
 
+/* Variant-prefixed arbitrary overlay: TabsTrigger's active state uses
+   `data-[state=active]:bg-white/[0.08]`, a distinct class token that the bare
+   `[class~="bg-white/[0.08]"]` rule above does NOT match (the prefix is part
+   of the token). Without this the active tab keeps its white tint and vanishes
+   on the light background. Guard with [data-state] so only the *active* trigger
+   inverts — every trigger carries the class token, but only the active one sets
+   data-state="active". */
+:root[data-scheme="light"] [data-state="active"][class~="data-[state=active]:bg-white/[0.08]"] { background-color: rgba(0, 0, 0, 0.08); }
+
 :root[data-scheme="light"] [class~="border-white/[0.04]"] { border-color: rgba(0, 0, 0, 0.04); }
 :root[data-scheme="light"] [class~="border-white/[0.06]"] { border-color: rgba(0, 0, 0, 0.06); }
 :root[data-scheme="light"] [class~="border-white/[0.08]"] { border-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="border-white/[0.18]"] { border-color: rgba(0, 0, 0, 0.18); }
+
+/* Divide overlay: `divide-white/[0.04]` colours the row separators, which
+   Tailwind targets with `> :not([hidden]) ~ :not([hidden])` on the *children*
+   of the element carrying the class — not the element itself. The inversion
+   must re-target those same children, or the file/archive row dividers render
+   white-on-light and vanish. No plain-fraction `divide-white/N` rule exists, so
+   there is no arbitrary counterpart yet either; add it here. */
+:root[data-scheme="light"] [class~="divide-white/[0.04]"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(0, 0, 0, 0.04); }
 
 /* Slate accent fills — light-scheme values (mirror the approved Messages
    mockup): a touch cooler/darker so tinted surfaces and the unread badge

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -108,6 +108,28 @@
 :root[data-scheme="light"] [class~="text-white/20"] { color: rgba(0, 0, 0, 0.40); }
 :root[data-scheme="light"] [class~="text-white/15"] { color: rgba(0, 0, 0, 0.38); }
 
+/* Arbitrary-value overlays (bg-white/[0.04], border-white/[0.06], …).
+   The plain-fraction rules above cover `bg-white/5` & friends, but Tailwind's
+   arbitrary-value form produces a distinct class token that matches none of
+   those selectors — and the shared primitives (card, button, tabs) plus ~126
+   app surfaces use exactly this form. Invert 1:1: an additive white overlay at
+   alpha a becomes a subtractive black overlay at the same alpha, so it reads on
+   the light graphite background instead of vanishing. */
+:root[data-scheme="light"] [class~="bg-white/[0.01]"] { background-color: rgba(0, 0, 0, 0.01); }
+:root[data-scheme="light"] [class~="bg-white/[0.02]"] { background-color: rgba(0, 0, 0, 0.02); }
+:root[data-scheme="light"] [class~="bg-white/[0.03]"] { background-color: rgba(0, 0, 0, 0.03); }
+:root[data-scheme="light"] [class~="bg-white/[0.04]"] { background-color: rgba(0, 0, 0, 0.04); }
+:root[data-scheme="light"] [class~="bg-white/[0.05]"] { background-color: rgba(0, 0, 0, 0.05); }
+:root[data-scheme="light"] [class~="bg-white/[0.06]"] { background-color: rgba(0, 0, 0, 0.06); }
+:root[data-scheme="light"] [class~="bg-white/[0.07]"] { background-color: rgba(0, 0, 0, 0.07); }
+:root[data-scheme="light"] [class~="bg-white/[0.08]"] { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="bg-white/[0.1]"]  { background-color: rgba(0, 0, 0, 0.1); }
+
+:root[data-scheme="light"] [class~="border-white/[0.04]"] { border-color: rgba(0, 0, 0, 0.04); }
+:root[data-scheme="light"] [class~="border-white/[0.06]"] { border-color: rgba(0, 0, 0, 0.06); }
+:root[data-scheme="light"] [class~="border-white/[0.08]"] { border-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="border-white/[0.18]"] { border-color: rgba(0, 0, 0, 0.18); }
+
 /* Slate accent fills — light-scheme values (mirror the approved Messages
    mockup): a touch cooler/darker so tinted surfaces and the unread badge
    read correctly on the light graphite background. */
@@ -124,7 +146,15 @@
    does not flatten under the base-state override. */
 :root[data-scheme="light"] [class~="hover:bg-white/5"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="hover:bg-white/10"]:hover { background-color: rgba(0, 0, 0, 0.07); }
-:root[data-scheme="light"] [class~="hover:bg-white/[0.06]"]:hover { background-color: rgba(0, 0, 0, 0.05); }
+/* Arbitrary-value hover overlays — same 1:1 inversion as the base rules above,
+   so the hover affordance survives the light-scheme flip. */
+:root[data-scheme="light"] [class~="hover:bg-white/[0.03]"]:hover { background-color: rgba(0, 0, 0, 0.03); }
+:root[data-scheme="light"] [class~="hover:bg-white/[0.04]"]:hover { background-color: rgba(0, 0, 0, 0.04); }
+:root[data-scheme="light"] [class~="hover:bg-white/[0.05]"]:hover { background-color: rgba(0, 0, 0, 0.05); }
+:root[data-scheme="light"] [class~="hover:bg-white/[0.06]"]:hover { background-color: rgba(0, 0, 0, 0.06); }
+:root[data-scheme="light"] [class~="hover:bg-white/[0.08]"]:hover { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="hover:bg-white/[0.1]"]:hover  { background-color: rgba(0, 0, 0, 0.1); }
+:root[data-scheme="light"] [class~="hover:border-white/[0.06]"]:hover { border-color: rgba(0, 0, 0, 0.06); }
 
 /* Safari backdrop-filter repaint guard
    ====================================


### PR DESCRIPTION
## Summary

Fixes the light-theme gap across ~126 sites. `desktop/src/theme/tokens.css` inverts an enumerated set of overlay utilities via attribute-selector rules, but it covered only the **plain-fraction** form (`bg-white/5`, `border-white/10`, …). The **arbitrary-value** form (`bg-white/[0.04]`, `border-white/[0.06]`, …) produces a distinct class token that matches no attribute selector — and the shared primitives (`card`, `button`, `tabs`) plus ~126 app surfaces use exactly that uncovered form. Their additive white overlays therefore survived the light-scheme flip and vanished on the light graphite background.

## Change

- Added 1:1 white→black inversion rules in `tokens.css` for every distinct arbitrary-value overlay utility present in the codebase (base + hover; `bg` + `border`), keyed off the same `:root[data-scheme="light"]` gate so dark is untouched.
- Normalised the pre-existing `hover:bg-white/[0.06]` rule from `0.05` → `0.06` so the whole arbitrary-value set is consistently 1:1.
- Added a regression test (`desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts`) plus a changelog fragment.

## Acceptance / how it is tested

The test compares the **computed colour** across schemes — never the class name (the class is present in both light and dark, so a class-name assertion could never fail). It reads `tokens.css` via `node:fs` (a `css` raw import returns an empty string under this repo's vitest config) and asserts the load actually happened. `bg-white/[0.04]` computes `rgba(255,255,255,0.04)` in dark and `rgba(0,0,0,0.04)` in light; the same inversion is asserted for every arbitrary value.

Relevant frontend tests pass (`src/theme` + `src/components/ui`: 52/52).

## Merge gate

**Merge-gated — do NOT merge on a bot green.** jaylfc reviews and merges this personally (blast radius is every app's render).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved light-theme rendering for arbitrary-opacity white overlays.
  - Cards, buttons, tabs, borders, dividers, and hover states now display correctly against light backgrounds.
  - Corrected a hover overlay opacity mismatch for consistent styling.

- **Tests**
  - Added regression coverage for background, border, active-tab, divider, and hover behavior across themes.
  - Added checks to detect unsupported overlay variants.

- **Documentation**
  - Added a changelog entry describing the light-theme compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->