### PR TITLE
SECURITY: agent_name is caller-asserted - any deployed agent can claim any handle

### DIFF
--- a/changelog.d/tsk-2km65o-skill-exec-agent-identity.md
+++ b/changelog.d/tsk-2km65o-skill-exec-agent-identity.md
@@ -1,0 +1,8 @@
+### Security
+
+- Skill-exec agent identity is now derived from the presented local-token
+  credential binding, not from the request body. A deployed agent passing
+  another agent's handle in the body is rejected with 403 instead of being
+  served. `_resolve_agent_workspace`, `_capture_tool_receipt`,
+  `_check_execution_policy`, notes and todo tools all key off the same
+  credential-bound `agent_name`.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1086,3 +1086,25 @@ Container provisioning request (P1, agent-container-provisioning spec):
   escalated to a Decisions-app item for Jay. This is an identity-only check
   (no scope grant required), matching the scope-request create flow's use of
   `check_agent_identity`.
+
+## Skill-exec agent identity (credential-bound, not body-supplied)
+
+`POST /api/skill-exec/{skill_id}/call` and `GET /api/skill-exec/tools` now
+derive the agent identity from the PRESENTED CREDENTIAL, not from the request
+body. A deployed agent presenting the host local token (`TAOS_LOCAL_TOKEN`) is
+bound to a single agent name at deploy time (`AuthManager.bind_local_token_agent`
+in `tinyagentos/auth.py`; called from `tinyagentos/deployer.py`). The auth
+middleware sets `request.state.agent_name` from that binding, and the route
+rejects any local-token caller whose body claims a different `agent_name` with
+403. Admin sessions are unaffected: a human-driven call may still supply
+`agent_name` in the body.
+
+Blast radius: `_resolve_agent_workspace`, `_capture_tool_receipt`,
+`_check_execution_policy`, `execute_notes_list_shared_docs`, and the todo tools
+all key off the same `agent_name` string, so binding it at the credential layer
+closes the hole for every downstream consumer in one place. This is option (b)
+from the tsk-2km65o review: per-agent tokens (option a) and registry-JWT
+verification (option c, which slice 8 of #1800 will supply) are both strictly
+stronger but require broader changes; the binding is the minimal fix that
+rejects impersonation today without inventing a parallel scheme, and it reuses
+the existing local-token path so no client changes are required.

--- a/tests/test_skill_exec_authz.py
+++ b/tests/test_skill_exec_authz.py
@@ -226,3 +226,113 @@ class TestIsAdminOrLocalToken:
 
         assert "error" in result
         mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestSkillExecCredentialAgentName:
+    """Agent identity must come from the credential, not the request body."""
+
+    async def test_local_token_mismatched_agent_name_rejected(self, client, app):
+        """A deployed agent presenting a valid local token but claiming a
+        different agent_name in the body must be rejected."""
+        await _ensure_skills_seeded(app)
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.post(
+                "/api/skill-exec/code_exec/call",
+                json={"args": {"code": "print('should not run')"},
+                      "agent_name": "victim"},
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 403
+
+    async def test_local_token_matching_agent_name_accepted(self, client, app):
+        """A deployed agent presenting a valid local token and claiming the
+        bound agent_name must be accepted."""
+        await _ensure_skills_seeded(app)
+        await app.state.execution_policies.set_policy("code-exec", "allow")
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello')"},
+                          "agent_name": "alice"},
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_local_token_no_body_agent_name_uses_credential(self, client, app):
+        """When no agent_name is in the body, the credential-bound name is used."""
+        await _ensure_skills_seeded(app)
+        await app.state.execution_policies.set_policy("code-exec", "allow")
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello')"}},
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_admin_session_body_agent_name_still_honoured(self, client, app):
+        """Admin sessions are trusted: body-supplied agent_name is still honoured
+        so the human-driven OS agent keeps working."""
+        await _ensure_skills_seeded(app)
+        resp = await client.post(
+            "/api/skill-exec/code_exec/call",
+            json={"args": {"code": "print('hello')"},
+                  "agent_name": "whatever"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+
+    async def test_list_tools_mismatched_agent_name_rejected(self, client, app):
+        """GET /api/skill-exec/tools with a mismatched agent_name for a
+        local-token caller is rejected."""
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.get(
+                "/api/skill-exec/tools",
+                params={"agent_name": "victim"},
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 403

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -1127,6 +1127,41 @@ class AuthManager:
         stored = path.read_text().strip()
         return secrets.compare_digest(presented, stored)
 
+    def _local_token_agent_path(self) -> Path:
+        return self.data_dir / ".auth_local_token_bindings.json"
+
+    def bind_local_token_agent(self, token: str, agent_name: str) -> None:
+        """Record that *token* is bound to *agent_name* for skill-exec identity.
+
+        The bindings file maps ``sha256(token) -> agent_name`` so the raw token
+        is never written to disk a second time.  Atomic write keeps the file
+        consistent under concurrent deploys.
+        """
+        path = self._local_token_agent_path()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        data = {}
+        if path.exists():
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                data = {}
+        data[token_hash] = agent_name
+        atomic_write_text(path, json.dumps(data), mode=0o600)
+
+    def get_local_token_agent(self, presented: str) -> str | None:
+        """Return the agent name bound to this local token, or ``None``."""
+        if not presented:
+            return None
+        path = self._local_token_agent_path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        token_hash = hashlib.sha256(presented.encode()).hexdigest()
+        return data.get(token_hash)
+
     def update_last_login(self, user_id: str) -> None:
         data = self._read_users()
         users = data.get("users", [])

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -569,6 +569,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.user_id = None
                     request.state.is_admin = False
                     request.state.via = "local_token"
+                bound_agent = auth_mgr.get_local_token_agent(presented)
+                if bound_agent:
+                    request.state.agent_name = bound_agent
                 return await call_next(request)
 
         # Agent-token endpoints (registry feeds + A2A bus proxy + project kanban)

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -332,7 +332,15 @@ async def deploy_agent(req: DeployRequest) -> dict:
     try:
         local_token_path = req.data_dir / ".auth_local_token"
         if local_token_path.exists():
-            env["TAOS_LOCAL_TOKEN"] = local_token_path.read_text().strip()
+            token = local_token_path.read_text().strip()
+            env["TAOS_LOCAL_TOKEN"] = token
+            # Bind this local token to the agent being deployed so skill-exec
+            # derives identity from the credential, not from the body.
+            try:
+                from tinyagentos.auth import AuthManager
+                AuthManager(req.data_dir).bind_local_token_agent(token, req.name)
+            except Exception:
+                pass
     except Exception:
         pass
     env["TAOS_TRACE_URL"] = f"http://{req.taos_host}:{req.taos_port}/api/trace"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -79,7 +79,8 @@ def _resolve_agent_workspace(request: Request, args: dict) -> Path:
     rebuild or framework swap. See ``docs/design/framework-agnostic-runtime.md``.
     """
     agent_name = (
-        args.get("agent_name")
+        getattr(request.state, "agent_name", None)
+        or args.get("agent_name")
         or request.query_params.get("agent_name")
         or "default"
     )
@@ -494,6 +495,12 @@ async def list_tools(request: Request, agent_name: str):
     format matches the OpenAI / MCP tool definition so adapters can pass it
     straight through to framework tool registries.
     """
+    credential_agent = getattr(request.state, "agent_name", None)
+    if credential_agent and agent_name != credential_agent:
+        return JSONResponse(
+            {"error": "forbidden: agent_name does not match credential"},
+            status_code=403,
+        )
     skill_store = request.app.state.skills
     skills = await skill_store.get_agent_skills(agent_name)
 
@@ -537,7 +544,10 @@ def _capture_tool_receipt(request: Request, skill_id: str, args: dict, result) -
         from tinyagentos.receipts import emit_tool_receipt
 
         store = getattr(request.app.state, "receipt_store", None)
-        agent = (args.get("agent_name") or "").strip()
+        agent = (
+            getattr(request.state, "agent_name", None)
+            or (args.get("agent_name") or "").strip()
+        )
         if store is None or not agent:
             return
         # agent_name is identity, not a tool argument; keep it out of tool_args.
@@ -696,10 +706,21 @@ async def execute_skill(skill_id: str, request: Request):
 
     body = await request.json()
     args = body.get("args", {})
-    # Propagate agent_name from the request body into args so file-read
-    # and file-write resolve the right per-agent workspace.
-    if "agent_name" in body and "agent_name" not in args:
-        args["agent_name"] = body["agent_name"]
+
+    # Agent identity must come from the CREDENTIAL, not the body.
+    # Local-token callers are bound to a single agent at deploy time; a
+    # deployed agent passing another agent's handle must be rejected.
+    credential_agent = getattr(request.state, "agent_name", None)
+    body_agent = body.get("agent_name")
+    if credential_agent:
+        if body_agent and body_agent != credential_agent:
+            return JSONResponse(
+                {"error": "forbidden: agent_name does not match credential"},
+                status_code=403,
+            )
+        args["agent_name"] = credential_agent
+    elif body_agent:
+        args["agent_name"] = body_agent
 
     skill_store = request.app.state.skills
     skill = await skill_store.get_skill(skill_id)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): SECURITY: agent_name is caller-asserted - any deployed agent can claim any handle

Autonomous build of board card tsk-2km65o.

Option (b): bind the host-wide local token to a single agent name at
injection time so skill-exec derives identity from the credential, not the
request body.

- AuthManager gains bind_local_token_agent/get_local_token_agent, storing
  sha256(token) -> agent_name in .auth_local_token_bindings.json.
- deployer.py writes the binding after injecting TAOS_LOCAL_TOKEN.
- auth_middleware.py sets request.state.agent_name from the binding for
  local-token callers.
- routes/skill_exec.py rejects a local-token POST/GET whose body claims a
  different agent_name (403); admin sessions keep body-honoured behaviour.
  _capture_tool_receipt and _resolve_agent_workspace also prefer credential.

Tests added in TestSkillExecCredentialAgentName: mismatched local-token
caller rejected, matching caller accepted, no-body caller uses credential,
admin session body still honoured, list_tools mismatch rejected.

Fixes the hole where any deployed agent could claim any handle via the
shared TAOS_LOCAL_TOKEN and unverified agent_name body field.

Docs: docs/agent-coordination.md updated with skill-exec identity section.

Proof: 152 tests pass across test_skill_exec_authz.py,
test_skill_exec_governance.py, test_routes_skill_exec.py, test_auth.py

Files:
 .../tsk-2km65o-skill-exec-agent-identity.md        |   8 ++
 docs/agent-coordination.md                         |  22 +++++
 tests/test_skill_exec_authz.py                     | 110 +++++++++++++++++++++
 tinyagentos/auth.py                                |  35 +++++++
 tinyagentos/auth_middleware.py                     |   3 +
 tinyagentos/deployer.py                            |  10 +-
 tinyagentos/routes/skill_exec.py                   |  33 +++++--
 7 files changed, 214 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Skill execution now binds agent identity to the authenticated credential.
  * Requests that claim an agent identity different from the credential are rejected.
  * Workspace resolution, tool access, execution checks, receipts, notes, and todo actions consistently use the authenticated agent identity.
  * Credentials are securely stored using hashed values rather than raw tokens.

* **Documentation**
  * Added guidance describing credential-bound skill-execution identity and its behavior for local-token and admin authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->