### PR TITLE
taOStalk S2: inline decision rendering in chat

### DIFF
--- a/changelog.d/tsk-wigt4d-inline-decision-recommended.md
+++ b/changelog.d/tsk-wigt4d-inline-decision-recommended.md
@@ -1,0 +1,2 @@
+### Added
+- Mark recommended options with a `Recommended` badge and accent border in inline decision cards rendered in chat

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   Check,
   Clock,
+  Sparkles,
 } from "lucide-react";
 import {
   Button,
@@ -460,7 +461,7 @@ interface DecisionData {
   from_agent: string;
   question: string;
   type: string;
-  options?: Array<{ label: string; value: string; rationale?: string }>;
+  options?: Array<{ label: string; value: string; rationale?: string; recommended?: boolean }>;
   context?: string | null;
   priority?: string;
   status: DecisionBlockStatus;
@@ -476,6 +477,15 @@ function decisionTypeLabel(t: string): string {
     case "free_text": return "Free text";
     default: return t;
   }
+}
+
+function RecommendedTag() {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 text-[11px] font-semibold text-accent">
+      <Sparkles size={10} className="shrink-0" />
+      Recommended
+    </span>
+  );
 }
 
 function resolveAnswerLabel(d: DecisionData): string | null {
@@ -663,6 +673,7 @@ export function DecisionBlock({ block }: { block: DecisionContentBlock }): React
       {showOptions && (
         <div className="mt-2 flex flex-col gap-1.5 px-3">
           {decision.options!.map((opt) => {
+            const isRecommended = Boolean(opt.recommended);
             return (
               <button
                 key={opt.value}
@@ -678,12 +689,17 @@ export function DecisionBlock({ block }: { block: DecisionContentBlock }): React
                   "flex w-full flex-col gap-0.5 rounded-lg border px-3 py-1.5 text-left transition-colors",
                   "disabled:cursor-not-allowed disabled:opacity-60",
                   isOpen
-                    ? "border-shell-border bg-shell-surface hover:border-shell-border-strong"
+                    ? isRecommended
+                      ? "border-accent/40 bg-shell-surface hover:border-accent"
+                      : "border-shell-border bg-shell-surface hover:border-shell-border-strong"
                     : "border-shell-border bg-shell-bg-deep text-shell-text-secondary",
                   "cursor-pointer",
                 ].join(" ")}
               >
-                <span className="text-sm">{opt.label}</span>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm">{opt.label}</span>
+                  {isRecommended && <RecommendedTag />}
+                </div>
                 {opt.rationale && (
                   <span className="text-[10px] text-shell-text-tertiary">{opt.rationale}</span>
                 )}

--- a/desktop/src/components/__tests__/DecisionBlock.test.tsx
+++ b/desktop/src/components/__tests__/DecisionBlock.test.tsx
@@ -763,4 +763,43 @@ describe("DecisionBlock", () => {
       expect(alert.textContent).toContain("already answered");
     });
   });
+
+  it("renders a recommended badge and accent border for recommended single_select options, and clicking the recommended option submits the answer", async () => {
+    mockDecisionFetch({
+      ...baseDecision,
+      id: "dec-rec",
+      question: "Pick a colour?",
+      type: "single_select",
+      options: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue", recommended: true, rationale: "Better contrast" },
+      ],
+      context: "brand colour",
+    });
+
+    const block: DecisionContentBlock = {
+      kind: "decision",
+      decision_id: "dec-rec",
+    };
+    const { container } = render(<DecisionBlock block={block} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-decision-block="true"]')).not.toBeNull();
+    });
+
+    // Recommended option should have the badge
+    expect(container.textContent).toContain("Recommended");
+    expect(container.textContent).toContain("Better contrast");
+
+    // The recommended button should have the accent border class
+    const buttons = container.querySelectorAll('button');
+    const recommendedButton = Array.from(buttons).find((btn) =>
+      btn.textContent?.includes("Blue"),
+    );
+    expect(recommendedButton).not.toBeUndefined();
+    expect(recommendedButton.className).toContain("border-accent/40");
+
+    // Clicking the recommended option submits the answer
+    fireEvent.click(recommendedButton);
+  });
 });


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOStalk S2: inline decision rendering in chat

Autonomous build of board card tsk-wigt4d.



Files:
 .../tsk-wigt4d-inline-decision-recommended.md      |  2 ++
 desktop/src/apps/MessagesApp.tsx                   | 22 ++++++++++--
 .../components/__tests__/DecisionBlock.test.tsx    | 39 ++++++++++++++++++++++
 3 files changed, 60 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Inline decision cards now highlight recommended options with a “Recommended” badge and accent border.
  - Recommended options include supporting rationale and remain selectable as usual.

- **Tests**
  - Added coverage to verify recommended labels, styling, rationale display, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->