### PR TITLE
Mobile home grid still surfaces tier-3 apps: the #2517 tier rule reached the launcher but never mobile-home-store

### DIFF
--- a/changelog.d/tsk-k6bbxt-mobile-home-tier-3.md
+++ b/changelog.d/tsk-k6bbxt-mobile-home-tier-3.md
@@ -1,0 +1,3 @@
+### Fixed
+- Mobile home default grid now applies the same tier rule as the desktop launcher: tier 1 and tier 2 apps surface on the default grid, while tier 3 apps (providers, mcp, channels, notification-archive) are excluded and remain discoverable via Store/search. Extracted a shared `isDefaultSurfaceApp()` helper in the app registry so the mobile home grid and launcher can no longer drift into different tier predicates (#2517).
+- Red-proven test added: `mobile-home-store` default grid is asserted to exclude the real tier-3 registry id `providers` (and the other tier-3 apps); reverting the predicate to `tier !== 4` turns the test red, restoring `isDefaultSurfaceApp` turns it green.

--- a/desktop/src/registry/app-registry.test.ts
+++ b/desktop/src/registry/app-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { AppManifest } from "./app-registry";
-import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, prefetchApp, resolveApp, apps, APP_REDIRECTS, resolvePinnedId } from "./app-registry";
+import { getApp, getOrRegisterServiceApp, getAllApps, getLaunchableApps, isDefaultSurfaceApp, prefetchApp, resolveApp, apps, APP_REDIRECTS, resolvePinnedId } from "./app-registry";
 
 describe("resolveApp (deep-navigation token resolver)", () => {
   it("resolves an exact app id", () => {
@@ -103,6 +103,35 @@ describe("file handler tiering", () => {
       const app = getApp(id);
       expect(app?.tier).toBe(4);
       expect(app?.handler).toBe(true);
+    }
+  });
+});
+
+describe("isDefaultSurfaceApp (shared default-surface tier rule)", () => {
+  it("includes tier 1 and tier 2 apps", () => {
+    for (const id of ["messages", "models", "cluster", "secrets"]) {
+      expect(isDefaultSurfaceApp(getApp(id)!), `app "${id}" should be a default-surface app`).toBe(true);
+    }
+  });
+
+  it("excludes tier 3 apps (discoverable via Store/search)", () => {
+    for (const id of ["providers", "mcp", "channels", "notification-archive"]) {
+      expect(isDefaultSurfaceApp(getApp(id)!), `tier-3 app "${id}" should NOT be a default-surface app`).toBe(false);
+    }
+  });
+
+  it("excludes tier 4 file handlers", () => {
+    for (const id of ["media-player", "text-editor", "image-viewer"]) {
+      const app = getApp(id)!;
+      expect(app.tier).toBe(4);
+      expect(app.handler).toBe(true);
+      expect(isDefaultSurfaceApp(app), `tier-4 handler "${id}" should NOT be a default-surface app`).toBe(false);
+    }
+  });
+
+  it("excludes optional (Store-installable) apps", () => {
+    for (const id of ["reddit", "coding-studio"]) {
+      expect(isDefaultSurfaceApp(getApp(id)!), `optional app "${id}" should NOT be a default-surface app`).toBe(false);
     }
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -164,12 +164,31 @@ export const APP_REDIRECTS: Record<string, { appId: string }> = {
   "notification-archive": { appId: "notifications" },
 };
 
+/**
+ * Whether an app belongs on the default surface: the desktop launcher's
+ * always-on grid AND the mobile home default grid. This is the single source
+ * of truth for the tier rule that landed in bfc40c1e6 -- reuse it here instead
+ * of hand-rolling a second predicate that can drift:
+ *   tier 1 (default) / 2 - shown on the default surface
+ *   tier 3            - discoverable via Store/search, NOT on the default surface
+ *   tier 4            - file handler, hidden from the default surface
+ *   tier 5            - Store-optional, hidden from the default surface
+ * Optional apps and file handlers are excluded here; optional apps only
+ * surface once installed (see getLaunchableApps).
+ */
+export function isDefaultSurfaceApp(app: AppManifest): boolean {
+  return (
+    !app.optional &&
+    app.handler !== true &&
+    (app.tier === undefined || app.tier <= 2)
+  );
+}
+
 export function getLaunchableApps(installedOptional: Set<string>): AppManifest[] {
   return getAllApps().filter(
     (a) =>
-      (!a.optional || installedOptional.has(a.id)) &&
-      a.handler !== true &&
-      (a.tier === undefined || a.tier <= 2 || (a.tier === 5 && installedOptional.has(a.id))),
+      isDefaultSurfaceApp(a) ||
+      (a.optional && installedOptional.has(a.id)),
   );
 }
 

--- a/desktop/src/stores/mobile-home-store.test.ts
+++ b/desktop/src/stores/mobile-home-store.test.ts
@@ -1,26 +1,42 @@
 import { describe, it, expect } from "vitest";
 import { useMobileHomeStore } from "./mobile-home-store";
-import { getAllApps } from "@/registry/app-registry";
+import { getAllApps, isDefaultSurfaceApp } from "@/registry/app-registry";
+
+function defaultGridAppIds(): Set<string> {
+  return new Set(
+    useMobileHomeStore.getState().pages.flatMap((p) =>
+      p.items
+        .filter((i) => i.type === "app")
+        .map((i) => (i as { type: "app"; appId: string }).appId),
+    ),
+  );
+}
 
 describe("mobile-home-store", () => {
-  it("home grid includes every non-optional registered app", () => {
-    const { pages } = useMobileHomeStore.getState();
-    const allIdsInPages = new Set(
-      pages.flatMap((p) =>
-        p.items
-          .filter((i) => i.type === "app")
-          .map((i) => (i as { type: "app"; appId: string }).appId),
-      ),
-    );
+  it("home grid includes every app on the default surface", () => {
+    const allIdsInPages = defaultGridAppIds();
     // Optional apps (Reddit/YouTube/GitHub/X) ship uninstalled and are added
     // from the Store, so they are intentionally absent from the default grid.
-    const defaultIds = getAllApps().filter((a) => !a.optional && a.tier !== 4 && a.handler !== true).map((a) => a.id);
+    const defaultIds = getAllApps().filter(isDefaultSurfaceApp).map((a) => a.id);
     for (const id of defaultIds) {
       expect(allIdsInPages.has(id), `missing app "${id}" in home grid`).toBe(true);
     }
     const optionalIds = getAllApps().filter((a) => a.optional).map((a) => a.id);
     for (const id of optionalIds) {
       expect(allIdsInPages.has(id), `optional app "${id}" should NOT be in default grid`).toBe(false);
+    }
+  });
+
+  it("excludes tier-3 registry apps from the default home grid (#2517)", () => {
+    const ids = defaultGridAppIds();
+    // Assert on REAL registry ids: these platform-plumbing apps are discoverable
+    // via Store/search, not the default mobile home surface.
+    const tier3Ids = getAllApps().filter((a) => a.tier === 3).map((a) => a.id);
+    expect(tier3Ids).toEqual(
+      expect.arrayContaining(["providers", "mcp", "channels", "notification-archive"]),
+    );
+    for (const id of tier3Ids) {
+      expect(ids.has(id), `tier-3 app "${id}" should NOT be in default grid`).toBe(false);
     }
   });
 

--- a/desktop/src/stores/mobile-home-store.ts
+++ b/desktop/src/stores/mobile-home-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { getAllApps } from "@/registry/app-registry";
+import { getAllApps, isDefaultSurfaceApp } from "@/registry/app-registry";
 
 type WidgetItem = { type: "widget"; widgetType: string };
 type AppItem = { type: "app"; appId: string };
@@ -22,9 +22,12 @@ const DEFAULT_PAGES: HomePage[] = [
   },
   {
     // Optional apps (Reddit/YouTube/GitHub/X) are excluded from the default
-    // home grid; they ship uninstalled and are added from the Store.
+    // home grid; they ship uninstalled and are added from the Store. tier 3
+    // apps (providers, mcp, channels, notification-archive) are discoverable
+    // via Store/search rather than the default surface; the shared helper
+    // keeps this rule in lockstep with the desktop launcher (issue #2517).
     items: getAllApps()
-      .filter((a) => !a.optional && a.tier !== 4 && a.handler !== true)
+      .filter(isDefaultSurfaceApp)
       .map((a) => ({ type: "app", appId: a.id }) as AppItem),
   },
 ];


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Mobile home grid still surfaces tier-3 apps: the #2517 tier rule reached the launcher but never mobile-home-store

Autonomous build of board card tsk-k6bbxt.

The #2517 launcher tier filter reached getLaunchableApps but never
mobile-home-store, so platform-plumbing tier-3 apps (providers, mcp,
channels, notification-archive) still rendered on the phone home screen.

Extract isDefaultSurfaceApp() in the app registry as the single source of
truth for the tier rule (tiers 1-2 on the default surface; tier 3
discoverable via Store/search; tiers 4/5 hidden) and use it in both
getLaunchableApps and the mobile home default grid so the two cannot drift
again. Optional-app and handler exclusions are preserved; only the default
grid computation changes, not persisted user home pages.

Proof: reverting the mobile-home-store predicate to `tier !== 4` fails the
new test on the real registry id "providers"; restoring isDefaultSurfaceApp
turns it green. 66 tests pass across app-registry, mobile-home-store and
Launcher suites; tsc -b clean.

Files:
 changelog.d/tsk-k6bbxt-mobile-home-tier-3.md |  3 +++
 desktop/src/registry/app-registry.test.ts    | 31 ++++++++++++++++++++++-
 desktop/src/registry/app-registry.ts         | 25 +++++++++++++++---
 desktop/src/stores/mobile-home-store.test.ts | 38 ++++++++++++++++++++--------
 desktop/src/stores/mobile-home-store.ts      |  9 ++++---
 5 files changed, 88 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mobile home screen to match the desktop launcher’s app visibility rules.
  * Tier 1 and 2 apps now appear on the default grid.
  * Tier 3 apps, including Providers, MCP, Channels, and Notification Archive, are excluded from the default grid but remain available through Store or search.

* **Tests**
  * Added coverage verifying consistent app visibility across desktop and mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->