### PR TITLE
fix-forward #2664: onboarding guide still normalizes the held freshness cron, self-contradicts on bus identity, keeps GitHub issues canonical in two sections, and the path test skips root-level references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,7 @@ desktop/node_modules
 /vitest.config.ts
 /vitest.config.js
 
-# Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)
-docs/AGENT_HANDOFF.md
+
 docs/audit/
 .understand-anything/
 docs/agent-jobs/

--- a/.gitignore
+++ b/.gitignore
@@ -114,8 +114,8 @@ desktop/node_modules
 /package-lock.json
 /vitest.config.ts
 /vitest.config.js
-
-
+# Local-only operational playbook (contains LAN IP + ops detail; agents read it from the working tree)
+docs/AGENT_HANDOFF.md
 docs/audit/
 .understand-anything/
 docs/agent-jobs/

--- a/changelog.d/tsk-hoi7zs-fix-agent-onboarding-guide.md
+++ b/changelog.d/tsk-hoi7zs-fix-agent-onboarding-guide.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `docs/agent-onboarding.md` no longer references non-existent files (`docs/STATUS.md`, `docs/AGENT_HANDOFF.md`), removes the freshness-cron re-arm instruction, corrects the canonical task list to the `prj-5y722y` board, fixes the A2A bus identity rule, quotes all required CI contexts, corrects Kilo and CodeRabbit review policies, and adds `changelog.d/tsk-<cardid>-<slug>.md` as an equally valid fragment naming convention.

--- a/changelog.d/tsk-q5qqkj-fix-agent-onboarding-guide.md
+++ b/changelog.d/tsk-q5qqkj-fix-agent-onboarding-guide.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `docs/agent-onboarding.md` freshness-cron section rewritten to state fleet HOLD (crons stopped, no re‑arm, manual sweep)
+- identity rule reordered: `@taOS` is the PROJECT identity; every post uses the current seat's registry identity
+- canonical task list rewritten: project board `prj-5y722y` is canonical store, GitHub issues are auxiliary
+- `_extract_doc_paths` filter removed so root-level `.md` references are extracted and validated

