### PR TITLE
Agent container provisioning P1: request record + configurable approval policy

### DIFF
--- a/changelog.d/tsk-zg7ux2-container-requests.md
+++ b/changelog.d/tsk-zg7ux2-container-requests.md
@@ -1,0 +1,11 @@
+### Added
+
+- Agent container provisioning request API: `POST /api/containers/requests`
+  lets an active agent submit a provisioning request using its own registry JWT.
+  A `ContainerRequestStore` (`tinyagentos/container_requests_store.py`) tracks the
+  request state machine (requested, approved, pending-approval, provisioned,
+  failed), and a `ProvisioningPolicy` (`tinyagentos/containers/provisioning_policy.py`)
+  evaluates per-agent quota and threshold from `container_provisioning` config:
+  under quota auto-approves, over quota lands in pending-approval, and over
+  threshold escalates to a Decisions-app item for Jay. No provisioning happens in
+  this slice (P1); the executor lands in P2.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1075,3 +1075,14 @@ Task checklist items (added with the OS-owned objective checklist, #2415):
 - `DELETE` and per-item subpaths (`.../checklist-items/{item_id}`) stay
   session-only: no agent-reachable handler exists, and the allowlist must not
   widen past list + create.
+
+Container provisioning request (P1, agent-container-provisioning spec):
+
+- `POST /api/containers/requests` -- an active agent submits a container
+  provisioning request with its own registry JWT. The route resolves the
+  canonical_id from the token (never from the request body) and applies the
+  provisioning policy (per-agent quota + threshold). Under quota the request is
+  auto-approved; over quota it lands in `pending-approval`; over threshold it is
+  escalated to a Decisions-app item for Jay. This is an identity-only check
+  (no scope grant required), matching the scope-request create flow's use of
+  `check_agent_identity`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,6 +567,10 @@ async def client(app, tmp_data_dir):
     if coding_session_store._db is not None:
         await coding_session_store.close()
     await coding_session_store.init()
+    container_request_store = app.state.container_request_store
+    if container_request_store._db is not None:
+        await container_request_store.close()
+    await container_request_store.init()
     app.state.projects_root.mkdir(parents=True, exist_ok=True)
     canvas_store = app.state.canvas_store
     if canvas_store._db is not None:

--- a/tests/test_container_requests.py
+++ b/tests/test_container_requests.py
@@ -1,0 +1,572 @@
+"""Tests for POST /api/containers/requests (P1 container provisioning).
+
+Covers the policy evaluation: under quota auto-approves, over quota lands in
+pending-approval, over threshold escalates to a Decisions-app item. Includes
+policy-mutation tests that prove the policy is the actual gate (mutating the
+quota changes whether an over-quota request is auto-approved).
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import (
+    AgentRegistryStore,
+    load_or_create_signing_keypair,
+    mint_registry_token,
+)
+from tinyagentos.agent_grants_store import AgentGrantsStore
+from tinyagentos.container_requests_store import ContainerRequestStore
+from tinyagentos.containers.provisioning_policy import (
+    PolicyConfig,
+    ProvisioningPolicy,
+)
+from taos_test_csrf import csrf_event_hooks
+
+
+class _Env:
+    """Fresh stores + a registered active agent, wired onto app.state."""
+
+    def __init__(
+        self,
+        registry,
+        grants,
+        request_store,
+        decision_store,
+        priv,
+        pub,
+        admin_uid,
+    ):
+        self.registry = registry
+        self.grants = grants
+        self.request_store = request_store
+        self.decision_store = decision_store
+        self.priv = priv
+        self.pub = pub
+        self.admin_uid = admin_uid
+
+    def agent_token(self, canonical_id: str, framework: str = "claude") -> str:
+        return mint_registry_token(
+            canonical_id, self.priv, user_id=self.admin_uid, framework=framework
+        )
+
+    async def close(self):
+        await self.registry.close()
+        await self.grants.close()
+        await self.request_store.close()
+        await self.decision_store.close()
+
+
+async def _wire(client, monkeypatch, tmp_path, *, owner_uid=None, policy=None):
+    """Build fresh stores, register one ACTIVE agent, monkeypatch app.state."""
+    app = client._transport.app
+    admin = app.state.auth.find_user("admin")
+    admin_uid = admin["id"] if admin else ""
+    owner_uid = owner_uid if owner_uid is not None else admin_uid
+
+    registry = AgentRegistryStore(tmp_path / "reg.db")
+    await registry.init()
+    grants = AgentGrantsStore(tmp_path / "grants.db")
+    await grants.init()
+    request_store = ContainerRequestStore(tmp_path / "cr.db")
+    await request_store.init()
+    decision_store = app.state.decision_store
+    if decision_store._db is not None:
+        await decision_store.close()
+    await decision_store.init()
+    priv, pub = load_or_create_signing_keypair(tmp_path / "keys")
+
+    monkeypatch.setattr(app.state, "agent_registry", registry)
+    monkeypatch.setattr(app.state, "agent_grants", grants)
+    monkeypatch.setattr(app.state, "agent_registry_keypair", (priv, pub))
+    monkeypatch.setattr(app.state, "container_request_store", request_store)
+    monkeypatch.setattr(app.state, "decision_store", decision_store)
+
+    if policy is not None:
+        monkeypatch.setattr(app.state, "provisioning_policy", policy)
+    else:
+        monkeypatch.setattr(
+            app.state,
+            "provisioning_policy",
+            ProvisioningPolicy(PolicyConfig(quota=1, threshold=3, per_agent_quota={}, per_agent_threshold={})),
+        )
+
+    env = _Env(registry, grants, request_store, decision_store, priv, pub, admin_uid)
+    env.owner_uid = owner_uid
+    return env
+
+
+async def _register_active(env, *, handle="@worker", display="worker", framework="claude"):
+    rec = await env.registry.register(
+        framework=framework,
+        display_name=display,
+        user_id=env.owner_uid,
+        origin="taos-deployed",
+        handle=handle,
+    )
+    return rec["canonical_id"]
+
+
+def _app(client):
+    return client._transport.app
+
+
+# ---------------------------------------------------------------------------
+# Basic auth
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_no_token_returns_401(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        resp = await client.post(
+            "/api/containers/requests",
+            json={"image": "images:debian/bookworm"},
+        )
+        assert resp.status_code == 401, resp.text
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_returns_401(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        app = _app(client)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": "Bearer garbage"},
+                json={"image": "images:debian/bookworm"},
+            )
+        assert resp.status_code == 401, resp.text
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: under quota auto-approves
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_under_quota_auto_approved(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = _app(client)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "first"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "approved", body
+        assert body["canonical_id"] == cid
+        assert "request_id" in body
+        assert "decision_id" not in body
+
+        stored = await env.request_store.get(body["request_id"])
+        assert stored["status"] == "approved"
+        assert stored["canonical_id"] == cid
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: over quota -> pending-approval (NOT auto-approved)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_over_quota_not_auto_approved(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+
+        # First request: under quota (0 active) -> approved.
+        token = env.agent_token(cid)
+        app = _app(client)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp1 = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "first"},
+            )
+        assert resp1.status_code == 200, resp1.text
+        assert resp1.json()["status"] == "approved"
+
+        # Second request: now 1 active, quota=1 -> NOT approved.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp2 = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "second"},
+            )
+        assert resp2.status_code == 200, resp2.text
+        body2 = resp2.json()
+        assert body2["status"] == "pending-approval", body2
+        assert "decision_id" not in body2  # not escalated, just pending
+
+        stored2 = await env.request_store.get(body2["request_id"])
+        assert stored2["status"] == "pending-approval"
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: mutate quota and prove the gate flips
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_policy_mutation_changes_approval(client, monkeypatch, tmp_path):
+    """With quota=5 the same over-quota (was 1) scenario auto-approves.
+    Mutating the policy makes an over-quota request flip from not-approved
+    to approved, proving the policy is the actual gate."""
+    app = _app(client)
+    env = await _wire(
+        client,
+        monkeypatch,
+        tmp_path,
+        policy=ProvisioningPolicy(PolicyConfig(quota=5, threshold=10)),
+    )
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+
+        # Create ONE request: 0 active, under quota=5 -> approved.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp1 = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "first"},
+            )
+        assert resp1.status_code == 200
+        assert resp1.json()["status"] == "approved"
+
+        # Second request: 1 active, still under quota=5 -> approved.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp2 = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "second"},
+            )
+        assert resp2.status_code == 200, resp2.text
+        assert resp2.json()["status"] == "approved", resp2.json()
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: over threshold -> escalated to a Decision
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_over_threshold_escalates_to_decision(client, monkeypatch, tmp_path):
+    """With quota=1, threshold=3: fill to 3 active, then the 4th escalates."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = _app(client)
+
+        # Pre-fill 3 requests so the agent is AT the threshold (count == 3).
+        for _ in range(3):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as bare:
+                r = await bare.post(
+                    "/api/containers/requests",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"image": "images:debian/bookworm"},
+                )
+            assert r.status_code == 200, r.text
+
+        # 4th request: count=3 >= threshold=3 -> escalate.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "escalated"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "pending-approval", body
+        assert "decision_id" in body, body
+
+        # The Decision must exist and reference the request in its metadata.
+        decision = await env.decision_store.get(body["decision_id"])
+        assert decision is not None
+        assert decision["from_agent"] == cid
+        assert decision["type"] == "approve_deny"
+        assert decision["status"] == "pending"
+        meta = decision["metadata"]
+        assert meta["request_id"] == body["request_id"]
+        assert meta["canonical_id"] == cid
+
+        # The request record must be linked to the decision.
+        stored = await env.request_store.get(body["request_id"])
+        assert stored["decision_id"] == body["decision_id"]
+        assert stored["status"] == "pending-approval"
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: per-agent override
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_agent_quota_override(client, monkeypatch, tmp_path):
+    """A per-agent override of quota takes precedence over the default."""
+    app = _app(client)
+    env = await _wire(
+        client,
+        monkeypatch,
+        tmp_path,
+        policy=ProvisioningPolicy(
+            PolicyConfig(quota=1, threshold=5, per_agent_quota={"agent-xyz": 3})
+        ),
+    )
+    try:
+        # Register with handle "xyz" -> canonical_id will be a generated "ag-..." id,
+        # not "agent-xyz". We need to inject the override for the ACTUAL canonical_id.
+        cid = await _register_active(env, handle="@xyz", display="xyz")
+        # Override the per-agent quota for the real canonical_id.
+        env_policy = app.state.provisioning_policy
+        env_policy.configure(
+            PolicyConfig(quota=1, threshold=5, per_agent_quota={cid: 3, "agent-xyz": 3})
+        )
+
+        token = env.agent_token(cid)
+
+        # 3 requests under quota=3 -> first 3 approved, 4th pending.
+        statuses = []
+        for i in range(4):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as bare:
+                r = await bare.post(
+                    "/api/containers/requests",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"image": "images:debian/bookworm", "reason": f"req-{i}"},
+                )
+            assert r.status_code == 200, r.text
+            statuses.append(r.json()["status"])
+
+        assert statuses[:3] == ["approved", "approved", "approved"], statuses
+        assert statuses[3] == "pending-approval", statuses
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Policy: threshold below quota is clamped to quota
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_threshold_clamped_to_quota(client, monkeypatch, tmp_path):
+    """If threshold < quota, the policy clamps threshold to quota so it never
+    escalates before the quota is even reached."""
+    env = await _wire(
+        client,
+        monkeypatch,
+        tmp_path,
+        policy=ProvisioningPolicy(PolicyConfig(quota=5, threshold=2)),
+    )
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = _app(client)
+
+        # 5 requests: all should be approved (threshold clamped to 5).
+        statuses = []
+        for _ in range(5):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as bare:
+                r = await bare.post(
+                    "/api/containers/requests",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"image": "images:debian/bookworm"},
+                )
+            assert r.status_code == 200, r.text
+            statuses.append(r.json()["status"])
+        assert all(s == "approved" for s in statuses), statuses
+
+        # 6th request: 5 active, >= quota (5), >= threshold (5) -> escalate.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            r = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "sixth"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "pending-approval"
+        assert "decision_id" in body, body
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Default config (no explicit policy monkeypatched)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_default_config_aut_approve_and_escalate(client, monkeypatch, tmp_path):
+    """With the DEFAULT policy (quota=2, threshold=5), the first 2 are approved,
+    3rd and 4th are pending-approval, and the 5th escalates."""
+    app = _app(client)
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        # Restore the default policy from config (the _wire helper sets quota=1).
+        monkeypatch.setattr(
+            app.state,
+            "provisioning_policy",
+            ProvisioningPolicy(PolicyConfig(quota=2, threshold=5)),
+        )
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+
+        statuses = []
+        decision_ids = []
+        for i in range(5):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as bare:
+                r = await bare.post(
+                    "/api/containers/requests",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"image": "images:debian/bookworm", "reason": f"req-{i}"},
+                )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            statuses.append(body["status"])
+            decision_ids.append(body.get("decision_id"))
+
+        # 0 active -> approved; 1 active -> approved; 2 active -> pending.
+        assert statuses[:2] == ["approved", "approved"], statuses
+        # 3rd and 4th are pending-approval (over quota, under threshold).
+        assert statuses[2:4] == ["pending-approval", "pending-approval"], statuses
+        assert decision_ids[2:4] == [None, None], decision_ids
+        # 5th: count=4, < threshold=5, so still pending-approval, NOT escalated.
+        assert statuses[4] == "pending-approval", statuses
+        assert decision_ids[4] is None, decision_ids
+
+        # 6th: count=5 >= threshold=5 -> escalate.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            r = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm", "reason": "sixth"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "pending-approval"
+        assert "decision_id" in body, body
+
+        decision = await env.decision_store.get(body["decision_id"])
+        assert decision is not None
+        assert decision["from_agent"] == cid
+        assert decision["type"] == "approve_deny"
+        meta = decision["metadata"]
+        assert meta["request_id"] == body["request_id"]
+        assert meta["canonical_id"] == cid
+        assert meta["active_count"] == 5
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Failed terminal state does NOT count toward quota
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_failed_request_does_not_count_toward_quota(client, monkeypatch, tmp_path):
+    """A request in the 'failed' state is terminal and does not consume quota,
+    so the next request under a tight quota is auto-approved."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = _app(client)
+
+        # First request: approved (under quota=1).
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            r = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm"},
+            )
+        assert r.status_code == 200
+        assert r.json()["status"] == "approved"
+
+        # Mark that request as failed (simulating a P2 provisioning failure).
+        crq_id = r.json()["request_id"]
+        await env.request_store.set_status(crq_id, "failed")
+
+        # Second request: active_count is now 0 (failed doesn't count) -> approved.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            r2 = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "images:debian/bookworm"},
+            )
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["status"] == "approved", r2.json()
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Identity is taken from the token, not the body
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_canonical_id_from_token_not_body(client, monkeypatch, tmp_path):
+    """The canonical_id is always derived from the verified token. A request
+    body cannot bill another agent's quota."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = _app(client)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                "/api/containers/requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"image": "img", "canonical_id": "agent-evil", "reason": "x"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["canonical_id"] == cid
+        assert body["status"] == "approved"
+    finally:
+        await env.close()

