### PR TITLE
Push payload: image + approve/reject/note actions (blocked on native shell)

### DIFF
--- a/changelog.d/tsk-cf7wzc-native-decision-payload.md
+++ b/changelog.d/tsk-cf7wzc-native-decision-payload.md
@@ -1,0 +1,4 @@
+### Added
+- Native decision push payloads now carry a rich image attachment and the full approve / reject / add-note action set so iPhone and Apple Watch can render the buttons and the native shell can wire the callback to the Decisions answer route (tsk-cf7wzc).
+- APNs payloads set `aps.category` and `aps.mutable-content` whenever an action set or image is present, so the iOS service extension can attach the image and surface the registered `UNNotificationCategory` buttons.
+- Web-push payloads now include the optional `image` on both the top-level `Notification.image` field and the inner `data.image`; clients that ignore `image` still receive a valid text notification.

--- a/tests/push/test_apns.py
+++ b/tests/push/test_apns.py
@@ -107,3 +107,53 @@ async def test_http_sender_does_not_close_injected_client():
 async def test_null_sender_aclose_is_noop():
     # NullApnsSender exposes a no-op aclose so shutdown can call it uniformly.
     assert await NullApnsSender().aclose() is None
+
+
+# ---------------------------------------------------------------------------
+# tsk-cf7wzc: image + actions wiring for the native decision shell
+# ---------------------------------------------------------------------------
+
+
+def test_build_payload_sets_category_and_mutable_content_for_actions():
+    # Approve/reject/add-note decisions must hit the iOS shell's
+    # UNNotificationCategory and let the service extension attach an image, so
+    # aps.category + aps.mutable-content must both be set.
+    payload = build_apns_payload(
+        title="Decide",
+        body="deploy?",
+        actions=[{"id": "approve", "label": "Approve"}],
+        category="DECISION_APPROVE_DENY",
+    )
+    assert payload["aps"]["category"] == "DECISION_APPROVE_DENY"
+    assert payload["aps"]["mutable-content"] == 1
+
+
+def test_build_payload_sets_mutable_content_when_image_present():
+    # Rich attachments need the notification service extension to download the
+    # image and attach it; APNs only allows that mutation when mutable-content
+    # is set, even with no actions.
+    payload = build_apns_payload(
+        title="Deploy",
+        body="queued",
+        image="https://cdn.example.com/run/42.png",
+    )
+    assert payload["aps"]["mutable-content"] == 1
+    assert payload["image"] == "https://cdn.example.com/run/42.png"
+
+
+def test_build_payload_omits_mutable_content_for_plain_alert():
+    # A plain alert with no image and no actions must not set mutable-content
+    # so the system shows the unmodified payload.
+    payload = build_apns_payload(title="Hi", body="there")
+    assert "mutable-content" not in payload["aps"]
+    assert "image" not in payload
+    assert "category" not in payload["aps"]
+
+
+def test_build_payload_does_not_override_content_available_for_mutable_content():
+    # A silent push (content-available) that ALSO carries an image is fine; we
+    # must not clobber content-available by enabling mutable-content on top.
+    payload = build_apns_payload(
+        title="", body="", content_available=True, image="https://x.test/i.png",
+    )
+    assert payload["aps"]["content-available"] == 1

--- a/tests/push/test_unifiedpush.py
+++ b/tests/push/test_unifiedpush.py
@@ -32,6 +32,20 @@ def test_build_payload_with_actions():
     assert payload["actions"] == actions
 
 
+def test_build_payload_with_image():
+    # tsk-cf7wzc: a rich image attachment rides on the top-level `image` key so
+    # UnifiedPush distributors can render it without inspecting `data`.
+    payload = build_unifiedpush_payload(
+        title="Deploy", body="queued", image="https://cdn.example.com/run/42.png",
+    )
+    assert payload["image"] == "https://cdn.example.com/run/42.png"
+
+
+def test_build_payload_omits_image_when_absent():
+    payload = build_unifiedpush_payload(title="Hi", body="there")
+    assert "image" not in payload
+
+
 @pytest.mark.asyncio
 async def test_null_sender_returns_false():
     assert await NullUnifiedPushSender().send("https://example.com/endpoint", {}) is False