--- a/changelog.d/tsk-sy4626-fix-forward.md
+++ b/changelog.d/tsk-sy4626-fix-forward.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Restore `.gitignore` entry for `docs/AGENT_HANDOFF.md`, publish public guide at `docs/agent-onboarding.md`, correct CodeRabbit claim in local playbook, and fold four CodeRabbit contradictions (bus port, URL shape, Kilo output examination, duplicate checklists) in tsk-sy4626

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,0 +1,176 @@
+# Agent Handoff Playbook
+
+**Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge**: re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + `STATUS.md` + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
+
+The golden rule: **durable state lives in three committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/STATUS.md`, (3) the A2A bus. If it isn't in one of those, the next agent can't see it.
+
+---
+
+## Bootstrap (paste this into a fresh agent, or just tell it "read docs/AGENT_HANDOFF.md")
+
+> You are taking over @taOS work on the taOS repo (`~/Development/tinyagentos`, GitHub `jaylfc/taOS`). Another agent was driving and may have hit a rate limit. Orient yourself from the durable state before doing anything; do not trust assumptions:
+>
+> 1. Read `docs/STATUS.md`: current branch tips, open PRs, in-flight work, blockers.
+> 2. Read the rest of this file (`docs/AGENT_HANDOFF.md`): rules, identity, hop protocol. Follow it exactly.
+> 3. `git fetch origin && git log origin/master..origin/dev --oneline`: what is on dev not yet promoted.
+> 4. `gh issue list --state open --limit 40` (canonical task list) and `gh pr list --state open`.
+> 5. A2A bus, live coordination: tail `taos-progress`, `general`, `observability`, `integration` (Pi is `jay@<pi>`, key auth, bus on :7900).
+> 6. (Claude Code only) read `~/.claude/projects/-*-tinyagentos/memory/MEMORY.md`.
+>
+> Then take the top unblocked GitHub issue or continue what STATUS.md flags as in flight. You ARE @taOS on the bus: post as `@taOS`, and drop a status line in `taos-progress` when you start, finish, or learn something. Follow the Identity rules below to the letter.
+
+---
+
+## On arrival: orient before you act (5 steps, ~2 min)
+
+Run these before touching anything:
+
+1. **Read `docs/STATUS.md`** (repo root -> docs/). Current branch tips, open PRs, in-flight work, blockers.
+2. **`git fetch origin && git log origin/master..origin/dev --oneline`**: what's on dev not yet promoted.
+3. **`gh issue list --state open --limit 40`**: the canonical task list. `gh pr list --state open`: what's mid-review.
+4. **A2A bus tail** (live coordination): `curl -s "http://<pi>:7900/a2a/messages?thread=general&limit=15"` (also observability, integration). The Pi IP is in your private notes, not committed here.
+5. **(Claude Code only) `~/.claude/.../memory/MEMORY.md`**: durable context index. Other platforms: skip; everything you need is in 1-4.
+
+Only after those: pick the top unblocked GitHub issue, or continue what `STATUS.md` says is in flight.
+
+---
+
+## Identity & non-negotiable rules
+
+- **You are @taOS on the A2A bus.** Adopt that handle for every post (`"from": "@taOS"`). You speak as the taOS controller agent, coordinating with @taOSmd (memory/bench) and @hermes (framework agent).
+- **Git identity:** `user.name=jaylfc`, `user.email=jaylfc25@gmail.com`. ALL activity appears as jaylfc.
+- **No AI attribution** anywhere: commits, PR bodies, issue comments, A2A. No "Co-Authored-By: Claude", no "Generated with...". Public repos and the bus must read as fully human-authored.
+- **Voice (anything posted publicly as Jay: commits, PRs, issues, A2A, docs, web copy): NO em dashes, ever.** Use commas, colons, parentheses, or two sentences instead. Strip the usual AI tells (no "it's not just X, it's Y", no "delve", no breathless hedging). For user-facing prose (release notes, web copy, replies), run it through the `content-humanizer` skill before posting. Keep internal terse-but-human.
+- **Design:** any taOS or taOSmd dashboard / inspector / web UI work uses the `frontend-design` (impeccable) skill, kept offline / no-CDN friendly.
+- **No secrets in git:** no IPs, tokens, credentials, Tailscale IPs, env-specific config. The Pi IP and bus URL stay out of committed files (they live in your private notes / this is why the bootstrap names them in chat, not in tracked code).
+- **Branch policy:** small fixes go straight to `dev`. Features/refactors/redesigns get a branch + PR to `dev`. `master` is **protected**: promote only via a `dev`->`master` PR (squash). Protected-master merge needs a `ghp_` PAT or the GitHub UI button (the gh OAuth token 401s on that endpoint). **NEVER `--delete-branch` on a dev->master PR** (deleting `dev` auto-closes every open PR that targets it).
+- **Verify before claiming done:** run the tests/commands, paste real output. Evidence before assertions.
+
+---
+
+## When YOU get rate-limited: hand off cleanly (do this the moment you see the limit warning, if you still can)
+
+1. **Commit or stash WIP** on a branch (never leave uncommitted work that only your session knows about). Push it.
+2. **Update `docs/STATUS.md`**: move your task to "In flight" with the branch name + exactly where you stopped + the next concrete step.
+3. **Post one A2A note** as your handle: what you finished, what's mid-flight, the branch, the next step.
+4. **(Claude Code) update memory** if a durable fact changed.
+
+If the limit hits before you can do this, the incoming agent recovers from: last pushed commit + open PR + `STATUS.md` + issues. That's why you push early and often.
+
+---
+
+## The freshness cron (keeps the durable layer honest)
+
+An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is the durable backstop) re-checks README / docs / memory / `STATUS.md` against merged commits and fixes trivial drift, opens PRs for bigger rewrites. If you are the active driver, keep it armed. Its job is to ensure steps 1-5 above never read stale.
+
+---
+
+## Task hygiene: so nothing is lost
+
+- **Every feature idea, bug, or TODO -> a GitHub issue immediately.** Ideas in chat or memory evaporate across a handoff; issues don't. Label them (`feature`, `bug`, `security`, `docs`, `infra`).
+- **One issue = one pickup-able unit** with enough context that a cold agent can start it.
+- `STATUS.md` links to issues; it does not duplicate them.
+
+---
+
+## A2A channels (use them; they feed the project memory)
+
+The taosmd-hosted bus ingests messages into the project memory store, so posting there is also how progress becomes durable, searchable context.
+
+- **`taos-progress`** (post here often): @taOS status updates, lessons learned, decisions, "starting X / finished Y / gotcha Z". One line when you start a task, one when you finish, one for anything non-obvious you learned. This is the running log that survives handoffs and lands in memory.
+- **`general`**: cross-agent coordination and @mentions with @taOSmd / @hermes.
+- **`observability`**: memory/bench/observability contract talk with @taOSmd.
+- **`integration`**: cross-repo integration design.
+- @taOSmd keeps its own **`taosmd-progress`** channel for the same purpose on its side.
+
+## The durable stores at a glance
+
+| Store | Scope | Visible to | Use for |
+|-------|-------|-----------|---------|
+| GitHub issues | canonical task list | every platform | backlog, features, bugs, audit findings |
+| `docs/STATUS.md` | current snapshot | every platform (in repo) | "where are we right now" |
+| `docs/AGENT_HANDOFF.md` | the rules + protocol | every platform (in repo) | onboarding, identity, hop protocol |
+| A2A `taos-progress` | running progress log | bus agents + project memory | status, lessons, decisions (feeds memory) |
+| A2A bus (:7900) | live coordination | the bus agents | real-time @mentions, decisions |
+| @taOS Pi memory | durable context | Claude Code only | per-session continuity for CC |
+
+---
+
+## Commit conventions
+
+- Subject line: imperative mood, lowercase, no period at the end. Max 72 chars.
+- Body: explain what changed and why, not how (the diff shows how).
+- Reference issues and PRs with `#123` or `GH-123`.
+- Co-authors: none. No "Co-Authored-By", no "Generated with...".
+- Conventional commits preferred: `fix(scope): description`, `feat(scope): description`, `docs: description`, `chore: description`.
+- One logical change per commit. If you find yourself writing "and" in the subject, split it.
+
+---
+
+## Documentation standards
+
+- User-facing docs live under `docs/` or the component's own README.
+- Run prose through the `content-humanizer` skill before committing if it will be visible to users or contributors.
+- Keep line length under 100 chars for plain text, 80 for code examples.
+- Link to files with relative paths from the repo root (`docs/STATUS.md`, not `/docs/STATUS.md`).
+- Do not commit screenshots or large binaries to the repo without checking with a lead first.
+
+---
+
+## Test requirements
+
+Every PR must include tests for new behaviour. Run them with `uv run --extra dev pytest <paths> -q`.
+
+- Mock at the narrowest scope: patch the specific function under test.
+- Never patch the whole imported library.
+- If the code catches library exceptions, keep the real exception classes.
+- Add a test for every bug fix.
+
+---
+
+## Changelog fragments
+
+A non-test change under `tinyagentos/` or `desktop/src/` requires a `changelog.d/<pr>-<slug>.md` fragment containing a `### Added` or `### Fixed` heading and one bullet describing the change. Do not edit `CHANGELOG.md` directly.
+
+---
+
+## PR review requirements
+
+Every PR targeting `dev` or `master` must clear the following before merge:
+
+- CI green: `test (3.12/3.13)` and `lint` both passing.
+- Human review: at least one project lead has approved.
+- Bot review considered: CodeRabbit or Kilo output examined, but a bot review is never a blocking requirement on its own.
+
+A lead may apply the `bot-review-allow` label when the only CodeRabbit output is a rate-limit stub and `scripts/check_bot_review.py` confirms the stub classification. This is an explicit waiver, not a pass: the underlying infra condition still exists and should be retried on the next PR if the quota recovers.
+
+Do not merge a PR that is green on CI but has never been read by a human. Bot checks are signals, not substitutes for judgment.
+
+---
+
+## Kilo review policy
+
+Kilo is the inline coding agent used during development. It does not post PR reviews. Do not wait for Kilo output before merging.
+
+Kilo output is not a substitute for human review or CI. If Kilo finds a problem, fix it before requesting human review.
+
+When Kilo is inline during a development session, its suggestions are working hypotheses, not finished code. Review them, test them, then commit.
+
+Treat Kilo inline suggestions as draft code, not committed truth.
+
+---
+
+## CodeRabbit review policy
+
+CodeRabbit is an external review bot that posts on some PRs. Its behaviour is intermittent:
+
+- Some PRs receive a genuine multi-item review with real findings.
+- Other PRs receive only a rate-limit stub comment (a short notice that the review quota was exhausted).
+- Some PRs receive no CodeRabbit output at all.
+
+`scripts/check_bot_review.py` is the arbiter. It fetches the PR's CodeRabbit comments and reviews, distinguishes real review items from rate-limit stubs and auto-generated scaffolding, and exits:
+- `0 PASS` when a real review exists or CodeRabbit is entirely absent.
+- `1 FAIL` when the only CodeRabbit output is a stub or scaffolding.
+- `2 ERROR` on infrastructure failure.
+
+CodeRabbit is intermittent: some PRs get a genuine multi-item review, others get only a rate-limit stub. `scripts/check_bot_review.py` is the arbiter. Do not block on it, do not retrigger it, and its red is not clearable by retriggering.

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -2,7 +2,7 @@
 
 **Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge**: re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + `STATUS.md` + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
 
