### PR TITLE
fix(gate): resolve deleted symbols through .py -> symlink typechange

### DIFF
--- a/changelog.d/tsk-qew5vk-deleted-symbols-symlink-typechange.md
+++ b/changelog.d/tsk-qew5vk-deleted-symbols-symlink-typechange.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The deleted-symbols gate no longer crashes or mis-resolves on a `.py -> symlink`
+  typechange. `_get_symbols_at_ref` now skips symlink/hardlink tar members (a symlink is
+  not a real source file, and `tarfile.extractfile` raises `KeyError` on a dangling
+  symlink target on Python 3.12+), and `_resolve_symbol` resolves a symlinked module to
+  its real target while pinning the result inside the extracted merge tree — a symlink
+  that escapes the tree (absolute target or `..`) is treated as not importable instead of
+  re-entering the working tree and crashing or mis-reporting.

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -115,6 +115,15 @@ def _get_symbols_at_ref(ref: str, repo_root: Path = REPO_ROOT) -> dict[str, str]
         for member in tar.getmembers():
             if not member.name.endswith(".py"):
                 continue
+            if member.issym() or member.islnk():
+                # A .py -> symlink typechange means this path is no longer a
+                # real source file: its symbols live at the link target. Skip
+                # it here (so the target's symbols are not attributed to the
+                # symlink path) and never call extractfile -- on a dangling
+                # symlink git archive emits no link target member and
+                # tarfile.extractfile raises KeyError (py3.12+), which is the
+                # "rc != 0, empty output" failure mode of this gate.
+                continue
             f = tar.extractfile(member)
             if f is None:
                 continue
@@ -169,6 +178,24 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
             abs_file = package_init
         else:
             return False
+
+    # Resolve symlinks so a .py -> symlink typechange loads the real target,
+    # and pin the resolved path inside the extracted merge tree. A symlink
+    # that escapes the tree (absolute target, or a relative target climbing
+    # out with `..`) would otherwise re-enter the working tree / installed
+    # package -- the exact editable-install path hook this loader exists to
+    # bypass -- producing wrong findings or a hard crash with no message.
+    # strict=False leaves a dangling target resolvable so the containment and
+    # is_file checks below classify it as not-importable instead of raising.
+    merge_root_resolved = merge_result_dir.resolve()
+    real_file = abs_file.resolve(strict=False)
+    try:
+        real_file.relative_to(merge_root_resolved)
+    except ValueError:
+        return False
+    if not real_file.is_file():
+        return False
+    abs_file = real_file
 
     name_parts = name.split(".")
     attr_name = name_parts[-1]

--- a/scripts/check_deleted_symbols.py
+++ b/scripts/check_deleted_symbols.py
@@ -195,7 +195,16 @@ def _resolve_symbol(merge_result_dir: Path, file_path: str, name: str) -> bool:
         return False
     if not real_file.is_file():
         return False
-    abs_file = real_file
+    # Preserve the logical path for a package initializer. Passing the
+    # resolved symlink target (e.g. _impl.py) to spec_from_file_location()
+    # loses the __init__.py name and disables package semantics, so a
+    # relative re-export inside the target raises ImportError and
+    # _resolve_symbol reports a false deletion. The logical path is already
+    # validated above (real_file is contained in the merge tree and is a
+    # regular file), so keeping it here is safe. Other files keep the
+    # resolved target so the loader reads the real content.
+    if abs_file.name != "__init__.py":
+        abs_file = real_file
 
     name_parts = name.split(".")
     attr_name = name_parts[-1]

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -397,6 +397,27 @@ class TestResolveSymbolSymlinkTypechange:
         finally:
             self._purge_package("tinyagentos")
 
+    def test_symlinked_package_init_keeps_relative_reexport(self, tmp_path: Path):
+        """A symlinked pkg/__init__.py that re-exports via a relative import
+        must keep package semantics. Resolving the symlink target (_impl.py)
+        before spec_from_file_location() strips the __init__.py name and turns
+        `from .child import func_a` into an ImportError, so _resolve_symbol
+        would report a false deletion. Preserving the logical __init__.py path
+        keeps package semantics and the symbol stays importable."""
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/_impl.py": "from .child import func_a\n",
+                "tinyagentos/child.py": "def func_a():\n    pass\n",
+            },
+        )
+        os.symlink("_impl.py", merge / "tinyagentos/__init__.py")
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/__init__.py", "func_a") is True
+        finally:
+            self._purge_package("tinyagentos")
+
 
 # ---------------------------------------------------------------------------
 # Integration tests with synthetic git repos (merge-result model)
@@ -791,7 +812,7 @@ class TestTypechangeSymlink:
         repo = tmp_path / "repo"
         base_tip = self._build(repo, "bar.py", bar_has_func=False)
 
