### PR TITLE
Light theme: 21 plain-fraction white-overlay forms (66 uses) uninverted and invisible to the #2637 derived guard

### DIFF
--- a/changelog.d/tsk-frub5v-light-theme-plain-fraction-overlays.md
+++ b/changelog.d/tsk-frub5v-light-theme-plain-fraction-overlays.md
@@ -1,0 +1,2 @@
+### Fixed
+- Light-theme white-overlay inversion: added missing `[class~=]` rules for 21 plain-fraction forms (bg-white/8, hover:bg-white/20, divide-white/5, data-[state=unchecked]:bg-white/10, etc.) that were invisible to the #2637 derived guard; widened the coverage test regex to catch both arbitrary-value and plain-fraction gaps going forward.

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -3,8 +3,8 @@
 // Regression guard for the light-scheme gap in tokens.css. The compatibility
 // layer inverted the *plain-fraction* overlay utilities (bg-white/5, …) but
 // NOT the arbitrary-value form (bg-white/[0.04]) used by the shared primitives
-// (card, button, tabs) and ~126 app surfaces. This test proves the arbitrary
-// values now invert too.
+// (card, button, tabs) and ~126 app surfaces. This test proves both forms
+// now invert.
 //
 // Two traps this test is built to avoid:
 //   1. It asserts on COMPUTED colour, never on the class name — the class is
@@ -42,6 +42,8 @@ const TAILWIND_BASE = `
 [class~="border-white/[0.18]"] { border-color: rgba(255, 255, 255, 0.18); }
 [class~="data-[state=active]:bg-white/[0.08]"][data-state="active"] { background-color: rgba(255, 255, 255, 0.08); }
 [class~="divide-white/[0.04]"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(255, 255, 255, 0.04); }
+[class~="divide-white/5"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(255, 255, 255, 0.05); }
+[class~="data-[state=unchecked]:bg-white/10"][data-state="unchecked"] { background-color: rgba(255, 255, 255, 0.1); }
 `;
 
 // Walk desktop/src collecting every source module that can carry a class token,
@@ -147,11 +149,13 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     expect(COVERED_OVERLAYS.has("bg-white/[0.04]")).toBe(true);
   });
 
