### PR TITLE
taOStalk S4: mobile PWA layout + bottom tabs

### DIFF
--- a/changelog.d/tsk-fw7abl-taostalk-mobile-tabs.md
+++ b/changelog.d/tsk-fw7abl-taostalk-mobile-tabs.md
@@ -1,0 +1,10 @@
+### Added
+
+- taOStalk mobile PWA (chat-pwa) now ships a bottom tab bar with Chats,
+  Projects, Decisions, and Agents. The Chats tab keeps the user on the
+  in-place MessagesApp; the other three deep-link into the desktop shell
+  via `/desktop?app=<id>` so the chat PWA stays a focused comms surface
+  without re-implementing sibling platform apps. The bar is hidden on
+  desktop viewports and never overflows horizontally on a phone-size
+  viewport, so the new tabs do not regress the existing single-column
+  message view or the `MobileSplitView` back-nav.

--- a/desktop/src/ChatStandalone.tsx
+++ b/desktop/src/ChatStandalone.tsx
@@ -1,9 +1,29 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useState, useCallback } from "react";
 import { InstallPromptBanner } from "./shell/InstallPromptBanner";
+import { useIsMobile } from "./hooks/use-is-mobile";
+import { MobileChatTabs, CHAT_TAB_APP_IDS, type ChatTab } from "./components/mobile/MobileChatTabs";
 
 const MessagesApp = lazy(() => import("./apps/MessagesApp").then((m) => ({ default: m.MessagesApp })));
 
 export function ChatStandalone() {
+  const isMobile = useIsMobile();
+  const [tab, setTab] = useState<ChatTab>("chats");
+
+  const handleSelectTab = useCallback((next: ChatTab) => {
+    if (next === "chats") {
+      setTab("chats");
+      return;
+    }
+    // Sibling platform apps live in the desktop shell; deep-link there so the
+    // chat PWA stays a focused comms surface rather than re-implementing
+    // Projects/Decisions/Agents inline.
+    const appId = CHAT_TAB_APP_IDS[next];
+    const target = `/desktop?app=${encodeURIComponent(appId)}`;
+    if (typeof window !== "undefined") {
+      window.location.href = target;
+    }
+  }, []);
+
   return (
     <div
       className="w-screen flex flex-col overflow-hidden"
@@ -17,13 +37,16 @@ export function ChatStandalone() {
       }}
     >
       <InstallPromptBanner />
-      <Suspense fallback={
-        <div className="flex items-center justify-center h-full" style={{ color: "rgba(255,255,255,0.4)" }}>
-          Loading…
-        </div>
-      }>
-        <MessagesApp windowId="standalone-chat" title="taOS talk" />
-      </Suspense>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <Suspense fallback={
+          <div className="flex items-center justify-center h-full" style={{ color: "rgba(255,255,255,0.4)" }}>
+            Loading…
+          </div>
+        }>
+          <MessagesApp windowId="standalone-chat" title="taOS talk" />
+        </Suspense>
+      </div>
+      {isMobile && <MobileChatTabs active={tab} onSelect={handleSelectTab} />}
     </div>
   );
 }

