### PR TITLE
fix-forward #2623: _degrade is STILL inert (zero production callers), miscounts parts, and discards its notices

### DIFF
--- a/changelog.d/tsk-itxxdo-lora-off-grid-degradation.md
+++ b/changelog.d/tsk-itxxdo-lora-off-grid-degradation.md
@@ -1,0 +1,2 @@
+### Fixed
+- _degrade now reads response.buttons, response.images, response.cards and emits one-time notices; chunks on encoded bytes with [part N/M] prefix byte-accounting; total derived from byte-accurate chunking

--- a/changelog.d/tsk-z4fdv4-meshtastic-degrade-send.md
+++ b/changelog.d/tsk-z4fdv4-meshtastic-degrade-send.md
@@ -1,0 +1,2 @@
+### Fixed
+- Meshtastic (LoRa) send path now degrades rich replies via `_degrade` instead of bypassing it, so dropped-element notices reach the transport; the `[part N/M]` denominator is derived from the actual chunking and always equals the emitted part count; multibyte characters are chunked on UTF-8 codepoint boundaries so frames never exceed the 237-byte wire budget.

--- a/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
+++ b/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
@@ -1,12 +1,12 @@
 # tsk-ha5iau: LoRa Off-Grid Transport for taOS - Design Note
 
 ## Executive Summary
-This design note addresses the requirement to bridge Meshtastic onto the A2A bus as a CONTROL channel, not a data tunnel, for LoRa off-grid transport. The solution implements a taOS <-> Meshtastic bridge that operates within the existing A2A bus architecture while addressing LoRa's broadcast nature and limited throughput constraints.
+This design note addresses the requirement to add Meshtastic as a first-class platform in the taOS channel hub, routing messages to the correct agent via the existing `MessageRouter`. The solution adds a `meshtastic_connector.py` alongside the seven existing connectors and a Talk app surface, inheriting routing, archive and the existing app for free. The hard work is degradation policy for the 237-byte text-only link, not transport plumbing.
 
 ## 1. Enforced Security Model for the Bridge
 
 ### Core Principles
-- **Zero Trust Extension**: The bridge does NOT inherit A2A bus trust. Messages must be authenticated at the bridge layer before reaching the bus.
+- **Zero Trust Extension**: The connector does NOT inherit channel hub trust. Messages must be authenticated at the connector ingress before reaching the router.
 - **Per-Device Authentication**: Each Heltec module is registered with unique cryptographic keys.
 - **Message Replay Protection**: All frames include a timestamp and sequence number to prevent replay attacks.
 - **Payload Integrity**: AES-256-GCM encryption with per-frame nonces for message integrity.
@@ -18,35 +18,36 @@ This design note addresses the requirement to bridge Meshtastic onto the A2A bus
 │  • Signed payload (device key)                              │
 │  • Sequence number + timestamp                             │
 │  • AES-256-GCM encrypted                                        │
-└─────────────────┬-------------------------------------------─┘
-                  │ Verify signature & decrypt
+└─────────────────┬-------------------------------------------┘
+                   │ Verify signature & decrypt
 ┌─────────────────▼-------------------------------------------─┐
-│  Bridge Server                                               │
+│  meshtastic_connector.py                                    │
 │  • Device key registry                                       │
 │  • Sequence number validation                                 │
 │  • Timestamp freshness check                                  │
 │  • If verification fails: drop & log                        │
 └─────────────────┬-------------------------------------------─┘
-                  │ Message passes security validation
+                   │ Emits IncomingMessage with platform="meshtastic"
+                   │ Routes via MessageRouter.get_agent_for_channel
 ┌─────────────────▼-------------------------------------------─┐
-│  A2A Bus (Controlled Trust)                                  │
-│  • Messages injected with bridge handle (@bridge-<id>)       │
-│  • No inheritance of sender field from LoRa                 │
-│  • Bridge is the verified source of all radio messages       │
+│  channel_hub/router.py MessageRouter                        │
+│  • assign_channel(platform="meshtastic", bot_id, agent_name) │
+│  • get_agent_for_channel resolves the target agent           │
+│  • Standard routing and archive pipeline                     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ### Security Handling Policies
 
 **Unsigned Frames:**
-- Dropped immediately at bridge ingress
+- Dropped immediately at connector ingress
 - Logged with device identifier and geolocation (if available)
 - Alert generation: `"LoRa security breach: unsigned frame from <MAC>"
 
 **Replayed Frames:**
 - Detected via sequence number gap analysis
 - Old frames (timestamp > 5 minutes or sequence number < last_seen) rejected
-- Bridge maintains sliding window per device
+- Connector maintains sliding window per device
 - Alert generation: `"LoRa replay detected from <MAC> (seq <n>)"
 
 **Corrupted Frames:**
@@ -55,128 +56,110 @@ This design note addresses the requirement to bridge Meshtastic onto the A2A bus
 - Dropped, logged, and alert generated
 
 **Allowed Security Violations:**
-- Bridge may accept unencrypted messages during testing mode (configurable)
-- Bridge logs and forwards with bridge handle for debugging
+- Connector may accept unencrypted messages during testing mode (configurable)
+- Connector logs and forwards with testing flag for debugging
 - All production deployments require encryption
 
-## 2. Message Schema and Size Budget
+## 2. Integration via channel_hub
 
-### Meshtastic Payload Constraints
-- Maximum payload: 237 bytes per packet
-- Physical layer: LoRa SF7-BW500 @ 10kbps theoretical
-- Effective throughput: ~1kbps with Meshtastic defaults
-- Half-duplex with ~2-5 second latency
+### Existing Seam
+`tinyagentos/channel_hub/` holds seven working connectors on a common envelope: discord, telegram, slack, matrix, email, webchat, webhook (4-5K each). `channel_hub/message.py` defines `IncomingMessage` with a `platform` field and `OutgoingMessage` for replies. `channel_hub/router.py` `MessageRouter` already provides `assign_channel(platform, bot_id, agent_name)` and `get_agent_for_channel(platform, bot_id)`.
 
-### Bridge Message Schema
-```json
-{
-  "from": "@bridge-<module-id>",
-  "thread": "<a2a-thread-name>",
-  "body": "<meshtastic-payload>",
-  "metadata": {
-    "device_id": "<hex-mac-or-uuid>",
-    "sequence": <uint32>,
-    "timestamp": <unix-timestamp>,
-    "hop_limit": <uint8>,
-    "channel": "<meshtastic-channel-name>"
-  }
-}
-```
+### meshtastic_connector.py
+The new connector sits alongside the existing seven. It emits `IncomingMessage(platform="meshtastic", ...)` and calls `self.router.route_message(self.agent_name, incoming)`, exactly like `telegram_connector.py` or `webchat_connector.py`. A Meshtastic channel (or node) maps to one agent via `assign_channel`. Addressing lives on the channel the message arrived on, not in the payload.
 
-### Size Analysis
-| Component | Size (bytes) | Notes |
-|-----------|--------------|-------|
-| AES-256-GCM overhead | 16 | Tag + IV |
-| JSON serialization | 20-80 | Depends on content |
-| Bridge message wrapper | 30-50 | Static headers |
-| Actual Meshtastic data | ~130-180 | Remaining budget |
-| **Total** | **<=237** | **Fits exactly** |
+### Routing Keys on the Channel, Not the Payload
+Map one Meshtastic channel (or node) to one agent and addressing costs ZERO bytes of the ~237 byte packet. The naive alternative is bad: real agent identities on this fleet are 25-30 chars (kilo-taos-20260711-000740, laguna-s-ora-20260721-191750, stepflash-taos-20260713-103907). Carrying sender + recipient in-payload would burn ~60 of 237 bytes, a quarter of the packet, before a single character of content. Meshtastic supports 8 channels, so channel-per-agent caps there and node-per-agent needs a board per agent; past that use a SHORT-CODE REGISTRY (2-4 bytes) mapped to canonical identity. Never put canonical ids on the radio.
 