--- a/tests/test_register_all_routers.py
+++ b/tests/test_register_all_routers.py
@@ -19,6 +19,7 @@ def test_create_app_registers_routers(tmp_data_dir):
         "/api/cluster/workers",
         "/api/settings/platform",
         "/api/store/app/{app_id}",
+        "/api/containers/requests",
     }
     missing = expected - paths
     assert not missing, f"expected routes missing (router not registered?): {sorted(missing)}"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -456,6 +456,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.coding_sessions.store import CodingSessionStore
     coding_session_store = CodingSessionStore(data_dir / "coding_sessions.db")
     coding_launcher = CodingSessionLauncher()
+
+    from tinyagentos.container_requests_store import ContainerRequestStore
+    container_request_store = ContainerRequestStore(data_dir / "container_requests.db")
     projects_root = data_dir / "projects"
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
@@ -654,6 +657,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.todo_store = todo_store
         await coding_session_store.init()
         app.state.coding_launcher = coding_launcher
+        await container_request_store.init()
         projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
         await desktop_settings.init()
@@ -1731,6 +1735,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.shared_docs_store = shared_docs_store
     app.state.todo_store = todo_store
     app.state.coding_session_store = coding_session_store
+    app.state.container_request_store = container_request_store
+    from tinyagentos.containers.provisioning_policy import PolicyConfig, ProvisioningPolicy
+    app.state.provisioning_policy = ProvisioningPolicy(
+        PolicyConfig.from_app_config(config)
+    )
     app.state.beads_bridge = None
     app.state.canvas_snapshotter = None
     projects_root.mkdir(parents=True, exist_ok=True)

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -55,10 +55,24 @@ _OBSERVATORY_PATHS = frozenset({
     "/api/observatory/fleet",
     "/api/observatory/wake-budget",
 })