@@ -318,7 +332,15 @@ async def test_send_device_push_broadcast_actions_for_decision_types():
     devices_ios = [{"device_id": "d1", "platform": "ios", "push_token": "apns-tok", "user_id": "u1"}]
 
     for dtype, expected_actions in [
-        ("approve_deny", [{"id": "approve", "label": "Approve"}, {"id": "deny", "label": "Deny"}]),
+        # tsk-cf7wzc: approve_deny decisions pin the action set to approve /
+        # reject / add-note. The single_select/free_text rows keep their
+        # narrower button sets; the add-note row is asserted in a dedicated
+        # test below.
+        ("approve_deny", [
+            {"id": "approve", "label": "Approve"},
+            {"id": "reject", "label": "Reject"},
+            {"id": "add_note", "label": "Add note"},
+        ]),
         ("single_select", [{"id": "opt1", "label": "Option 1"}]),
         ("free_text", [{"id": "quick_reply", "label": "Reply"}]),
     ]:

--- a/tests/test_notifications_push.py
+++ b/tests/test_notifications_push.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import pathlib
 import tempfile
 from unittest.mock import patch
@@ -237,6 +238,50 @@ class TestSendWebPush:
             result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
         mock.assert_not_called()
         assert result == {"sent": 0, "failed": 0, "removed": 0}
+
+    async def test_payload_includes_image_when_row_carries_one(self, push_store):
+        # tsk-cf7wzc: web push carries the rich attachment on both top-level
+        # `image` (Notification API) and inner `data.image` so PWA service workers
+        # that only inspect one shape still see it. Non-native clients that
+        # ignore `image` still get a valid text notification.
+        await _seed(push_store, _ENDPOINT_A)
+        row = {
+            "id": 9,
+            "title": "Deploy",
+            "message": "queued",
+            "source": "decisions",
+            "data": {
+                "image": "https://cdn.example.com/run/42.png",
+                "decision_type": "approve_deny",
+            },
+        }
+        captured: list[bytes] = []
+
+        def capture(**kwargs):
+            captured.append(kwargs["data"].encode("utf-8"))
+
+        with patch("pywebpush.webpush", side_effect=capture):
+            await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        assert len(captured) == 1
+        payload = json.loads(captured[0].decode("utf-8"))
+        assert payload["image"] == "https://cdn.example.com/run/42.png"
+        assert payload["data"]["image"] == "https://cdn.example.com/run/42.png"
+        # Non-native clients still see a valid text notification.
+        assert payload["title"] == "Deploy"
+        assert payload["body"] == "queued"
+
+    async def test_payload_omits_image_when_absent(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        captured: list[bytes] = []
+
+        def capture(**kwargs):
+            captured.append(kwargs["data"].encode("utf-8"))
+
+        with patch("pywebpush.webpush", side_effect=capture):
+            await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        payload = json.loads(captured[0].decode("utf-8"))
+        assert "image" not in payload
+        assert "image" not in payload["data"]
 
 
 # ---------------------------------------------------------------------------
@@ -612,7 +657,11 @@ class TestSendDevicePush:
         assert FakeUP.sent[0][0] == "https://up.example.com/endpoint"
         body = FakeUP.sent[0][1]
         assert body["title"] == "Decide"
-        assert body["actions"] == [{"id": "approve", "label": "Approve"}, {"id": "deny", "label": "Deny"}]
+        assert body["actions"] == [
+            {"id": "approve", "label": "Approve"},
+            {"id": "reject", "label": "Reject"},
+            {"id": "add_note", "label": "Add note"},
+        ]
 
     async def test_ios_routes_to_apns_unchanged(self):
         class FakeApns:
@@ -719,3 +768,121 @@ class TestSendDevicePush:
         )
         assert result["sent"] == 1
         assert result["skipped"] == 1
