### PR TITLE
ready_tasks view is blind to blocked-on: labels AND its limit param is inert

### DIFF
--- a/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
+++ b/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+- `/api/projects/{pid}/tasks/ready` now honours `blocked-on:<id>` labels alongside `task_relationships` edges: a task carrying a `blocked-on:<id>` label whose target is OPEN in the same project is excluded from the ready set; closing the target re-surfaces it
+- The route's `?limit` query param is now honoured: clamped to `[1, 500]`, so `?limit=0` and `?limit=-1` no longer silently widen to unbounded or fall back to the default 50

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -885,3 +885,106 @@ async def test_create_claimable_with_empty_body_returns_422(client):
     )
     assert resp.status_code == 200
 
+
+# ---------------------------------------------------------------------------
+# tsk-wkah3z: ready view honour blocked-on:<id> labels and the limit param
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ready_excludes_open_blocked_on_label(client):
+    """Arm A: a task labelled blocked-on:<id> with <id> OPEN is excluded.
+
+    Hits the real HTTP route with the real auth dependency (the shared
+    ``client`` fixture signs in as the test admin via the session cookie
+    path), not a fixture that bypasses the router.
+    """
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "bo"})).json()["id"]
+    blocker = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "Blocker"}
+    )).json()
+    blocked = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "Blocked"}
+    )).json()
+
+    patch_resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{blocked['id']}",
+        json={"labels": [f"blocked-on:{blocker['id']}"]},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert f"blocked-on:{blocker['id']}" in patch_resp.json()["labels"]
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids = [t["id"] for t in resp.json()["items"]]
+    assert blocked["id"] not in ids, (
+        f"ready returned {blocked['id']} carrying an open blocked-on:{blocker['id']} label"
+    )
+    assert blocker["id"] in ids
+
+    close_resp = await client.post(
+        f"/api/projects/{pid}/tasks/{blocker['id']}/close",
+        json={"closed_by": "admin", "reason": "done"},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+
+    resp_after = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids_after = [t["id"] for t in resp_after.json()["items"]]
+    assert blocked["id"] in ids_after, (
+        "un-blocking direction: closing the blocker must re-surface the blocked task"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_stale_blocked_on_label_is_ready(client):
+    """Arm B: a blocked-on:<id> label pointing at a CLOSED task is stale -> ready."""
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "stale"})).json()["id"]
+    gone = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "AlreadyClosed"}
+    )).json()
+    close_resp = await client.post(
+        f"/api/projects/{pid}/tasks/{gone['id']}/close",
+        json={"closed_by": "admin"},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+
+    stale = (await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "Stale", "labels": [f"blocked-on:{gone['id']}"]},
+    )).json()
+    assert f"blocked-on:{gone['id']}" in stale["labels"]
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids = [t["id"] for t in resp.json()["items"]]
+    assert stale["id"] in ids, (
+        f"stale blocked-on label (target {gone['id']} is closed) must not exclude {stale['id']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_limit_param_honoured_and_clamped(client):
+    """Arm C: ?limit is honoured, 0/-1 clamp to the floor, >500 clamps to 500."""
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "lim"})).json()["id"]
+    for i in range(10):
+        r = await client.post(
+            f"/api/projects/{pid}/tasks", json={"title": f"T{i}"}
+        )
+        assert r.status_code == 200
+
+    five = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": 5})
+    assert five.status_code == 200
+    assert len(five.json()["items"]) == 5
+
+    zero = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": 0})
+    assert zero.status_code == 200
+    assert len(zero.json()["items"]) >= 1, "?limit=0 must NOT return unbounded / 0 items"
+
+    neg = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": -1})
+    assert neg.status_code == 200
+    assert len(neg.json()["items"]) >= 1, "?limit=-1 must NOT return unbounded"
+
+    huge = await client.get(
+        f"/api/projects/{pid}/tasks/ready", params={"limit": 99999}
+    )
+    assert huge.status_code == 200
+    assert len(huge.json()["items"]) <= 500
+

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -79,6 +79,12 @@ WHERE t.status = 'open'
       WHERE r.from_task_id = t.id
         AND r.kind = 'blocks'
         AND bt.status NOT IN ('closed', 'cancelled')
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM json_each(t.labels) je
+      JOIN project_tasks bt
+        ON 'blocked-on:' || bt.id = je.value
+      WHERE bt.status NOT IN ('closed', 'cancelled')
   );
 
 CREATE TABLE IF NOT EXISTS task_checklist_items (
@@ -197,6 +203,34 @@ class ProjectTaskStore(BaseStore):
         await self._db.execute(
             "CREATE INDEX IF NOT EXISTS idx_tasks_element "
             "ON project_tasks(project_id, element_id)"
+        )
+        await self._db.commit()
+        # Ready-view migration: re-create ready_tasks so it honours the
+        # ``blocked-on:<id>`` label mechanism (defect tsk-wkah3z). SQLite's
+        # ``CREATE VIEW IF NOT EXISTS`` is a no-op when the view already
+        # exists, so databases created before this change keep the old view
+        # body and silently keep returning tasks whose blocker is still
+        # open. Drop + recreate is safe here: the view is a derived
+        # projection of project_tasks, so a rebuild after the drop picks up
+        # the new WHERE clause with no data movement.
+        await self._db.execute("DROP VIEW IF EXISTS ready_tasks")
+        await self._db.execute(
+            "CREATE VIEW ready_tasks AS "
+            "SELECT t.* FROM project_tasks t "
+            "WHERE t.status = 'open' "
+            "AND t.claimed_by IS NULL "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM task_relationships r "
+            "JOIN project_tasks bt ON bt.id = r.to_task_id "
+            "WHERE r.from_task_id = t.id "
+            "AND r.kind = 'blocks' "
+            "AND bt.status NOT IN ('closed', 'cancelled')"
+            ") "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM json_each(t.labels) je "
+            "JOIN project_tasks bt ON 'blocked-on:' || bt.id = je.value "
+            "WHERE bt.status NOT IN ('closed', 'cancelled')"
+            ")"
         )
         await self._db.commit()
         # Add created_by column for checklist items (defect tsk-6xymzj).
@@ -608,7 +642,11 @@ class ProjectTaskStore(BaseStore):
     async def list_ready_tasks(
         self, project_id: str, limit: int = 50, element_id: str | None = None
     ) -> list[dict]:
-        limit = max(1, min(limit, 200))
+        # Clamp to [1, 500]. The floor stops ``limit=0`` / negative inputs from
+        # being silently widened to ``unbounded`` or the default 50, and the
+        # cap protects the route from a caller asking for an unreasonable
+        # window (defect tsk-wkah3z).
+        limit = max(1, min(limit, 500))
         conds = ["project_id = ?"]
         params: list = [project_id]
         if element_id is not None:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -917,13 +917,25 @@ async def ready_tasks(
     project_id: str,
     request: Request,
     element_id: str | None = None,
+    limit: int = 50,
 ):
+    """List ready (open, unclaimed, unblocked) tasks for the project.
+
+    ``limit`` is clamped to ``[1, 500]`` in the store: a floor of 1 stops
+    ``?limit=0`` / negative inputs from being silently widened to unbounded
+    or the default 50 (the LIMIT -1 SQLite trap, see taosmd #415), and the
+    500 cap keeps the route from streaming an unreasonable window back to a
+    caller.  The view honours the ``blocked-on:<id>`` label convention
+    alongside ``task_relationships`` edges (defect tsk-wkah3z).
+    """
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(request, pstore, project_id)
     if isinstance(auth, JSONResponse):
         return auth
     store = request.app.state.project_task_store
-    return {"items": await store.list_ready_tasks(project_id=project_id, element_id=element_id)}
+    return {"items": await store.list_ready_tasks(
+        project_id=project_id, element_id=element_id, limit=limit
+    )}
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): ready_tasks view is blind to blocked-on: labels AND its limit param is inert