-### Payload Allocation
-- **Control Messages** (Status beacons): 50 bytes
-- **Command Messages**: 80 bytes  
-- **Data Messages** (short telemetry): 107 bytes
-- **Keep-Alive Messages**: 20 bytes
+## 3. Degradation Policy
 
-### Compression Strategies
-- Use CBOR instead of JSON for control messages (saves ~40%)
-- Delta encoding for timestamps and sequence numbers
-- Binary framing for critical messages
+### The Problem
+`OutgoingMessage` carries buttons, images and cards, and `message.py:parse_inline_hints` parses `[button:Label:action]` and `[image:path]` out of agent replies. NONE of that survives a text-only ~237 byte link. The connector needs an explicit policy for rich elements, long replies, and a hard per-message size budget enforced BEFORE transmit. An agent that answers in 2KB of prose must not silently become a 12-packet flood.
 
-## 3. Allowed A2A Kinds Over Radio
+### Rich Element Policy
+| Element | Policy |
+|---------|--------|
+| Buttons | Drop. Log a one-time notice per conversation: `"[button dropped: Meshtastic is text-only]"` |
+| Images | Drop. Log a one-time notice per conversation: `"[image dropped: Meshtastic is text-only]"` |
+| Cards | Drop. Log a one-time notice per conversation: `"[card dropped: Meshtastic is text-only]"` |
 
-### Permitted A2A Message Types
-The bridge allows only these A2A kinds to prevent security issues:
+### Long Reply Policy
+| Length | Policy |
+|--------|--------|
+| <= 237 bytes | Transmit as-is |
+| > 237 bytes | Chunk into 237-byte segments with a `[part N/M]` prefix; reassemble on receive if needed |
 
-**✓ Allowed (Read-Only):**
-- `status`: System status beacons from nodes
-- `alert`: Critical alerts and warnings
-- `command`: Short administrative commands
-- `heartbeat`: Connection health monitoring
+### Hard Size Budget
+Before transmit, the connector enforces a 237-byte limit on the serialized payload. Messages exceeding the budget are chunked or truncated with a `[truncated]` marker. No message exceeds 237 bytes on the wire.
 
-**✗ Refused (Security Risk):**
-- `chat`: User-to-user messaging (cannot be trusted)
-- `decision`: Decision records (require authentication)
-- `task`: Project task updates (must be authenticated)
-- `action`: State-changing operations
-- `file`: File transfers
-
-### A2A Kind Filtering Implementation
+### Example Degradation
 ```python
-# In bridge service
-ALLOWED_RADIO_KINDS = frozenset({
-    "status", "alert", "command", "heartbeat"
-})
+# In meshtastic_connector.py
+MAX_PAYLOAD = 237
 
-# Example bridge filtering logic
-if message["kind"] not in ALLOWED_RADIO_KINDS:
-    logger.warning("A2A kind %s rejected over radio", message["kind"])
-    return None  # Drop message
+def _degrade(self, response: OutgoingMessage) -> list[str]:
+    parts = []
+    text = response.content
+    text = text.replace("[button:", "[button dropped: Meshtastic is text-only] ")
+    text = text.replace("[image:", "[image dropped: Meshtastic is text-only] ")
+    text = text.replace("[card:", "[card dropped: Meshtastic is text-only] ")
+    text = text.strip()
+    if len(text.encode("utf-8")) <= MAX_PAYLOAD:
+        return [text]
+    chunks = []
+    start = 0
+    idx = 1
+    total = (len(text) + MAX_PAYLOAD - 1) // MAX_PAYLOAD
+    while start < len(text):
+        end = start + MAX_PAYLOAD - len(f"[part {idx}/{total}] ".encode("utf-8"))
+        chunk = text[start:end]
+        chunks.append(f"[part {idx}/{total}] {chunk}")
+        start = end
+        idx += 1
+    return chunks
 ```
 
-### Thread Channel Mapping
-| Radio Channel | A2A Thread | Purpose |
-|---------------|------------|---------|
-| `status` | `taos-status` | Node health + metrics |
-| `alerts` | `taos-alerts` | Critical system alerts |
-| `commands` | `taos-commands` | Administrative commands |
-| `heartbeats` | `taos-heartbeats` | Connection monitoring |
+## 4. Sovereignty
 
-## 4. Concrete First Milestone (Hardware Phase)
+### Real, With One Caveat
+Every other connector except webchat/webhook puts a company in the path. The sharper claim is not merely self-hosted but INFRASTRUCTURE INDEPENDENT: it keeps working with no ISP, no internet and no LAN. Caveat to design around rather than a blocker: encryption protects CONTENT, not PRESENCE. Broadcast RF means anyone in range observes that a transmission happened, roughly from where, how often and how large, and RF is direction-findable. Sovereignty over custody and content, not invisibility. Do not let the pitch drift into the latter.
+
+## 5. Concrete First Milestone (Hardware Phase)
 
 ### Version 0.1.0 - "Point-to-Point Prototype"
 **Target**: Q3 2026 (after hardware arrival)
 
 #### Primary Objectives
 1. **Hardware Setup**: Deploy two Heltec V4 modules in point-to-point configuration
-2. **Bridge Development**: Implement basic message forwarding from Meshtastic to A2A bus
+2. **Connector Development**: Implement `meshtastic_connector.py` emitting `platform="meshtastic"`
 3. **Authentication**: Complete per-device key registration and validation system
-4. **Security Testing**: Verify replay protection and message authenticity
+4. **Degradation Testing**: Verify rich elements are dropped, long replies are chunked, and the 237-byte budget is enforced
 
 #### Technical Deliverables
-- [ ] Bridge service daemon (`taos-lora-bridge`) with command-line interface
+- [ ] `meshtastic_connector.py` alongside the seven existing connectors
 - [ ] Device key management system with secure storage
-- [ ] Integration with existing A2A bus proxy (`/api/a2a/bus/send`)
+- [ ] `MessageRouter.assign_channel("meshtastic", <node_id>, <agent_name>)` wiring
 - [ ] Configuration management for radio parameters (freq, SF, channel)
-- [ ] Logging and monitoring for security events
-- [ ] Test suite for bridge functionality and security properties
+- [ ] Logging and monitoring for security events and degradation decisions
+- [ ] Test suite for connector functionality, security properties, and degradation policy
 
 #### Deployment Architecture
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  TAOS Controller (Bridge Host)                          │
+│  TAOS Controller                                        │
 │                                                         │
 │  ┌─────────────────────────────────────────────────┐   │
-│  │                                                 │   │
-│  │  +----------------------+    +----------------+ │   │
-│  │  │   taos-lora-bridge   │───▶│  A2A Bus       │ │   │
-│  │  │  (REST API)          │    │  @bridge-node1 │ │   │
-│  │  +----------------------+    +----------------+ │   │
-│  │                                                 │   │
-│  │  +----------------------+    +----------------+ │   │
-│  │  │  taos-lora-bridge   │───▶│  A2A Bus       │ │   │
-│  │  │  (REST API)          │    │  @bridge-node2 │ │   │
-│  │  +----------------------+    +----------------+ │   │
+│  │  channel_hub                                    │   │
+│  │  • MessageRouter.get_agent_for_channel("meshtastic", node_id) │
+│  │  • Archive and routing pipeline                  │   │
+│  └─────────────────────────────────────────────────┘   │
+│                                                         │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │  meshtastic_connector.py                         │   │
+│  │  • Ingest Meshtastic packets                     │   │
+│  │  • Verify signature & decrypt                    │   │
+│  │  • Degrade rich elements, chunk long replies     │   │
+│  │  • Emit IncomingMessage(platform="meshtastic")   │   │
 │  └─────────────────────────────────────────────────┘   │
 │                                                         │
 │  ┌─────────────────────────────────────────────────┐   │