-The golden rule: **durable state lives in three committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/STATUS.md`, (3) the A2A bus. If it isn't in one of those, the next agent can't see it.
+The golden rule: **durable state lives in six committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/STATUS.md`, (3) the A2A bus, (4) A2A `taos-progress`, (5) A2A bus coordination, (6) @taOS Pi memory. If it isn't in one of those, the next agent can't see it.
 
 ---
 
@@ -14,27 +14,12 @@ The golden rule: **durable state lives in three committed/hosted places, not in 
 > 2. Read the rest of this file (`docs/AGENT_HANDOFF.md`): rules, identity, hop protocol. Follow it exactly.
 > 3. `git fetch origin && git log origin/master..origin/dev --oneline`: what is on dev not yet promoted.
 > 4. `gh issue list --state open --limit 40` (canonical task list) and `gh pr list --state open`.
-> 5. A2A bus, live coordination: tail `taos-progress`, `general`, `observability`, `integration` (Pi is `jay@<pi>`, key auth, bus on :7900).
+> 5. A2A bus, live coordination: tail `taos-progress`, `general`, `observability`, `integration` (Pi is `jay@<pi>`, key auth, bus on).
 > 6. (Claude Code only) read `~/.claude/projects/-*-tinyagentos/memory/MEMORY.md`.
 >
 > Then take the top unblocked GitHub issue or continue what STATUS.md flags as in flight. You ARE @taOS on the bus: post as `@taOS`, and drop a status line in `taos-progress` when you start, finish, or learn something. Follow the Identity rules below to the letter.
 
 ---
