### PR TITLE
Agent desktop D1: install and run a desktop inside an existing agent LXC

### DIFF
--- a/changelog.d/tsk-eofalz-agent-desktop-lifecycle.md
+++ b/changelog.d/tsk-eofalz-agent-desktop-lifecycle.md
@@ -1,0 +1,2 @@
+### Added
+- Per-agent desktop lifecycle routes: install XFCE + x11vnc into an existing agent LXC on demand, plus start, stop, and status endpoints under `/api/agents/{agent_name}/desktop/*`.

--- a/docs/routes.d/13-index.md
+++ b/docs/routes.d/13-index.md
@@ -20,3 +20,4 @@ Run `python3 scripts/build-routes-doc.py` to compile these into `docs/routes.md`
 | `10-cluster-admin.md` | Cluster node revoke, block and unblock (admin-only) |
 | `11-select-decision.md` | Answering a select decision with free text (`other_value`) |
 | `12-share-routes.md` | User resource sharing (share routes) |
+| `14-agent-desktop.md` | Agent desktop lifecycle (install, start, stop, status) |

--- a/docs/routes.d/14-agent-desktop.md
+++ b/docs/routes.d/14-agent-desktop.md
@@ -1,0 +1,31 @@
+# Agent desktop lifecycle (install, start, stop, status)
+
+<!-- Route module `tinyagentos/routes/agent_desktop.py`. Owner routes behind the session cookie; no registry scope reaches them -->
+
+## Routes
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/agents/{agent_name}/desktop/install` | Install XFCE + x11vnc into the agent container |
+| `POST` | `/api/agents/{agent_name}/desktop/start` | Start the XFCE desktop + VNC server |
+| `POST` | `/api/agents/{agent_name}/desktop/stop` | Stop the running desktop session |
+| `GET` | `/api/agents/{agent_name}/desktop/status` | Report install and runtime state |
+
+## States
+
+| state | meaning |
+|---|---|
+| `not_installed` | desktop packages not yet installed |
+| `installed` | packages installed, session not running |
+| `starting` | start in progress |
+| `running` | x11vnc is listening on :5900 inside the container |
+| `stopping` | stop in progress |
+| `stopped` | packages installed but no session running |
+| `error` | last operation failed |
+
+## Key points
+
+- Install is **on demand** and **opt-in per agent**. It does not change the default agent image or boot time.
+- Start is idempotent: calling start on a running desktop returns 200 without side effects.
+- Stop is idempotent: calling stop on a stopped desktop returns the current state.
+- Status probes the container for the `x11vnc` process when the cached state says running; if the process is absent it resets the cached state to `stopped`.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -408,3 +408,36 @@ Run `python3 scripts/build-routes-doc.py` to compile these into `docs/routes.md`
 | `10-cluster-admin.md` | Cluster node revoke, block and unblock (admin-only) |
 | `11-select-decision.md` | Answering a select decision with free text (`other_value`) |
 | `12-share-routes.md` | User resource sharing (share routes) |
+| `14-agent-desktop.md` | Agent desktop lifecycle (install, start, stop, status) |
+
+---
+
+# Agent desktop lifecycle (install, start, stop, status)
+
+## Routes
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/agents/{agent_name}/desktop/install` | Install XFCE + x11vnc into the agent container |
+| `POST` | `/api/agents/{agent_name}/desktop/start` | Start the XFCE desktop + VNC server |
+| `POST` | `/api/agents/{agent_name}/desktop/stop` | Stop the running desktop session |
+| `GET` | `/api/agents/{agent_name}/desktop/status` | Report install and runtime state |
+
+## States
+
+| state | meaning |
+|---|---|
+| `not_installed` | desktop packages not yet installed |
+| `installed` | packages installed, session not running |
+| `starting` | start in progress |
+| `running` | x11vnc is listening on :5900 inside the container |
+| `stopping` | stop in progress |
+| `stopped` | packages installed but no session running |
+| `error` | last operation failed |
+
+## Key points
+
+- Install is **on demand** and **opt-in per agent**. It does not change the default agent image or boot time.
+- Start is idempotent: calling start on a running desktop returns 200 without side effects.
+- Stop is idempotent: calling stop on a stopped desktop returns the current state.
+- Status probes the container for the `x11vnc` process when the cached state says running; if the process is absent it resets the cached state to `stopped`.

