### PR TITLE
fix-forward #2678: credential-bound skill-exec identity is last-deploy-wins - the binding keys on the SHARED host local token; mint per-agent tokens (option a)

### DIFF
--- a/changelog.d/tsk-2km65o-skill-exec-agent-identity.md
+++ b/changelog.d/tsk-2km65o-skill-exec-agent-identity.md
@@ -1,0 +1,8 @@
+### Security
+
+- Skill-exec agent identity is now derived from the presented local-token
+  credential binding, not from the request body. A deployed agent passing
+  another agent's handle in the body is rejected with 403 instead of being
+  served. `_resolve_agent_workspace`, `_capture_tool_receipt`,
+  `_check_execution_policy`, notes and todo tools all key off the same
+  credential-bound `agent_name`.

--- a/changelog.d/tsk-bf44mt-per-agent-local-tokens.md
+++ b/changelog.d/tsk-bf44mt-per-agent-local-tokens.md
@@ -1,0 +1,11 @@
+### Security
+
+- Skill-exec agent identity now uses per-agent local tokens minted at deploy
+  time instead of the shared host token. Each deployed agent receives its own
+  distinct `TAOS_LOCAL_TOKEN` bound to its name, so concurrent deploys can no
+  longer overwrite each other's credential binding. The shared host local token
+  remains valid for admin/system callers but is no longer bound to any agent
+  name, so an unbound local-token caller falls back to the body-asserted
+  behaviour (or is denied where the credential mismatch check applies).
+  `request.state.agent_name` set by the auth middleware is now reliable for all
+  local-token callers, not just skill-exec.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1086,3 +1086,25 @@ Container provisioning request (P1, agent-container-provisioning spec):
   escalated to a Decisions-app item for Jay. This is an identity-only check
   (no scope grant required), matching the scope-request create flow's use of
   `check_agent_identity`.
