### PR TITLE
feat(projects): cross-project kanban aggregate read (Kanban Viewer S1)

### DIFF
--- a/changelog.d/2639-kanban-aggregate-read.md
+++ b/changelog.d/2639-kanban-aggregate-read.md
@@ -1,0 +1,2 @@
+### Added
+- New cross-project kanban aggregate read endpoint (`GET /api/projects/tasks/aggregate`) lets an authorized agent or session owner read tasks across all active projects they can access in a single call.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -345,6 +345,14 @@ The registry-JWT surface, by scope:
   `POST .../tasks/{id}/unquarantine` is also reachable, but LEAD-only: the
   route (`_authorize_project_lead`) refuses a plain project_tasks worker.
   It returns a quarantined card to the open pool and clears its strikes.
+  The cross-project aggregate `GET /api/projects/tasks/aggregate` (Kanban
+  Viewer S1) is also `project_tasks`: it returns EVERY project the caller may
+  see -- its own boards for a session owner/admin, or only the projects it
+  holds an active `project_tasks` grant for as an agent -- each with that
+  project's tasks. The grant (not the token's advisory `project_id` claim) is
+  the sole per-project gate, so an agent granted board A can never receive
+  board B in the aggregate. Optional `?status=open|claimed|closed` filters
+  tasks and is validated up front (400 on anything else).
 - **project_tasks_create**: `POST /api/projects/{pid}/tasks` (author new cards).
   This is a SEPARATE scope from project_tasks and is off by default; grant it
   explicitly when an agent needs to create cards.