Autonomous build of board card tsk-wkah3z.

The /api/projects/{pid}/tasks/ready view returned tasks carrying an open
blocked-on:<id> label, and the ?limit query param was silently dropped
(defaulting to 50). Fix both:

- tinyagentos/projects/task_store.py: extend the ready_tasks view with a
  NOT EXISTS guard over json_each(t.labels) that joins on
  'blocked-on:' || bt.id, so a label whose target task is OPEN (status
  not in closed/cancelled) excludes the labelled task. Add a
  _post_init migration that drops and recreates the view, because
  CREATE VIEW IF NOT EXISTS is a no-op on existing databases and would
  leave installed copies stuck on the old body.

- tinyagentos/projects/task_store.py: clamp list_ready_tasks's limit to
  [1, 500] (was [1, 200]). The floor stops ?limit=0 / ?limit=-1 from
  being silently widened to unbounded or the default 50, the same
  SQLite LIMIT -1 trap found on taosmd #415.

- tinyagentos/routes/projects.py: ready_tasks now accepts the limit
  query param and forwards it to the store (previously dropped, hence
  ?limit=5 and ?limit=200 both returned 50).

Tests: tests/test_routes_projects.py gains three HTTP-route tests that
hit the real auth dependency (shared client fixture, session cookie,
not an over-privileged bypass):

  Arm A (exclusion): task X labelled blocked-on:Y with Y open -> X
    ABSENT from ready. Closing Y re-surfaces X. RED against the prior
    code: 'ready returned tsk-juykds carrying an open
    blocked-on:tsk-ztp3jr label'.
  Arm B (stale label): X labelled blocked-on:Z where Z is closed at
    creation -> X PRESENT (stale label must NOT exclude).
  Arm C (limit): ?limit=5 returns exactly 5 (RED against prior code:
    returned 10); ?limit=0 and ?limit=-1 are clamped to the floor, not
    unbounded or default-50-silently; ?limit=99999 clamps to 500.

Changelog: changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md

Proof: 111 tests pass (tests/test_routes_projects.py +
tests/test_task_store.py). Existing ready tests (test_list_ready_tasks_*
and test_ready_endpoint, test_ready_tasks_filter_by_element) still
pass with the wider 500 cap.

Docs-Reviewed: docs/agent-coordination.md describes the project_tasks
scope surface (line ~356) at the endpoint level. The fix changes the
semantics of an existing endpoint rather than adding/removing a route,
and the doc does not currently enumerate the blocked-on: label
convention or the ?limit param, so no doc change is needed.

Files:
 .../tsk-wkah3z-ready-blocked-on-and-limit.md       |   3 +
 tests/test_routes_projects.py                      | 103 +++++++++++++++++++++
 tinyagentos/projects/task_store.py                 |  40 +++++++-
 tinyagentos/routes/projects.py                     |  14 ++-
 4 files changed, 158 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ready-task results now exclude tasks blocked by an open task referenced through a `blocked-on:<id>` label.
  - Blocked tasks reappear when the referenced task is closed or cancelled; labels targeting closed tasks are treated as stale.
  - The ready-task `limit` parameter is now honored, constrained to between 1 and 500 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->