+
+## Skill-exec agent identity (credential-bound, not body-supplied)
+
+`POST /api/skill-exec/{skill_id}/call` and `GET /api/skill-exec/tools` now
+derive the agent identity from the PRESENTED CREDENTIAL, not from the request
+body. A deployed agent presenting the host local token (`TAOS_LOCAL_TOKEN`) is
+bound to a single agent name at deploy time (`AuthManager.bind_local_token_agent`
+in `tinyagentos/auth.py`; called from `tinyagentos/deployer.py`). The auth
+middleware sets `request.state.agent_name` from that binding, and the route
+rejects any local-token caller whose body claims a different `agent_name` with
+403. Admin sessions are unaffected: a human-driven call may still supply
+`agent_name` in the body.
+
+Blast radius: `_resolve_agent_workspace`, `_capture_tool_receipt`,
+`_check_execution_policy`, `execute_notes_list_shared_docs`, and the todo tools
+all key off the same `agent_name` string, so binding it at the credential layer
+closes the hole for every downstream consumer in one place. This is option (b)
+from the tsk-2km65o review: per-agent tokens (option a) and registry-JWT
+verification (option c, which slice 8 of #1800 will supply) are both strictly
+stronger but require broader changes; the binding is the minimal fix that
+rejects impersonation today without inventing a parallel scheme, and it reuses
+the existing local-token path so no client changes are required.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1092,7 +1092,7 @@ Container provisioning request (P1, agent-container-provisioning spec):
 `POST /api/skill-exec/{skill_id}/call` and `GET /api/skill-exec/tools` now
 derive the agent identity from the PRESENTED CREDENTIAL, not from the request
 body. A deployed agent presenting the host local token (`TAOS_LOCAL_TOKEN`) is
-bound to a single agent name at deploy time (`AuthManager.bind_local_token_agent`
+issued a distinct per-agent token at deploy time (`AuthManager.mint_agent_local_token`
 in `tinyagentos/auth.py`; called from `tinyagentos/deployer.py`). The auth
 middleware sets `request.state.agent_name` from that binding, and the route
 rejects any local-token caller whose body claims a different `agent_name` with
@@ -1102,9 +1102,8 @@ rejects any local-token caller whose body claims a different `agent_name` with
 Blast radius: `_resolve_agent_workspace`, `_capture_tool_receipt`,
 `_check_execution_policy`, `execute_notes_list_shared_docs`, and the todo tools
 all key off the same `agent_name` string, so binding it at the credential layer
-closes the hole for every downstream consumer in one place. This is option (b)
-from the tsk-2km65o review: per-agent tokens (option a) and registry-JWT
-verification (option c, which slice 8 of #1800 will supply) are both strictly
-stronger but require broader changes; the binding is the minimal fix that
-rejects impersonation today without inventing a parallel scheme, and it reuses
-the existing local-token path so no client changes are required.
+closes the hole for every downstream consumer in one place. Per-agent tokens
+replace the earlier shared-token binding: each deploy mints a fresh token,
+eliminating the last-deploy-wins collision where two agents bound to the same
+host token would overwrite each other's identity. The shared host token remains
+valid for admin/system callers but is no longer bound to any agent name.

--- a/tests/test_skill_exec_authz.py
+++ b/tests/test_skill_exec_authz.py
@@ -12,9 +12,11 @@ This suite locks in the fix end-to-end through the real ``AuthMiddleware``:
   (a) a non-admin user session is rejected 403 and ``subprocess.run`` is
       never invoked;
   (b) an admin session is allowed;
-  (c) a request presenting the valid local token is allowed;
+  (c) a request presenting a valid per-agent local token is allowed;
   (d) an invalid/absent token from a non-admin caller is rejected and never
       elevates privilege, and ``subprocess.run`` is never invoked.
+  (e) two deployed agents with distinct per-agent tokens each resolve to their
+      own identity; a token cannot impersonate another agent.
 """
 from __future__ import annotations
 
@@ -101,15 +103,16 @@ class TestSkillExecAuthz:
         mock_run.assert_called_once()
 
     async def test_valid_local_token_allowed(self, client, app):
-        """(c) A request presenting the valid local token is allowed, with no
-        session cookie at all."""
+        """(c) A request presenting a valid per-agent local token is allowed,
+        with no session cookie at all."""
         await _ensure_skills_seeded(app)
         # A local-token caller (a deployed agent) IS governed, unlike an admin
         # session -- so neutralize the conservative code-exec gate here to keep
         # this test focused on the auth gate. Governance itself is covered in
         # test_skill_exec_governance.py.
         await app.state.execution_policies.set_policy("code-exec", "allow")
-        local_token = app.state.auth.get_local_token()
+        # Use the deployer's real token-minting flow, not the shared host token.
+        alice_token = app.state.auth.mint_agent_local_token("alice")
         bare_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         )
@@ -118,7 +121,7 @@ class TestSkillExecAuthz:
                 resp = await bare_client.post(
                     "/api/skill-exec/code_exec/call",
                     json={"args": {"code": "print('hello')"}},
-                    headers={"Authorization": f"Bearer {local_token}"},
+                    headers={"Authorization": f"Bearer {alice_token}"},
                 )
         finally:
             await bare_client.aclose()
@@ -232,12 +235,11 @@ class TestIsAdminOrLocalToken:
 class TestSkillExecCredentialAgentName:
     """Agent identity must come from the credential, not the request body."""
 
-    async def test_local_token_mismatched_agent_name_rejected(self, client, app):
-        """A deployed agent presenting a valid local token but claiming a
+    async def test_per_agent_token_mismatched_agent_name_rejected(self, client, app):
+        """A deployed agent presenting its own per-agent token but claiming a
         different agent_name in the body must be rejected."""
         await _ensure_skills_seeded(app)
-        local_token = app.state.auth.get_local_token()
-        app.state.auth.bind_local_token_agent(local_token, "alice")
+        alice_token = app.state.auth.mint_agent_local_token("alice")
 
         bare_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
@@ -247,20 +249,19 @@ class TestSkillExecCredentialAgentName:
                 "/api/skill-exec/code_exec/call",
                 json={"args": {"code": "print('should not run')"},
                       "agent_name": "victim"},
-                headers={"Authorization": f"Bearer {local_token}"},
+                headers={"Authorization": f"Bearer {alice_token}"},
             )
         finally:
             await bare_client.aclose()
 
         assert resp.status_code == 403
 
-    async def test_local_token_matching_agent_name_accepted(self, client, app):
-        """A deployed agent presenting a valid local token and claiming the
+    async def test_per_agent_token_matching_agent_name_accepted(self, client, app):
+        """A deployed agent presenting its own per-agent token and claiming the
         bound agent_name must be accepted."""
         await _ensure_skills_seeded(app)
         await app.state.execution_policies.set_policy("code-exec", "allow")
-        local_token = app.state.auth.get_local_token()
-        app.state.auth.bind_local_token_agent(local_token, "alice")
+        alice_token = app.state.auth.mint_agent_local_token("alice")
 
         bare_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
@@ -271,7 +272,7 @@ class TestSkillExecCredentialAgentName:
                     "/api/skill-exec/code_exec/call",
                     json={"args": {"code": "print('hello')"},
                           "agent_name": "alice"},
-                    headers={"Authorization": f"Bearer {local_token}"},
+                    headers={"Authorization": f"Bearer {alice_token}"},
                 )
         finally:
             await bare_client.aclose()
@@ -280,12 +281,11 @@ class TestSkillExecCredentialAgentName:
         assert resp.json()["returncode"] == 0
         mock_run.assert_called_once()
 
-    async def test_local_token_no_body_agent_name_uses_credential(self, client, app):
+    async def test_per_agent_token_no_body_agent_name_uses_credential(self, client, app):
         """When no agent_name is in the body, the credential-bound name is used."""
         await _ensure_skills_seeded(app)
         await app.state.execution_policies.set_policy("code-exec", "allow")
-        local_token = app.state.auth.get_local_token()
-        app.state.auth.bind_local_token_agent(local_token, "alice")
+        alice_token = app.state.auth.mint_agent_local_token("alice")
 
         bare_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
@@ -295,7 +295,7 @@ class TestSkillExecCredentialAgentName:
                 resp = await bare_client.post(
                     "/api/skill-exec/code_exec/call",
                     json={"args": {"code": "print('hello')"}},
-                    headers={"Authorization": f"Bearer {local_token}"},
+                    headers={"Authorization": f"Bearer {alice_token}"},
                 )
         finally:
             await bare_client.aclose()
@@ -320,8 +320,7 @@ class TestSkillExecCredentialAgentName:
     async def test_list_tools_mismatched_agent_name_rejected(self, client, app):
         """GET /api/skill-exec/tools with a mismatched agent_name for a
         local-token caller is rejected."""
-        local_token = app.state.auth.get_local_token()
-        app.state.auth.bind_local_token_agent(local_token, "alice")
+        alice_token = app.state.auth.mint_agent_local_token("alice")
 
         bare_client = AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
@@ -330,9 +329,74 @@ class TestSkillExecCredentialAgentName:
             resp = await bare_client.get(
                 "/api/skill-exec/tools",
                 params={"agent_name": "victim"},
-                headers={"Authorization": f"Bearer {local_token}"},
+                headers={"Authorization": f"Bearer {alice_token}"},
             )
         finally:
             await bare_client.aclose()
+
+        assert resp.status_code == 403
+
+    async def test_two_deploys_distinct_tokens_resolve_correctly(self, client, app):
+        """Two deployed agents with distinct per-agent tokens each resolve to
+        their own identity. This is the collision regression: on the old shared-
+        token design, the second deploy overwrites the binding and the first
+        agent's honest call 403s."""
+        await _ensure_skills_seeded(app)
+        await app.state.execution_policies.set_policy("code-exec", "allow")
+
+        alice_token = app.state.auth.mint_agent_local_token("alice")
+        bob_token = app.state.auth.mint_agent_local_token("bob")
+
+        # alice's honest call (her own token + agent_name alice) -> 200
+        alice_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await alice_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello from alice')"},
+                          "agent_name": "alice"},
+                    headers={"Authorization": f"Bearer {alice_token}"},
+                )
+        finally:
+            await alice_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+        # bob's honest call (his own token + agent_name bob) -> 200
+        bob_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bob_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello from bob')"},
+                          "agent_name": "bob"},
+                    headers={"Authorization": f"Bearer {bob_token}"},
+                )
+        finally:
+            await bob_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+        # alice presenting agent_name bob with HER token -> 403
+        alice_impersonator = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await alice_impersonator.post(
+                "/api/skill-exec/code_exec/call",
+                json={"args": {"code": "print('should not run')"},
+                      "agent_name": "bob"},
+                headers={"Authorization": f"Bearer {alice_token}"},
+            )
+        finally:
+            await alice_impersonator.aclose()
 
         assert resp.status_code == 403

