### PR TITLE
fix-forward #2679: checklist created_by fix deletes two live regression tests, ships zero coverage of its own fix, and its ALTER migration swallows every failure

### DIFF
--- a/changelog.d/tsk-6xymzj-fix-checklist-attribution.md
+++ b/changelog.d/tsk-6xymzj-fix-checklist-attribution.md
@@ -1,0 +1,2 @@
+### Fixed
+- Fixed checklist item attribution: added `created_by` column to `task_checklist_items` table and persisted it when creating checklist items

--- a/changelog.d/tsk-dj2mhv-checklist-created-by-fix.md
+++ b/changelog.d/tsk-dj2mhv-checklist-created-by-fix.md
@@ -1,0 +1,4 @@
+### Fixed
+- Restored two deleted regression tests for checklist item event delivery and agent restart survival
+- Fixed blind `ALTER TABLE` migration for `created_by` column: now checks `PRAGMA table_info` first and surfaces non-duplicate ALTER failures instead of swallowing them
+- Added round-trip and existing-DB upgrade test coverage for `created_by` persistence on checklist items

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -214,11 +214,7 @@ async def test_ready_tasks_excludes_blocked(store):
     b = await store.create_task(project_id="p", title="B", created_by="u")
     # b blocks a
     await store.add_relationship(
-        project_id="p",
-        from_task_id=a["id"],
-        to_task_id=b["id"],
-        kind="blocks",
-        created_by="u",
+        project_id="p", from_task_id=a["id"], to_task_id=b["id"], kind="blocks", created_by="u"
     )
     ready = await store.list_ready_tasks(project_id="p")
     assert [t["id"] for t in ready] == [b["id"]]
@@ -411,7 +407,7 @@ async def test_cannot_archive_unverified(store):
     t = await store.create_task(project_id="p", title="Objective", created_by="u")
     item = await store.create_checklist_item(task_id=t["id"], text="Unverified item", created_by="u")
     with pytest.raises(ValueError, match="item cannot be archived: not verified"):
-        await store.archive_checklist_item(item_id=item["id"], reported_by="u")
+        await store.archive_checklist_item(item_id=item["id"])
 
 
 @pytest.mark.asyncio
@@ -420,7 +416,7 @@ async def test_cannot_archive_unreported(store):
     item = await store.create_checklist_item(task_id=t["id"], text="Unreported item", created_by="u")
     await store.update_checklist_item(item_id=item["id"], verified=True)
     with pytest.raises(ValueError, match="item cannot be archived: not reported"):
-        await store.archive_checklist_item(item_id=item["id"], reported_by="u")
+        await store.archive_checklist_item(item_id=item["id"])
 
 
 @pytest.mark.asyncio
@@ -428,44 +424,10 @@ async def test_can_archive_after_verification_and_report(store):
     t = await store.create_task(project_id="p", title="Objective", created_by="u")
     item = await store.create_checklist_item(task_id=t["id"], text="Complete item", created_by="u")
     await store.update_checklist_item(item_id=item["id"], verified=True, reported=True)
-    archived = await store.archive_checklist_item(item_id=item["id"], reported_by="u")
+    archived = await store.archive_checklist_item(item_id=item["id"])
     assert archived["archived"] is True
     all_items = await store.list_checklist_items(task_id=t["id"], include_archived=True)
     assert any(i["id"] == item["id"] for i in all_items)
-
-
-@pytest.mark.asyncio
-async def test_survives_agent_restart(store):
-    t = await store.create_task(project_id="p", title="Objective", created_by="u")
-    item = await store.create_checklist_item(task_id=t["id"], text="Persistent item", created_by="u")
-    items = await store.list_checklist_items(task_id=t["id"])
-    assert len(items) == 1
-    assert items[0]["text"] == "Persistent item"
-    assert items[0]["archived"] is False
-    all_items = await store.list_checklist_items(task_id=t["id"], include_archived=True)
-    assert len(all_items) == 1
-
-
-@pytest.mark.asyncio
-async def test_checklist_item_event_delivered_at_project_scope(store_with_broker):
-    """Defect 1: checklist.item.created must be published under the PROJECT id
-    so project-scoped subscribers receive it.
-
-    On the BASE branch the event is published under the task_id, so the project
-    subscription never fires and this test fails.
-    """
-    store, broker = store_with_broker
-    t = await store.create_task(project_id="proj-red", title="Objective", created_by="u")
-    queue = await broker.subscribe("proj-red")
-    await store.create_checklist_item(task_id=t["id"], text="step one", created_by="u")
-    collected = []
-    while not queue.empty():
-        collected.append(queue.get_nowait())
-    checklist_events = [e for e in collected if e.kind == "checklist.item.created"]
-    assert checklist_events, (
-        f"expected checklist.item.created at project scope, got: {[e.kind for e in collected]}"
-    )
-    assert checklist_events[0].payload["task_id"] == t["id"]
 
 
 @pytest.mark.asyncio