-
-## On arrival: orient before you act (5 steps, ~2 min)
-
-Run these before touching anything:
-
-1. **Read `docs/STATUS.md`** (repo root -> docs/). Current branch tips, open PRs, in-flight work, blockers.
-2. **`git fetch origin && git log origin/master..origin/dev --oneline`**: what's on dev not yet promoted.
-3. **`gh issue list --state open --limit 40`**: the canonical task list. `gh pr list --state open`: what's mid-review.
-4. **A2A bus tail** (live coordination): `curl -s "http://<pi>:7900/a2a/messages?thread=general&limit=15"` (also observability, integration). The Pi IP is in your private notes, not committed here.
-5. **(Claude Code only) `~/.claude/.../memory/MEMORY.md`**: durable context index. Other platforms: skip; everything you need is in 1-4.
-
-Only after those: pick the top unblocked GitHub issue, or continue what `STATUS.md` says is in flight.
-
----
-
 ## Identity & non-negotiable rules
 
 - **You are @taOS on the A2A bus.** Adopt that handle for every post (`"from": "@taOS"`). You speak as the taOS controller agent, coordinating with @taOSmd (memory/bench) and @hermes (framework agent).
@@ -91,7 +76,7 @@ The taosmd-hosted bus ingests messages into the project memory store, so posting
 | `docs/STATUS.md` | current snapshot | every platform (in repo) | "where are we right now" |
 | `docs/AGENT_HANDOFF.md` | the rules + protocol | every platform (in repo) | onboarding, identity, hop protocol |
 | A2A `taos-progress` | running progress log | bus agents + project memory | status, lessons, decisions (feeds memory) |
-| A2A bus (:7900) | live coordination | the bus agents | real-time @mentions, decisions |
+| A2A bus | live coordination | the bus agents | real-time @mentions, decisions |
 | @taOS Pi memory | durable context | Claude Code only | per-session continuity for CC |
 
 ---
@@ -140,7 +125,7 @@ Every PR targeting `dev` or `master` must clear the following before merge:
 
 - CI green: `test (3.12/3.13)` and `lint` both passing.
 - Human review: at least one project lead has approved.
-- Bot review considered: CodeRabbit or Kilo output examined, but a bot review is never a blocking requirement on its own.
+- Bot review considered: CodeRabbit output examined, but a bot review is never a blocking requirement on its own.
 
 A lead may apply the `bot-review-allow` label when the only CodeRabbit output is a rate-limit stub and `scripts/check_bot_review.py` confirms the stub classification. This is an explicit waiver, not a pass: the underlying infra condition still exists and should be retried on the next PR if the quota recovers.
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -1,28 +1,27 @@
-# Agent Handoff Playbook
+# Agent Onboarding
 
-**Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge**: re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + `STATUS.md` + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
+**Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge**: re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
 
-The golden rule: **durable state lives in six committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/STATUS.md`, (3) the A2A bus, (4) A2A `taos-progress`, (5) A2A bus coordination, (6) @taOS Pi memory. If it isn't in one of those, the next agent can't see it.
+The golden rule: **durable state lives in five committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/agent-onboarding.md`, (3) the A2A bus, (4) A2A `taos-progress`, (5) @taOS Pi memory. If it isn't in one of those, the next agent can't see it.
 
 ---
 