-        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+        violations, _, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "func_a" in violations[0].symbol
@@ -805,7 +826,7 @@ class TestTypechangeSymlink:
         repo = tmp_path / "repo"
         base_tip = self._build(repo, "does_not_exist.py", bar_has_func=True)
 
-        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+        violations, _, _ = cds.check_deleted_symbols(base_tip, repo)
 
         assert len(violations) == 1
         assert "func_a" in violations[0].symbol

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -324,10 +324,32 @@ class TestResolveSymbolSymlinkTypechange:
         return root
 
     @staticmethod
-    def _purge_package(name: str) -> None:
+    def _purge_package(name: str) -> dict[str, tuple[bool, types.ModuleType | None]]:
+        """Remove every `name.*` module for the duration of a test, returning a
+        snapshot so the caller can restore them in a finally.
+
+        Snapshot each touched key's (was_present, old_obj) BEFORE deleting,
+        mirroring the `touched`/`preexisting_keys` discipline in _resolve_symbol.
+        Without the restore, the real tinyagentos.* modules stay evicted for the
+        rest of the pytest process: a later mock.patch("tinyagentos....") target
+        re-imports a DIFFERENT module object than the collection-time one and
+        silently no-ops -- the exact isolation defect that turned 56 unrelated
+        tests red.
+        """
+        touched: dict[str, tuple[bool, types.ModuleType | None]] = {}
         for key in list(sys.modules):
             if key == name or key.startswith(name + "."):
+                touched[key] = (key in sys.modules, sys.modules.get(key))
                 del sys.modules[key]
+        return touched
+
+    @staticmethod
+    def _restore_package(touched: dict[str, tuple[bool, types.ModuleType | None]]) -> None:
+        for key, (was_present, old_obj) in touched.items():
+            if was_present:
+                sys.modules[key] = old_obj
+            else:
+                sys.modules.pop(key, None)
 
     def test_in_tree_symlink_resolves_to_target(self, tmp_path: Path):
         """foo.py is a symlink to bar.py inside the merge tree: the symbol is
@@ -340,11 +362,11 @@ class TestResolveSymbolSymlinkTypechange:
             },
         )
         os.symlink("bar.py", merge / "tinyagentos/foo.py")
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is True
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
     def test_symlink_losing_symbol_is_deletion(self, tmp_path: Path):
         """foo.py symlinks to bar.py which no longer defines func_a: the symbol
@@ -357,11 +379,11 @@ class TestResolveSymbolSymlinkTypechange:
             },
         )
         os.symlink("bar.py", merge / "tinyagentos/foo.py")
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
     def test_symlink_escaping_tree_is_not_followed(self, tmp_path: Path):
         """A symlink whose target leaves the merge tree (absolute or ..) must
@@ -370,32 +392,32 @@ class TestResolveSymbolSymlinkTypechange:
         outside = tmp_path / "outside.py"
         outside.write_text("def func_a():\n    pass\n", encoding="utf-8")
         os.symlink(str(outside), merge / "tinyagentos/foo.py")  # absolute escape
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
     def test_dangling_symlink_is_not_importable(self, tmp_path: Path):
         """A dangling symlink resolves to no file: the symbol is gone."""
         merge = self._write_tree(tmp_path, {"tinyagentos/__init__.py": ""})
         os.symlink("does_not_exist.py", merge / "tinyagentos/foo.py")
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
     def test_self_loop_symlink_is_not_importable(self, tmp_path: Path):
         """A self-referential symlink must not hang or crash; it is simply not
         importable."""
         merge = self._write_tree(tmp_path, {"tinyagentos/__init__.py": ""})
         os.symlink("foo.py", merge / "tinyagentos/foo.py")
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
     def test_symlinked_package_init_keeps_relative_reexport(self, tmp_path: Path):
         """A symlinked pkg/__init__.py that re-exports via a relative import
@@ -412,11 +434,11 @@ class TestResolveSymbolSymlinkTypechange:
             },
         )
         os.symlink("_impl.py", merge / "tinyagentos/__init__.py")
-        self._purge_package("tinyagentos")
+        touched = self._purge_package("tinyagentos")
         try:
             assert cds._resolve_symbol(merge, "tinyagentos/__init__.py", "func_a") is True
         finally:
-            self._purge_package("tinyagentos")
+            self._restore_package(touched)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_deleted_symbols.py
+++ b/tests/test_check_deleted_symbols.py
@@ -53,6 +53,16 @@ def _delete_file(repo: Path, rel_path: str) -> None:
     _git(repo, "commit", "-m", f"refactor: delete {rel_path}")
 
 
+def _symlink_file(repo: Path, rel_path: str, target: str) -> None:
+    """Replace rel_path with a symlink to target (a .py -> symlink typechange)."""
+    full = repo / rel_path
+    if full.exists() or full.is_symlink():
+        full.unlink()
+    os.symlink(target, full)
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", f"typechange: {rel_path} -> symlink to {target}")
+
+
 def _branch(repo: Path, name: str) -> None:
     _git(repo, "branch", name)
 