--- a/tests/test_skill_exec_authz.py
+++ b/tests/test_skill_exec_authz.py
@@ -226,3 +226,113 @@ class TestIsAdminOrLocalToken:
 
         assert "error" in result
         mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestSkillExecCredentialAgentName:
+    """Agent identity must come from the credential, not the request body."""
+
+    async def test_local_token_mismatched_agent_name_rejected(self, client, app):
+        """A deployed agent presenting a valid local token but claiming a
+        different agent_name in the body must be rejected."""
+        await _ensure_skills_seeded(app)
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.post(
+                "/api/skill-exec/code_exec/call",
+                json={"args": {"code": "print('should not run')"},
+                      "agent_name": "victim"},
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 403
+
+    async def test_local_token_matching_agent_name_accepted(self, client, app):
+        """A deployed agent presenting a valid local token and claiming the
+        bound agent_name must be accepted."""
+        await _ensure_skills_seeded(app)
+        await app.state.execution_policies.set_policy("code-exec", "allow")
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello')"},
+                          "agent_name": "alice"},
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_local_token_no_body_agent_name_uses_credential(self, client, app):
+        """When no agent_name is in the body, the credential-bound name is used."""
+        await _ensure_skills_seeded(app)
+        await app.state.execution_policies.set_policy("code-exec", "allow")
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello')"}},
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_admin_session_body_agent_name_still_honoured(self, client, app):
+        """Admin sessions are trusted: body-supplied agent_name is still honoured
+        so the human-driven OS agent keeps working."""
+        await _ensure_skills_seeded(app)
+        resp = await client.post(
+            "/api/skill-exec/code_exec/call",
+            json={"args": {"code": "print('hello')"},
+                  "agent_name": "whatever"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+
+    async def test_list_tools_mismatched_agent_name_rejected(self, client, app):
+        """GET /api/skill-exec/tools with a mismatched agent_name for a
+        local-token caller is rejected."""
+        local_token = app.state.auth.get_local_token()
+        app.state.auth.bind_local_token_agent(local_token, "alice")
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.get(
+                "/api/skill-exec/tools",
+                params={"agent_name": "victim"},
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 403

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -1114,18 +1114,43 @@ class AuthManager:
         return token
 
     def validate_local_token(self, presented: str) -> bool:
-        """Return True if *presented* matches the on-disk local token.
+        """Return True if *presented* matches the on-disk local token or any
+        bound agent token.
 
         Always re-reads the file so rotating the file takes effect on the
         next request. Uses ``secrets.compare_digest`` to avoid timing leaks.
+        Bound agent tokens are accepted too: each per-agent token is minted at
+        deploy time and its hash is stored in the bindings file.
         """
         if not presented:
             return False
         path = self.local_token_path()
-        if not path.exists():
+        if path.exists():
+            stored = path.read_text().strip()
+            if secrets.compare_digest(presented, stored):
+                return True
+        bindings_path = self._local_token_agent_path()
+        if not bindings_path.exists():
             return False
-        stored = path.read_text().strip()
-        return secrets.compare_digest(presented, stored)
+        try:
+            data = json.loads(bindings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return False
+        presented_hash = hashlib.sha256(presented.encode()).hexdigest()
+        for stored_hash in data:
+            if secrets.compare_digest(presented_hash, stored_hash):
+                return True
+        return False
+
+    def mint_agent_local_token(self, agent_name: str) -> str:
+        """Mint a distinct local token for *agent_name* and bind it.
+
+        Returns the new token. The caller is responsible for delivering it to
+        the agent (e.g. via ``TAOS_LOCAL_TOKEN`` env var at deploy time).
+        """
+        token = secrets.token_urlsafe(32)
+        self.bind_local_token_agent(token, agent_name)
+        return token
 
     def _local_token_agent_path(self) -> Path:
         return self.data_dir / ".auth_local_token_bindings.json"

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -1127,6 +1127,41 @@ class AuthManager:
         stored = path.read_text().strip()
         return secrets.compare_digest(presented, stored)
 
+    def _local_token_agent_path(self) -> Path:
+        return self.data_dir / ".auth_local_token_bindings.json"
+
+    def bind_local_token_agent(self, token: str, agent_name: str) -> None:
+        """Record that *token* is bound to *agent_name* for skill-exec identity.
+
+        The bindings file maps ``sha256(token) -> agent_name`` so the raw token
+        is never written to disk a second time.  Atomic write keeps the file
+        consistent under concurrent deploys.
+        """
+        path = self._local_token_agent_path()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        data = {}
+        if path.exists():
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                data = {}
+        data[token_hash] = agent_name
+        atomic_write_text(path, json.dumps(data), mode=0o600)
+
+    def get_local_token_agent(self, presented: str) -> str | None:
+        """Return the agent name bound to this local token, or ``None``."""
+        if not presented:
+            return None
+        path = self._local_token_agent_path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+        token_hash = hashlib.sha256(presented.encode()).hexdigest()
+        return data.get(token_hash)
+
     def update_last_login(self, user_id: str) -> None:
         data = self._read_users()
         users = data.get("users", [])

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -569,6 +569,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.user_id = None
                     request.state.is_admin = False
                     request.state.via = "local_token"
+                bound_agent = auth_mgr.get_local_token_agent(presented)
+                if bound_agent:
+                    request.state.agent_name = bound_agent
                 return await call_next(request)
 
         # Agent-token endpoints (registry feeds + A2A bus proxy + project kanban)

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -330,19 +330,17 @@ async def deploy_agent(req: DeployRequest) -> dict:
 
     # Trace capture — local auth token + trace API URL.
     try:
-        local_token_path = req.data_dir / ".auth_local_token"
-        if local_token_path.exists():
-            token = local_token_path.read_text().strip()
-            env["TAOS_LOCAL_TOKEN"] = token
-            # Bind this local token to the agent being deployed so skill-exec
-            # derives identity from the credential, not from the body.
-            try:
-                from tinyagentos.auth import AuthManager
-                AuthManager(req.data_dir).bind_local_token_agent(token, req.name)
-            except Exception:
-                pass
-    except Exception:
-        pass
+        from tinyagentos.auth import AuthManager
+        auth_mgr = AuthManager(req.data_dir)
+        agent_token = auth_mgr.mint_agent_local_token(req.name)
+        env["TAOS_LOCAL_TOKEN"] = agent_token
+    except Exception as exc:
+        logger.error("deploy %s: failed to mint agent local token: %s", req.name, exc)
+        return {
+            "success": False,
+            "error": f"failed to mint agent local token: {exc}",
+            "steps": steps,
+        }
     env["TAOS_TRACE_URL"] = f"http://{req.taos_host}:{req.taos_port}/api/trace"
 
     # Agent-bridge shared token (issue #672 — defense-in-depth auth guard).

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -332,7 +332,15 @@ async def deploy_agent(req: DeployRequest) -> dict:
     try:
         local_token_path = req.data_dir / ".auth_local_token"
         if local_token_path.exists():
-            env["TAOS_LOCAL_TOKEN"] = local_token_path.read_text().strip()
+            token = local_token_path.read_text().strip()
+            env["TAOS_LOCAL_TOKEN"] = token
+            # Bind this local token to the agent being deployed so skill-exec
+            # derives identity from the credential, not from the body.
+            try:
+                from tinyagentos.auth import AuthManager
+                AuthManager(req.data_dir).bind_local_token_agent(token, req.name)
+            except Exception:
+                pass
     except Exception:
         pass
     env["TAOS_TRACE_URL"] = f"http://{req.taos_host}:{req.taos_port}/api/trace"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -79,7 +79,8 @@ def _resolve_agent_workspace(request: Request, args: dict) -> Path:
     rebuild or framework swap. See ``docs/design/framework-agnostic-runtime.md``.
     """
     agent_name = (
-        args.get("agent_name")
+        getattr(request.state, "agent_name", None)
+        or args.get("agent_name")
         or request.query_params.get("agent_name")
         or "default"
     )
@@ -494,6 +495,12 @@ async def list_tools(request: Request, agent_name: str):
     format matches the OpenAI / MCP tool definition so adapters can pass it
     straight through to framework tool registries.
     """
+    credential_agent = getattr(request.state, "agent_name", None)
+    if credential_agent and agent_name != credential_agent:
+        return JSONResponse(
+            {"error": "forbidden: agent_name does not match credential"},
+            status_code=403,
+        )
     skill_store = request.app.state.skills
     skills = await skill_store.get_agent_skills(agent_name)
 
@@ -537,7 +544,10 @@ def _capture_tool_receipt(request: Request, skill_id: str, args: dict, result) -
         from tinyagentos.receipts import emit_tool_receipt
 
         store = getattr(request.app.state, "receipt_store", None)
-        agent = (args.get("agent_name") or "").strip()
+        agent = (
+            getattr(request.state, "agent_name", None)
+            or (args.get("agent_name") or "").strip()
+        )
         if store is None or not agent:
             return
         # agent_name is identity, not a tool argument; keep it out of tool_args.
@@ -696,10 +706,21 @@ async def execute_skill(skill_id: str, request: Request):
 
     body = await request.json()
     args = body.get("args", {})
-    # Propagate agent_name from the request body into args so file-read
-    # and file-write resolve the right per-agent workspace.
-    if "agent_name" in body and "agent_name" not in args:
-        args["agent_name"] = body["agent_name"]
+
+    # Agent identity must come from the CREDENTIAL, not the body.
+    # Local-token callers are bound to a single agent at deploy time; a
+    # deployed agent passing another agent's handle must be rejected.
+    credential_agent = getattr(request.state, "agent_name", None)
+    body_agent = body.get("agent_name")
+    if credential_agent:
+        if body_agent and body_agent != credential_agent:
+            return JSONResponse(
+                {"error": "forbidden: agent_name does not match credential"},
+                status_code=403,
+            )
+        args["agent_name"] = credential_agent
+    elif body_agent:
+        args["agent_name"] = body_agent
 
     skill_store = request.app.state.skills
     skill = await skill_store.get_skill(skill_id)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2678: credential-bound skill-exec identity is last-deploy-wins - the binding keys on the SHARED host local token; mint per-agent tokens (option a)

Autonomous build of board card tsk-bf44mt.

REVISION: built on `exec/tsk-2km65o` (cut at `9b0a26110e00f8df05d6ea4e6188374841877b75`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

The shared host .auth_local_token was bound to every deploy, so the last
deploy overwrote the binding and earlier agents' honest skill-exec calls
403'd while their anonymous calls executed as the last-deployed agent.

Now deployer.py calls auth_mgr.mint_agent_local_token(name) to mint a
distinct token per agent, passes it via TAOS_LOCAL_TOKEN, and binds the
hash to that agent name. The shared host token stays valid but unbound
for admin/system callers. auth_middleware already sets request.state
.agent_name from the binding; validate_local_token now also accepts
bound agent tokens with constant-time compare.

deployer.py no longer swallows token-mint failures silently -- a failed
mint aborts the deploy with an error step.

Tests updated to use the deployer's real minting seam; new test covers
the two-agent collision case.

Files:
 changelog.d/tsk-bf44mt-per-agent-local-tokens.md   |  11 ++
 docs/agent-coordination.md                         |  21 +++
 tests/test_skill_exec_authz.py                     | 184 ++++++++++++++++++++-
 tinyagentos/auth.py                                |  68 +++++++-
 tinyagentos/auth_middleware.py                     |   3 +
 tinyagentos/deployer.py                            |  16 +-
 tinyagentos/routes/skill_exec.py                   |  33 +++-
 8 files changed, 324 insertions(+), 20 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added per-agent local authentication tokens during deployment.
  - Skill execution now verifies agent identity against the presented credential, preventing impersonation and returning 403 for mismatched identities.
  - Tool access, workspace selection, receipts, notes, and todos consistently use the authenticated agent identity.

- **Documentation**
  - Documented credential-bound agent identity, token behavior, and administrative access rules.

- **Tests**
  - Added coverage for matching, mismatched, absent, and concurrent agent identities across skill execution and tool discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->