@@ -196,31 +179,35 @@ if message["kind"] not in ALLOWED_RADIO_KINDS:
 ```
 
 #### MVP Testing Requirements
-- [ ] Message round-trip testing: Radio → Bridge → A2A → Bridge → Radio
+- [ ] Message round-trip testing: Radio -> connector -> router -> agent -> connector -> Radio
 - [ ] Security validation: Verify unsigned frames are rejected
+- [ ] Degradation validation: Verify buttons and images are dropped with logged notices
+- [ ] Size budget validation: Verify long replies are chunked or truncated to 237 bytes
 - [ ] Performance testing: 1kbps sustained throughput with <1s latency
-- [ ] Integration testing: Verify A2A bus messages appear correctly
 
 #### Success Criteria
 1. **Functional**: Both radio modules connect and exchange messages
 2. **Security**: All unsigned/replayed messages are rejected
-3. **Performance**: Status beacons sent every 30 seconds
-4. **Reliability**: Bridge survives controller reboot without reconnection
+3. **Degradation**: Rich elements are dropped and long replies are chunked
+4. **Performance**: Status beacons sent every 30 seconds
+5. **Reliability**: Connector survives controller reboot without reconnection
 
 ### Notes
 - This design focuses on the security model first as required
 - Firmware implementation will follow after this design is approved
-- The bridge operates as a CONTROL channel, not a data tunnel
+- The connector is a CONTROL channel, not a data tunnel
 - All security decisions must be made before hardware deployment
 
 ## References
 - [Heltec WiFi LoRa 32 V4 Datasheet](https://docs.heltec.org/en/latest/wifi_lora_32/tty/v4.html)
 - [Meshtastic Documentation](https://meshtastic.org/)
-- [taOS A2A Bus Architecture](/tinyagentos/routes/a2a_bus.py)
+- [taOS channel_hub Architecture](/tinyagentos/channel_hub/)
+- [channel_hub/message.py](/tinyagentos/channel_hub/message.py)
+- [channel_hub/router.py](/tinyagentos/channel_hub/router.py)
 - [Jay's Note 2026-08-28](note-260828-f0fa88.md - reference implementation)
 
 ---
 *Document created: 2026-08-28*
 *Status: Draft design note*
 *Author: taOS Lead*
-*Tags: lora, meshtastic, bridge, security, radio*
+*Tags: lora, meshtastic, channel_hub, security, radio*

--- a/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
+++ b/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
@@ -98,25 +98,64 @@ Before transmit, the connector enforces a 237-byte limit on the serialized paylo
 MAX_PAYLOAD = 237
 
 def _degrade(self, response: OutgoingMessage) -> list[str]:
-    parts = []
+    """Degrade rich elements and chunk long replies for text-only link.
+
+    - Reads response.buttons, response.images, response.cards; drops them
+      and emits a one-time notice per element kind.
+    - Chunks on encoded bytes, not characters, never splitting a multibyte
+      character and always accounting for the '[part N/M] ' prefix bytes.
+    - Derives total from byte-accurate chunking, not len(text).
+    """
+    notices: list[str] = []
+
+    # Drop buttons — emit one-time notice per conversation
+    if response.buttons:
+        if (
+            "[button dropped: Meshtastic is text-only]"
+            not in {n for n in notices}
+        ):
+            notices.append("[button dropped: Meshtastic is text-only]")
+        response.buttons = []
+
+    # Drop images — emit one-time notice per conversation
+    if response.images:
+        if (
+            "[image dropped: Meshtastic is text-only]"
+            not in {n for n in notices}
+        ):
+            notices.append("[image dropped: Meshtastic is text-only]")
+        response.images = []
+
+    # Drop cards — emit one-time notice per conversation
+    if response.cards:
+        if (
+            "[card dropped: Meshtastic is text-only]"
+            not in {n for n in notices}
+        ):
+            notices.append("[card dropped: Meshtastic is text-only]")
+        response.cards = []
+
+    # The text is already clean (parse_inline_hints stripped markup),
+    # but we work with whatever content remains.
     text = response.content
-    text = text.replace("[button:", "[button dropped: Meshtastic is text-only] ")
-    text = text.replace("[image:", "[image dropped: Meshtastic is text-only] ")
-    text = text.replace("[card:", "[card dropped: Meshtastic is text-only] ")
-    text = text.strip()
-    if len(text.encode("utf-8")) <= MAX_PAYLOAD:
-        return [text]
-    chunks = []
-    start = 0
+
+    # Chunk on encoded bytes, not characters.
+    encoded = text.encode("utf-8")
+    chunk_size = 237  # bytes
+    total = (len(encoded) + chunk_size - 1) // chunk_size if encoded else 0
+
+    parts: list[str] = []
     idx = 1
-    total = (len(text) + MAX_PAYLOAD - 1) // MAX_PAYLOAD
-    while start < len(text):
-        end = start + MAX_PAYLOAD - len(f"[part {idx}/{total}] ".encode("utf-8"))
-        chunk = text[start:end]
-        chunks.append(f"[part {idx}/{total}] {chunk}")
+    start = 0
+    while start < len(encoded):
+        end = start + chunk_size
+        byte_chunk = encoded[start:end]
+        chunk_text = byte_chunk.decode("utf-8", errors="replace")
+        parts.append(f"[part {idx}/{total}] {chunk_text}")
         start = end
         idx += 1
-    return chunks
+
+    return parts
 ```
 
 ## 4. Sovereignty

--- a/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
+++ b/docs/specs/tsk-ha5iau/2026-08-28-lora-off-grid-transport-design.md
@@ -90,72 +90,71 @@ Map one Meshtastic channel (or node) to one agent and addressing costs ZERO byte
 | > 237 bytes | Chunk into 237-byte segments with a `[part N/M]` prefix; reassemble on receive if needed |
 
 ### Hard Size Budget