-## Bootstrap (paste this into a fresh agent, or just tell it "read docs/AGENT_HANDOFF.md")
+## Bootstrap (paste this into a fresh agent, or just tell it "read docs/agent-onboarding.md")
 
 > You are taking over @taOS work on the taOS repo (`~/Development/tinyagentos`, GitHub `jaylfc/taOS`). Another agent was driving and may have hit a rate limit. Orient yourself from the durable state before doing anything; do not trust assumptions:
 >
-> 1. Read `docs/STATUS.md`: current branch tips, open PRs, in-flight work, blockers.
-> 2. Read the rest of this file (`docs/AGENT_HANDOFF.md`): rules, identity, hop protocol. Follow it exactly.
-> 3. `git fetch origin && git log origin/master..origin/dev --oneline`: what is on dev not yet promoted.
-> 4. `gh issue list --state open --limit 40` (canonical task list) and `gh pr list --state open`.
-> 5. A2A bus, live coordination: tail `taos-progress`, `general`, `observability`, `integration` (Pi is `jay@<pi>`, key auth, bus on).
-> 6. (Claude Code only) read `~/.claude/projects/-*-tinyagentos/memory/MEMORY.md`.
+> 1. Read the rest of this file (`docs/agent-onboarding.md`): rules, identity, hop protocol. Follow it exactly.
+> 2. `git fetch origin && git log origin/master..origin/dev --oneline`: what is on dev not yet promoted.
+> 3. Check the board `prj-5y722y` (canonical task list) and `gh pr list --state open`.
+> 4. A2A bus, live coordination: tail `taos-progress`, `general`, `observability`, `integration` (Pi is `jay@<pi>`, key auth, bus on).
+> 5. (Claude Code only) read `~/.claude/projects/-*-tinyagentos/memory/MEMORY.md`.
 >
-> Then take the top unblocked GitHub issue or continue what STATUS.md flags as in flight. You ARE @taOS on the bus: post as `@taOS`, and drop a status line in `taos-progress` when you start, finish, or learn something. Follow the Identity rules below to the letter.
+> Then take the top unblocked card from the board or continue what durable state flags as in flight. Drop a status line in `taos-progress` when you start, finish, or learn something. Follow the Identity rules below to the letter.
 
 ---
 ## Identity & non-negotiable rules
 
-- **You are @taOS on the A2A bus.** Adopt that handle for every post (`"from": "@taOS"`). You speak as the taOS controller agent, coordinating with @taOSmd (memory/bench) and @hermes (framework agent).
+- **You are @taOS on the A2A bus.** Seats post under their own registry identity. The bus enforces `token sub == from` whenever a Bearer token is present, so posting as `@taOS` produces 403s or unattributable posts.
 - **Git identity:** `user.name=jaylfc`, `user.email=jaylfc25@gmail.com`. ALL activity appears as jaylfc.
 - **No AI attribution** anywhere: commits, PR bodies, issue comments, A2A. No "Co-Authored-By: Claude", no "Generated with...". Public repos and the bus must read as fully human-authored.
 - **Voice (anything posted publicly as Jay: commits, PRs, issues, A2A, docs, web copy): NO em dashes, ever.** Use commas, colons, parentheses, or two sentences instead. Strip the usual AI tells (no "it's not just X, it's Y", no "delve", no breathless hedging). For user-facing prose (release notes, web copy, replies), run it through the `content-humanizer` skill before posting. Keep internal terse-but-human.
@@ -36,17 +35,17 @@ The golden rule: **durable state lives in six committed/hosted places, not in an
 ## When YOU get rate-limited: hand off cleanly (do this the moment you see the limit warning, if you still can)
 
 1. **Commit or stash WIP** on a branch (never leave uncommitted work that only your session knows about). Push it.
-2. **Update `docs/STATUS.md`**: move your task to "In flight" with the branch name + exactly where you stopped + the next concrete step.
+2. **Update the board**: move your card to "In flight" with the branch name + exactly where you stopped + the next concrete step.
 3. **Post one A2A note** as your handle: what you finished, what's mid-flight, the branch, the next step.
 4. **(Claude Code) update memory** if a durable fact changed.
 
-If the limit hits before you can do this, the incoming agent recovers from: last pushed commit + open PR + `STATUS.md` + issues. That's why you push early and often.
+If the limit hits before you can do this, the incoming agent recovers from: last pushed commit + open PR + the board + issues. That's why you push early and often.
 
 ---
 
 ## The freshness cron (keeps the durable layer honest)
 
-An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is the durable backstop) re-checks README / docs / memory / `STATUS.md` against merged commits and fixes trivial drift, opens PRs for bigger rewrites. If you are the active driver, keep it armed. Its job is to ensure steps 1-5 above never read stale.
+An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is the durable backstop) re-checks README / docs / memory against merged commits and fixes trivial drift, opens PRs for bigger rewrites. Its job is to ensure steps above never read stale.
 
 ---
 