@@ -474,11 +436,10 @@ async def test_archive_nonexistent_item_raises_value_error(store):
     ValueError, not a TypeError from indexing None.
     """
     with pytest.raises(ValueError, match="not found"):
-        await store.archive_checklist_item(item_id="cki-nonexistent", reported_by="u")
+        await store.archive_checklist_item(item_id="cki-nonexistent")
 
 
 # ── close_task ownership guard ──────────────────────────────────────────────
-
 
 @pytest.mark.asyncio
 async def test_close_by_claimer_passes(store):

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -431,6 +431,113 @@ async def test_can_archive_after_verification_and_report(store):
 
 
 @pytest.mark.asyncio
+async def test_survives_agent_restart(store):
+    t = await store.create_task(project_id="p", title="Objective", created_by="u")
+    item = await store.create_checklist_item(task_id=t["id"], text="Persistent item", created_by="u")
+    items = await store.list_checklist_items(task_id=t["id"])
+    assert len(items) == 1
+    assert items[0]["text"] == "Persistent item"
+    assert items[0]["archived"] is False
+    all_items = await store.list_checklist_items(task_id=t["id"], include_archived=True)
+    assert len(all_items) == 1
+
+
+@pytest.mark.asyncio
+async def test_checklist_item_event_delivered_at_project_scope(store_with_broker):
+    """Defect 1: checklist.item.created must be published under the PROJECT id
+    so project-scoped subscribers receive it.
+
+    On the BASE branch the event is published under the task_id, so the project
+    subscription never fires and this test fails.
+    """
+    store, broker = store_with_broker
+    t = await store.create_task(project_id="proj-red", title="Objective", created_by="u")
+    queue = await broker.subscribe("proj-red")
+    await store.create_checklist_item(task_id=t["id"], text="step one", created_by="u")
+    collected = []
+    while not queue.empty():
+        collected.append(queue.get_nowait())
+    checklist_events = [e for e in collected if e.kind == "checklist.item.created"]
+    assert checklist_events, (
+        f"expected checklist.item.created at project scope, got: {[e.kind for e in collected]}"
+    )
+    assert checklist_events[0].payload["task_id"] == t["id"]
+
+
+@pytest.mark.asyncio
+async def test_checklist_item_created_by_persists(store):
+    """Acceptance 1: Round-trip test: create_checklist_item(created_by="u") -> list_checklist_items returns created_by == "u". RED on origin/dev (column absent), green on the fix."""
+    t = await store.create_task(project_id="p", title="Objective", created_by="u")
+    item = await store.create_checklist_item(task_id=t["id"], text="Test item", created_by="user-123")
+    assert item["created_by"] == "user-123"
+
+    items = await store.list_checklist_items(task_id=t["id"])
+    assert len(items) == 1
+    assert items[0]["created_by"] == "user-123"
+    assert items[0]["text"] == "Test item"
+
+
+@pytest.mark.asyncio
+async def test_checklist_item_created_by_upgrade_from_pre_schema(tmp_path):
+    """Acceptance 2: Existing-DB upgrade test: build a db with the PRE-change schema (no created_by), run store init, then create_checklist_item succeeds and persists created_by."""
+    db_path = tmp_path / "old_schema.db"
+    await _create_old_schema_db(db_path)
+
+    s = ProjectTaskStore(db_path)
+    await s.init()
+
+    try:
+        t = await s.create_task(project_id="p", title="Objective", created_by="u")
+        item = await s.create_checklist_item(task_id=t["id"], text="Test item", created_by="upgraded-user")
+        assert item["created_by"] == "upgraded-user"
+
+        items = await s.list_checklist_items(task_id=t["id"])
+        assert len(items) == 1
+        assert items[0]["created_by"] == "upgraded-user"
+    finally:
+        await s.close()
+
+
+@pytest.mark.asyncio
+async def test_checklist_item_created_by_migration_failure(tmp_path):
+    """Acceptance 3: Migration-failure path: a non-duplicate ALTER failure surfaces (raises), it is NOT read as already-migrated."""
+    import sqlite3
+
+    db_path = tmp_path / "locked.db"
+    await _create_old_schema_db(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("BEGIN EXCLUSIVE")
+    try:
+        s = ProjectTaskStore(db_path)
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            await s.init()
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+async def _create_old_schema_db(db_path):
+    """Helper to create a database with the pre-change schema (without created_by column)."""
+    import aiosqlite
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute("""
+            CREATE TABLE task_checklist_items (
+                id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                text TEXT NOT NULL DEFAULT '',
+                done INTEGER NOT NULL DEFAULT 0,
+                verified INTEGER NOT NULL DEFAULT 0,
+                reported INTEGER NOT NULL DEFAULT 0,
+                archived INTEGER NOT NULL DEFAULT 0,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+        """)
+        await db.commit()
+
+
+@pytest.mark.asyncio
 async def test_archive_nonexistent_item_raises_value_error(store):
     """Defect 2: archiving a missing checklist item should raise a clean
     ValueError, not a TypeError from indexing None.

--- a/tests/test_routes_task_checklist.py
+++ b/tests/test_routes_task_checklist.py
@@ -165,7 +165,7 @@ class TestArchiveFiltering:
 
         store = ctx.app.state.project_task_store
         await store.update_checklist_item(item_id, verified=True, reported=True)
-        await store.archive_checklist_item(item_id, reported_by=ctx.uid)
+        await store.archive_checklist_item(item_id)
 
         resp = await ctx.client.get(_url(pid, tid))
         rows = resp.json()

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -199,15 +199,23 @@ class ProjectTaskStore(BaseStore):
             "ON project_tasks(project_id, element_id)"
         )
         await self._db.commit()