-Before transmit, the connector enforces a 237-byte limit on the serialized payload. Messages exceeding the budget are chunked or truncated with a `[truncated]` marker. No message exceeds 237 bytes on the wire.
+Before transmit, every frame is verified to be <= 237 bytes on the wire. Long replies are chunked with a `[part N/M]` prefix whose denominator always equals the emitted part count; the connector guard raises (rather than shipping an over-budget frame) if any part still exceeds the limit after degradation.
 
 ### Example Degradation
 ```python
-# In meshtastic_connector.py
+# In channel_hub/message.py
 MAX_PAYLOAD = 237
 
-def _degrade(self, response: OutgoingMessage) -> list[str]:
-    """Degrade rich elements and chunk long replies for text-only link.
+def _degrade(response: OutgoingMessage) -> tuple[list[str], list[str]]:
+    """Degrade rich elements and chunk long replies for the text-only link.
 
     - Reads response.buttons, response.images, response.cards; drops them
-      and emits a one-time notice per element kind.
-    - Chunks on encoded bytes, not characters, never splitting a multibyte
-      character and always accounting for the '[part N/M] ' prefix bytes.
-    - Derives total from byte-accurate chunking, not len(text).
+      and emits a notice per element kind (a fresh notice list per response).
+    - Chunks on encoded bytes, never splitting a multibyte character: the
+      chunk boundary is walked back to the last codepoint boundary before
+      decoding, and the '[part N/M] ' prefix bytes always count against
+      the 237-byte budget.
+    - Derives total from the same chunking the parts use, so the label
+      denominator always equals the number of emitted parts.
     """
     notices: list[str] = []
 
-    # Drop buttons — emit one-time notice per conversation
+    # Drop buttons -- emit a notice per response
     if response.buttons:
-        if (
-            "[button dropped: Meshtastic is text-only]"
-            not in {n for n in notices}
-        ):
-            notices.append("[button dropped: Meshtastic is text-only]")
+        notices.append("[button dropped: Meshtastic is text-only]")
         response.buttons = []
 
-    # Drop images — emit one-time notice per conversation
+    # Drop images -- emit a notice per response
     if response.images:
-        if (
-            "[image dropped: Meshtastic is text-only]"
-            not in {n for n in notices}
-        ):
-            notices.append("[image dropped: Meshtastic is text-only]")
+        notices.append("[image dropped: Meshtastic is text-only]")
         response.images = []
 
-    # Drop cards — emit one-time notice per conversation
+    # Drop cards -- emit a notice per response
     if response.cards:
-        if (
-            "[card dropped: Meshtastic is text-only]"
-            not in {n for n in notices}
-        ):
-            notices.append("[card dropped: Meshtastic is text-only]")
+        notices.append("[card dropped: Meshtastic is text-only]")
         response.cards = []
 
     # The text is already clean (parse_inline_hints stripped markup),
     # but we work with whatever content remains.
-    text = response.content
+    encoded = response.content.encode("utf-8")
+    if not encoded:
+        return [], notices
 
-    # Chunk on encoded bytes, not characters.
-    encoded = text.encode("utf-8")
-    chunk_size = 237  # bytes
-    total = (len(encoded) + chunk_size - 1) // chunk_size if encoded else 0
-
-    parts: list[str] = []
-    idx = 1
-    start = 0
-    while start < len(encoded):
-        end = start + chunk_size
-        byte_chunk = encoded[start:end]
-        chunk_text = byte_chunk.decode("utf-8", errors="replace")
-        parts.append(f"[part {idx}/{total}] {chunk_text}")
-        start = end
-        idx += 1
-
-    return parts
+    # Provisional total ignores the prefix length; refine until the label
+    # denominator equals the actual number of emitted parts.
+    total = max(1, (len(encoded) + MAX_PAYLOAD - 1) // MAX_PAYLOAD)
+    while True:
+        parts: list[str] = []
+        idx = 1
+        start = 0
+        while start < len(encoded):
+            prefix = f"[part {idx}/{total}] ".encode("utf-8")
+            content_bytes = MAX_PAYLOAD - len(prefix)
+            end = min(start + content_bytes, len(encoded))
+            # Walk back to a codepoint boundary so we never slice a
+            # multibyte character (which would corrupt it and inflate the
+            # re-encoded size past the budget).
+            while end < len(encoded) and (encoded[end] & 0xC0) == 0x80:
+                end -= 1
+            chunk_text = encoded[start:end].decode("utf-8")
+            parts.append(f"[part {idx}/{total}] {chunk_text}")
+            start = end
+            idx += 1
+        if len(parts) == total:
+            return parts, notices
+        total = len(parts)
 ```
 
 ## 4. Sovereignty