+# Container provisioning request: an agent may POST its own registry JWT
+# (identity verified by check_agent_identity in the route; no scope grant
+# required since any active agent may request its own container). The route
+# resolves the canonical_id from the token and never trusts a body field for
+# identity, so a token cannot bill another agent's quota.
+_CONTAINER_REQUEST_PATHS = frozenset({
+    "/api/containers/requests",
+})
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate any other route (no skeleton key).
-_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS | _OBSERVATORY_PATHS
+_AGENT_TOKEN_PATHS = (
+    _REGISTRY_FEED_PATHS
+    | _A2A_BUS_READ_PATHS
+    | _A2A_BUS_WRITE_PATHS
+    | _OBSERVATORY_PATHS
+    | _CONTAINER_REQUEST_PATHS
+)
 
 # Project kanban routes an agent may reach with its own registry JWT (scope
 # project_tasks, verified + project-bound by the route).  These are DYNAMIC

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -37,6 +37,13 @@ DEFAULT_CONFIG = {
     "memory_url": "http://localhost:7900",
     "webhooks": [],
     "wake_budget": {"global_default": 2, "per_agent": {}, "per_project": {}},
+    "container_provisioning": {
+        "quota": 2,
+        "threshold": 5,
+        "per_agent_quota": {},
+        "per_agent_threshold": {},
+        "default_image": "images:debian/bookworm",
+    },
 }
 
 _config_lock = asyncio.Lock()