-  it("declares inversion rules for every arbitrary-value white overlay used in desktop/src", () => {
+  it("declares inversion rules for every white overlay used in desktop/src", () => {
     // Scope to white overlays only: black overlays (e.g. bg-black/[0.18])
     // already read on the light background and are deliberately not inverted.
-    const ARB_WHITE_RE =
-      /(?:^|:)(bg|text|border|ring|outline|shadow|divide|from|via|to)-white\/\[[^\]]*\]/;
+    // Matches both arbitrary-value (bg-white/[0.04]) and plain-fraction
+    // (bg-white/5, hover:bg-white/20, divide-white/5) forms.
+    const WHITE_OVERLAY_RE =
+      /(?:^|:)(bg|text|border|ring|outline|shadow|divide|from|via|to)-white\/(?:\d+|\[[^\]]*\])/;
 
     const srcFiles = collectSourceFiles(resolve(process.cwd(), "src"));
     expect(srcFiles.length).toBeGreaterThan(100);
@@ -168,7 +172,7 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
       // added anywhere in the markup — including under a variant prefix like
       // `data-[state=active]:` — is seen.
       for (const tok of code.split(/[\s"'`{}()]+/)) {
-        if (ARB_WHITE_RE.test(tok) && !COVERED_OVERLAYS.has(tok)) {
+        if (WHITE_OVERLAY_RE.test(tok) && !COVERED_OVERLAYS.has(tok)) {
           offenders.add(tok);
         }
       }
@@ -176,7 +180,7 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     expect(Array.from(offenders)).toEqual([]);
   });
 
-  it("maps each arbitrary-value hover token to its inverted colour on :hover", () => {
+  it("maps each hover token to its inverted colour on :hover", () => {
     // jsdom cannot apply :hover for getComputedStyle, so assert the exact
     // declaration value inside the :hover rule — selector AND mapped colour —
     // rather than only that the token's selector appears somewhere in the css.
@@ -191,6 +195,14 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
       ["hover:bg-white/[0.08]", "background-color", "rgba(0, 0, 0, 0.08)"],
       ["hover:bg-white/[0.1]", "background-color", "rgba(0, 0, 0, 0.1)"],
       ["hover:border-white/[0.06]", "border-color", "rgba(0, 0, 0, 0.06)"],
+      ["hover:bg-white/3", "background-color", "rgba(0, 0, 0, 0.03)"],
+      ["hover:bg-white/8", "background-color", "rgba(0, 0, 0, 0.08)"],
+      ["hover:bg-white/15", "background-color", "rgba(0, 0, 0, 0.08)"],
+      ["hover:bg-white/20", "background-color", "rgba(0, 0, 0, 0.10)"],
+      ["hover:border-white/15", "border-color", "rgba(0, 0, 0, 0.14)"],
+      ["hover:border-white/20", "border-color", "rgba(0, 0, 0, 0.16)"],
+      ["hover:text-white/40", "color", "rgba(0, 0, 0, 0.45)"],
+      ["hover:text-white/50", "color", "rgba(0, 0, 0, 0.50)"],
     ];
     for (const [token, property, value] of hoverRules) {
       const rule = `[class~="${token}"]:hover { ${property}: ${value}; }`;
@@ -240,12 +252,42 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     }
   });
 
+  it("inverts every plain-fraction background value 1:1", () => {
+    const cases: Array<[string, string]> = [
+      ["bg-white/3", "rgba(0, 0, 0, 0.03)"],
+      ["bg-white/5", "rgba(0, 0, 0, 0.04)"],
+      ["bg-white/8", "rgba(0, 0, 0, 0.08)"],
+      ["bg-white/10", "rgba(0, 0, 0, 0.06)"],
+      ["bg-white/15", "rgba(0, 0, 0, 0.08)"],
+      ["bg-white/20", "rgba(0, 0, 0, 0.1)"],
+    ];
+    setScheme("light");
+    for (const [className, expected] of cases) {
+      expect(bgColor(className), className).toBe(expected);
+    }
+  });
+
   it("inverts every arbitrary border value 1:1", () => {
     const cases: Array<[string, string]> = [
       ["border-white/[0.04]", "rgba(0, 0, 0, 0.04)"],
       ["border-white/[0.06]", "rgba(0, 0, 0, 0.06)"],
       ["border-white/[0.08]", "rgba(0, 0, 0, 0.08)"],
       ["border-white/[0.18]", "rgba(0, 0, 0, 0.18)"],
+    ];
+    setScheme("light");
+    for (const [className, expected] of cases) {
+      expect(borderColor(className), className).toBe(expected);
+    }
+  });
+
+  it("inverts every plain-fraction border value 1:1", () => {
+    const cases: Array<[string, string]> = [
+      ["border-white/5", "rgba(0, 0, 0, 0.08)"],
+      ["border-white/8", "rgba(0, 0, 0, 0.1)"],
+      ["border-white/10", "rgba(0, 0, 0, 0.12)"],
+      ["border-white/15", "rgba(0, 0, 0, 0.14)"],
+      ["border-white/20", "rgba(0, 0, 0, 0.16)"],
+      ["border-white/25", "rgba(0, 0, 0, 0.18)"],
     ];
     setScheme("light");
     for (const [className, expected] of cases) {
@@ -281,5 +323,32 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     expect(dark).toBe("rgba(255, 255, 255, 0.04)");
     expect(light).toBe("rgba(0, 0, 0, 0.04)");
     expect(light).not.toBe(dark);
+  });
+
+  it("inverts the computed divide row separators across schemes (divide-white/5)", () => {
+    setScheme("dark");
+    const dark = divideColor("divide-white/5");
+    setScheme("light");
+    const light = divideColor("divide-white/5");
+    expect(dark).toBe("rgba(255, 255, 255, 0.05)");
+    expect(light).toBe("rgba(0, 0, 0, 0.08)");
+    expect(light).not.toBe(dark);
+  });
+
+  it("inverts the unchecked state only when data-state=unchecked, and only in light scheme", () => {
+    setScheme("dark");
+    const darkUnchecked = bgColor("data-[state=unchecked]:bg-white/10", {
+      "data-state": "unchecked",
+    });
+    setScheme("light");
+    const lightUnchecked = bgColor("data-[state=unchecked]:bg-white/10", {
+      "data-state": "unchecked",
+    });
+    const lightChecked = bgColor("data-[state=unchecked]:bg-white/10", {
+      "data-state": "checked",
+    });
+    expect(darkUnchecked).toBe("rgba(255, 255, 255, 0.1)");
+    expect(lightUnchecked).toBe("rgba(0, 0, 0, 0.06)");
+    expect(lightChecked).toBe("rgba(0, 0, 0, 0)");
   });
 });

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -87,12 +87,14 @@
 :root[data-scheme="light"] [class~="bg-white/10"] { background-color: rgba(0, 0, 0, 0.06); }
 :root[data-scheme="light"] [class~="bg-white/15"] { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="bg-white/20"] { background-color: rgba(0, 0, 0, 0.10); }
+:root[data-scheme="light"] [class~="bg-white/8"]  { background-color: rgba(0, 0, 0, 0.08); }
 
 :root[data-scheme="light"] [class~="border-white/5"]  { border-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="border-white/8"]  { border-color: rgba(0, 0, 0, 0.10); }
 :root[data-scheme="light"] [class~="border-white/10"] { border-color: rgba(0, 0, 0, 0.12); }
 :root[data-scheme="light"] [class~="border-white/15"] { border-color: rgba(0, 0, 0, 0.14); }
 :root[data-scheme="light"] [class~="border-white/20"] { border-color: rgba(0, 0, 0, 0.16); }
+:root[data-scheme="light"] [class~="border-white/25"] { border-color: rgba(0, 0, 0, 0.18); }
 
 :root[data-scheme="light"] [class~="text-white"]    { color: rgba(0, 0, 0, 0.88); }
 :root[data-scheme="light"] [class~="text-white/90"] { color: rgba(0, 0, 0, 0.84); }
@@ -107,6 +109,13 @@
 :root[data-scheme="light"] [class~="text-white/25"] { color: rgba(0, 0, 0, 0.40); }
 :root[data-scheme="light"] [class~="text-white/20"] { color: rgba(0, 0, 0, 0.40); }
 :root[data-scheme="light"] [class~="text-white/15"] { color: rgba(0, 0, 0, 0.38); }
+
+/* text-white/85 is intentionally NOT blanket-inverted: several usages sit on
+   dark translucent backgrounds (bg-black/40, bg-[#1a1b2e]) and dark gradients
+   that stay dark in light mode and need white text for legibility. The
+   WallpaperPicker tile is the one context where the background can go light,
+   so it gets a scoped rule keyed on the dialog's aria-label. */
+:root[data-scheme="light"] [aria-label="Change Wallpaper"] [class~="text-white/85"] { color: rgba(0, 0, 0, 0.81); }
 
 /* Arbitrary-value overlays (bg-white/[0.04], border-white/[0.06], …).
    The plain-fraction rules above cover `bg-white/5` & friends, but Tailwind's
@@ -133,6 +142,7 @@
    inverts — every trigger carries the class token, but only the active one sets
    data-state="active". */
 :root[data-scheme="light"] [data-state="active"][class~="data-[state=active]:bg-white/[0.08]"] { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [data-state="unchecked"][class~="data-[state=unchecked]:bg-white/10"] { background-color: rgba(0, 0, 0, 0.06); }
 
 :root[data-scheme="light"] [class~="border-white/[0.04]"] { border-color: rgba(0, 0, 0, 0.04); }
 :root[data-scheme="light"] [class~="border-white/[0.06]"] { border-color: rgba(0, 0, 0, 0.06); }
@@ -146,6 +156,7 @@
    white-on-light and vanish. No plain-fraction `divide-white/N` rule exists, so
    there is no arbitrary counterpart yet either; add it here. */
 :root[data-scheme="light"] [class~="divide-white/[0.04]"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(0, 0, 0, 0.04); }
+:root[data-scheme="light"] [class~="divide-white/5"] > :not([hidden]) ~ :not([hidden]) { border-color: rgba(0, 0, 0, 0.08); }
 
 /* Slate accent fills — light-scheme values (mirror the approved Messages
    mockup): a touch cooler/darker so tinted surfaces and the unread badge
@@ -163,6 +174,10 @@
    does not flatten under the base-state override. */
 :root[data-scheme="light"] [class~="hover:bg-white/5"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="hover:bg-white/10"]:hover { background-color: rgba(0, 0, 0, 0.07); }
+:root[data-scheme="light"] [class~="hover:bg-white/3"]:hover  { background-color: rgba(0, 0, 0, 0.03); }
+:root[data-scheme="light"] [class~="hover:bg-white/8"]:hover  { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="hover:bg-white/15"]:hover { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="hover:bg-white/20"]:hover { background-color: rgba(0, 0, 0, 0.10); }
 /* Arbitrary-value hover overlays — same 1:1 inversion as the base rules above,
    so the hover affordance survives the light-scheme flip. */
 :root[data-scheme="light"] [class~="hover:bg-white/[0.03]"]:hover { background-color: rgba(0, 0, 0, 0.03); }
@@ -172,6 +187,21 @@
 :root[data-scheme="light"] [class~="hover:bg-white/[0.08]"]:hover { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="hover:bg-white/[0.1]"]:hover  { background-color: rgba(0, 0, 0, 0.1); }
 :root[data-scheme="light"] [class~="hover:border-white/[0.06]"]:hover { border-color: rgba(0, 0, 0, 0.06); }
+:root[data-scheme="light"] [class~="hover:border-white/15"]:hover { border-color: rgba(0, 0, 0, 0.14); }
+:root[data-scheme="light"] [class~="hover:border-white/20"]:hover { border-color: rgba(0, 0, 0, 0.16); }
+:root[data-scheme="light"] [class~="hover:text-white/40"]:hover { color: rgba(0, 0, 0, 0.45); }
+:root[data-scheme="light"] [class~="hover:text-white/50"]:hover { color: rgba(0, 0, 0, 0.50); }
+
+/* Focus and active overlays: re-assert the inverted fill on :focus/:active so
+   the affordance survives the light-scheme flip. */
+:root[data-scheme="light"] [class~="focus:bg-white/5"]:focus { background-color: rgba(0, 0, 0, 0.04); }
+:root[data-scheme="light"] [class~="focus:bg-white/8"]:focus { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="focus:border-white/25"]:focus { border-color: rgba(0, 0, 0, 0.16); }
+:root[data-scheme="light"] [class~="focus:border-white/30"]:focus { border-color: rgba(0, 0, 0, 0.18); }
+:root[data-scheme="light"] [class~="focus:ring-white/20"]:focus { --tw-ring-color: rgba(0, 0, 0, 0.2); }
+:root[data-scheme="light"] [class~="active:bg-white/10"]:active { background-color: rgba(0, 0, 0, 0.06); }
+:root[data-scheme="light"] [class~="active:bg-white/20"]:active { background-color: rgba(0, 0, 0, 0.10); }
+:root[data-scheme="light"] [class~="placeholder:text-white/40"]::placeholder { color: rgba(0, 0, 0, 0.45); }
 
 /* Safari backdrop-filter repaint guard
    ====================================


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Light theme: 21 plain-fraction white-overlay forms (66 uses) uninverted and invisible to the #2637 derived guard

Autonomous build of board card tsk-frub5v.

- Add [class~=] inversion rules for all 21 uncovered plain-fraction forms
  (bg-white/8, hover:bg-white/20, divide-white/5, data-[state=unchecked]:bg-white/10,
  focus:ring-white/20, placeholder:text-white/40, active:bg-white/10, etc.)
- text-white/85 is intentionally NOT blanket-inverted because several usages sit on
  dark translucent backgrounds (bg-black/40, bg-[#1a1b2e]) that stay dark in light mode;
  WallpaperPicker gets a scoped rule keyed on aria-label="Change Wallpaper"
- Widen coverage test regex to match both arbitrary-value and plain-fraction forms
- Add computed-colour assertions for divide-white/5 and data-[state=unchecked]:bg-white/10
- Add plain-fraction background/border/hover 1:1 computed assertions
- Changelog: tsk-frub5v-light-theme-plain-fraction-overlays.md

Proof: 14 tests pass (light-scheme-arbitrary-values.test.ts), build passes

Files:
 ...k-frub5v-light-theme-plain-fraction-overlays.md |  2 +
 .../light-scheme-arbitrary-values.test.ts          | 83 ++++++++++++++++++++--
 desktop/src/theme/tokens.css                       | 30 ++++++++
 3 files changed, 108 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved light-theme rendering for fractional white overlays across backgrounds, borders, hover states, dividers, focus states, and unchecked controls.
  * Fixed inversion behavior for placeholder text and specific wallpaper-dialog text while preserving other white text.
* **Tests**
  * Expanded coverage to verify arbitrary-value and plain-fraction overlay styles, including background, border, divide, hover, and unchecked-state variants.
* **Documentation**
  * Added a changelog entry describing the light-theme overlay fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->