@@ -54,7 +53,7 @@ An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is th
 
 - **Every feature idea, bug, or TODO -> a GitHub issue immediately.** Ideas in chat or memory evaporate across a handoff; issues don't. Label them (`feature`, `bug`, `security`, `docs`, `infra`).
 - **One issue = one pickup-able unit** with enough context that a cold agent can start it.
-- `STATUS.md` links to issues; it does not duplicate them.
+- The board links to issues; it does not duplicate them.
 
 ---
 
@@ -72,9 +71,8 @@ The taosmd-hosted bus ingests messages into the project memory store, so posting
 
 | Store | Scope | Visible to | Use for |
 |-------|-------|-----------|---------|
-| GitHub issues | canonical task list | every platform | backlog, features, bugs, audit findings |
-| `docs/STATUS.md` | current snapshot | every platform (in repo) | "where are we right now" |
-| `docs/AGENT_HANDOFF.md` | the rules + protocol | every platform (in repo) | onboarding, identity, hop protocol |
+| GitHub project board `prj-5y722y` | canonical task list | every platform | backlog, features, bugs, audit findings |
+| `docs/agent-onboarding.md` | the rules + protocol | every platform (in repo) | onboarding, identity, hop protocol |
 | A2A `taos-progress` | running progress log | bus agents + project memory | status, lessons, decisions (feeds memory) |
 | A2A bus | live coordination | the bus agents | real-time @mentions, decisions |
 | @taOS Pi memory | durable context | Claude Code only | per-session continuity for CC |
@@ -97,7 +95,7 @@ The taosmd-hosted bus ingests messages into the project memory store, so posting
 - User-facing docs live under `docs/` or the component's own README.
 - Run prose through the `content-humanizer` skill before committing if it will be visible to users or contributors.
 - Keep line length under 100 chars for plain text, 80 for code examples.
-- Link to files with relative paths from the repo root (`docs/STATUS.md`, not `/docs/STATUS.md`).
+- Link to files with relative paths from the repo root (`docs/agent-onboarding.md`, not `/docs/agent-onboarding.md`).
 - Do not commit screenshots or large binaries to the repo without checking with a lead first.
 
 ---
@@ -115,7 +113,7 @@ Every PR must include tests for new behaviour. Run them with `uv run --extra dev
 
 ## Changelog fragments
 
-A non-test change under `tinyagentos/` or `desktop/src/` requires a `changelog.d/<pr>-<slug>.md` fragment containing a `### Added` or `### Fixed` heading and one bullet describing the change. Do not edit `CHANGELOG.md` directly.
+A non-test change under `tinyagentos/` or `desktop/src/` requires a `changelog.d/<pr>-<slug>.md` or `changelog.d/tsk-<cardid>-<slug>.md` fragment containing a `### Added` or `### Fixed` heading and one bullet describing the change. Do not edit `CHANGELOG.md` directly.
 
 ---
 
