### PR TITLE
peer.deliver_handshake: unguarded SSRF egress + dict/str endpoint mismatch — must be fixed before it gets a caller

### DIFF
--- a/changelog.d/tsk-cuvpep-ssrf-type-fix.md
+++ b/changelog.d/tsk-cuvpep-ssrf-type-fix.md
@@ -1,0 +1,2 @@
+### Fixed
+- `deliver_handshake` now validates each peer endpoint URL through the shared SSRF guard (`validate_url_or_raise`) before POSTing, blocking loopback, link-local, multicast, CGNAT (100.64/10), and RFC1918 targets. It also accepts the normalized dict endpoint form `{"kind", "url", "priority"}` stored by `establish_peer_link`, fixing the `AttributeError` on `.rstrip` that fires when the first caller reads endpoints via `get_peer_link`.

--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -5,6 +5,7 @@ import json
 import time
 from pathlib import Path
 
+import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -12,6 +13,7 @@ from httpx import ASGITransport, AsyncClient
 from tinyagentos.contacts_store import ContactsStore, generate_peer_token, _hash_token
 from tinyagentos.peer import (
     build_envelope,
+    deliver_handshake,
     resolve_local_identity_id,
     verify_envelope,
     verify_envelope_signature,
@@ -914,3 +916,137 @@ class TestPeerRoutes:
             statuses.append(resp.status_code)
 
         assert 429 in statuses, f"expected 429 in statuses, got: {set(statuses)}"
+
+
+# ---------------------------------------------------------------------------
+# deliver_handshake tests (SSRF guard + dict endpoint handling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDeliverHandshake:
+    """Tests for peer.deliver_handshake: SSRF guard + dict endpoint handling."""
+
+    @staticmethod
+    def _mock_client(seen: dict) -> httpx.AsyncClient:
+        """Build an httpx client with a MockTransport that records POSTs."""
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen["called"] = True
+            seen["url"] = str(req.url)
+            return httpx.Response(200)
+
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    async def test_ssrf_blocks_cgnat_tailnet_endpoint(self):
+        """deliver_handshake must not POST to a literal CGNAT (100.64/10) address.
+
+        The A2A bus lives in this range; a CGNAT-blind guard would let it
+        through.  Uses a literal IP (NOT a rebinding test) to probe the real
+        gap proven on #2556.
+        """
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            result = await deliver_handshake(
+                {"envelope": "test"}, ["http://100.64.0.1/"],
+                http_client=client,
+            )
+            assert result is False
+            assert "called" not in seen
+        finally:
+            await client.aclose()
+
+    async def test_ssrf_blocks_rfc1918_lan_endpoint(self):
+        """deliver_handshake must not POST to a literal RFC1918 LAN address."""
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            result = await deliver_handshake(
+                {"envelope": "test"}, ["http://192.168.1.1/"],
+                http_client=client,
+            )
+            assert result is False
+            assert "called" not in seen
+        finally:
+            await client.aclose()
+
+    async def test_ssrf_blocks_loopback_endpoint(self):
+        """Baseline: loopback (127.0.0.1) is also blocked."""
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            result = await deliver_handshake(
+                {"envelope": "test"}, ["http://127.0.0.1/"],
+                http_client=client,
+            )
+            assert result is False
+            assert "called" not in seen
+        finally:
+            await client.aclose()
+
+    async def test_delivers_to_public_endpoint(self):
+        """A public endpoint must succeed (guard does not block legit delivery)."""
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            result = await deliver_handshake(
+                {"envelope": "test"}, ["http://93.184.216.34/"],
+                http_client=client,
+            )
+            assert result is True
+            assert seen["url"] == "http://93.184.216.34/api/peer/inbox"
+        finally:
+            await client.aclose()
+
+    async def test_delivers_to_dict_endpoints_from_stored_link(self, store):
+        """deliver_handshake handles dict-format endpoints from get_peer_link.
+
+        Drives the REAL stored-link path: establish_peer_link -> get_peer_link
+        -> deliver_handshake.  Before the fix this raised AttributeError
+        because deliver_handshake called .rstrip on dicts.
+        """
+        await store.add_contact(
+            contact_id="hub:dict-ep",
+            hub_username="dict-ep",
+            display_name="D",
+            ed25519_pub="pk",
+            x25519_pub="ek",
+        )
+        # Dict endpoints, exactly as _try_handshake normalizes them.
+        await store.establish_peer_link(
+            contact_id="hub:dict-ep",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+            endpoints=[{"kind": "hub", "url": "http://93.184.216.34/", "priority": 0}],
+        )
+        link = await store.get_peer_link("hub:dict-ep")
+        assert isinstance(link["endpoints"][0], dict)  # real dict form
+
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            envelope = {"from": "hub:local", "to": "hub:dict-ep", "kind": "handshake"}
+            # Must NOT raise AttributeError.
+            result = await deliver_handshake(
+                envelope, link["endpoints"], http_client=client,
+            )
+            assert result is True
+            assert seen["url"] == "http://93.184.216.34/api/peer/inbox"
+        finally:
+            await client.aclose()
+
+    async def test_skips_blocked_then_delivers_next(self):
+        """A blocked endpoint is skipped; delivery proceeds to the next."""
+        seen = {}
+        client = self._mock_client(seen)
+        try:
+            result = await deliver_handshake(
+                {"envelope": "test"},
+                ["http://100.64.0.1/", "http://93.184.216.34/"],
+                http_client=client,
+            )
+            assert result is True
+            assert seen["url"] == "http://93.184.216.34/api/peer/inbox"
+        finally:
+            await client.aclose()

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -169,12 +169,14 @@ def mint_peer_token(sub: str) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 # Handshake delivery
 # ---------------------------------------------------------------------------
-# WARNING: send_handshake / deliver_handshake currently have zero callers
-# repo-wide.  deliver_handshake POSTs to peer-supplied URLs with no SSRF
-# guard — wire a validating transport (e.g. an ssrf-safe httpx wrapper that
-# blocks internal/loopback/cloud-metadata targets) before either function
-# gets a caller.  Without it, a malicious peer endpoint could probe or
-# traverse the local network.
+# deliver_handshake POSTs to peer-supplied URLs.  Each target URL is passed
+# through the shared SSRF guard (tinyagentos.routes.desktop_browser.ssrf)
+# before the POST, so a peer endpoint can never reach loopback, link-local,
+# multicast, CGNAT (100.64/10, where our own A2A bus lives), or other private
+# ranges.  Endpoints may arrive as bare strings (send_handshake output) or as
+# normalized dicts {"kind", "url", "priority"} (from _try_handshake in
+# routes/hub.py, persisted via establish_peer_link); _endpoint_url handles
+# both.  The first caller is A2's friend-accept flow in routes/hub.py.
 
 
 def send_handshake(
@@ -216,13 +218,37 @@ def send_handshake(
     )
 
 
+def _endpoint_url(ep: str | dict) -> str | None:
+    """Extract a URL string from a peer endpoint.
+
+    Accepts both bare strings (legacy / send_handshake output) and the
+    normalized dict form ``{"kind", "url", "priority"}`` produced by
+    ``_try_handshake`` in routes/hub.py and persisted by
+    ``establish_peer_link``.  Returns None for anything that is neither.
+    """
+    if isinstance(ep, dict):
+        return ep.get("url")
+    if isinstance(ep, str):
+        return ep
+    return None
+
+
 async def deliver_handshake(
     envelope: dict,
-    peer_endpoints: list[str],
+    peer_endpoints: list[str | dict],
     *,
     http_client=None,
 ) -> bool:
     """Deliver a handshake envelope to the peer's endpoints (best-effort).
+
+    Handles both bare-string endpoints and the normalized dict form
+    ``{"kind", "url", "priority"}`` used by peer links (see
+    ``_try_handshake`` in routes/hub.py and ``establish_peer_link``).
+
+    Each target URL is validated against the shared SSRF guard before the
+    POST so a peer-supplied pointer can never reach loopback, link-local,
+    multicast, CGNAT (100.64/10, where our own A2A bus lives), or other
+    private ranges.
 
     Tries each endpoint in order; stops on the first 2xx response.  Returns
     True if at least one endpoint accepted the envelope, False otherwise.
@@ -232,13 +258,25 @@ async def deliver_handshake(
     """
     import httpx
 
+    from tinyagentos.routes.desktop_browser.ssrf import (
+        SsrfBlockedError,
+        validate_url_or_raise,
+    )
+
     own_client = http_client is None
     if own_client:
         http_client = httpx.AsyncClient(timeout=15.0)
 
     try:
         for ep in peer_endpoints:
-            url = ep.rstrip("/") + "/api/peer/inbox"
+            ep_url = _endpoint_url(ep)
+            if not ep_url:
+                continue
+            url = ep_url.rstrip("/") + "/api/peer/inbox"
+            try:
+                validate_url_or_raise(url)
+            except SsrfBlockedError:
+                continue
             try:
                 resp = await http_client.post(
                     url, json={"envelope": envelope},


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): peer.deliver_handshake: unguarded SSRF egress + dict/str endpoint mismatch — must be fixed before it gets a caller

Autonomous build of board card tsk-cuvpep.

deliver_handshake POSTs to peer-supplied URLs.  Two issues blocked its
use by a first caller:

1. SSRF: no URL validation before POSTing, so a malicious peer endpoint
   could probe or traverse the local network, including our own A2A bus
   in the 100.64/10 CGNAT range.  Now every target URL is passed through
   the shared validate_url_or_raise guard (same module used by the
   UnifiedPush #2556 block), which always rejects CGNAT, loopback,
   link-local, multicast and unspecified addresses, plus RFC1918 by
   default.

2. Type mismatch: _try_handshake (routes/hub.py) normalizes endpoints to
   dict form {kind, url, priority} and stores them via establish_peer_link;
   get_peer_link returns those dicts.  deliver_handshake called .rstrip on
   each item, raising AttributeError on the dict path.  Added _endpoint_url
   to normalize both bare strings and dict endpoints.

Tests:
- SSRF red-tests on literal (not rebound) internal IPs: 100.64.0.1 (CGNAT)
  and 192.168.1.1 (RFC1918), plus a loopback baseline.  The mock transport
  records the POST; on unfixed code the POST fires (test fails), after the
  fix it is blocked (test passes).
- Type test drives the real stored-link path: establish_peer_link ->
  get_peer_link -> deliver_handshake, confirming dict endpoints are
  handled without AttributeError.
- Positive control: a public endpoint (93.184.216.34) still delivers.
- Blocked-then-next: a CGNAT endpoint is skipped and delivery falls through
  to the next endpoint.

124 tests pass (test_contacts_peer, test_unifiedpush, test_ssrf,
test_collab_a2_handshake).

Files:
 changelog.d/tsk-cuvpep-ssrf-type-fix.md |   2 +
 tests/test_contacts_peer.py             | 136 ++++++++++++++++++++++++++++++++
 tinyagentos/peer.py                     |  54 +++++++++++--
 3 files changed, 184 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Handshake delivery now supports normalized peer endpoint records without errors.
  - Unsafe local, private, multicast, link-local, and CGNAT destinations are blocked before requests are sent.
  - Blocked endpoints are skipped so delivery can continue using another reachable endpoint.
  - Public endpoints continue to receive handshakes successfully.

- **Tests**
  - Added coverage for endpoint formats, SSRF protection, successful delivery, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->