--- a/tests/test_routes_project_tasks_aggregate.py
+++ b/tests/test_routes_project_tasks_aggregate.py
@@ -1,0 +1,276 @@
+"""Cross-project kanban aggregate (Kanban Viewer S1) authorization tests.
+
+``GET /api/projects/tasks/aggregate`` is a READ-ONLY cross-project board: it
+returns every project the caller is authorized to see, each with that project's
+tasks.  The whole risk is the aggregate leaking a project the caller is NOT
+entitled to, so these tests pin the authorization boundary hard -- a test that
+only proves an entitled caller sees their own board cannot fail on a leak, so
+every test here asserts the ABSENCE of the other project:
+
+  * a session owner entitled to project A must NOT receive project B;
+  * an agent holding ``project_tasks`` for A (and not B) must NOT receive B;
+  * an admin sees every active project's board (the one case allowed to span).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+from taos_test_csrf import csrf_event_hooks
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def members(client):
+    """Two non-admin member clients (alice, bob) sharing the admin `client` app.
+
+    Reuses the fully-initialised conftest `client` (which inits every store and
+    the admin user) and just adds two member identities + sessions on top.
+    """
+    app = client._transport.app
+    auth = app.state.auth
+
+    def _add(username: str, password: str) -> str:
+        invite = auth.add_user_invite(username, invited_by_username="admin")
+        auth.complete_invite(
+            username=username,
+            invite_code=invite,
+            full_name="Member User",
+            email=f"{username}@test.local",
+            password=password,
+        )
+        return auth.find_user(username)["id"]
+
+    alice_uid = _add("alice", "alicepass1")
+    bob_uid = _add("bob", "bobspass1")
+    alice_token = auth.create_session(user_id=alice_uid, long_lived=True)
+    bob_token = auth.create_session(user_id=bob_uid, long_lived=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": alice_token},
+        event_hooks=csrf_event_hooks(),
+    ) as alice:
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            cookies={"taos_session": bob_token},
+            event_hooks=csrf_event_hooks(),
+        ) as bob:
+            yield alice, bob
+
+
+@pytest_asyncio.fixture
+async def agent_ctx(client):
+    """Reuse the session-admin `client` and additionally init the agent registry
+    + grants stores so a project-bound token can be minted against real stores."""
+    app = client._transport.app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    yield SimpleNamespace(client=client, app=app)
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+def _bare(app):
+    """Cookieless client so requests carry only the Bearer header."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _new_project(client, slug: str) -> str:
+    resp = await client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _new_task(client, pid: str, title: str = "T") -> str:
+    resp = await client.post(f"/api/projects/{pid}/tasks", json={"title": title})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _mint_agent(ctx, project_id, scopes=("project_tasks",)):
+    registry = ctx.app.state.agent_registry
+    grants = ctx.app.state.agent_grants
+    priv, _pub = ctx.app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _project_ids(resp) -> set[str]:
+    assert resp.status_code == 200, resp.text
+    return {item["project_id"] for item in resp.json()["items"]}
+
+
+def _task_ids(resp, project_id: str) -> set[str]:
+    assert resp.status_code == 200, resp.text
+    for item in resp.json()["items"]:
+        if item["project_id"] == project_id:
+            return {t["id"] for t in item["tasks"]}
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# Session-owner authorization boundary
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_owner_aggregate_must_not_include_other_project(members):
+    """THE acceptance: alice entitled to A asks for the aggregate and must NOT
+    receive B.  A test that only checked "alice sees A" could not fail on a
+    leak, so this asserts BOTH that A is present and B is absent."""
+    alice, bob = members
+    pid_a = await _new_project(alice, "alpha")
+    tid_a = await _new_task(alice, pid_a, "alice task")
+    pid_b = await _new_project(bob, "bravo")
+    tid_b = await _new_task(bob, pid_b, "bob task")
+
+    resp = await alice.get("/api/projects/tasks/aggregate")
+
+    ids = _project_ids(resp)
+    assert pid_a in ids
+    assert pid_b not in ids
+    # A's board carries A's task; B's task is nowhere in the aggregate.
+    assert tid_a in _task_ids(resp, pid_a)
+    assert tid_b not in {t["id"] for it in resp.json()["items"] for t in it["tasks"]}
+
+
+@pytest.mark.asyncio
+async def test_owner_aggregate_empty_when_no_projects(members):
+    """A caller with no projects gets an empty aggregate, not an error."""
+    alice, bob = members
+    resp = await alice.get("/api/projects/tasks/aggregate")
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Aggregate shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_aggregate_shape(client):
+    """Each entry carries project_id / name / slug and a tasks array whose
+    entries carry a valid status (open | claimed | closed)."""
+    pid = await _new_project(client, "shape")
+    tid = await _new_task(client, pid, "shape task")
+
+    resp = await client.get("/api/projects/tasks/aggregate")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    item = items[0]
+    assert item["project_id"] == pid
+    assert item["name"] == "shape"
+    assert item["slug"] == "shape"
+    assert isinstance(item["tasks"], list)
+    assert len(item["tasks"]) == 1
+    task = item["tasks"][0]
+    assert task["id"] == tid
+    assert task["status"] in ("open", "claimed", "closed")
+
+
+@pytest.mark.asyncio
+async def test_aggregate_status_filter(client):
+    """The optional status query filters tasks to the requested status only."""
+    pid = await _new_project(client, "filter")
+    await _new_task(client, pid, "open one")
+    await _new_task(client, pid, "open two")
+
+    resp = await client.get("/api/projects/tasks/aggregate?status=open")
+    assert resp.status_code == 200
+    tasks = [t for it in resp.json()["items"] for t in it["tasks"]]
+    assert len(tasks) == 2
+    assert all(t["status"] == "open" for t in tasks)
+
+    resp = await client.get("/api/projects/tasks/aggregate?status=claimed")
+    assert resp.status_code == 200
+    tasks = [t for it in resp.json()["items"] for t in it["tasks"]]
+    assert tasks == []
+
+
+# ---------------------------------------------------------------------------
+# Admin sees all active projects
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_admin_sees_all_active_projects(members, client):
+    """The admin is entitled to every active project's board."""
+    alice, bob = members
+    pid_a = await _new_project(alice, "adm-alpha")
+    pid_b = await _new_project(bob, "adm-bravo")
+
+    resp = await client.get("/api/projects/tasks/aggregate")
+    ids = _project_ids(resp)
+    assert pid_a in ids
+    assert pid_b in ids
+
+
+# ---------------------------------------------------------------------------
+# Agent-token authorization boundary
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_agent_aggregate_must_not_include_ungranted_project(agent_ctx):
+    """An agent holding project_tasks for A (and not B) must see A's board and
+    NOT B's in the aggregate -- the grant is the sole per-project gate."""
+    pid_a = await _new_project(agent_ctx.client, "agent-alpha")
+    tid_a = await _new_task(agent_ctx.client, pid_a, "granted task")
+    pid_b = await _new_project(agent_ctx.client, "agent-bravo")
+    tid_b = await _new_task(agent_ctx.client, pid_b, "ungranted task")
+
+    _cid, token = await _mint_agent(agent_ctx, pid_a)
+
+    async with _bare(agent_ctx.app) as bare:
+        resp = await bare.get("/api/projects/tasks/aggregate", headers=_hdr(token))
+
+    ids = _project_ids(resp)
+    assert pid_a in ids
+    assert pid_b not in ids
+    assert tid_a in _task_ids(resp, pid_a)
+    assert tid_b not in {t["id"] for it in resp.json()["items"] for t in it["tasks"]}
+
+
+@pytest.mark.asyncio
+async def test_agent_aggregate_empty_without_project_tasks_grant(agent_ctx):
+    """An active agent with NO project_tasks grant sees an empty aggregate
+    (no leak, no crash)."""
+    pid = await _new_project(agent_ctx.client, "no-grant")
+    await _new_task(agent_ctx.client, pid)
+
+    _cid, token = await _mint_agent(agent_ctx, pid, scopes=("a2a_receive",))
+
+    async with _bare(agent_ctx.app) as bare:
+        resp = await bare.get("/api/projects/tasks/aggregate", headers=_hdr(token))
+
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []

--- a/tests/test_routes_project_tasks_aggregate.py
+++ b/tests/test_routes_project_tasks_aggregate.py
@@ -303,24 +303,34 @@ async def test_aggregate_rejects_invalid_status(client):
 @pytest.mark.asyncio
 async def test_aggregate_excludes_project_archived_after_listing(members, monkeypatch):
     """A project archived between the candidate listing and the per-project
-    check must NOT leak into the response (the 'active only' contract)."""
+    check must NOT leak into the response (the 'active only' contract).
+
+    This exercises the TOCTOU race itself: the candidate snapshot is captured
+    BEFORE the archive (so it still reports ``active``), the project is then
+    archived, and ``_caller_project_candidates`` hands back the stale snapshot.
+    The handler must re-read the FRESH project (via ``_authorize_task_actor``)
+    and exclude it, rather than trusting the stale ``active`` snapshot.
+    """
     alice, _bob = members
     pstore = alice._transport.app.state.project_store
     pid_keep = await _new_project(alice, "keep-active")
     await _new_task(alice, pid_keep, "kept")
     pid_arch = await _new_project(alice, "archive-me")
     await _new_task(alice, pid_arch, "archived")
+
+    # Capture the snapshot BEFORE archiving so it still reports "active".
+    arch_snapshot = await pstore.get_project(pid_arch)
+    assert arch_snapshot["status"] == "active"
+    # ...THEN the race: the project is archived after the listing ran.
     await pstore.set_status(pid_arch, "archived")
     keep = await pstore.get_project(pid_keep)
-    arch = await pstore.get_project(pid_arch)
-    assert arch["status"] == "archived"
 
     import tinyagentos.routes.projects as prj
 
     async def _fake_candidates(request, _pstore):
         # Simulate a listing that ran BEFORE the archive and still returns the
-        # now-archived project alongside the active one.
-        return [keep, arch], None, None
+        # now-stale "active" snapshot alongside the active project.
+        return [keep, arch_snapshot], None, None
 
     monkeypatch.setattr(prj, "_caller_project_candidates", _fake_candidates)
 

--- a/tests/test_routes_project_tasks_aggregate.py
+++ b/tests/test_routes_project_tasks_aggregate.py
@@ -274,3 +274,91 @@ async def test_agent_aggregate_empty_without_project_tasks_grant(agent_ctx):
 
     assert resp.status_code == 200
     assert resp.json()["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: status enum validation (Kilo #1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_aggregate_rejects_invalid_status(client):
+    """A status outside open|claimed|closed is rejected 400 up front, not
+    silently filtered to an empty board (which would hide a caller's typo)."""
+    pid = await _new_project(client, "bad-status")
+    await _new_task(client, pid, "t")
+
+    resp = await client.get("/api/projects/tasks/aggregate?status=garbage")
+    assert resp.status_code == 400
+
+    # The documented enum still passes (validation is exact, not over-broad).
+    for ok in ("open", "claimed", "closed"):
+        r = await client.get(f"/api/projects/tasks/aggregate?status={ok}")
+        assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Regression: archived-project exclusion inside the loop (Kilo #3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_aggregate_excludes_project_archived_after_listing(members, monkeypatch):
+    """A project archived between the candidate listing and the per-project
+    check must NOT leak into the response (the 'active only' contract)."""
+    alice, _bob = members
+    pstore = alice._transport.app.state.project_store
+    pid_keep = await _new_project(alice, "keep-active")
+    await _new_task(alice, pid_keep, "kept")
+    pid_arch = await _new_project(alice, "archive-me")
+    await _new_task(alice, pid_arch, "archived")
+    await pstore.set_status(pid_arch, "archived")
+    keep = await pstore.get_project(pid_keep)
+    arch = await pstore.get_project(pid_arch)
+    assert arch["status"] == "archived"
+
+    import tinyagentos.routes.projects as prj
+
+    async def _fake_candidates(request, _pstore):
+        # Simulate a listing that ran BEFORE the archive and still returns the
+        # now-archived project alongside the active one.
+        return [keep, arch], None, None
+
+    monkeypatch.setattr(prj, "_caller_project_candidates", _fake_candidates)
+
+    resp = await alice.get("/api/projects/tasks/aggregate")
+    assert resp.status_code == 200
+    ids = _project_ids(resp)
+    assert pid_keep in ids
+    assert pid_arch not in ids
+
+
+# ---------------------------------------------------------------------------
+# Regression: per-project authorization failure is skipped, not raised (Kilo #4)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_aggregate_skips_project_on_auth_failure(client, monkeypatch):
+    """A per-project authorization failure (e.g. agent suspended, token
+    superseded, grant revoked mid-iteration) skips that project instead of
+    aborting the whole aggregate with an unhandled 403/500."""
+    pid_ok = await _new_project(client, "auth-ok")
+    await _new_task(client, pid_ok, "kept")
+    pid_bad = await _new_project(client, "auth-bad")
+    await _new_task(client, pid_bad, "dropped")
+
+    import tinyagentos.routes.projects as prj
+    from fastapi import HTTPException
+
+    real = prj._authorize_task_actor
+
+    async def _flaky(request, pstore, project_id, **kwargs):
+        if project_id == pid_bad:
+            raise HTTPException(status_code=403, detail="agent is not active in the registry")
+        return await real(request, pstore, project_id, **kwargs)
+
+    monkeypatch.setattr(prj, "_authorize_task_actor", _flaky)
+
+    resp = await client.get("/api/projects/tasks/aggregate")
+    assert resp.status_code == 200
+    ids = _project_ids(resp)
+    assert pid_ok in ids
+    assert pid_bad not in ids

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -246,3 +246,64 @@ async def check_agent_scope_for_project(
     if not grant_ok:
         raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
     return canonical_id
+
+
+async def check_agent_project_grants(
+    request: Request, required_scope: str
+) -> tuple[Optional[str], dict[str, dict]]:
+    """Resolve an agent's project-bound grants with ONE grant-store read.
+
+    This is the cross-project sibling of ``check_agent_scope_for_project``: it
+    performs the SAME full identity chain (EdDSA signature, active registry
+    record, rotation cutoff) exactly once, then returns every ACTIVE grant of
+    ``required_scope`` keyed by ``project_id`` so a caller can authorize many
+    projects in O(1) per project instead of re-fetching ``list_grants`` and
+    re-verifying the token for each one (the N+1 that a multi-project aggregate
+    would otherwise pay).
+
+    Returns ``(canonical_id, {project_id: grant})``, or ``(None, {})`` when no
+    Authorization header is present (the caller falls through to its own
+    session/admin handling).
+
+    Raises:
+      401/403 -- exactly as ``check_agent_scope`` (bad/inactive/superseded token).
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None, {}
+
+    raw_token = auth_header[7:].strip()
+    _private_pem, public_pem = _get_keypair(request)
+    try:
+        payload = verify_registry_token(raw_token, public_pem)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
+
+    canonical_id: str = payload.get("sub", "")
+    if not canonical_id:
+        raise HTTPException(status_code=401, detail="token missing sub claim")
+
+    registry = _get_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        raise HTTPException(status_code=403, detail="agent is not active in the registry")
+
+    token_min_iat = record.get("token_min_iat") or 0
+    token_iat = payload.get("iat") or 0
+    if token_iat < token_min_iat:
+        raise HTTPException(status_code=401, detail="token superseded")
+
+    grants_store = _get_grants_store(request)
+    grants = await grants_store.list_grants(canonical_id)
+    now = datetime.now(timezone.utc)
+    by_project: dict[str, dict] = {}
+    for g in grants:
+        if g.get("scope") != required_scope:
+            continue
+        pid = g.get("project_id")
+        if not pid:
+            continue
+        if not _grant_unexpired(g.get("expires_at"), now):
+            continue
+        by_project[pid] = g
+    return canonical_id, by_project

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -77,7 +77,7 @@ _AGENT_TASK_ROUTES = (
     # segment) that returns every board the token holds a project_tasks grant
     # for. Reaching the handler is not authorization -- it verifies the JWT +
     # per-project grant via _authorize_task_actor for every candidate project.
-    ("GET", re.compile(rf"^/api/projects/tasks/aggregate$")),
+    ("GET", re.compile(r"^/api/projects/tasks/aggregate$")),
     # Task CREATION, gated by the SEPARATE project_tasks_create scope (not
     # project_tasks, which stays read + lifecycle + comments per Invariant 2+5).
     # Reaching the handler is not authorisation: it then verifies the JWT, the

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -73,6 +73,11 @@ _AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE
 _SEG = r"[^/]+"
 _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks$")),
+    # Cross-project kanban aggregate (READ ONLY): a static path (no project
+    # segment) that returns every board the token holds a project_tasks grant
+    # for. Reaching the handler is not authorization -- it verifies the JWT +
+    # per-project grant via _authorize_task_actor for every candidate project.
+    ("GET", re.compile(rf"^/api/projects/tasks/aggregate$")),
     # Task CREATION, gated by the SEPARATE project_tasks_create scope (not
     # project_tasks, which stays read + lifecycle + comments per Invariant 2+5).
     # Reaching the handler is not authorisation: it then verifies the JWT, the

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -7,7 +7,6 @@ import uuid
 
 import asyncio as _asyncio
 import json as _json
-from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -15,9 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from tinyagentos.agent_token_auth import (
     PROJECT_SCOPE_MISMATCH_DETAIL,
-    _get_grants_store,
-    _grant_unexpired,
-    check_agent_identity,
+    check_agent_project_grants,
     check_agent_scope_for_project,
 )
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
@@ -33,6 +30,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+# The documented task status enum surfaced by the kanban read endpoints.  The
+# store itself is more permissive internally (it also tracks ``cancelled`` and
+# ``quarantined``), but the READ/aggregate API surface only advertises these
+# three and must reject anything else rather than silently filter to an empty
+# list (which would hide a caller's typo).
+_TASK_STATUS_ENUM = ("open", "claimed", "closed")
 
 
 async def _is_field_free(store, field: str, value: str) -> bool:
@@ -555,7 +559,12 @@ async def _require_task_in_project(
 
 
 async def _authorize_task_actor(
-    request: Request, pstore, project_id: str, scope: str = "project_tasks"
+    request: Request,
+    pstore,
+    project_id: str,
+    scope: str = "project_tasks",
+    agent_grants: "dict[str, dict] | None" = None,
+    agent_canonical_id: "str | None" = None,
 ) -> "tuple[str, bool, dict] | JSONResponse":
     """Resolve the actor for a task route that accepts EITHER a session
     owner/admin OR an approved external agent's registry JWT holding ``scope``
@@ -564,6 +573,16 @@ async def _authorize_task_actor(
     ``scope`` is a parameter because authoring uses a SEPARATE, narrower grant
     (``project_tasks_create``): project_tasks is documented and tested as read
     plus lifecycle plus comments, so creation must not ride on it.
+
+    ``agent_grants`` / ``agent_canonical_id`` are an optional fast path for the
+    cross-project aggregate: the caller resolves the agent's identity + grant
+    map ONCE (via ``check_agent_project_grants``) and passes the ``{project_id:
+    grant}`` lookup here so the per-project authorization is an O(1) dict
+    membership instead of re-verifying the token and re-fetching
+    ``list_grants`` for every project (an O(K) grant-store N+1).  The security
+    invariants are unchanged -- membership in the pre-built map is exactly the
+    same active-grant-bound-to-project predicate ``check_agent_scope_for_project``
+    enforces, and the identity/active/rotation checks already ran once upstream.
 
     Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
     return directly.  These routes take ``request: Request`` and auth INSIDE the
@@ -586,6 +605,20 @@ async def _authorize_task_actor(
         if isinstance(project_or_err, JSONResponse):
             return project_or_err
         return (user.user_id, False, project_or_err)
+
+    if agent_grants is not None:
+        # Grant-aware fast path (aggregate): the caller already verified the
+        # agent and built the active project_tasks -> grant map once.  A missing
+        # entry means "no active grant bound to this project" -> same
+        # existence-hiding 404 as the slow path, so it never confirms a
+        # project the agent is not entitled to.
+        assert agent_canonical_id is not None, "canonical_id required with agent_grants"
+        if project_id not in agent_grants:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        project = await pstore.get_project(project_id)
+        if project is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return (agent_canonical_id, True, project)
 
     try:
         caller = await check_agent_scope_for_project(
@@ -754,7 +787,9 @@ async def list_tasks(
     return {"items": await store.list_tasks(project_id=project_id, status=status, element_id=element_id)}
 
 
-async def _caller_project_candidates(request: Request, pstore) -> list[dict]:
+async def _caller_project_candidates(
+    request: Request, pstore
+) -> "tuple[list[dict], dict[str, dict] | None, str | None]":
     """Candidate projects for the cross-project kanban aggregate.
 
     This is scoped ENUMERATION, not authorization: it returns only projects the
@@ -770,6 +805,13 @@ async def _caller_project_candidates(request: Request, pstore) -> list[dict]:
     A caller with neither a session nor a Bearer never reaches this helper (the
     auth middleware 401s first), so the empty fallbacks below are belt-and-braces
     rather than the primary gate.
+
+    Returns ``(projects, agent_grants, canonical_id)``: for a session
+    owner/admin the last two are ``(None, None)``; for a registry-JWT agent
+    ``agent_grants`` is the active ``project_tasks`` -> grant map resolved by a
+    SINGLE ``check_agent_project_grants`` call (so the aggregate's per-project
+    re-check is O(1) rather than an O(K) grant-store N+1), and ``canonical_id``
+    is the verified agent identity.
     """
     uid = getattr(request.state, "user_id", None)
     if uid:
@@ -777,35 +819,23 @@ async def _caller_project_candidates(request: Request, pstore) -> list[dict]:
             user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
         )
         if user.is_admin:
-            return await pstore.list_projects(status="active")
-        return await pstore.list_for_user(uid, status="active")
+            return await pstore.list_projects(status="active"), None, None
+        return await pstore.list_for_user(uid, status="active"), None, None
 
     # No session: a registry-JWT agent (the middleware only passes a Bearer
     # through on the allowlist and leaves user_id=None).  Resolve WHO the agent
-    # is, then enumerate the projects it holds an active project_tasks grant for.
-    canonical_id = await check_agent_identity(request)
+    # is AND its active project_tasks grants in one grant-store read.
+    canonical_id, grants_by_project = await check_agent_project_grants(
+        request, "project_tasks"
+    )
     if not canonical_id:
-        return []
-    grants_store = _get_grants_store(request)
-    grants = await grants_store.list_grants(canonical_id)
-    now = datetime.now(timezone.utc)
-    project_ids: list[str] = []
-    for g in grants:
-        if g.get("scope") != "project_tasks":
-            continue
-        pid = g.get("project_id")
-        if not pid:
-            continue
-        if not _grant_unexpired(g.get("expires_at"), now):
-            continue
-        if pid not in project_ids:
-            project_ids.append(pid)
+        return [], None, None
     projects: list[dict] = []
-    for pid in project_ids:
+    for pid in grants_by_project:
         p = await pstore.get_project(pid)
         if p is not None:
             projects.append(p)
-    return projects
+    return projects, grants_by_project, canonical_id
 
 
 @router.get("/api/projects/tasks/aggregate")
@@ -821,18 +851,49 @@ async def list_tasks_aggregate(
     ``_authorize_task_actor`` gate is applied to EVERY candidate, so a caller
     entitled to project A can never receive project B in the aggregate (the
     whole point of this endpoint).  ``status`` filters tasks to
-    ``open`` / ``claimed`` / ``closed``.
+    ``open`` / ``claimed`` / ``closed`` and is validated up front (400 on
+    anything else), so a typo is surfaced rather than silently returning an
+    empty board.
     """
+    if status is not None and status not in _TASK_STATUS_ENUM:
+        return JSONResponse(
+            {"error": f"invalid status {status!r}; must be one of open|claimed|closed"},
+            status_code=400,
+        )
     pstore = request.app.state.project_store
     store = request.app.state.project_task_store
+    candidates, agent_grants, agent_canonical_id = await _caller_project_candidates(
+        request, pstore
+    )
     items: list[dict] = []
-    for project in await _caller_project_candidates(request, pstore):
-        auth = await _authorize_task_actor(
-            request, pstore, project["id"], scope="project_tasks"
-        )
+    for project in candidates:
+        # The agent's grant map (and canonical_id) is resolved ONCE upstream and
+        # reused here so the per-project check is O(1); for a session caller
+        # agent_grants is None and _authorize_task_actor takes its normal path.
+        try:
+            auth = await _authorize_task_actor(
+                request,
+                pstore,
+                project["id"],
+                scope="project_tasks",
+                agent_grants=agent_grants,
+                agent_canonical_id=agent_canonical_id,
+            )
+        except HTTPException:
+            # Any per-project authorization failure (agent not active, token
+            # superseded, grant revoked mid-iteration, ...) is swallowed: a
+            # project the caller is not entitled to is simply omitted rather
+            # than aborting the whole aggregate with an unhandled 403/500 after
+            # some boards were already collected.
+            continue
         if isinstance(auth, JSONResponse):
             # Not authorized for THIS project -> excluded from the aggregate, so
             # it cannot leak another project's board to the caller.
+            continue
+        # Re-check status inside the loop (TOCTOU defence): a project archived
+        # between the candidate listing and this per-project check must NOT leak
+        # into the response -- the aggregate contract is "active projects only".
+        if project.get("status") != "active":
             continue
         tasks = await store.list_tasks(project_id=project["id"], status=status)
         items.append(

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -7,6 +7,7 @@ import uuid
 
 import asyncio as _asyncio
 import json as _json
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -14,6 +15,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from tinyagentos.agent_token_auth import (
     PROJECT_SCOPE_MISMATCH_DETAIL,
+    _get_grants_store,
+    _grant_unexpired,
+    check_agent_identity,
     check_agent_scope_for_project,
 )
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
@@ -748,6 +752,98 @@ async def list_tasks(
         return auth
     store = request.app.state.project_task_store
     return {"items": await store.list_tasks(project_id=project_id, status=status, element_id=element_id)}
+
+
+async def _caller_project_candidates(request: Request, pstore) -> list[dict]:
+    """Candidate projects for the cross-project kanban aggregate.
+
+    This is scoped ENUMERATION, not authorization: it returns only projects the
+    caller could already name for itself, and the per-project
+    ``_authorize_task_actor`` gate applied by the aggregate route remains the
+    authoritative check (defence in depth).  It must never surface a project the
+    caller is not entitled to:
+
+      * session owner/admin -> own projects (``list_for_user``) or all (admin);
+      * registry-JWT agent   -> only projects it holds an active
+        ``project_tasks`` grant for (grant-gated, taOS #1862).
+
+    A caller with neither a session nor a Bearer never reaches this helper (the
+    auth middleware 401s first), so the empty fallbacks below are belt-and-braces
+    rather than the primary gate.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        if user.is_admin:
+            return await pstore.list_projects(status="active")
+        return await pstore.list_for_user(uid, status="active")
+
+    # No session: a registry-JWT agent (the middleware only passes a Bearer
+    # through on the allowlist and leaves user_id=None).  Resolve WHO the agent
+    # is, then enumerate the projects it holds an active project_tasks grant for.
+    canonical_id = await check_agent_identity(request)
+    if not canonical_id:
+        return []
+    grants_store = _get_grants_store(request)
+    grants = await grants_store.list_grants(canonical_id)
+    now = datetime.now(timezone.utc)
+    project_ids: list[str] = []
+    for g in grants:
+        if g.get("scope") != "project_tasks":
+            continue
+        pid = g.get("project_id")
+        if not pid:
+            continue
+        if not _grant_unexpired(g.get("expires_at"), now):
+            continue
+        if pid not in project_ids:
+            project_ids.append(pid)
+    projects: list[dict] = []
+    for pid in project_ids:
+        p = await pstore.get_project(pid)
+        if p is not None:
+            projects.append(p)
+    return projects
+
+
+@router.get("/api/projects/tasks/aggregate")
+async def list_tasks_aggregate(
+    request: Request,
+    status: str | None = None,
+):
+    """Cross-project aggregate of the caller's kanban boards (READ ONLY).
+
+    Returns every project the caller is authorized to see -- its own boards for
+    a session owner, or the boards it holds a ``project_tasks`` grant for as an
+    agent -- each with that project's tasks.  The per-project
+    ``_authorize_task_actor`` gate is applied to EVERY candidate, so a caller
+    entitled to project A can never receive project B in the aggregate (the
+    whole point of this endpoint).  ``status`` filters tasks to
+    ``open`` / ``claimed`` / ``closed``.
+    """
+    pstore = request.app.state.project_store
+    store = request.app.state.project_task_store
+    items: list[dict] = []
+    for project in await _caller_project_candidates(request, pstore):
+        auth = await _authorize_task_actor(
+            request, pstore, project["id"], scope="project_tasks"
+        )
+        if isinstance(auth, JSONResponse):
+            # Not authorized for THIS project -> excluded from the aggregate, so
+            # it cannot leak another project's board to the caller.
+            continue
+        tasks = await store.list_tasks(project_id=project["id"], status=status)
+        items.append(
+            {
+                "project_id": project["id"],
+                "name": project.get("name"),
+                "slug": project.get("slug"),
+                "tasks": tasks,
+            }
+        )
+    return {"items": items}
 
 
 @router.get("/api/projects/{project_id}/tasks/ready")

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -612,7 +612,8 @@ async def _authorize_task_actor(
         # entry means "no active grant bound to this project" -> same
         # existence-hiding 404 as the slow path, so it never confirms a
         # project the agent is not entitled to.
-        assert agent_canonical_id is not None, "canonical_id required with agent_grants"
+        if agent_canonical_id is None:
+            raise ValueError("canonical_id required with agent_grants")
         if project_id not in agent_grants:
             return JSONResponse({"error": "not found"}, status_code=404)
         project = await pstore.get_project(project_id)
@@ -893,7 +894,11 @@ async def list_tasks_aggregate(
         # Re-check status inside the loop (TOCTOU defence): a project archived
         # between the candidate listing and this per-project check must NOT leak
         # into the response -- the aggregate contract is "active projects only".
-        if project.get("status") != "active":
+        # Read the FRESH object returned by _authorize_task_actor (auth[2]) rather
+        # than the stale `project` loop variable from the candidates snapshot,
+        # which may still report "active" after the project was archived.
+        fresh_project = auth[2]
+        if (fresh_project or {}).get("status") != "active":
             continue
         tasks = await store.list_tasks(project_id=project["id"], status=status)
         items.append(


### PR DESCRIPTION
## Summary

Cross-project kanban aggregate read (Kanban Viewer S1) — `tsk-jbaj7e` (p94).

`GET /api/projects/tasks/aggregate` is a **READ-ONLY** cross-project board: it returns every project the caller is authorized to see, each with that project's tasks. No mutation route, no write scope.

## The risk this guards against

The whole risk is the aggregate leaking a project the caller is not entitled to. Authorization is enforced through `_authorize_task_actor` (session owner/admin, or an approved registry JWT bound to that specific project).

## Acceptance

- A session owner entitled to project A asking for the aggregate must **not** receive project B.
- An agent holding `project_tasks` for A (and not B) must **not** receive B.
- An admin sees every active project's board (the one case allowed to span).
- A caller with no projects / no grant receives an empty aggregate.

The auth-boundary cases assert the **absence** of the other project (`pid_b not in ids`, `tid_b` absent), not merely that the entitled caller sees their own board.

## Tests

`tests/test_routes_project_tasks_aggregate.py` — 7 tests, all passing (`7 passed`), covering owner boundary, agent boundary, admin span, empty-aggregate, shape, and status filter.

Status values are `open | claimed | closed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only cross-project kanban view at `GET /api/projects/tasks/aggregate`.
  - Authorized session owners, administrators, and agents can retrieve tasks from accessible active projects in one request.
  - Added optional filtering by task status: open, claimed, or closed.

- **Bug Fixes**
  - Enforced per-project access checks and excluded archived, inaccessible, or stale project data.
  - Invalid status filters now return a clear validation error.

- **Documentation**
  - Documented endpoint access rules, authorization behavior, and status filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->