@@ -63,6 +70,7 @@ class AppConfig:
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
     wake_budget: dict = field(default_factory=lambda: copy.deepcopy(DEFAULT_CONFIG["wake_budget"]))
+    container_provisioning: dict = field(default_factory=lambda: copy.deepcopy(DEFAULT_CONFIG["container_provisioning"]))
     # Locally-hosted taOSmd deployment hooks for /api/settings/update: the git
     # checkout the running service imports from, and the command that restarts
     # it (e.g. "sudo systemctl restart taosmd"). Both empty on installs where

--- a/tinyagentos/container_requests_store.py
+++ b/tinyagentos/container_requests_store.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+"""SQLite-backed store for agent container provisioning requests (P1).
+
+An agent submits a request to provision a container for hosting a project.
+The request record tracks the state machine:
+
+    requested -> approved            (policy auto-approved: under quota)
+    requested -> pending-approval    (over quota: needs manual review)
+    requested -> pending-approval    (over threshold: escalated to Decisions)
+
+``approved`` is the P2 trigger: the provisioning executor creates the incus
+container and transitions to ``provisioned``. ``failed`` captures provisioning
+errors. Terminal states are ``provisioned`` and ``failed``; all others are
+non-terminal (an active/in-progress request that still consumes quota).
+"""
+
+import json
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+# Open set of states. Stored as strings so they are inspectable in raw SQL and
+# can be added to without a schema migration in early slices.
+STATES = ("requested", "approved", "pending-approval", "provisioned", "failed")
+TERMINAL_STATES = ("provisioned", "failed")
+
+CONTAINER_REQUESTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS container_requests (
+    id               TEXT PRIMARY KEY,
+    canonical_id     TEXT NOT NULL,
+    image            TEXT NOT NULL DEFAULT '',
+    status           TEXT NOT NULL DEFAULT 'requested',
+    reason           TEXT NOT NULL DEFAULT '',
+    config_json      TEXT NOT NULL DEFAULT '{}',
+    decision_id      TEXT,
+    container_name   TEXT,
+    error            TEXT,
+    created_at       REAL NOT NULL,
+    updated_at       REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_crq_canonical ON container_requests(canonical_id, status, created_at);
+CREATE INDEX IF NOT EXISTS idx_crq_status ON container_requests(status);
+"""
+
+_JSON_FIELDS = ("config_json",)
+
+
+def _row_to_request(row, description) -> dict:
+    d = dict(zip([c[0] for c in description], row))
+    for f in _JSON_FIELDS:
+        if d.get(f) is not None:
+            try:
+                d[f] = json.loads(d[f])
+            except (json.JSONDecodeError, TypeError):
+                d[f] = {}
+    return d
+
+
+class ContainerRequestStore(BaseStore):
+    SCHEMA = CONTAINER_REQUESTS_SCHEMA
+
+    async def create(
+        self,
+        canonical_id: str,
+        *,
+        image: str = "",
+        reason: str = "",
+        config: dict | None = None,
+    ) -> dict:
+        """Insert a new request in the ``requested`` state and return the row."""
+        if canonical_id is None or not canonical_id.strip():
+            raise ValueError("canonical_id is required")
+        crq_id = new_id("crq")
+        now = time.time()
+        config_str = json.dumps(config or {})
+        await self._db.execute(
+            """INSERT INTO container_requests
+               (id, canonical_id, image, status, reason, config_json, created_at, updated_at)
+               VALUES (?, ?, ?, 'requested', ?, ?, ?, ?)""",
+            (crq_id, canonical_id, image, reason, config_str, now, now),
+        )
+        await self._db.commit()
+        return await self.get(crq_id)
+
+    async def get(self, request_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM container_requests WHERE id = ?", (request_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_request(row, cur.description)
+
+    async def list(
+        self,
+        *,
+        canonical_id: str | None = None,
+        status: str | None = None,
+        limit: int = 200,
+    ) -> list[dict]:
+        conds, params = [], []
+        if canonical_id is not None:
+            conds.append("canonical_id = ?")
+            params.append(canonical_id)
+        if status is not None:
+            conds.append("status = ?")
+            params.append(status)
+        where = (" WHERE " + " AND ".join(conds)) if conds else ""
+        limit = max(1, min(int(limit), 500))
+        async with self._db.execute(
+            f"SELECT * FROM container_requests{where} ORDER BY created_at DESC LIMIT ?",
+            [*params, limit],
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_request(r, desc) for r in rows]
+
+    async def count_active_for_agent(self, canonical_id: str) -> int:
+        """Count non-terminal requests for an agent (quota-consuming)."""
+        async with self._db.execute(
+            """SELECT COUNT(*) FROM container_requests
+               WHERE canonical_id = ? AND status NOT IN ('provisioned', 'failed')""",
+            (canonical_id,),
+        ) as cur:
+            row = await cur.fetchone()
+            return row[0] if row else 0
+
+    async def set_status(
+        self,
+        request_id: str,
+        status: str,
+        *,
+        container_name: str | None = None,
+        error: str | None = None,
+        decision_id: str | None = None,
+    ) -> dict | None:
+        if status not in STATES:
+            raise ValueError(f"invalid status: {status!r}")
+        now = time.time()
+        updates: list[str] = ["status = ?", "updated_at = ?"]
+        params: list = [status, now]
+        if container_name is not None:
+            updates.append("container_name = ?")
+            params.append(container_name)
+        if error is not None:
+            updates.append("error = ?")
+            params.append(error)
+        if decision_id is not None:
+            updates.append("decision_id = ?")
+            params.append(decision_id)
+        params.append(request_id)
+        cur = await self._db.execute(
+            f"UPDATE container_requests SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
+        await self._db.commit()
+        if cur.rowcount != 1:
+            return None
+        return await self.get(request_id)
+
+    async def link_decision(self, request_id: str, decision_id: str) -> dict | None:
+        now = time.time()
+        cur = await self._db.execute(
+            "UPDATE container_requests SET decision_id = ?, updated_at = ? WHERE id = ?",
+            (decision_id, now, request_id),
+        )
+        await self._db.commit()
+        if cur.rowcount != 1:
+            return None
+        return await self.get(request_id)

--- a/tinyagentos/containers/provisioning_policy.py
+++ b/tinyagentos/containers/provisioning_policy.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Provisioning policy: decides what happens to a container request.
+
+The policy is driven entirely by config (``app.state.config.container_provisioning``):
+
+- ``quota``: max containers an agent may have auto-approved at once.
+- ``threshold``: if an agent already has >= threshold non-terminal requests,
+  the new request is escalated to a Decisions-app item for Jay instead of
+  auto-approving or pending.
+- ``per_agent_quota`` / ``per_agent_threshold``: per-agent overrides.
+
+A request is auto-approved when the agent's current non-terminal count is
+below the effective quota. When the count sits between the quota and the
+threshold, the request lands in ``pending-approval`` (manual review). When
+the count meets or exceeds the threshold, the request is escalated to a
+Decision and its state is set to ``pending-approval`` so a human can resolve
+the Decision and then approve/reject.
+
+The policy engine is intentionally pure: it takes a count and returns a
+verdict. The route wires the verdict to the store + DecisionStore.
+"""
+
+from dataclasses import dataclass
+
+# Policy verdicts
+APPROVE = "approve"
+PENDING = "pending-approval"
+ESCALATE = "escalate"
+
+_VERDICT_PRIORITY = {APPROVE: 0, PENDING: 1, ESCALATE: 2}
+
+
+@dataclass
+class PolicyConfig:
+    quota: int
+    threshold: int
+    per_agent_quota: dict = None
+    per_agent_threshold: dict = None
+
+    def __post_init__(self):
+        self.per_agent_quota = self.per_agent_quota or {}
+        self.per_agent_threshold = self.per_agent_threshold or {}
+
+    @classmethod
+    def from_app_config(cls, config) -> "PolicyConfig":
+        cp = getattr(config, "container_provisioning", None)
+        if cp is None:
+            cp = {}
+        return cls(
+            quota=int(cp.get("quota", 2)),
+            threshold=int(cp.get("threshold", 5)),
+            per_agent_quota=dict(cp.get("per_agent_quota", {})),
+            per_agent_threshold=dict(cp.get("per_agent_threshold", {})),
+        )
+
+
+class ProvisioningPolicy:
+    """Evaluates container requests against quota + threshold rules."""
+
+    def __init__(self, config: PolicyConfig | None = None):
+        self._config = config
+
+    def configure(self, config: PolicyConfig) -> None:
+        self._config = config
+
+    @property
+    def config(self) -> PolicyConfig | None:
+        return self._config
+
+    def _effective_limits(self, canonical_id: str) -> tuple[int, int]:
+        if self._config is None:
+            return 2, 5
+        quota = self._config.per_agent_quota.get(canonical_id, self._config.quota)
+        threshold = self._config.per_agent_threshold.get(canonical_id, self._config.threshold)
+        if threshold < quota:
+            threshold = quota
+        return quota, threshold
+
+    def evaluate(self, canonical_id: str, active_count: int) -> str:
+        """Return the policy verdict for an agent's request given its current
+        non-terminal container count."""
+        quota, threshold = self._effective_limits(canonical_id)
+        if active_count >= threshold:
+            return ESCALATE
+        if active_count >= quota:
+            return PENDING
+        return APPROVE

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm", "note", "str")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm", "note", "str", "crq")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -418,6 +418,9 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_images import router as agent_images_router
     app.include_router(agent_images_router, dependencies=_csrf)
 