--- a/desktop/src/__tests__/ChatStandalone.mobile.test.tsx
+++ b/desktop/src/__tests__/ChatStandalone.mobile.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Mock the heavy MessagesApp lazy import so the test only exercises the
+// ChatStandalone shell (header, tabs, route) rather than the full chat
+// surface, which has its own suite.
+vi.mock("../apps/MessagesApp", () => ({
+  MessagesApp: ({ windowId }: { windowId: string }) => (
+    <div data-testid="messages-app-stub" data-window-id={windowId} />
+  ),
+}));
+
+vi.mock("../shell/InstallPromptBanner", () => ({
+  InstallPromptBanner: () => null,
+}));
+
+vi.mock("../hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+
+import { useIsMobile } from "../hooks/use-is-mobile";
+import { ChatStandalone } from "../ChatStandalone";
+
+describe("ChatStandalone mobile layout", () => {
+  beforeEach(() => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("renders the bottom tabs on mobile with Chats active by default", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    render(<ChatStandalone />);
+    const chatsTab = screen.getByTestId("mobile-chat-tab-chats");
+    expect(chatsTab).toHaveAttribute("aria-current", "page");
+    for (const id of ["chats", "projects", "decisions", "agents"]) {
+      expect(screen.getByTestId(`mobile-chat-tab-${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it("hides the bottom tabs on desktop viewports", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    render(<ChatStandalone />);
+    expect(screen.queryByTestId("mobile-chat-tabs")).not.toBeInTheDocument();
+  });
+
+  it("routes to the desktop shell with the correct app id when a sibling tab is tapped", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    // Stub window.location.href so the redirect can be asserted; jsdom treats
+    // assignments as a no-op without a real navigation, and we want to verify
+    // the deep-link URL is built correctly.
+    const originalLocation = window.location;
+    let capturedHref = "";
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, get href() { return capturedHref; }, set href(v: string) { capturedHref = v; } } as unknown as Location,
+    });
+    try {
+      render(<ChatStandalone />);
+      fireEvent.click(screen.getByTestId("mobile-chat-tab-projects"));
+      expect(capturedHref).toBe("/desktop?app=projects");
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+    }
+  });
+
+  it("keeps the Chats tab active when the Chats tab is tapped (no deep-link redirect)", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    render(<ChatStandalone />);
+    fireEvent.click(screen.getByTestId("mobile-chat-tab-chats"));
+    expect(screen.getByTestId("mobile-chat-tab-chats")).toHaveAttribute("aria-current", "page");
+  });
+});

--- a/desktop/src/apps/__tests__/MessagesApp.mobile.test.tsx
+++ b/desktop/src/apps/__tests__/MessagesApp.mobile.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Stub the heavy data hooks / stores MessagesApp transitively imports so the
+// test only cares about the mobile shell structure. Anything that would fire
+// a network request or open a WebSocket is replaced with a no-op.
+vi.mock("@/hooks/use-is-mobile", () => ({
+  useIsMobile: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-visual-viewport", () => ({
+  useVisualViewport: () => ({ height: 800, keyboardInset: 0 }),
+}));
+
+vi.mock("@/hooks/use-chat-notifications", () => ({
+  useChatNotifications: () => ({ notify: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-thread-panel", () => ({
+  useThreadPanel: () => ({
+    openThread: null,
+    openThreadFor: vi.fn(),
+    closeThread: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-bus-channels", () => ({
+  useBusChannels: () => ({ channels: [], loading: false }),
+}));
+
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ openWindow: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-drop-target", () => ({
+  useDropTarget: () => ({
+    isOver: false,
+    isValidTarget: false,
+    dropHandlers: {
+      onDragEnter: vi.fn(),
+      onDragOver: vi.fn(),
+      onDragLeave: vi.fn(),
+      onDrop: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@/registry/app-registry", () => ({
+  getApp: () => undefined,
+}));
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { MessagesApp } from "../MessagesApp";
+
+vi.mock("../chat/ChannelSidebar", () => ({
+  ChannelSidebar: () => <div data-testid="channel-sidebar" />,
+}));
+
+vi.mock("../chat/MessageList", () => ({
+  MessageList: () => <div data-testid="message-list" />,
+}));
+
+vi.mock("../chat/MessageInput", () => ({
+  MessageInput: () => <div data-testid="message-input" />,
+}));
+
+vi.mock("../chat/A2aBusPanel", () => ({
+  A2aBusMessageView: () => <div data-testid="a2a-bus-view" />,
+  useBusChannels: () => ({ channels: [], loading: false }),
+}));
+
+// Surface the listTitle so the test can verify the production code actually
+// routed through this component (vs a desktop-branch element wearing the
+// same testid).
+vi.mock("@/components/mobile/MobileSplitView", () => ({
+  MobileSplitView: ({ listTitle, list, detail }: { listTitle?: string; list?: React.ReactNode; detail?: React.ReactNode }) => (
+    <div data-testid="mobile-split-view" data-list-title={listTitle}>
+      <div data-testid="msv-list">{list}</div>
+      <div data-testid="msv-detail">{detail}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  attachmentFromPath: vi.fn(),
+  uploadDiskFile: vi.fn(),
+  uploadFileAttachment: vi.fn(),
+}));
+
+vi.mock("../MessagesApp.stallWatch", () => ({
+  useStallWatch: () => ({ stallInfo: null }),
+  computeStallInfo: () => null,
+}));
+
+vi.mock("../MessagesApp.a2aSelection", () => ({
+  selectInitialBusChannel: vi.fn(),
+  selectFirstBoundChannel: vi.fn(),
+}));
+
+describe("MessagesApp mobile shell", () => {
+  beforeEach(() => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it("renders the mobile split-view with a Chats list pane when isMobile=true", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    render(<MessagesApp windowId="test" />);
+    const splitView = screen.getByTestId("mobile-split-view");
+    expect(splitView).toBeInTheDocument();
+    expect(splitView).toHaveAttribute("data-list-title", "Messages");
+    // The list pane wraps the channel sidebar.
+    expect(screen.getByTestId("channel-sidebar")).toBeInTheDocument();
+  });
+
+  it("renders the channel sidebar on desktop too (mobile shell is gated on isMobile)", () => {
+    (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    render(<MessagesApp windowId="test" />);
+    // The channel sidebar still renders in the desktop side-by-side layout
+    // (it is the same list, just inside a different split-view variant).
+    expect(screen.getByTestId("channel-sidebar")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/components/mobile/MobileChatTabs.tsx
+++ b/desktop/src/components/mobile/MobileChatTabs.tsx
@@ -1,0 +1,66 @@
+import { MessageCircle, FolderKanban, Inbox, Bot } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type ChatTab = "chats" | "projects" | "decisions" | "agents";
+
+const TABS: { id: ChatTab; label: string; icon: ReactNode; appId: string }[] = [
+  { id: "chats", label: "Chats", icon: <MessageCircle size={20} strokeWidth={1.8} />, appId: "messages" },
+  { id: "projects", label: "Projects", icon: <FolderKanban size={20} strokeWidth={1.8} />, appId: "projects" },
+  { id: "decisions", label: "Decisions", icon: <Inbox size={20} strokeWidth={1.8} />, appId: "decisions" },
+  { id: "agents", label: "Agents", icon: <Bot size={20} strokeWidth={1.8} />, appId: "agents" },
+];
+
+interface Props {
+  active: ChatTab;
+  onSelect: (tab: ChatTab) => void;
+}
+
+/**
+ * Bottom tab bar for the chat PWA on mobile. The Chats tab is the local
+ * MessagesApp view; the other three are sibling platform apps reached via
+ * deep link to the desktop shell (`/desktop?app=<id>`), so the chat PWA
+ * stays a focused comms surface without re-implementing them inline.
+ */
+export function MobileChatTabs({ active, onSelect }: Props) {
+  return (
+    <nav
+      aria-label="Section"
+      data-testid="mobile-chat-tabs"
+      className="shrink-0 flex items-stretch justify-around"
+      style={{
+        height: 56,
+        backgroundColor: "var(--color-shell-bg-glass, var(--color-dock-bg))",
+        borderTop: "1px solid var(--color-shell-border)",
+        backdropFilter: "blur(20px) saturate(180%)",
+        WebkitBackdropFilter: "blur(20px) saturate(180%)",
+        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+      }}
+    >
+      {TABS.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onSelect(tab.id)}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={tab.label}
+            data-testid={`mobile-chat-tab-${tab.id}`}
+            className="flex-1 flex flex-col items-center justify-center gap-0.5 min-w-0 px-2 active:opacity-60 transition-opacity"
+            style={{
+              color: isActive ? "var(--color-accent, rgb(100, 180, 255))" : "var(--color-shell-text-tertiary, rgba(255,255,255,0.55))",
+            }}
+          >
+            <span className="flex items-center justify-center" aria-hidden="true">{tab.icon}</span>
+            <span className="text-[10px] font-medium leading-none truncate w-full text-center">{tab.label}</span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+export const CHAT_TAB_APP_IDS: Record<ChatTab, string> = TABS.reduce(
+  (acc, t) => ({ ...acc, [t.id]: t.appId }),
+  {} as Record<ChatTab, string>,
+);

--- a/desktop/src/components/mobile/__tests__/MobileChatTabs.test.tsx
+++ b/desktop/src/components/mobile/__tests__/MobileChatTabs.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MobileChatTabs, CHAT_TAB_APP_IDS, type ChatTab } from "../MobileChatTabs";
+
+describe("MobileChatTabs", () => {
+  it("renders all four expected tabs in order", () => {
+    render(<MobileChatTabs active="chats" onSelect={() => {}} />);
+    expect(screen.getByTestId("mobile-chat-tab-chats")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-chat-tab-projects")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-chat-tab-decisions")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-chat-tab-agents")).toBeInTheDocument();
+  });
+
+  it("marks the active tab with aria-current=page and leaves others unset", () => {
+    render(<MobileChatTabs active="decisions" onSelect={() => {}} />);
+    expect(screen.getByTestId("mobile-chat-tab-decisions")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("mobile-chat-tab-chats")).not.toHaveAttribute("aria-current");
+  });
+
+  it("calls onSelect with the clicked tab id", () => {
+    const onSelect = vi.fn();
+    render(<MobileChatTabs active="chats" onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId("mobile-chat-tab-agents"));
+    expect(onSelect).toHaveBeenCalledWith("agents");
+  });
+
+  it("does not overflow horizontally on a narrow viewport (no horizontal scroll)", () => {
+    const { container } = render(<MobileChatTabs active="chats" onSelect={() => {}} />);
+    const nav = container.querySelector("[data-testid='mobile-chat-tabs']") as HTMLElement;
+    expect(nav).toBeInTheDocument();
+    // The bar is laid out as a flex row of flex-1 buttons — it must never be
+    // wider than its parent or introduce a horizontal scroll. The parent is
+    // 100vw; the nav width is set by its own flexbox.
+    expect(nav.className).toMatch(/flex/);
+    // All four tabs share the row equally (each has flex-1); total natural
+    // width must not exceed the parent or the flex container would either
+    // shrink buttons or wrap to a second row.
+    const buttons = nav.querySelectorAll("button");
+    for (const b of Array.from(buttons)) {
+      expect(b.className).toMatch(/flex-1/);
+    }
+  });
+
+  it("maps each tab to the expected desktop app id for deep-link routing", () => {
+    expect(CHAT_TAB_APP_IDS.chats).toBe("messages");
+    expect(CHAT_TAB_APP_IDS.projects).toBe("projects");
+    expect(CHAT_TAB_APP_IDS.decisions).toBe("decisions");
+    expect(CHAT_TAB_APP_IDS.agents).toBe("agents");
+  });
+
+  it("exposes every ChatTab as a registered app id", () => {
+    const tabs: ChatTab[] = ["chats", "projects", "decisions", "agents"];
+    for (const t of tabs) {
+      expect(typeof CHAT_TAB_APP_IDS[t]).toBe("string");
+      expect(CHAT_TAB_APP_IDS[t].length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOStalk S4: mobile PWA layout + bottom tabs

Autonomous build of board card tsk-fw7abl.

taOStalk slice 4: add a bottom tab bar to the chat-pwa mobile PWA with
four sections (Chats, Projects, Decisions, Agents). The Chats tab keeps
the user on the in-place MessagesApp; Projects, Decisions, and Agents
deep-link to the desktop shell via /desktop?app=<id> so the chat PWA
stays a focused comms surface rather than re-implementing sibling
platform apps inline. The bar is hidden on desktop viewports and lays
out as a single flex row of equal-width buttons so it never overflows
horizontally on a phone-size viewport, preserving the single-column
message view and the existing MobileSplitView back-nav from the channel
list to the message detail.

Files:
- desktop/src/components/mobile/MobileChatTabs.tsx (new): the bar.
- desktop/src/ChatStandalone.tsx: mount the bar only on mobile.
- vitest coverage: tabs render + active state + click routing + deep-
  link URL, ChatStandalone mobile layout (tabs vs no tabs, redirect on
  sibling tab), and the existing MessagesApp MobileSplitView path.

Tests: 6/6 MobileChatTabs + 4/4 ChatStandalone.mobile + 2/2
MessagesApp.mobile pass; 20/20 mobile+__tests__+apps/__tests__ files
and 265/265 apps/chat tests pass; tsc --noEmit clean; vite build
green.

Files:
 changelog.d/tsk-fw7abl-taostalk-mobile-tabs.md     |  10 ++
 desktop/src/ChatStandalone.tsx                     |  39 +++++--
 .../src/__tests__/ChatStandalone.mobile.test.tsx   |  71 ++++++++++++
 .../src/apps/__tests__/MessagesApp.mobile.test.tsx | 124 +++++++++++++++++++++
 desktop/src/components/mobile/MobileChatTabs.tsx   |  66 +++++++++++
 .../mobile/__tests__/MobileChatTabs.test.tsx       |  58 ++++++++++
 6 files changed, 360 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a mobile bottom navigation bar with Chats, Projects, Decisions, and Agents tabs.
  - Chats stays within the mobile messaging experience, while other tabs open their corresponding desktop apps.
  - Navigation is hidden on desktop and remains usable without horizontal overflow on narrow screens.

- **Bug Fixes**
  - Preserved existing mobile message layout and back-navigation behavior.

- **Tests**
  - Added coverage for tab visibility, selection, routing, accessibility, and responsive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->