--- a/tests/channel_hub/test_meshtastic_connector.py
+++ b/tests/channel_hub/test_meshtastic_connector.py
@@ -1,0 +1,157 @@
+"""Tests for the Meshtastic (LoRa) connector -- the text-only send path that
+degrades rich OutgoingMessages via _degrade and transmits the parts.
+
+These tests use an injectable transport (an async callable) so no radio
+hardware is required. They pin the three #2623 regressions: _degrade is called
+from a real send path, the [part N/M] denominator equals the emitted part
+count, and the dropped-element notices reach the transport.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tinyagentos.channel_hub.meshtastic_connector import MeshtasticConnector
+from tinyagentos.channel_hub.message import MAX_PAYLOAD, OutgoingMessage
+
+
+def _make_connector(sink: list[str] | None = None):
+    async def transport(frame: str) -> None:
+        if sink is not None:
+            sink.append(frame)
+
+    router = AsyncMock()
+    connector = MeshtasticConnector(
+        agent_name="lora-agent", router=router, transport=transport
+    )
+    return connector, router
+
+
+class TestMeshtasticSendPath:
+    @pytest.mark.asyncio
+    async def test_degrade_is_called_from_the_send_path(self):
+        # The LoRa send path must not be inert: _degrade runs on every send.
+        sent: list[str] = []
+        connector, _ = _make_connector(sent)
+        response = OutgoingMessage(
+            content="x" * 474,
+            buttons=[{"label": "Yes", "action": "yes"}],
+            images=["img.png"],
+            cards=[{"title": "c"}],
+        )
+        await connector._send_response(response)
+
+        # Notices dropped by _degrade must reach the transport.
+        joined = "\n".join(sent)
+        assert "[button dropped: Meshtastic is text-only]" in joined
+        assert "[image dropped: Meshtastic is text-only]" in joined
+        assert "[card dropped: Meshtastic is text-only]" in joined
+
+        # Every part label denominator equals the emitted part count.
+        parts = [f for f in sent if f.startswith("[part ")]
+        assert len(parts) >= 1
+        for part in parts:
+            denom = part.split("/")[1].split("]")[0]
+            assert denom == str(len(parts)), f"{denom} != {len(parts)}"
+            assert len(part.encode("utf-8")) <= MAX_PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_notice_text_reaches_transport(self):
+        # Acceptance: the dropped-element notice text reaches the transport.
+        sent: list[str] = []
+        connector, _ = _make_connector(sent)
+        await connector._send_response(
+            OutgoingMessage(content="hi", buttons=[{"label": "OK", "action": "ok"}])
+        )
+        assert "[button dropped: Meshtastic is text-only]" in sent
+        assert any(f.startswith("[part ") for f in sent)
+
+    @pytest.mark.asyncio
+    async def test_denominator_matches_emitted_parts(self):
+        # Acceptance: label denominator equals the emitted part count, even when
+        # the prefix growth shifts the true part count above ceil(len/237).
+        sent: list[str] = []
+        connector, _ = _make_connector(sent)
+        await connector._send_response(OutgoingMessage(content="A" * 1000))
+        parts = [f for f in sent if f.startswith("[part ")]
+        assert len(parts) > 1
+        for part in parts:
+            assert len(part.encode("utf-8")) <= MAX_PAYLOAD
+            denom = part.split("/")[1].split("]")[0]
+            assert denom == str(len(parts)), f"{denom} != {len(parts)}"
+
+    @pytest.mark.asyncio
+    async def test_no_transport_does_not_raise(self):
+        # A connector with no configured radio must not crash on send.
+        connector = MeshtasticConnector(agent_name="lora-agent", router=AsyncMock())
+        await connector._send_response(
+            OutgoingMessage(content="hi", buttons=[{"label": "OK", "action": "ok"}])
+        )
+
+    @pytest.mark.asyncio
+    async def test_short_reply_single_part(self):
+        sent: list[str] = []
+        connector, _ = _make_connector(sent)
+        await connector._send_response(OutgoingMessage(content="hello"))
+        parts = [f for f in sent if f.startswith("[part ")]
+        assert len(parts) == 1
+        assert parts[0] == "[part 1/1] hello"
+
+    @pytest.mark.asyncio
+    async def test_handle_incoming_routes_and_sends(self):
+        sent: list[str] = []
+        connector, router = _make_connector(sent)
+        router.route_message = AsyncMock(
+            return_value=OutgoingMessage(content="A" * 474)
+        )
+        result = await connector.handle_incoming(
+            {"id": "pkt1", "from_id": "node-1", "text": "ping"}
+        )
+        router.route_message.assert_called_once()
+        incoming = router.route_message.call_args[0][1]
+        assert incoming.platform == "meshtastic"
+        assert incoming.from_id == "node-1"
+        assert incoming.text == "ping"
+        assert result is not None
+        # The reply was degraded and transmitted through the transport.
+        parts = [f for f in sent if f.startswith("[part ")]
+        assert len(parts) == 3
+        for part in parts:
+            denom = part.split("/")[1].split("]")[0]
+            assert denom == str(len(parts))
+
+    @pytest.mark.asyncio
+    async def test_never_transmits_over_budget(self):
+        # Multibyte content that, under the byte-slice bug, produced a 239-byte
+        # frame. The connector must never transmit an over-budget frame.
+        for text in ("日" * 76, "🌍" * 57):
+            sent: list[str] = []
+            connector, _ = _make_connector(sent)
+            await connector._send_response(OutgoingMessage(content=text))
+            assert sent, f"no frames transmitted for {text[:6]!r}..."
+            for frame in sent:
+                byte_len = len(frame.encode("utf-8"))
+                assert byte_len <= MAX_PAYLOAD, (
+                    f"frame over {MAX_PAYLOAD} bytes: {frame!r} ({byte_len})"
+                )
+            parts = [f for f in sent if f.startswith("[part ")]
+            reencoded = "".join(p.split("] ", 1)[1] for p in parts).encode("utf-8")
+            assert reencoded == text.encode("utf-8"), (
+                f"reassembly not byte-identical for {text[:6]!r}..."
+            )
+
+    @pytest.mark.asyncio
+    async def test_guard_raises_when_part_exceeds_budget(self):
+        # If _degrade ever emits an over-budget part, the send path must
+        # raise rather than narrate-truncate-and-ship an oversized frame.
+        sent: list[str] = []
+        connector, _ = _make_connector(sent)
+        with patch(
+            "tinyagentos.channel_hub.meshtastic_connector._degrade",
+            return_value=(["x" * 300], []),
+        ):
+            with pytest.raises(ValueError, match="exceeds"):
+                await connector._send_response(OutgoingMessage(content="stub"))
+            # _transmit must never be called with the oversize frame.
+            assert sent == []

--- a/tests/test_channel_hub_new.py
+++ b/tests/test_channel_hub_new.py
@@ -484,6 +484,28 @@ class TestChannelHubAPINew:
         assert connector_info["platform"] == "webchat"
 
     @pytest.mark.asyncio
+    async def test_connect_meshtastic_success(self, client):
+        resp = await client.post("/api/channel-hub/connect", json={
+            "platform": "meshtastic",
+            "agent_name": "lora-agent",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "connected"
+        assert data["platform"] == "meshtastic"
+        assert data["agent_name"] == "lora-agent"
+        # The connector is registered and reachable via the status endpoint.
+        status = await client.get("/api/channel-hub/status")
+        connectors = status.json()["connectors"]
+        assert "meshtastic:lora-agent" in connectors
+        assert connectors["meshtastic:lora-agent"]["platform"] == "meshtastic"
+        from tinyagentos.channel_hub.meshtastic_connector import MeshtasticConnector
+        connector = getattr(
+            client._transport.app.state, "channel_hub_connectors", {}
+        ).get("meshtastic:lora-agent")
+        assert isinstance(connector, MeshtasticConnector)
+
+    @pytest.mark.asyncio
     async def test_connect_unsupported_platform_still_fails(self, client):
         await client.post("/api/secrets", json={"name": "irc_token", "value": "fake"})
         resp = await client.post("/api/channel-hub/connect", json={

--- a/tests/test_channel_message.py
+++ b/tests/test_channel_message.py
@@ -6,6 +6,7 @@ import time
 import pytest
 
 from tinyagentos.channel_hub.message import (
+    MAX_PAYLOAD,
     IncomingMessage,
     OutgoingMessage,
     _degrade,
@@ -461,20 +462,33 @@ class TestParseInlineHints:
         result = parse_inline_hints("   ")
         assert result.content == ""
 
+    def _assert_denominator_matches_part_count(self, parts):
+        # The [part N/M] denominator (M) must equal the number of emitted parts.
+        for part in parts:
+            denom = part.split("/")[1].split("]")[0]
+            assert denom == str(len(parts)), (
+                f"label denominator {denom} != emitted part count "
+                f"{len(parts)}: {parts}"
+            )
+
     def test_degrade_drops_buttons_and_images(self):
         # Build a real OutgoingMessage using parse_inline_hints
         text = "Reboot the node? [button:Yes:reboot] [image:/tmp/node.png]"
         msg = parse_inline_hints(text)
-        parts = _degrade(msg)
+        parts, notices = _degrade(msg)
         # Buttons and images must be dropped (structured fields cleared)
         assert msg.buttons == [], f"buttons not dropped: {msg.buttons}"
         assert msg.images == [], f"images not dropped: {msg.images}"
+        # Notices must be returned, not discarded -- they reach the transport.
+        assert "[button dropped: Meshtastic is text-only]" in notices
+        assert "[image dropped: Meshtastic is text-only]" in notices
         # Chunk size must be byte-accurate
         for part in parts:
             assert len(part.encode("utf-8")) <= 237, (
                 f"part exceeds 237 bytes: {part!r} len={len(part.encode('utf-8'))}"
             )
-        # There should be at least one part
+        # Denominator equals the emitted part count (not len(text)/237).
+        self._assert_denominator_matches_part_count(parts)
         assert len(parts) >= 1
 
     def test_degrade_drops_cards_and_emits_notices(self):
@@ -484,20 +498,23 @@ class TestParseInlineHints:
             content="Use /help",
             cards=[{"title": "Help", "body": "Show help"}],
         )
-        parts = _degrade(msg)
+        parts, notices = _degrade(msg)
         # Cards must be dropped
         assert msg.cards == [], f"cards not dropped: {msg.cards}"
+        # The one-time notice must be surfaced, not discarded.
+        assert "[card dropped: Meshtastic is text-only]" in notices
         # At least one part produced
         assert len(parts) >= 1
         # Each part respects the byte budget including prefix
         for part in parts:
             assert len(part.encode("utf-8")) <= 237
+        self._assert_denominator_matches_part_count(parts)
 
     def test_degrade_chunks_large_payload(self):
         # Build a real OutgoingMessage with content exceeding 237 bytes
         long_text = "A" * 500  # 500 ASCII chars > 237 bytes
         msg = OutgoingMessage(content=long_text)
-        parts = _degrade(msg)
+        parts, notices = _degrade(msg)
         # Every part must satisfy the byte budget including [part N/M] prefix
         for part in parts:
             assert len(part.encode("utf-8")) <= 237, (
@@ -505,13 +522,29 @@ class TestParseInlineHints:
             )
         # total must be derived from byte-accurate chunking
         assert len(parts) > 1
+        # Denominator equals the emitted part count, not len(text)/237.
+        self._assert_denominator_matches_part_count(parts)
 
-    def test_degrade_with_malay_text_and_em_dash(self):
-        # Non-ASCII text with em-dash to verify byte-accurate chunking.
-        # Use enough text to require chunking (>237 bytes).
-        text = "Selamat pagi! — " * 20 + "selamat petang"
+    def test_degrade_denominator_matches_part_count_at_474_bytes(self):
+        # Regression for #2623: 474 bytes of content. total = ceil(474/237)
+        # = 2 undercounts because the [part N/M] prefix eats into the budget,
+        # so the old code emitted [part 1/2], [part 2/2], [part 3/2]. The
+        # denominator must equal the actual number of parts (3).
+        msg = OutgoingMessage(content="A" * 474)
+        parts, notices = _degrade(msg)
+        assert len(parts) == 3
+        self._assert_denominator_matches_part_count(parts)
+        for part in parts:
+            assert len(part.encode("utf-8")) <= 237
+
+    def test_degrade_with_multibyte_content(self):
+        # Non-ASCII (multibyte UTF-8) text to verify byte-accurate chunking
+        # and that the label denominator equals the emitted part count even as
+        # the [part N/M] prefix width grows across single- and double-digit
+        # part numbers. Enough text to require multiple parts.
+        text = ("héllo wörld " + "日本語 ") * 20
         msg = OutgoingMessage(content=text)
-        parts = _degrade(msg)
+        parts, notices = _degrade(msg)
         # Every part must satisfy the byte budget including [part N/M] prefix
         for part in parts:
             byte_len = len(part.encode("utf-8"))
@@ -520,17 +553,53 @@ class TestParseInlineHints:
             )
         # Must have chunked into multiple parts since text > 237 bytes
         assert len(parts) > 1, f"Expected multiple parts but got {len(parts)}"
-        # Verify total is consistent across all parts (byte-accurate, not char length)
-        # Extract the total (M from [part N/M]) from each part
-        totals = set()
-        for part in parts:
-            # [part 1/2] -> extract 2
-            try:
-                m_val = part.split("/")[1].split("]")[0]
-                totals.add(m_val)
-            except IndexError:
-                pass
-        assert len(totals) == 1, f"Inconsistent total values across parts: {totals}"
+        # Denominator equals the emitted part count (stronger than "consistent").
+        self._assert_denominator_matches_part_count(parts)
+        # Reassembly must be byte-identical to the original content.
+        reencoded = "".join(p.split("] ", 1)[1] for p in parts).encode("utf-8")
+        assert reencoded == text.encode("utf-8")
+
+    def test_degrade_multibyte_frame_boundaries(self):
+        # Regression: '日'*76 (76 * 3 = 228 bytes) and '🌍'*57 (57 * 4 = 228
+        # bytes) each cross the 237-byte boundary and, under the byte-slice
+        # bug, produced a 239-byte part with a U+FFFD injected. Every frame
+        # must be <= 237 bytes and the parts must reassemble byte-identical.
+        for text in ("日" * 76, "🌍" * 57):
+            msg = OutgoingMessage(content=text)
+            parts, _notices = _degrade(msg)
+            for part in parts:
+                byte_len = len(part.encode("utf-8"))
+                assert byte_len <= MAX_PAYLOAD, (
+                    f"{text[:6]!r}...: part over {MAX_PAYLOAD} bytes: "
+                    f"{part!r} ({byte_len} bytes)"
+                )
+            self._assert_denominator_matches_part_count(parts)
+            reencoded = "".join(p.split("] ", 1)[1] for p in parts).encode("utf-8")
+            assert reencoded == text.encode("utf-8"), (
+                f"reassembly not byte-identical for {text[:6]!r}...: "
+                f"U+FFFD injected or data lost"
+            )
+
+    def test_degrade_multibyte_sweep(self):
+        # Sweep across the 237-byte boundary for 3-byte and 4-byte chars.
+        # Zero over-budget or corrupting cases across all lengths.
+        for char, limit in (("日", 399), ("🌍", 299)):
+            for n in range(1, limit + 1):
+                text = char * n
+                msg = OutgoingMessage(content=text)
+                parts, _notices = _degrade(msg)
+                for part in parts:
+                    byte_len = len(part.encode("utf-8"))
+                    assert byte_len <= MAX_PAYLOAD, (
+                        f"char={char!r} n={n}: part over {MAX_PAYLOAD}: "
+                        f"{part!r} ({byte_len} bytes)"
+                    )
+                reencoded = "".join(
+                    p.split("] ", 1)[1] for p in parts
+                ).encode("utf-8")
+                assert reencoded == text.encode("utf-8"), (
+                    f"char={char!r} n={n}: reassembly corrupt"
+                )
 
     def test_hint_with_spaces_in_label(self):
         result = parse_inline_hints("[button:Click Here:action]")

--- a/tests/test_channel_message.py
+++ b/tests/test_channel_message.py
@@ -8,6 +8,7 @@ import pytest
 from tinyagentos.channel_hub.message import (
     IncomingMessage,
     OutgoingMessage,
+    _degrade,
     parse_inline_hints,
 )
 
@@ -459,6 +460,77 @@ class TestParseInlineHints:
     def test_only_whitespace_content_becomes_empty(self):
         result = parse_inline_hints("   ")
         assert result.content == ""
+
+    def test_degrade_drops_buttons_and_images(self):
+        # Build a real OutgoingMessage using parse_inline_hints
+        text = "Reboot the node? [button:Yes:reboot] [image:/tmp/node.png]"
+        msg = parse_inline_hints(text)
+        parts = _degrade(msg)
+        # Buttons and images must be dropped (structured fields cleared)
+        assert msg.buttons == [], f"buttons not dropped: {msg.buttons}"
+        assert msg.images == [], f"images not dropped: {msg.images}"
+        # Chunk size must be byte-accurate
+        for part in parts:
+            assert len(part.encode("utf-8")) <= 237, (
+                f"part exceeds 237 bytes: {part!r} len={len(part.encode('utf-8'))}"
+            )
+        # There should be at least one part
+        assert len(parts) >= 1
+
+    def test_degrade_drops_cards_and_emits_notices(self):
+        # Build a real OutgoingMessage with cards
+        from tinyagentos.channel_hub.message import OutgoingMessage
+        msg = OutgoingMessage(
+            content="Use /help",
+            cards=[{"title": "Help", "body": "Show help"}],
+        )
+        parts = _degrade(msg)
+        # Cards must be dropped
+        assert msg.cards == [], f"cards not dropped: {msg.cards}"
+        # At least one part produced
+        assert len(parts) >= 1
+        # Each part respects the byte budget including prefix
+        for part in parts:
+            assert len(part.encode("utf-8")) <= 237
+
+    def test_degrade_chunks_large_payload(self):
+        # Build a real OutgoingMessage with content exceeding 237 bytes
+        long_text = "A" * 500  # 500 ASCII chars > 237 bytes
+        msg = OutgoingMessage(content=long_text)
+        parts = _degrade(msg)
+        # Every part must satisfy the byte budget including [part N/M] prefix
+        for part in parts:
+            assert len(part.encode("utf-8")) <= 237, (
+                f"part exceeds 237 bytes: {part!r}"
+            )
+        # total must be derived from byte-accurate chunking
+        assert len(parts) > 1
+
+    def test_degrade_with_malay_text_and_em_dash(self):
+        # Non-ASCII text with em-dash to verify byte-accurate chunking.
+        # Use enough text to require chunking (>237 bytes).
+        text = "Selamat pagi! — " * 20 + "selamat petang"
+        msg = OutgoingMessage(content=text)
+        parts = _degrade(msg)
+        # Every part must satisfy the byte budget including [part N/M] prefix
+        for part in parts:
+            byte_len = len(part.encode("utf-8"))
+            assert byte_len <= 237, (
+                f"chunk over 237 bytes: {part!r} ({byte_len} bytes)"
+            )
+        # Must have chunked into multiple parts since text > 237 bytes
+        assert len(parts) > 1, f"Expected multiple parts but got {len(parts)}"
+        # Verify total is consistent across all parts (byte-accurate, not char length)
+        # Extract the total (M from [part N/M]) from each part
+        totals = set()
+        for part in parts:
+            # [part 1/2] -> extract 2
+            try:
+                m_val = part.split("/")[1].split("]")[0]
+                totals.add(m_val)
+            except IndexError:
+                pass
+        assert len(totals) == 1, f"Inconsistent total values across parts: {totals}"
 
     def test_hint_with_spaces_in_label(self):
         result = parse_inline_hints("[button:Click Here:action]")

--- a/tinyagentos/channel_hub/meshtastic_connector.py
+++ b/tinyagentos/channel_hub/meshtastic_connector.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from tinyagentos.channel_hub.message import (
+    MAX_PAYLOAD,
+    IncomingMessage,
+    OutgoingMessage,
+    _degrade,
+)
+
+logger = logging.getLogger(__name__)
+
+# The Meshtastic / LoRa link is a text-only ~237-byte radio frame, so rich
+# OutgoingMessages are degraded (buttons/images/cards dropped with one-time
+# notices, long replies chunked) before reaching the transport.
+
+
+class MeshtasticConnector:
+    """LoRa / Meshtastic text-only channel connector.
+
+    The transport is an injectable async callable ``send_text(frame)`` so the
+    send path is testable without radio hardware; when none is supplied frames
+    are logged at warning level rather than dropped silently.
+    """
+
+    def __init__(self, agent_name: str, router, *, transport=None):
+        self.agent_name = agent_name
+        self.router = router
+        self._transport = transport
+        self._running = False
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """No blocking radio I/O on start; the link is driven per-frame.
+
+        A real deployment opens the Meshtastic serial or BLE link here, but that
+        is deferred to the hardware phase (see tsk-ha5iau). start() must not
+        block so the channel-hub connect path can stand up the connector in
+        tests without hardware.
+        """
+        self._running = True
+        logger.info("Meshtastic connector started for agent '%s'", self.agent_name)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            self._task = None
+
+    async def _transmit(self, text: str) -> None:
+        """Push a single frame (<= MAX_PAYLOAD bytes) through the transport."""
+        if self._transport is None:
+            logger.warning(
+                "Meshtastic transport not configured; dropping frame: %r",
+                text[:40],
+            )
+            return
+        await self._transport(text)
+
+    async def _send_response(self, response: OutgoingMessage) -> None:
+        """Degrade a rich reply for the text-only link and transmit it.
+
+        This is the LoRa send path: it is the only production caller of
+        _degrade. Notices (dropped buttons/images/cards) are surfaced to the
+        transport alongside the chunked parts, and every emitted frame carries
+        a [part N/M] label whose denominator equals the number of parts.
+        """
+        parts, notices = _degrade(response)
+        for notice in notices:
+            await self._transmit(notice)
+        for part in parts:
+            if len(part.encode("utf-8")) > MAX_PAYLOAD:
+                raise ValueError(
+                    f"Meshtastic part exceeds {MAX_PAYLOAD} bytes after degradation: "
+                    f"{len(part.encode('utf-8'))} bytes"
+                )
+            await self._transmit(part)
+
+    async def handle_incoming(self, packet: dict) -> OutgoingMessage | None:
+        """Route an inbound LoRa packet and send the (degraded) reply back."""
+        incoming = IncomingMessage(
+            id=packet.get("id", ""),
+            from_id=packet.get("from_id", packet.get("from", "node")),
+            from_name=packet.get("from_name", "Node"),
+            platform="meshtastic",
+            channel_id=str(packet.get("channel_id", "mesh")),
+            channel_name=packet.get("channel_name", "Mesh"),
+            text=packet.get("text", ""),
+            raw=packet,
+        )
+        response = await self.router.route_message(self.agent_name, incoming)
+        if response is not None:
+            await self._send_response(response)
+        return response

--- a/tinyagentos/channel_hub/message.py
+++ b/tinyagentos/channel_hub/message.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
+import re
 import time
 
 
@@ -32,7 +33,6 @@ class OutgoingMessage:
 
 def parse_inline_hints(text: str) -> OutgoingMessage:
     """Parse inline hints like [button:Label:action] from plain text responses."""
-    import re
     buttons = []
     images = []
     clean_text = text
@@ -52,3 +52,59 @@ def parse_inline_hints(text: str) -> OutgoingMessage:
         buttons=buttons,
         images=images,
     )
+
+
+def _degrade(response: OutgoingMessage) -> list[str]:
+    """Degrade rich elements and chunk long replies for text-only link.
+
+    - Reads response.buttons, response.images, response.cards; drops them
+      and emits a one-time notice per element kind.
+    - Chunks on encoded bytes, not characters, never splitting a multibyte
+      character and always accounting for the '[part N/M] ' prefix bytes.
+    - Derives total from byte-accurate chunking, not len(text).
+    """
+    notices: list[str] = []
+
+    # Drop buttons — emit one-time notice per conversation
+    if response.buttons:
+        if "[button dropped: Meshtastic is text-only]" not in notices:
+            notices.append("[button dropped: Meshtastic is text-only]")
+        response.buttons = []
+
+    # Drop images — emit one-time notice per conversation
+    if response.images:
+        if "[image dropped: Meshtastic is text-only]" not in notices:
+            notices.append("[image dropped: Meshtastic is text-only]")
+        response.images = []
+
+    # Drop cards — emit one-time notice per conversation
+    if response.cards:
+        if "[card dropped: Meshtastic is text-only]" not in notices:
+            notices.append("[card dropped: Meshtastic is text-only]")
+        response.cards = []
+
+    # The text is already clean (parse_inline_hints stripped markup),
+    # but we work with whatever content remains.
+    text = response.content
+
+    # Chunk on encoded bytes, not characters.
+    encoded = text.encode("utf-8")
+    chunk_size = 237  # bytes budget per emitted part (including prefix)
+    total = (len(encoded) + chunk_size - 1) // chunk_size if encoded else 0
+
+    parts: list[str] = []
+    idx = 1
+    start = 0
+    while start < len(encoded):
+        prefix = f"[part {idx}/{total}] ".encode("utf-8")
+        content_bytes = chunk_size - len(prefix)
+        end = start + content_bytes
+        if end > len(encoded):
+            end = len(encoded)
+        byte_chunk = encoded[start:end]
+        chunk_text = byte_chunk.decode("utf-8", errors="replace")
+        parts.append(f"[part {idx}/{total}] {chunk_text}")
+        start = end
+        idx += 1
+
+    return parts

--- a/tinyagentos/channel_hub/message.py
+++ b/tinyagentos/channel_hub/message.py
@@ -54,57 +54,66 @@ def parse_inline_hints(text: str) -> OutgoingMessage:
     )
 
 
-def _degrade(response: OutgoingMessage) -> list[str]:
-    """Degrade rich elements and chunk long replies for text-only link.
+MAX_PAYLOAD = 237  # bytes budget per emitted part (including the [part N/M] prefix)
+
+
+def _degrade(response: OutgoingMessage) -> tuple[list[str], list[str]]:
+    """Degrade rich elements and chunk long replies for the text-only link.
 
     - Reads response.buttons, response.images, response.cards; drops them
-      and emits a one-time notice per element kind.
-    - Chunks on encoded bytes, not characters, never splitting a multibyte
-      character and always accounting for the '[part N/M] ' prefix bytes.
-    - Derives total from byte-accurate chunking, not len(text).
+      and returns a one-time notice per element kind. The notices are meant to
+      be surfaced to the transport, never silently discarded.
+    - Chunks on encoded bytes, never splitting a multibyte character: the
+      chunk boundary is walked back to the last codepoint boundary before
+      decoding, and the '[part N/M] ' prefix bytes always count against
+      the 237-byte budget.
+    - Derives total from the same chunking the parts use, so the label
+      denominator always equals the number of emitted parts even as the
+      prefix width grows (e.g. [part 9/9] -> [part 10/10]).
     """
     notices: list[str] = []
 
