### PR TITLE
fix-forward #2559: the SSE routing test re-implements the fix in a local closure, so reverting the production defect leaves all 42 tests green

### DIFF
--- a/changelog.d/tsk-3q32qc-per-user-event-routing.md
+++ b/changelog.d/tsk-3q32qc-per-user-event-routing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cross-user event leakage via EventBus broadcast channel. Events with a `user:<id>` target are now routed only to that user's channel instead of being published to broadcast, preventing one authenticated user from seeing another user's events through `/api/events/stream` and `/api/os/events`. Notifications scoped to a specific user are also routed to the per-user channel; system-wide notifications (no `user_id`) continue to use broadcast.

--- a/changelog.d/tsk-zjwmmz-sse-routing-test.md
+++ b/changelog.d/tsk-zjwmmz-sse-routing-test.md
@@ -1,0 +1,3 @@
+### Added
+
+- SSE routing test that drives the real `_notify_emitter` in app.py and asserts user-scoped notifications reach the owner's channel without leaking to broadcast or other users' channels.

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -457,3 +457,95 @@ async def test_store_list_huge_limit_clamped(tmp_path):
         assert len(rows) == 5
     finally:
         await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — per-user event routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_user_id_target_publishes_to_user_channel_not_broadcast():
+    """A target of the form ``user:<id>`` must reach that per-user channel
+    and must NOT leak to the broadcast channel."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    user_q = await bus.subscribe("user:user-1")
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user:user-1"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert user_q.get_nowait() is ev
+    assert bcast_q.empty(), "user-scoped event must not reach broadcast"
+
+
+@pytest.mark.asyncio
+async def test_user_id_target_with_explicit_broadcast_reaches_both():
+    """If ``broadcast`` is explicitly in targets alongside ``user:<id>``, both
+    channels receive the event."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    user_q = await bus.subscribe("user:user-1")
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user:user-1", "broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert user_q.get_nowait() is ev
+    assert bcast_q.get_nowait() is ev
+
+
+@pytest.mark.asyncio
+async def test_user_sentinel_alone_still_broadcasts():
+    """The ``user`` sentinel (no id) is a notification trigger, not a channel.
+    Events with only ``user`` in targets must still reach broadcast."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["user"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev
+    assert len(notifications.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_target_still_reaches_broadcast():
+    """Explicit ``broadcast`` in targets must still work."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=["broadcast"])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev
+
+
+@pytest.mark.asyncio
+async def test_no_targets_still_broadcasts():
+    """An event with no targets must still reach broadcast for backward compat."""
+    bus = EventBus()
+    notifications = FakeNotifications()
+    agent_messages = FakeAgentMessages()
+    trace = FakeTraceStore()
+
+    bcast_q = await bus.subscribe("broadcast")
+
+    ev = _make_event(targets=[])
+    await bus.emit(ev, notifications=notifications, agent_messages=agent_messages, trace_store=trace)
+
+    assert bcast_q.get_nowait() is ev

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -185,3 +185,55 @@ async def test_notification_add_reaches_event_bus_broadcast(notif_store):
     received = bcast_q.get_nowait()
     assert received.kind == "notification.added"
     assert received.payload["title"] == "Push Test"
+
+
+@pytest.mark.asyncio
+async def test_notification_add_with_user_id_routes_to_user_channel(notif_store):
+    """A notification with user_id set must reach the per-user channel, not broadcast."""
+    bus = EventBus()
+    user_q = await bus.subscribe("user:alice")
+    bcast_q = await bus.subscribe("broadcast")
+
+    async def emitter(row: dict) -> None:
+        ev = SystemEvent(
+            kind="notification.added",
+            source="system",
+            targets=["broadcast"],
+            payload=row,
+        )
+        uid = row.get("user_id")
+        if uid:
+            await bus.publish_to(f"user:{uid}", ev)
+        else:
+            await bus.broadcast(ev)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("Alice only", "secret msg", user_id="alice")
+
+    assert user_q.get_nowait() is not None
+    assert bcast_q.empty(), "user-scoped notification must not leak to broadcast"
+
+
+@pytest.mark.asyncio
+async def test_notification_add_without_user_id_still_broadcasts(notif_store):
+    """A notification without user_id (system-wide) must still reach broadcast."""
+    bus = EventBus()
+    bcast_q = await bus.subscribe("broadcast")
+
+    async def emitter(row: dict) -> None:
+        ev = SystemEvent(
+            kind="notification.added",
+            source="system",
+            targets=["broadcast"],
+            payload=row,
+        )
+        uid = row.get("user_id")
+        if uid:
+            await bus.publish_to(f"user:{uid}", ev)
+        else:
+            await bus.broadcast(ev)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("System alert", "everyone sees this")
+
+    assert bcast_q.get_nowait() is not None

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -1,0 +1,62 @@
+"""Tests for SSE event routing through the REAL _notify_emitter in app.py.
+
+The existing test_event_stream.py uses a local closure that re-implements the
+routing rule, so it cannot catch a regression in app.py. These tests drive the
+actual emitter wired during app startup and assert on the EventBus side effect.
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from tinyagentos.app import create_app
+
+
+def _make_app(tmp_path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return create_app(data_dir=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_event_never_reaches_other_user(tmp_path):
+    """An event for user-a must reach user-a's channel and must NOT appear on
+    user-b's channel or broadcast."""
+    app = _make_app(tmp_path)
+    async with app.router.lifespan_context(app):
+        bus = app.state.event_bus
+        notif_store = app.state.notifications
+
+        user_a_q = await bus.subscribe("user:user-a")
+        user_b_q = await bus.subscribe("user:user-b")
+        bcast_q = await bus.subscribe("broadcast")
+
+        await notif_store.add("Alice only", "secret msg", user_id="user-a")
+
+        assert user_a_q.get_nowait() is not None
+        assert user_b_q.empty()
+        assert bcast_q.empty()
+
+
+@pytest.mark.asyncio
+async def test_owner_scoped_event_does_reach_owner(tmp_path):
+    """Control: a user-scoped notification must actually arrive on the owner's
+    channel. Catches an over-tightened guard that drops user-scoped events."""
+    app = _make_app(tmp_path)
+    async with app.router.lifespan_context(app):
+        bus = app.state.event_bus
+        notif_store = app.state.notifications
+
+        user_a_q = await bus.subscribe("user:user-a")
+
+        await notif_store.add("Alice only", "secret msg", user_id="user-a")
+
+        assert user_a_q.get_nowait() is not None

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1338,7 +1338,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 targets=["broadcast"],
                 payload=row,
             )