+
+    async def test_ios_decision_sets_category_mutable_content_and_actions(self):
+        # tsk-cf7wzc: an approve_deny decision must reach iOS with the
+        # DECISION_APPROVE_DENY category so the native shell maps it to a
+        # UNNotificationCategory with approve / reject / add-note buttons, and
+        # mutable-content so the service extension can attach the image and
+        # wire the action callback that posts back to Decisions answer.
+        class FakeApns:
+            sent = []
+
+            async def send(self, push_token, payload, *, topic=None):
+                FakeApns.sent.append(payload)
+                return True
+
+            async def aclose(self):
+                pass
+
+        class FakeUP:
+            async def send(self, *args, **kwargs):
+                return True
+
+            async def aclose(self):
+                pass
+
+        class FakeStore:
+            async def list_for_user(self, user_id):
+                return [
+                    {"device_id": "d1", "platform": "ios", "push_token": "apns-tok", "user_id": "u1"}
+                ]
+
+        row = {
+            "id": 1,
+            "title": "Deploy",
+            "message": "approve?",
+            "source": "decisions",
+            "user_id": "u1",
+            "data": {
+                "decision_type": "approve_deny",
+                "image": "https://cdn.example.com/run/42.png",
+            },
+        }
+        await send_device_push(
+            row,
+            device_store=FakeStore(),
+            apns_sender=FakeApns(),
+            up_sender=FakeUP(),
+        )
+        assert len(FakeApns.sent) == 1
+        payload = FakeApns.sent[0]
+        assert payload["aps"]["category"] == "DECISION_APPROVE_DENY"
+        assert payload["aps"]["mutable-content"] == 1
+        assert payload["aps"]["alert"] == {"title": "Deploy", "body": "approve?"}
+        # APNs flattens `data` into the top-level payload (per Apple docs), so
+        # the iOS shell + service extension read actions / image directly off
+        # the root, not under a nested `data` key.
+        assert payload["actions"] == [
+            {"id": "approve", "label": "Approve"},
+            {"id": "reject", "label": "Reject"},
+            {"id": "add_note", "label": "Add note"},
+        ]
+        assert payload["image"] == "https://cdn.example.com/run/42.png"
+        assert payload["decision_type"] == "approve_deny"
+
+    async def test_android_decision_carries_image_and_actions(self):
+        # tsk-cf7wzc: UnifiedPush distributors get a uniform shape -- top-level
+        # `image` for distributors that render attachments, `actions` for
+        # button rows, and the inner `data` mirror for clients that only read
+        # one of the two.
+        class FakeApns:
+            async def send(self, *args, **kwargs):
+                return True
+
+            async def aclose(self):
+                pass
+
+        class FakeUP:
+            sent = []
+
+            async def send(self, push_token, payload):
+                FakeUP.sent.append(payload)
+                return True
+
+            async def aclose(self):
+                pass
+
+        class FakeStore:
+            async def list_for_user(self, user_id):
+                return [
+                    {"device_id": "d1", "platform": "android", "push_token": "https://up.example.com/e", "user_id": "u1"}
+                ]
+
+        row = {
+            "id": 1,
+            "title": "Deploy",
+            "message": "approve?",
+            "source": "decisions",
+            "user_id": "u1",
+            "data": {
+                "decision_type": "approve_deny",
+                "image": "https://cdn.example.com/run/42.png",
+            },
+        }
+        await send_device_push(
+            row,
+            device_store=FakeStore(),
+            apns_sender=FakeApns(),
+            up_sender=FakeUP(),
+        )
+        assert len(FakeUP.sent) == 1
+        body = FakeUP.sent[0]
+        assert body["image"] == "https://cdn.example.com/run/42.png"
+        assert body["actions"] == [
+            {"id": "approve", "label": "Approve"},
+            {"id": "reject", "label": "Reject"},
+            {"id": "add_note", "label": "Add note"},
+        ]
+        assert body["data"]["image"] == "https://cdn.example.com/run/42.png"
+        assert body["data"]["actions"] == body["actions"]