@@ -294,6 +304,96 @@ class TestResolveSymbolIsolation:
             verdict_after_a = cds._resolve_symbol(merge, bar_file, bar_name)
 
             assert verdict_after_a == verdict_alone
+        finally:
+            self._purge_package("tinyagentos")
+
+
+class TestResolveSymbolSymlinkTypechange:
+    """_resolve_symbol must handle a .py -> symlink typechange in the merge
+    result: follow an in-tree symlink to its real target, but never follow a
+    symlink that escapes the extracted merge tree (the re-entry that loaded the
+    installed/working-tree copy and crashed or mis-reported)."""
+
+    @staticmethod
+    def _write_tree(tmp_path: Path, files: dict[str, str]) -> Path:
+        root = tmp_path / "merge"
+        for rel, content in files.items():
+            full = root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content, encoding="utf-8")
+        return root
+
+    @staticmethod
+    def _purge_package(name: str) -> None:
+        for key in list(sys.modules):
+            if key == name or key.startswith(name + "."):
+                del sys.modules[key]
+
+    def test_in_tree_symlink_resolves_to_target(self, tmp_path: Path):
+        """foo.py is a symlink to bar.py inside the merge tree: the symbol is
+        still importable through foo.py, so it is not a deletion."""
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/__init__.py": "",
+                "tinyagentos/bar.py": "def func_a():\n    pass\n",
+            },
+        )
+        os.symlink("bar.py", merge / "tinyagentos/foo.py")
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is True
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_symlink_losing_symbol_is_deletion(self, tmp_path: Path):
+        """foo.py symlinks to bar.py which no longer defines func_a: the symbol
+        is gone, so _resolve_symbol reports it as not importable."""
+        merge = self._write_tree(
+            tmp_path,
+            {
+                "tinyagentos/__init__.py": "",
+                "tinyagentos/bar.py": "def other():\n    pass\n",
+            },
+        )
+        os.symlink("bar.py", merge / "tinyagentos/foo.py")
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_symlink_escaping_tree_is_not_followed(self, tmp_path: Path):
+        """A symlink whose target leaves the merge tree (absolute or ..) must
+        not be followed: the outside file is not part of the merge result."""
+        merge = self._write_tree(tmp_path, {"tinyagentos/__init__.py": ""})
+        outside = tmp_path / "outside.py"
+        outside.write_text("def func_a():\n    pass\n", encoding="utf-8")
+        os.symlink(str(outside), merge / "tinyagentos/foo.py")  # absolute escape
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_dangling_symlink_is_not_importable(self, tmp_path: Path):
+        """A dangling symlink resolves to no file: the symbol is gone."""
+        merge = self._write_tree(tmp_path, {"tinyagentos/__init__.py": ""})
+        os.symlink("does_not_exist.py", merge / "tinyagentos/foo.py")
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
+        finally:
+            self._purge_package("tinyagentos")
+
+    def test_self_loop_symlink_is_not_importable(self, tmp_path: Path):
+        """A self-referential symlink must not hang or crash; it is simply not
+        importable."""
+        merge = self._write_tree(tmp_path, {"tinyagentos/__init__.py": ""})
+        os.symlink("foo.py", merge / "tinyagentos/foo.py")
+        self._purge_package("tinyagentos")
+        try:
+            assert cds._resolve_symbol(merge, "tinyagentos/foo.py", "func_a") is False
         finally:
             self._purge_package("tinyagentos")
 
@@ -652,6 +752,64 @@ class TestCheckDeletedSymbols:
         assert len(violations) == 1
         assert "function_b" in violations[0].symbol
         assert "tinyagentos/__init__.py" in violations[0].symbol