@@ -123,11 +121,11 @@ A non-test change under `tinyagentos/` or `desktop/src/` requires a `changelog.d
 
 Every PR targeting `dev` or `master` must clear the following before merge:
 
-- CI green: `test (3.12/3.13)` and `lint` both passing.
+- CI green: `test (3.12)`, `test (3.13)`, `spa-build`, `lint`, `doc-gate`, `shards (3.12, 1-4)`, `shards (3.13, 1-4)`, `bot-review-gate` all passing.
 - Human review: at least one project lead has approved.
-- Bot review considered: CodeRabbit output examined, but a bot review is never a blocking requirement on its own.
+- `bot-review-gate` is required, so it blocks on its own.
 
-A lead may apply the `bot-review-allow` label when the only CodeRabbit output is a rate-limit stub and `scripts/check_bot_review.py` confirms the stub classification. This is an explicit waiver, not a pass: the underlying infra condition still exists and should be retried on the next PR if the quota recovers.
+`bot-review-allow` is inert on any PR that already has a failed run. The real path is `--admin` with the justification posted first.
 
 Do not merge a PR that is green on CI but has never been read by a human. Bot checks are signals, not substitutes for judgment.
 
@@ -135,7 +133,7 @@ Do not merge a PR that is green on CI but has never been read by a human. Bot ch
 
 ## Kilo review policy
 
-Kilo is the inline coding agent used during development. It does not post PR reviews. Do not wait for Kilo output before merging.
+Kilo is the inline coding agent used during development. It posts a `Kilo Code Review` check run whose output has caught real defects. Read the output, never the `conclusion` field, and treat `Assistant service is unavailable` as an outage rather than a finding. Do not wait for Kilo output before merging.
 
 Kilo output is not a substitute for human review or CI. If Kilo finds a problem, fix it before requesting human review.
 
@@ -154,8 +152,9 @@ CodeRabbit is an external review bot that posts on some PRs. Its behaviour is in
 - Some PRs receive no CodeRabbit output at all.
 
 `scripts/check_bot_review.py` is the arbiter. It fetches the PR's CodeRabbit comments and reviews, distinguishes real review items from rate-limit stubs and auto-generated scaffolding, and exits:
-- `0 PASS` when a real review exists or CodeRabbit is entirely absent.
+- `0 PASS` when a real review exists.
+- `0 PASS (absent, not stubbed)` when CodeRabbit is entirely absent, which is not reviewed and must not read as clean.
 - `1 FAIL` when the only CodeRabbit output is a stub or scaffolding.
 - `2 ERROR` on infrastructure failure.
 
-CodeRabbit is intermittent: some PRs get a genuine multi-item review, others get only a rate-limit stub. `scripts/check_bot_review.py` is the arbiter. Do not block on it, do not retrigger it, and its red is not clearable by retriggering.
+Do not block on CodeRabbit, do not retrigger it, and its red is not clearable by retriggering.

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -2,7 +2,7 @@
 
 **Why this exists.** Work on taOS runs across rate-limit-prone agents on different platforms (Claude Code, Cursor, Codex, web, etc.). When one hits a limit, another picks up. The failure mode to prevent: an incoming agent acting on **stale knowledge**: re-doing finished work, missing in-flight tasks, or clobbering a branch. This playbook + GitHub issues make the project's state **durable and platform-independent** so a handoff never loses work.
 
-The golden rule: **durable state lives in five committed/hosted places, not in any one agent's memory**: (1) GitHub issues, (2) `docs/agent-onboarding.md`, (3) the A2A bus, (4) A2A `taos-progress`, (5) @taOS Pi memory. If it isn't in one of those, the next agent can't see it.
+The golden rule: **durable state lives in the project board `prj-5y722y` (canonical task list), with `docs/agent-onboarding.md`, the A2A bus, A2A `taos-progress`, and @taOS Pi memory as auxiliary stores. GitHub issues are secondary and always linked from the board.**
 
 ---
 
@@ -21,7 +21,7 @@ The golden rule: **durable state lives in five committed/hosted places, not in a
 ---
 ## Identity & non-negotiable rules
 
-- **You are @taOS on the A2A bus.** Seats post under their own registry identity. The bus enforces `token sub == from` whenever a Bearer token is present, so posting as `@taOS` produces 403s or unattributable posts.
+- **@taOS is the project identity.** Every post uses the current seat's registry identity. The bus enforces `token sub == from` whenever a Bearer token is present, so posting as `@taOS` from outside a seat context produces 403s or unattributable posts.
 - **Git identity:** `user.name=jaylfc`, `user.email=jaylfc25@gmail.com`. ALL activity appears as jaylfc.
 - **No AI attribution** anywhere: commits, PR bodies, issue comments, A2A. No "Co-Authored-By: Claude", no "Generated with...". Public repos and the bus must read as fully human-authored.
 - **Voice (anything posted publicly as Jay: commits, PRs, issues, A2A, docs, web copy): NO em dashes, ever.** Use commas, colons, parentheses, or two sentences instead. Strip the usual AI tells (no "it's not just X, it's Y", no "delve", no breathless hedging). For user-facing prose (release notes, web copy, replies), run it through the `content-humanizer` skill before posting. Keep internal terse-but-human.
@@ -43,15 +43,15 @@ If the limit hits before you can do this, the incoming agent recovers from: last
 
 ---
 
-## The freshness cron (keeps the durable layer honest)
+## Freshness cron held under fleet HOLD (2026-08-31)
 
-An hourly sweep (session-scoped on the active agent; the Pi's :00/:30 cron is the durable backstop) re-checks README / docs / memory against merged commits and fixes trivial drift, opens PRs for bigger rewrites. Its job is to ensure steps above never read stale.
+The hourly sweep is under fleet HOLD (Jay, 2026-08-24, reaffirmed 2026-08-30). Crons stay stopped; no re‑arm. The durable layer is swept manually when needed. The Pi's :00/:30 cron remains the durable backstop only as a reference point.
 
 ---
 
 ## Task hygiene: so nothing is lost
 
-- **Every feature idea, bug, or TODO -> a GitHub issue immediately.** Ideas in chat or memory evaporate across a handoff; issues don't. Label them (`feature`, `bug`, `security`, `docs`, `infra`).
+- **Every feature idea, bug, or TODO becomes a card on the project board `prj-5y722y` first.** GitHub issues are auxiliary and referenced from the board. Ideas in chat or memory evaporate across a handoff; the board persists. Label board cards (`feature`, `bug`, `security`, `docs`, `infra`).
 - **One issue = one pickup-able unit** with enough context that a cold agent can start it.
 - The board links to issues; it does not duplicate them.
 

--- a/tests/test_agent_onboarding_doc_paths.py
+++ b/tests/test_agent_onboarding_doc_paths.py
@@ -17,8 +17,6 @@ def _extract_doc_paths(text: str) -> set[str]:
             continue
         if "<" in candidate or ">" in candidate:
             continue
-        if "/" not in candidate:
-            continue
         paths.add(candidate)
     return paths
 
@@ -36,3 +34,21 @@ class TestAgentOnboardingDocPaths:
     def test_does_not_reference_itself_as_agent_handoff(self):
         text = ONBOARDING.read_text(encoding="utf-8")
         assert "docs/AGENT_HANDOFF.md" not in text
+
+    def test_phantom_root_level_md_is_caught(self):
+        """Mutation test: a phantom root-level .md reference must FAIL the test.
+
+        After removing the '/' filter, a doc text referencing a phantom
+        root-level .md should extract the path and report it as missing,
+        causing this test to fail if such a reference exists in the doc.
+        """
+        text = "See `PHANTOM-DOES-NOT-EXIST.md` for details."
+        paths = _extract_doc_paths(text)
+        # Without the "/" filter, root-level .md is now extracted
+        assert "PHANTOM-DOES-NOT-EXIST.md" in paths, (
+            f"Root-level .md should be extracted after filter removal, got: {paths}"
+        )
+        missing = [p for p in sorted(paths) if not (REPO_ROOT / p).exists()]
+        assert missing, (
+            f"Phantom root-level .md should be reported as missing, got extracted: {paths}"
+        )

--- a/tests/test_agent_onboarding_doc_paths.py
+++ b/tests/test_agent_onboarding_doc_paths.py
@@ -1,0 +1,38 @@
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ONBOARDING = REPO_ROOT / "docs" / "agent-onboarding.md"
+
+_PATH_RE = re.compile(r"`([^`]+\.(?:md|txt|rst|yaml|yml|json))`")
+
+
+def _extract_doc_paths(text: str) -> set[str]:
+    paths = set()
+    for match in _PATH_RE.finditer(text):
+        candidate = match.group(1)
+        if candidate.startswith(("/", "~", "http")):
+            continue
+        if "<" in candidate or ">" in candidate:
+            continue
+        if "/" not in candidate:
+            continue
+        paths.add(candidate)
+    return paths
+
+
+class TestAgentOnboardingDocPaths:
+    def test_all_repo_relative_doc_paths_resolve(self):
+        text = ONBOARDING.read_text(encoding="utf-8")
+        paths = _extract_doc_paths(text)
+        missing = [p for p in sorted(paths) if not (REPO_ROOT / p).exists()]
+        assert not missing, (
+            "docs/agent-onboarding.md references paths not present in the tree:\n"
+            + "\n".join(f"  FAIL  {p}" for p in missing)
+        )
+
+    def test_does_not_reference_itself_as_agent_handoff(self):
+        text = ONBOARDING.read_text(encoding="utf-8")
+        assert "docs/AGENT_HANDOFF.md" not in text


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2664: onboarding guide still normalizes the held freshness cron, self-contradicts on bus identity, keeps GitHub issues canonical in two sections, and the path test skips root-level references

Autonomous build of board card tsk-q5qqkj.

REVISION: built on `exec/tsk-hoi7zs` (cut at `89cd9ee0e5c85685eb37e353493147de050a2f2a`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.



Files:
 .gitignore                                         |   1 -
 .../tsk-hoi7zs-fix-agent-onboarding-guide.md       |   3 +
 .../tsk-q5qqkj-fix-agent-onboarding-guide.md       |   6 +
 changelog.d/tsk-sy4626-fix-forward.md              |   3 +
 docs/agent-onboarding.md                           | 160 +++++++++++++++++++++
 tests/test_agent_onboarding_doc_paths.py           |  54 +++++++
 6 files changed, 226 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a platform-independent onboarding and handoff guide covering setup, identity, task tracking, communication, testing, documentation, and review practices.
  - Corrected outdated file references, task-board details, identity guidance, CI requirements, and review-policy instructions.
  - Documented supported changelog fragment naming conventions and operational procedures.

- **Tests**
  - Added automated validation to ensure documentation references point to existing repository files and exclude obsolete references.

- **Chores**
  - Restored the required handoff documentation entry in repository ignore settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->