--- a/tests/test_agent_desktop.py
+++ b/tests/test_agent_desktop.py
@@ -1,0 +1,169 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestAgentDesktopLifecycle:
+    async def test_status_before_install_is_not_installed(self, client):
+        resp = await client.get("/api/agents/test-agent/desktop/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "not_installed"
+        assert data["running"] is False
+
+    async def test_install_returns_installed(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp = await client.post("/api/agents/test-agent/desktop/install")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "installed"
+        assert len(calls) == 1
+        assert calls[0][0] == "taos-agent-test-agent"
+        assert "apt-get install" in " ".join(calls[0][1])
+
+    async def test_install_is_idempotent(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp1 = await client.post("/api/agents/test-agent/desktop/install")
+        assert resp1.status_code == 200
+        resp2 = await client.post("/api/agents/test-agent/desktop/install")
+        assert resp2.status_code == 200
+        assert len(calls) == 1
+
+    async def test_start_after_install(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        resp = await client.post("/api/agents/test-agent/desktop/install")
+        assert resp.status_code == 200
+
+        resp = await client.post("/api/agents/test-agent/desktop/start")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "running"
+        assert any("x11vnc" in " ".join(c[1]) for c in calls)
+
+    async def test_full_lifecycle_mutates_status(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            cmd_str = " ".join(cmd)
+            if "apt-get" in cmd_str:
+                return (0, "OK")
+            if "pgrep" in cmd_str:
+                return (0, "RUNNING")
+            if "x11vnc" in cmd_str:
+                return (0, "OK")
+            if "pkill" in cmd_str:
+                return (0, "OK")
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        install = await client.post("/api/agents/test-agent/desktop/install")
+        assert install.json()["state"] == "installed"
+
+        start = await client.post("/api/agents/test-agent/desktop/start")
+        assert start.json()["state"] == "running"
+
+        status_running = await client.get("/api/agents/test-agent/desktop/status")
+        assert status_running.json()["running"] is True
+        assert status_running.json()["state"] == "running"
+
+        stop = await client.post("/api/agents/test-agent/desktop/stop")
+        assert stop.json()["state"] == "stopped"
+
+        status_stopped = await client.get("/api/agents/test-agent/desktop/status")
+        assert status_stopped.json()["running"] is False
+        assert status_stopped.json()["state"] == "stopped"
+
+    async def test_start_without_install_is_rejected(self, client):
+        resp = await client.post("/api/agents/test-agent/desktop/start")
+        assert resp.status_code == 409
+
+    async def test_stop_when_not_running_is_idempotent(self, client):
+        resp = await client.post("/api/agents/test-agent/desktop/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["state"] == "not_installed"
+
+    async def test_status_probes_running_process(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            cmd_str = " ".join(cmd)
+            if "apt-get" in cmd_str:
+                return (0, "OK")
+            if "pgrep" in cmd_str:
+                return (0, "RUNNING")
+            if "x11vnc" in cmd_str:
+                return (0, "OK")
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        await client.post("/api/agents/test-agent/desktop/install")
+        await client.post("/api/agents/test-agent/desktop/start")
+
+        resp = await client.get("/api/agents/test-agent/desktop/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is True
+        assert data["state"] == "running"
+
+    async def test_status_detects_stopped_process(self, client, monkeypatch):
+        calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            calls.append((name, list(cmd)))
+            cmd_str = " ".join(cmd)
+            if "apt-get" in cmd_str:
+                return (0, "OK")
+            if "x11vnc" in cmd_str:
+                return (0, "OK")
+            if "pgrep" in cmd_str:
+                return (0, "STOPPED")
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        await client.post("/api/agents/test-agent/desktop/install")
+        await client.post("/api/agents/test-agent/desktop/start")
+
+        resp = await client.get("/api/agents/test-agent/desktop/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["state"] == "stopped"
+
+    async def test_default_agent_image_unchanged_without_desktop(self, client, monkeypatch):
+        install_calls = []
+
+        async def fake_exec(name, cmd, timeout=300):
+            install_calls.append((name, list(cmd)))
+            return (0, "OK")
+
+        monkeypatch.setattr("tinyagentos.containers.exec_in_container", fake_exec)
+
+        await client.get("/api/agents/test-agent/desktop/status")
+        await client.post("/api/agents/test-agent/desktop/stop")
+        assert len(install_calls) == 0

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -180,6 +180,9 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_workspace import router as agent_workspace_router
     app.include_router(agent_workspace_router, dependencies=_csrf)
 
+    from tinyagentos.routes.agent_desktop import router as agent_desktop_router
+    app.include_router(agent_desktop_router, dependencies=_csrf)
+
     from tinyagentos.routes.project_files import router as project_files_router
     app.include_router(project_files_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/agent_desktop.py
+++ b/tinyagentos/routes/agent_desktop.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_DESKTOP_STATES = ("not_installed", "installed", "starting", "running", "stopping", "stopped", "error")
+
+
+def _get_desktop_store(request: Request) -> dict[str, dict[str, Any]]:
+    store = getattr(request.app.state, "agent_desktops", None)
+    if store is None:
+        store = {}
+        request.app.state.agent_desktops = store
+    return store
+
+
+def _desktop_state(request: Request, agent_name: str) -> dict[str, Any]:
+    store = _get_desktop_store(request)
+    return store.setdefault(agent_name, {"state": "not_installed"})
+
+
+def _container_name(agent_name: str) -> str:
+    return f"taos-agent-{agent_name}"
+
+
+@router.post("/api/agents/{agent_name}/desktop/install")
+async def install_desktop(request: Request, agent_name: str):
+    """Install XFCE + x11vnc into the agent container on demand.
+
+    This mutates the container rootfs by installing packages. It is idempotent:
+    a second call returns success without re-running apt.
+    """
+    from tinyagentos.containers import exec_in_container
+
+    state = _desktop_state(request, agent_name)
+    current = state["state"]
+
+    if current == "running":
+        return JSONResponse({"error": "desktop is running; stop it before reinstalling"}, status_code=409)
+    if current == "starting":
+        return JSONResponse({"error": "desktop is starting; wait or stop it first"}, status_code=409)
+
+    container = _container_name(agent_name)
+
+    if current == "not_installed":
+        code, output = await exec_in_container(
+            container,
+            ["bash", "-c", "apt-get update -qq && apt-get install -y -qq xfce4 xfce4-goodies x11vnc xdotool dbus-x11"],
+            timeout=300,
+        )
+        if code != 0:
+            state["state"] = "error"
+            state["last_error"] = output
+            return JSONResponse({"error": f"desktop install failed: {output}"}, status_code=500)
+        state["state"] = "installed"
+        state.pop("last_error", None)
+
+    return JSONResponse({"agent_name": agent_name, "state": state["state"]})
+
+
+@router.post("/api/agents/{agent_name}/desktop/start")
+async def start_desktop(request: Request, agent_name: str):
+    """Start the XFCE desktop session inside the agent container."""
+    from tinyagentos.containers import exec_in_container
+
+    state = _desktop_state(request, agent_name)
+
+    if state["state"] == "running":
+        return JSONResponse({"agent_name": agent_name, "state": "running"})
+
+    if state["state"] not in ("installed", "stopped", "error"):
+        return JSONResponse({"error": f"cannot start desktop in state '{state['state']}'"}, status_code=409)
+
+    container = _container_name(agent_name)
+    state["state"] = "starting"
+
+    setup_rc, setup_out = await exec_in_container(
+        container,
+        ["bash", "-c", "mkdir -p ~/.vnc && printf 'testpass' | vncpasswd -f > ~/.vnc/passwd && chmod 600 ~/.vnc/passwd"],
+        timeout=30,
+    )
+    if setup_rc != 0:
+        state["state"] = "error"
+        state["last_error"] = setup_out
+        return JSONResponse({"error": f"vnc setup failed: {setup_out}"}, status_code=500)
+
+    start_rc, start_out = await exec_in_container(
+        container,
+        [
+            "bash", "-c",
+            "Xvfb :1 -screen 0 1024x768x16 & sleep 1 && "
+            "dbus-launch --exit-with-session startxfce4 & sleep 2 && "
+            "x11vnc -display :1 -rfbport 5900 -forever -shared -passwdfile ~/.vnc/passwd & sleep 1 && "
+            "echo OK",
+        ],
+        timeout=30,
+    )
+    if start_rc != 0:
+        state["state"] = "error"
+        state["last_error"] = start_out
+        return JSONResponse({"error": f"desktop start failed: {start_out}"}, status_code=500)
+
+    state["state"] = "running"
+    state.pop("last_error", None)
+    return JSONResponse({"agent_name": agent_name, "state": "running"})
+
+
+@router.post("/api/agents/{agent_name}/desktop/stop")
+async def stop_desktop(request: Request, agent_name: str):
+    """Stop the running XFCE desktop session inside the agent container."""
+    from tinyagentos.containers import exec_in_container
+
+    state = _desktop_state(request, agent_name)
+
+    if state["state"] not in ("running", "starting"):
+        return JSONResponse({"agent_name": agent_name, "state": state["state"]})
+
+    container = _container_name(agent_name)
+    state["state"] = "stopping"
+
+    stop_rc, stop_out = await exec_in_container(
+        container,
+        ["bash", "-c", "pkill -f x11vnc || true; pkill -f Xvfb || true; pkill -f xfce4-session || true; echo OK"],
+        timeout=30,
+    )
+
+    state["state"] = "stopped"
+    state.pop("last_error", None)
+    return JSONResponse({"agent_name": agent_name, "state": "stopped"})
+
+
+@router.get("/api/agents/{agent_name}/desktop/status")
+async def desktop_status(request: Request, agent_name: str):
+    """Report whether a desktop is installed and running for the agent."""
+    from tinyagentos.containers import exec_in_container
+
+    state = _desktop_state(request, agent_name)
+    current = state["state"]
+
+    if current not in ("running", "starting"):
+        return JSONResponse({
+            "agent_name": agent_name,
+            "state": current,
+            "running": False,
+        })
+
+    container = _container_name(agent_name)
+    code, output = await exec_in_container(
+        container,
+        ["bash", "-c", "pgrep -f x11vnc > /dev/null && echo RUNNING || echo STOPPED"],
+        timeout=10,
+    )
+    probe = "running" if code == 0 and "RUNNING" in output else "stopped"
+
+    if probe == "stopped":
+        state["state"] = "stopped"
+        return JSONResponse({
+            "agent_name": agent_name,
+            "state": "stopped",
+            "running": False,
+        })
+
+    return JSONResponse({
+        "agent_name": agent_name,
+        "state": "running",
+        "running": True,
+    })


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent desktop D1: install and run a desktop inside an existing agent LXC

Autonomous build of board card tsk-eofalz.

Docs-Reviewed: routes doc updated in docs/routes.d/14-agent-desktop.md and docs/routes.d/13-index.md; agent-manual is infrastructure-level lifecycle, not agent-facing behavior change

Files:
 changelog.d/tsk-eofalz-agent-desktop-lifecycle.md |   2 +
 docs/routes.d/13-index.md                         |   3 +-
 docs/routes.d/14-agent-desktop.md                 |  31 ++++
 docs/routes.md                                    |  33 +++++
 tests/test_agent_desktop.py                       | 169 +++++++++++++++++++++
 tinyagentos/routes/__init__.py                    |   3 +
 tinyagentos/routes/agent_desktop.py               | 173 ++++++++++++++++++++++
 7 files changed, 413 insertions(+), 1 deletion(-)