-            await app.state.event_bus.broadcast(ev)
+            user_id = row.get("user_id")
+            if user_id:
+                await app.state.event_bus.publish_to(f"user:{user_id}", ev)
+            else:
+                await app.state.event_bus.broadcast(ev)
 
         notif_store.set_event_emitter(_notify_emitter)
 

--- a/tinyagentos/events/bus.py
+++ b/tinyagentos/events/bus.py
@@ -163,11 +163,24 @@ class EventBus:
                 )
 
         # e. In-process pub/sub — deduplicate, then ensure broadcast is published
-        #    exactly once even if it appeared in targets.
+        #    exactly once even if it appeared in targets. Events whose targets
+        #    contain a ``user:<id>`` channel are scoped to that user and must
+        #    NOT leak to the broadcast channel, so they are published only to
+        #    the per-user channel(s). The ``user`` sentinel alone (no id) is a
+        #    notification trigger, not a channel, so it is skipped here.
         async with self._lock:
+            has_user_channel = False
             for target in _seen_targets:
-                await self._publish_to_channel(target, event)
-            if _BROADCAST_CHANNEL not in _seen_targets:
+                if target.startswith("user:"):
+                    await self._publish_to_channel(target, event)
+                    has_user_channel = True
+                elif target == _BROADCAST_CHANNEL:
+                    await self._publish_to_channel(target, event)
+                elif target == "user":
+                    continue
+                else:
+                    await self._publish_to_channel(target, event)
+            if not has_user_channel and _BROADCAST_CHANNEL not in _seen_targets:
                 await self._publish_to_channel(_BROADCAST_CHANNEL, event)
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2559: the SSE routing test re-implements the fix in a local closure, so reverting the production defect leaves all 42 tests green

Autonomous build of board card tsk-zjwmmz.

REVISION: built on `exec/tsk-3q32qc` (cut at `a91959dada8c356a3ffed5f95cbbe0e53f555850`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Red-first proof:
- Reverted _notify_emitter guard in app.py to always-broadcast defect
- Ran: uv run pytest tests/test_sse_events.py -q
- Result: 2 failed
- Restored guard
- Ran: uv run pytest tests/test_sse_events.py -q
- Result: 2 passed

The new test file drives the REAL emitter wired during app lifespan,
not a local closure. It asserts that a user-scoped notification reaches
the owner's channel and does not leak to broadcast or other users.

Control test confirms the allowed path still works.

Files:
 changelog.d/tsk-3q32qc-per-user-event-routing.md |  3 +
 changelog.d/tsk-zjwmmz-sse-routing-test.md       |  3 +
 tests/test_event_bus.py                          | 92 ++++++++++++++++++++++++
 tests/test_event_stream.py                       | 52 ++++++++++++++
 tests/test_sse_events.py                         | 62 ++++++++++++++++
 tinyagentos/app.py                               |  6 +-
 tinyagentos/events/bus.py                        | 19 ++++-
 7 files changed, 233 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-specific notifications and events now route only to the intended user’s channel.
  * System-wide notifications without a user assignment continue to be broadcast to all connected clients.

* **Bug Fixes**
  * Prevented user-scoped events from appearing in other users’ channels or global event streams.

* **Tests**
  * Added coverage for per-user routing, broadcast behavior, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->