-    # Drop buttons — emit one-time notice per conversation
+    # Drop buttons -- emit one-time notice per conversation
     if response.buttons:
-        if "[button dropped: Meshtastic is text-only]" not in notices:
-            notices.append("[button dropped: Meshtastic is text-only]")
+        notices.append("[button dropped: Meshtastic is text-only]")
         response.buttons = []
 
-    # Drop images — emit one-time notice per conversation
+    # Drop images -- emit one-time notice per conversation
     if response.images:
-        if "[image dropped: Meshtastic is text-only]" not in notices:
-            notices.append("[image dropped: Meshtastic is text-only]")
+        notices.append("[image dropped: Meshtastic is text-only]")
         response.images = []
 
-    # Drop cards — emit one-time notice per conversation
+    # Drop cards -- emit one-time notice per conversation
     if response.cards:
-        if "[card dropped: Meshtastic is text-only]" not in notices:
-            notices.append("[card dropped: Meshtastic is text-only]")
+        notices.append("[card dropped: Meshtastic is text-only]")
         response.cards = []
 
     # The text is already clean (parse_inline_hints stripped markup),
     # but we work with whatever content remains.
-    text = response.content
+    encoded = response.content.encode("utf-8")
+    if not encoded:
+        return [], notices
 
-    # Chunk on encoded bytes, not characters.
-    encoded = text.encode("utf-8")
-    chunk_size = 237  # bytes budget per emitted part (including prefix)
-    total = (len(encoded) + chunk_size - 1) // chunk_size if encoded else 0
-
-    parts: list[str] = []
-    idx = 1
-    start = 0
-    while start < len(encoded):
-        prefix = f"[part {idx}/{total}] ".encode("utf-8")
-        content_bytes = chunk_size - len(prefix)
-        end = start + content_bytes
-        if end > len(encoded):
-            end = len(encoded)
-        byte_chunk = encoded[start:end]
-        chunk_text = byte_chunk.decode("utf-8", errors="replace")
-        parts.append(f"[part {idx}/{total}] {chunk_text}")
-        start = end
-        idx += 1
-
-    return parts
+    # Provisional total ignores the prefix length; refine until the label
+    # denominator equals the actual number of emitted parts. The prefix grows
+    # with both idx and total, so the per-part content budget is smaller than
+    # MAX_PAYLOAD and a naive len/237 overcounts capacity and mislabels the last
+    # part (e.g. [part 3/2]).
+    total = max(1, (len(encoded) + MAX_PAYLOAD - 1) // MAX_PAYLOAD)
+    while True:
+        parts: list[str] = []
+        idx = 1
+        start = 0
+        while start < len(encoded):
+            prefix = f"[part {idx}/{total}] ".encode("utf-8")
+            content_bytes = MAX_PAYLOAD - len(prefix)
+            end = min(start + content_bytes, len(encoded))
+            while end < len(encoded) and (encoded[end] & 0xC0) == 0x80:
+                end -= 1
+            chunk_text = encoded[start:end].decode("utf-8")
+            parts.append(f"[part {idx}/{total}] {chunk_text}")
+            start = end
+            idx += 1
+        if len(parts) == total:
+            return parts, notices
+        total = len(parts)

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -105,6 +105,25 @@ async def connect_bot(request: Request):
             request.app.state.channel_hub_connectors = connectors
         return {"status": "connected", "platform": "webchat", "agent_name": agent_name}
 
+    # Meshtastic (LoRa) does not need a bot token secret; the transport is
+    # None until hardware lands, _transmit handles the no-transport path.
+    if platform == "meshtastic":
+        if not agent_name:
+            return JSONResponse({"error": "agent_name is required"}, status_code=400)
+        router_obj = request.app.state.channel_hub_router
+        connectors = getattr(request.app.state, "channel_hub_connectors", {})
+        connector_key = f"meshtastic:{agent_name}"
+
+        from tinyagentos.channel_hub.meshtastic_connector import MeshtasticConnector
+        async with _connect_lock(connector_key):
+            await _stop_prior_connector(connectors, connector_key)
+            connector = MeshtasticConnector(
+                agent_name=agent_name, router=router_obj
+            )
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+        return {"status": "connected", "platform": "meshtastic", "agent_name": agent_name}
+
     bot_token_secret = body.get("bot_token_secret", "")
 
     if not platform or not bot_token_secret or not agent_name:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2623: _degrade is STILL inert (zero production callers), miscounts parts, and discards its notices

Autonomous build of board card tsk-z4fdv4.

REVISION: built on `exec/tsk-itxxdo` (cut at `6501f809ade48959e9de34ae83a86f59a133b045`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

_degrade was inert (zero callers in tinyagentos/), miscounted parts, and
discarded its notices. Three defects fixed:

1. INERT: _degrade had no production caller. Add MeshtasticConnector._send_response
   as the text-only LoRa send path that calls _degrade and forwards each part and
   notice to the transport. The connector is wired onto POST /api/channel-hub/connect.
2. PART COUNTER: total was computed as ceil(len(encoded)/237) before chunking, but
   each part's [part N/M] prefix eats into the 237-byte budget, so the real count
   exceeded total and emitted impossible labels like [part 3/2]. Fix: derive total
   from the same chunking the parts use via a convergent total that re-chunks until
   len(parts) == total.
3. NOTICES DISCARDED: notices was built then never returned -- return parts only.
   Fix: _degrade now returns (parts, notices); the send path surfaces them to the
   transport. The vacuous 'if notice not in notices' guard is removed.

Bonus (#2632): chunk boundaries walk back to a UTF-8 codepoint boundary before
   decoding, so multibyte characters are never sliced mid-codepoint (which produced
   U+FFFD and inflated re-encoded frames past 237 bytes). The connector guard
   raises instead of narrate-truncating-and-shipping an oversize frame.

Proof (164 passed, uv run python -m pytest):
- tests/test_channel_message.py: 64 passed (474-byte regression, multibyte
  boundary + 698-iteration sweep over 'N' n=1..399 and 'W' n=1..299)
- tests/channel_hub/test_meshtastic_connector.py: 8 passed (notice text reaches
  transport, denominator == emitted part count, guard raises on oversize)
- tests/test_channel_hub_new.py: 58 passed (new meshtatic connect route)
- tests/test_channel_hub.py + tests/test_routes_channel_hub.py: 34 passed (no regressions)

Docs-Reviewed: tinyagentos/routes/channel_hub.py adds the meshtatic platform
   branch -- docs/agent-coordination.md documents coordination discipline, not
   the connect route's platform list, so no matching doc edit is required.

Files:
 .../2026-08-28-lora-off-grid-transport-design.md   | 259 +++++++++++----------
 tests/channel_hub/test_meshtastic_connector.py     | 157 +++++++++++++
 tests/test_channel_hub_new.py                      |  22 ++
 tests/test_channel_message.py                      | 141 +++++++++++
 tinyagentos/channel_hub/meshtastic_connector.py    |  96 ++++++++
 tinyagentos/channel_hub/message.py                 |  67 +++++-
 tinyagentos/routes/channel_hub.py                  |  19 ++
 9 files changed, 647 insertions(+), 118 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Meshtastic/LoRa channel connectivity through the Channel Hub.
  - Added support for receiving messages and sending routed replies over text-only radio links.
  - Added automatic handling of rich replies by removing unsupported buttons, images, and cards with notices.
  - Added byte-safe response chunking with `[part N/M]` labels within the 237-byte limit.

- **Bug Fixes**
  - Ensured multibyte characters remain intact and part counts accurately reflect transmitted chunks.

- **Documentation**
  - Updated the LoRa transport design and integration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->