-        # Add created_by column for checklist items (defect tsk-6xymzj)
-        try:
-            await self._db.execute(
-                "ALTER TABLE task_checklist_items ADD COLUMN created_by TEXT"
-            )
-            await self._db.commit()
-        except Exception:
-            # Column already exists on fresh installs (created by SCHEMA).
-            pass
+        # Add created_by column for checklist items (defect tsk-6xymzj).
+        # Fresh installs already have it from SCHEMA. SQLite cannot ADD COLUMN NOT
+        # NULL without a default, so migrated databases get a NULLABLE column
+        # here; legacy rows stay NULL -- intended.
+        import sqlite3
+        async with self._db.execute("PRAGMA table_info(task_checklist_items)") as cur:
+            columns = await cur.fetchall()
+            column_names = [col[1] for col in columns]
+            if "created_by" not in column_names:
+                try:
+                    await self._db.execute(
+                        "ALTER TABLE task_checklist_items ADD COLUMN created_by TEXT"
+                    )
+                    await self._db.commit()
+                except sqlite3.OperationalError as e:
+                    if "duplicate column" not in str(e):
+                        raise
 
     async def create_task(
         self,

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS task_checklist_items (
     verified INTEGER NOT NULL DEFAULT 0,
     reported INTEGER NOT NULL DEFAULT 0,
     archived INTEGER NOT NULL DEFAULT 0,
+    created_by TEXT NOT NULL,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL
 );
@@ -198,6 +199,15 @@ class ProjectTaskStore(BaseStore):
             "ON project_tasks(project_id, element_id)"
         )
         await self._db.commit()
+        # Add created_by column for checklist items (defect tsk-6xymzj)
+        try:
+            await self._db.execute(
+                "ALTER TABLE task_checklist_items ADD COLUMN created_by TEXT"
+            )
+            await self._db.commit()
+        except Exception:
+            # Column already exists on fresh installs (created by SCHEMA).
+            pass
 
     async def create_task(
         self,
@@ -746,9 +756,9 @@ class ProjectTaskStore(BaseStore):
         now = time.time()
         await self._db.execute(
             """INSERT INTO task_checklist_items
-               (id, task_id, text, done, verified, reported, archived, created_at, updated_at)
-               VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?)""",
-            (cid, task_id, text, now, now),
+               (id, task_id, text, done, verified, reported, archived, created_by, created_at, updated_at)
+               VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?)""",
+            (cid, task_id, text, created_by, now, now),
         )
         await self._db.commit()
         cur = await self._db.execute(
@@ -810,7 +820,7 @@ class ProjectTaskStore(BaseStore):
         await self._db.commit()
         return await self.get_checklist_item(item_id)
 
-    async def archive_checklist_item(self, item_id: str, reported_by: str) -> dict:
+    async def archive_checklist_item(self, item_id: str) -> dict:
         """Archive a checklist item. Only valid if verified=1 and reported=1.
 
         Raises ValueError if the item cannot be archived because it lacks


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2679: checklist created_by fix deletes two live regression tests, ships zero coverage of its own fix, and its ALTER migration swallows every failure

Autonomous build of board card tsk-dj2mhv.

REVISION: built on `exec/tsk-6xymzj` (cut at `19bc4b5cb902779ab8efd1b7a488dc24fb1729d3`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

- Restore test_survives_agent_restart and test_checklist_item_event_delivered_at_project_scope verbatim
- Fix migration: PRAGMA table_info(task_checklist_items) guards ALTER, catch only sqlite3 duplicate-column error, re-raise the rest
- Add round-trip test for created_by persistence
- Add existing-DB upgrade test (pre-change schema -> init -> create_checklist_item succeeds)
- Add migration-failure test (locked DB surfaces OperationalError, not swallowed)
- Note in comment: migrated DBs get NULLABLE created_by, fresh installs get NOT NULL, legacy rows stay NULL -- intended
- Add changelog fragment

Fixes: #2679

Files:
 .../tsk-6xymzj-fix-checklist-attribution.md        |  2 +
 changelog.d/tsk-dj2mhv-checklist-created-by-fix.md |  4 +
 tests/projects/test_task_store.py                  | 90 +++++++++++++++++++---
 tests/test_routes_task_checklist.py                |  4 +-
 tinyagentos/projects/task_store.py                 | 26 ++++++-
 5 files changed, 109 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checklist items now retain accurate creator attribution.
  * Existing databases are upgraded safely to support checklist creator information.
  * Checklist item archiving no longer requires an unnecessary reporter identifier.
  * Improved reliability for checklist event delivery and persistence after agent restarts.

* **Tests**
  * Added coverage for creator attribution, database upgrades, migration failures, event delivery, and restart recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->