+        assert violations[0].added_by != "unknown"
+
+
+class TestTypechangeSymlink:
+    """A PR that turns a .py file into a symlink (typechange) must resolve
+    symbols through the merge result without re-entering the symlinked path and
+    without crashing (the historical rc=139 / empty-output fail-closed shape)."""
+
+    def _build(self, repo: Path, target: str, bar_has_func: bool) -> str:
+        _init_repo(repo)
+        _commit_file(repo, "tinyagentos/__init__.py", "", "init package")
+        bar_body = "def func_a():\n    pass\n" if bar_has_func else "def other():\n    pass\n"
+        _commit_file(repo, "tinyagentos/bar.py", bar_body, "init bar")
+        _commit_file(repo, "tinyagentos/foo.py", "def func_a():\n    pass\n", "init foo")
+        base_tip = _get_head(repo)
+        _branch(repo, "pr-branch")
+        _checkout(repo, "pr-branch")
+        _symlink_file(repo, "tinyagentos/foo.py", target)
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr-branch", "--no-edit")
+        return base_tip
+
+    def test_py_to_symlink_keeping_symbol_is_silent(self, tmp_path: Path):
+        """foo.py -> symlink to bar.py (which still defines func_a): func_a is
+        still importable through foo.py, so nothing is deleted."""
+        repo = tmp_path / "repo"
+        base_tip = self._build(repo, "bar.py", bar_has_func=True)
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert violations == []
+        assert waived == set()
+
+    def test_py_to_symlink_losing_symbol_fires(self, tmp_path: Path):
+        """foo.py -> symlink to bar.py (which no longer defines func_a): func_a
+        is genuinely deleted and the gate names it."""
+        repo = tmp_path / "repo"
+        base_tip = self._build(repo, "bar.py", bar_has_func=False)
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert len(violations) == 1
+        assert "func_a" in violations[0].symbol
+        assert "foo.py" in violations[0].symbol
+        assert violations[0].added_by != "unknown"
+
+    def test_py_to_dangling_symlink_fires_without_crash(self, tmp_path: Path):
+        """foo.py -> dangling symlink: the symbol is gone and, crucially, the
+        gate emits a finding instead of crashing on tarfile.extractfile's
+        KeyError (the rc!=0 / empty-output failure mode)."""
+        repo = tmp_path / "repo"
+        base_tip = self._build(repo, "does_not_exist.py", bar_has_func=True)
+
+        violations, waived, _ = cds.check_deleted_symbols(base_tip, repo)
+
+        assert len(violations) == 1
+        assert "func_a" in violations[0].symbol
+        assert "foo.py" in violations[0].symbol
         assert violations[0].added_by != "unknown"
 
 


### PR DESCRIPTION
## Root cause

The deleted-symbols gate mishandles a PR that turns a `.py` file into a symlink (a git *typechange*). Two defects compound:

1. **`_get_symbols_at_ref` reads every `.py`-named tar member as source.** A symlink member is not a real source file — its symbols live at the link target. Worse, on a *dangling* symlink `git archive` emits no link-target member, so `tarfile.extractfile` raises `KeyError` on Python 3.12+ (`_find_link_target`). The gate died with a traceback and **no symbol list** — the "fail-closed with no message" shape (rc≠0, empty output).

2. **`_resolve_symbol` lets `spec_from_file_location` follow a symlink unconstrained.** The module path is joined under the extracted merge tree, but a symlink that escapes it (absolute target, or `..` climbing out) resolves back to the working tree / installed package — the exact editable-install path hook this loader exists to bypass. That "re-entry through the symlinked path" produces wrong findings or a hard crash.

Note (per jaylfc's measurement on #2587): the gate does **not** always segfault — on a clean deletion it emits a correct finding with a full symbol list. rc=139 with empty output is one failure mode; the dangling-symlink `KeyError` and the escape-path mis-resolution are the concrete defects fixed here.

## Fix

- **`_get_symbols_at_ref`** skips symlink/hardlink members (`member.issym() / member.islnk()`), so the target's symbols are never attributed to the symlink path and `extractfile` is never called on a member without a link target.
- **`_resolve_symbol`** resolves the module path to its real target with `Path.resolve(strict=False)` and pins the result inside the extracted merge tree (`relative_to(merge_result_dir.resolve())`). An escaping or dangling target is classified as **not importable** (a genuine deletion), never loaded from outside the tree. Self-loop symlinks also resolve safely to "not importable".

## Regression tests

- `TestResolveSymbolSymlinkTypechange` (unit): in-tree symlink resolves to the target; symlink losing the symbol is a deletion; escaping symlink is **not** followed; dangling symlink is not importable; self-loop does not hang/crash.
- `TestTypechangeSymlink` (integration): `.py -> symlink` keeping the symbol is silent; losing the symbol fires and names it; dangling symlink fires **without** the `KeyError` crash.

## Test evidence

```
$ PYTHONPATH=. python3 -m pytest tests/test_check_deleted_symbols.py -q
42 passed in 2.04s
```

Red-first: reverting only `scripts/check_deleted_symbols.py` makes `test_symlink_escaping_tree_is_not_followed` (re-entry returns `True`) and `test_py_to_dangling_symlink_fires_without_crash` (KeyError) fail.

## Scope

`scripts/check_deleted_symbols.py` + `tests/test_check_deleted_symbols.py` + one changelog fragment. No behavior change for non-symlink paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deleted-symbol checks for Python files changed into symlinks or hard links.
  * Correctly resolves in-project symlinks while rejecting dangling, self-referential, or out-of-tree links.
  * Preserves package behavior and relative imports for symlinked package initializers.
  * Prevented crashes when processing archive entries with invalid or missing link targets.

* **Tests**
  * Added coverage for symlink type changes, package initializers, symbol detection, and unsafe link paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->