--- a/tinyagentos/notifications_push.py
+++ b/tinyagentos/notifications_push.py
@@ -194,9 +194,12 @@ def _build_payload(row: dict) -> dict:
     JSON data, else the desktop shell. ``tag`` collapses re-notifies for the
     same source+id so a newer push replaces the older banner.
 
-    Routing fields (``source``, ``id``, and ``target`` when present) are copied
-    into the inner ``data`` dict so the service worker can route on them. The
-    SW only reads ``event.notification.data``, not the top-level payload.
+    Routing fields (``source``, ``id``, ``image`` (when present), and ``target``
+    when present) are copied into the inner ``data`` dict so the service worker
+    can route on them. The SW only reads ``event.notification.data``, not the
+    top-level payload. ``image`` is the standard Notification API field for a
+    rich attachment; non-native clients that ignore it still get a valid text
+    notification.
     """
     data = row.get("data") if isinstance(row.get("data"), dict) else {}
     url = _safe_url(data.get("url"))
@@ -205,16 +208,22 @@ def _build_payload(row: dict) -> dict:
         payload_data["source"] = row["source"]
     if "id" in row:
         payload_data["id"] = row["id"]
+    image = data.get("image")
+    if isinstance(image, str) and image:
+        payload_data["image"] = image
     target = data.get("target")
     if isinstance(target, dict):
         payload_data["target"] = target
-    return {
+    payload: dict = {
         "title": row.get("title") or "taOS",
         "body": row.get("message") or "",
         "tag": f"{row.get('source', 'system')}:{row.get('id', '')}",
         "source": row.get("source", "system"),
         "data": payload_data,
     }
+    if isinstance(image, str) and image:
+        payload["image"] = image
+    return payload
 
 
 def _vapid_signing_key(private_pem: str) -> str:
@@ -332,20 +341,37 @@ def _build_device_push_payload(row: dict) -> tuple[dict, list[dict] | None]:
     body = row.get("message") or ""
     data = row.get("data") if isinstance(row.get("data"), dict) else {}
     actions: list[dict] | None = None
+    category: str | None = None
     decision_type = data.get("decision_type")
     if decision_type == "approve_deny":
-        actions = [{"id": "approve", "label": "Approve"}, {"id": "deny", "label": "Deny"}]
+        # The native shell maps a category id to a registered UNNotificationCategory;
+        # tsk-cf7wzc pins the button set to approve / reject / add-note on both
+        # iPhone and Apple Watch.
+        category = "DECISION_APPROVE_DENY"
+        actions = [
+            {"id": "approve", "label": "Approve"},
+            {"id": "reject", "label": "Reject"},
+            {"id": "add_note", "label": "Add note"},
+        ]
     elif decision_type in ("single_select", "multi_select"):
+        category = "DECISION_OPTIONS"
         opts = data.get("options") or []
         actions = [{"id": o.get("value", o.get("label", "")), "label": o.get("label", "")} for o in opts]
     elif decision_type == "free_text":
+        category = "DECISION_FREE_TEXT"
         actions = [{"id": "quick_reply", "label": "Reply"}]
+    payload_data = dict(data)
+    image = data.get("image")
+    if isinstance(image, str) and image:
+        payload_data["image"] = image
     if actions:
-        payload_data = dict(data)
         payload_data["actions"] = actions
-    else:
-        payload_data = data
-    return {"title": title, "body": body, "data": payload_data}, actions
+    payload: dict = {"title": title, "body": body, "data": payload_data}
+    if category:
+        payload["category"] = category
+    if isinstance(image, str) and image:
+        payload["image"] = image
+    return payload, actions
 
 
 async def _send_one_device(
@@ -366,6 +392,9 @@ async def _send_one_device(
                 title=payload["title"],
                 body=payload["body"],
                 data=payload.get("data"),
+                category=payload.get("category"),
+                actions=actions,
+                image=payload.get("image"),
             )
             ok = await apns_sender.send(push_token, apns_payload)
         elif platform == "android":
@@ -375,6 +404,7 @@ async def _send_one_device(
                 body=payload["body"],
                 data=payload.get("data"),
                 actions=actions,
+                image=payload.get("image"),
             )
             ok = await up_sender.send(push_token, up_payload)
         else:

--- a/tinyagentos/push/apns.py
+++ b/tinyagentos/push/apns.py
@@ -40,14 +40,36 @@ class NullApnsSender:
 
 
 def build_apns_payload(
-    *, title: str, body: str, data: dict | None = None, content_available: bool = False
+    *,
+    title: str,
+    body: str,
+    data: dict | None = None,
+    content_available: bool = False,
+    category: str | None = None,
+    actions: list[dict] | None = None,
+    image: str | None = None,
 ) -> dict:
     aps: dict = {}
     if title or body:
         aps["alert"] = {"title": title, "body": body}
     if content_available:
         aps["content-available"] = 1
+    # Apple does not honour a JSON `actions` array; the native shell (tsk-cf7wzc)
+    # registers a UNNotificationCategory whose identifier matches the `category`
+    # below. Buttons come from the registered category, and tapping one fires a
+    # UNUserNotificationCenterDelegate callback the shell routes back to the
+    # controller's Decisions answer route.
+    if category:
+        aps["category"] = category
+    # Any rich attachment (image) or action set requires the notification service
+    # extension to mutate the payload before display: download the image, attach
+    # UNNotificationAttachment, and surface the action buttons. APNs only allows
+    # that mutation when `mutable-content` is set.
+    if (image or actions) and not content_available:
+        aps["mutable-content"] = 1
     payload = {"aps": aps}
+    if image:
+        payload["image"] = image
     if data:
         payload.update(data)
     return payload

--- a/tinyagentos/push/unifiedpush.py
+++ b/tinyagentos/push/unifiedpush.py
@@ -30,13 +30,16 @@ class NullUnifiedPushSender:
 
 
 def build_unifiedpush_payload(
-    *, title: str, body: str, data: dict | None = None, actions: list[dict] | None = None
+    *, title: str, body: str, data: dict | None = None, actions: list[dict] | None = None,
+    image: str | None = None,
 ) -> dict:
     payload: dict = {"title": title, "body": body}
     if data:
         payload["data"] = data
     if actions:
         payload["actions"] = actions
+    if image:
+        payload["image"] = image
     return payload
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Push payload: image + approve/reject/note actions (blocked on native shell)

Autonomous build of board card tsk-cf7wzc.

Build the device push payload with the full action set the iOS native shell
expects (approve / reject / add-note for approve_deny decisions) plus a rich
image attachment, so iPhone and Apple Watch can render the buttons and the
shell can wire the callback to the Decisions answer route. APNs now sets
aps.category (mapped to a registered UNNotificationCategory on the device)
and aps.mutable-content whenever an image or action set is present, so the
notification service extension can attach the image and surface the button
row. UnifiedPush carries image + actions on the top-level payload. Web push
threads image through both Notification.image and data.image and stays a
valid text notification for clients that ignore rich attachments.

Files:
 changelog.d/tsk-cf7wzc-native-decision-payload.md |   4 +
 tests/push/test_apns.py                           |  50 +++++++
 tests/push/test_unifiedpush.py                    |  24 ++-
 tests/test_notifications_push.py                  | 169 +++++++++++++++++++++-
 tinyagentos/notifications_push.py                 |  48 ++++--
 tinyagentos/push/apns.py                          |  24 ++-
 tinyagentos/push/unifiedpush.py                   |   5 +-
 7 files changed, 311 insertions(+), 13 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rich image support for web, iPhone, Apple Watch, and Android notifications.
  - Decision notifications now offer Approve, Reject, and Add Note actions where supported.
  - Added notification categories for decision actions, option selection, and free-text responses.
  - Actions can open the appropriate decision response flow directly from the notification.
  - Web notifications remain compatible with clients that do not support images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->