+    from tinyagentos.routes.container_requests import router as container_requests_router
+    app.include_router(container_requests_router, dependencies=_csrf)
+
     from tinyagentos.routes.notes import router as notes_router
     app.include_router(notes_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/container_requests.py
+++ b/tinyagentos/routes/container_requests.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+"""Routes for agent-requested container provisioning (P1).
+
+POST /api/containers/requests -- an agent with its own registry JWT submits a
+provisioning request. The policy engine evaluates quota + threshold against the
+agent's existing non-terminal requests:
+
+  - under quota       -> auto-approved (state: approved)
+  - over quota        -> pending-approval (manual review)
+  - over threshold    -> escalated to the Decisions app for Jay, then
+                         pending-approval
+
+No provisioning happens in P1; the executor lands in P2.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from tinyagentos.agent_token_auth import check_agent_identity
+from tinyagentos.containers.provisioning_policy import (
+    ESCALATE,
+    PENDING,
+    APPROVE,
+    PolicyConfig,
+    ProvisioningPolicy,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class CreateContainerRequest(BaseModel):
+    image: str | None = None
+    reason: str = ""
+    config: dict | None = None
+
+
+def _get_request_store(request: Request):
+    store = getattr(request.app.state, "container_request_store", None)
+    if store is None:
+        raise RuntimeError("container_request_store not on app.state")
+    return store
+
+
+def _get_decision_store(request: Request):
+    store = getattr(request.app.state, "decision_store", None)
+    if store is None:
+        raise RuntimeError("decision_store not on app.state")
+    return store
+
+
+def _get_policy(request: Request) -> ProvisioningPolicy:
+    policy = getattr(request.app.state, "provisioning_policy", None)
+    if policy is None:
+        cfg = getattr(request.app.state, "config", None)
+        policy = ProvisioningPolicy(PolicyConfig.from_app_config(cfg))
+    return policy
+
+
+@router.post("/api/containers/requests")
+async def create_container_request(
+    request: Request,
+    body: CreateContainerRequest,
+):
+    """Submit a container provisioning request.
+
+    Auth: the agent's own registry JWT (Bearer). The verified canonical_id is
+    taken from the token, never from the request body, so an agent cannot
+    request a container billed to another identity.
+
+    Returns ``{request_id, canonical_id, status}``. ``status`` is the
+    post-policy state: ``approved`` or ``pending-approval``.
+    """
+    canonical_id = await check_agent_identity(request)
+    if canonical_id is None:
+        raise HTTPException(status_code=401, detail="agent identity required")
+
+    store = _get_request_store(request)
+    policy = _get_policy(request)
+
+    # Count EXISTING non-terminal requests BEFORE creating the new one, so the
+    # policy evaluates the agent's current quota usage, not the incoming request.
+    cfg = getattr(request.app.state, "config", None)
+    default_image = ""
+    if cfg is not None:
+        default_image = cfg.container_provisioning.get("default_image", "")
+    image = body.image or default_image or ""
+
+    active_count = await store.count_active_for_agent(canonical_id)
+    verdict = policy.evaluate(canonical_id, active_count)
+
+    record = await store.create(
+        canonical_id,
+        image=image,
+        reason=body.reason,
+        config=body.config or {},
+    )
+
+    decision_id = None
+    if verdict == APPROVE:
+        status = "approved"
+    elif verdict == PENDING:
+        status = "pending-approval"
+    else:
+        # Over threshold: escalate to a Decisions-app item for Jay.
+        decision_store = _get_decision_store(request)
+        crq_id = record["id"]
+        question = (
+            f"Agent {canonical_id} has exceeded its container provisioning "
+            f"threshold and is requesting a new container "
+            f"(request {crq_id}, image={image or 'default'}). "
+            f"Approve or deny?"
+        )
+        decision = await decision_store.create(
+            from_agent=canonical_id,
+            question=question,
+            type="approve_deny",
+            priority="normal",
+            project_id=None,
+            user_id="",
+            context=f"container_request:{crq_id}",
+            metadata={
+                "request_id": crq_id,
+                "canonical_id": canonical_id,
+                "image": image,
+                "reason": body.reason,
+                "active_count": active_count,
+            },
+        )
+        decision_id = decision["id"]
+        await store.link_decision(crq_id, decision_id)
+        status = "pending-approval"
+
+    updated = await store.set_status(record["id"], status, decision_id=decision_id)
+
+    result = {
+        "request_id": updated["id"],
+        "canonical_id": updated["canonical_id"],
+        "status": updated["status"],
+    }
+    if decision_id:
+        result["decision_id"] = decision_id
+    return result


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent container provisioning P1: request record + configurable approval policy

Autonomous build of board card tsk-zg7ux2.

Add POST /api/containers/requests so an active agent can submit a container
provisioning request using its own registry JWT. The request record tracks a
state machine (requested, approved, pending-approval, provisioned, failed).
A ProvisioningPolicy evaluates per-agent quota and threshold from the
container_provisioning config: under quota auto-approves, over quota lands
in pending-approval, and over threshold escalates to a Decisions-app item
for the operator. No provisioning happens in this slice; the executor lands
in P2.

- ContainerRequestStore (tinyagentos/container_requests_store.py): SQLite
  store with create, get, list, count_active_for_agent, set_status,
  link_decision.
- ProvisioningPolicy (tinyagentos/containers/provisioning_policy.py): pure
  quota + threshold evaluation with per-agent overrides.
- Route (tinyagentos/routes/container_requests.py): agent-authenticated via
  check_agent_identity; canonical_id taken from token, never the body.
- app.py: initialize ContainerRequestStore and ProvisioningPolicy on
  app.state; init store in lifespan.
- auth_middleware.py: add /api/containers/requests to the agent-token
  Bearer allowlist (_CONTAINER_REQUEST_PATHS).
- config.py: add container_provisioning DEFAULT_CONFIG + AppConfig field.
- projects/ids.py: register 'crq' ID prefix.
- docs/agent-coordination.md: document the new bearer allowlist path.
- changelog.d/tsk-zg7ux2-container-requests.md: changelog fragment.
- tests/test_container_requests.py: policy-gate coverage including quota
  mutation and decision escalation assertion.

Spec: agent-container-provisioning.md (P1)
Signed-off-by: jaylfc <jaylfc25@gmail.com>

Files:
 tinyagentos/auth_middleware.py                |  16 +-
 tinyagentos/config.py                         |   8 +
 tinyagentos/container_requests_store.py       | 172 ++++++++
 tinyagentos/containers/provisioning_policy.py |  88 ++++
 tinyagentos/projects/ids.py                   |   2 +-
 tinyagentos/routes/__init__.py                |   3 +
 tinyagentos/routes/container_requests.py      | 147 +++++++
 13 files changed, 1042 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an agent-facing API for requesting container provisioning.
  - Requests are authenticated using the agent’s registry token.
  - Provisioning requests are automatically approved within quota limits.
  - Requests exceeding quota enter pending approval; requests reaching escalation thresholds create a decision for review.
  - Added configurable global and per-agent quotas, thresholds, and default container image settings.
  - Request statuses can be tracked through their lifecycle.

- **Documentation**
  - Documented the new container provisioning request API and approval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->