### PR TITLE
wake-budget read reports consumed=0 the moment the charged tasks close; and enforcement quietly grants global_default per PROJECT per day, not per day

### DIFF
--- a/changelog.d/tsk-jgz4kr-wake-budget-per-agent.md
+++ b/changelog.d/tsk-jgz4kr-wake-budget-per-agent.md
@@ -1,0 +1,3 @@
+### Fixed
+- Wake-budget reader (`get_agent_wake_budget`, `get_fleet_wake_info`) no longer goes blind when an agent holds no task: consumption is now summed across all of the agent's project keys, so closing all tasks cannot make `consumed` report 0 while the enforcer charged under project keys.
+- Enforcer (`can_wake`, `get_next_scheduled_wake`) now applies the daily budget as a per-agent ceiling: `global_default: 2` and `per_agent` overrides limit the total number of scheduled wakes for the agent across all projects, matching TOKEN-DISCIPLINE rule 6. Reader and enforcer now use the same per-agent semantics.

--- a/docs/design/wake-budget.md
+++ b/docs/design/wake-budget.md
@@ -1,7 +1,7 @@
 # Wake-budget config
 
-**Status:** Proposed. Implements tsk-kj3hc2.
-**Date:** 2026-08-27
+**Status:** Implemented. Implements tsk-jgz4kr.
+**Date:** 2026-08-27 (semantics fixed 2026-09-02)
 
 ## Why
 
@@ -10,31 +10,38 @@ heartbeat can exhaust a daily budget in minutes. The current heartbeat loop
 has no per-agent ceiling, and external agents set their own poll cadence.
 This design adds a single, OS-enforced budget that agents cannot override.
 
+## Semantics (per-agent, fixed tsk-jgz4kr)
+
+The budget is per-agent, not per-project. `global_default: 2` means 2 scheduled
+checks per day for the agent, summed across all projects. The heartbeat charges
+one key per project (`{agent_id}:{project_id}`) in `wake_budget.json`; the
+reader and enforcer sum all of the agent's project keys before comparing to the
+budget. This matches TOKEN-DISCIPLINE rule 6 (2/day per agent) and prevents the
+blind read that occurred when all the agent's tasks were closed.
+
 ## Config model
 
 A new top-level `wake_budget` block in `config.yaml`:
 
 ```yaml
 wake_budget:
-  global_default: 2          # scheduled checks per day (rule 6 fleet default)
+  global_default: 2          # scheduled checks per day per agent (rule 6 fleet default)
   per_agent:                 # agent id -> override
     "agent-42": 5
-  per_project:               # project id -> override for project-bound agents
+  per_project:               # (retained in config schema but not applied by reader/enforcer;
+                             #  per-agent semantics means project_id is not a budget axis)
     "proj-abc": 1
 ```
 
-Resolution order (most specific wins):
-1. `per_project[project_id]` when the agent currently holds a claimed task in
-   that project, or when its next ready task is assigned to that project
-2. `per_agent[agent_id]`
-3. `global_default`
+Resolution order for the agent-level budget:
+1. `per_agent[agent_id]` when set
+2. `global_default`
 
-The `project_id` is not a stable agent binding. It is resolved at read time
-from the agent's current state: the project of the task the agent is actively
-holding (`held_task`), falling back to the project of the next ready task
-(`list_ready_tasks_for_assignee`), and finally to `None` (global key). This
-means the per-project budget applies to the work the agent is doing right now,
-not to a configured affiliation.
+The `project_id` in `wake_budget.json` keys is a storage detail (one key per
+project the agent was charged for); it is **not** used to resolve the budget at
+read or enforcement time. This means closing all the agent's tasks cannot make
+the reader fall through to an untouched `agent:global` key and report
+`consumed=0` while the enforcer charged under project keys.
 
 Resolutions are not currently logged; add structured logging to
 `resolve_budget` to make cost attributable.
@@ -42,7 +49,7 @@ Resolutions are not currently logged; add structured logging to
 ## Wake types
 
 - **Scheduled** -- heartbeat ticks, routine fires, external poll cadence.
-  Counts against the resolved budget. OS blocks further wakes once the
+  Counts against the agent's total daily budget. OS blocks further wakes once the
   budget is exhausted and surfaces the exhaustion to the agent.
 
 ## OS enforcement
@@ -64,10 +71,12 @@ not consult the wake budget. That is a deliberate follow-up.
   resolved wake budget; that surface is a follow-up.
 - **Observatory** -- `/api/observatory/wake-budget` returns each agent's
   `budget`, `consumed`, `remaining`, and `next_wake_epoch` for the current day.
-  Resolution is not currently logged; add structured logging to
-  `resolve_budget` to make cost attributable.
+  `consumed` is the sum of all the agent's project keys, so the figure is
+  accurate even when the agent holds no current task. Resolution is not
+  currently logged; add structured logging to `resolve_budget` to make cost
+  attributable.
 - **Decision** -- dec-sfdooy closed: the fleet default stays at 2/day until
-  this ships; per-agent and per-project overrides are opt-in.
+  this ships; per-agent overrides are opt-in.
 
 ## Interim
 

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1866,7 +1866,7 @@ class TestAgentWakeBudget:
         data = resp.json()
         assert data["consumed"] == 1
 
-    async def test_wake_budget_reports_per_project_override(
+    async def test_wake_budget_reports_per_agent_override(
         self, client, app, tmp_data_dir, monkeypatch
     ):
         from tinyagentos.agent_heartbeat import _heartbeat_tick
@@ -1881,8 +1881,8 @@ class TestAgentWakeBudget:
         )
         app.state.config.wake_budget = {
             "global_default": 2,
-            "per_agent": {},
-            "per_project": {project["id"]: 1},
+            "per_agent": {"test-agent": 1},
+            "per_project": {},
         }
         await app.state.project_task_store.create_task(
             project_id=project["id"],
@@ -1914,6 +1914,122 @@ class TestAgentWakeBudget:
         assert agent_row["budget"] == 1
         assert agent_row["consumed"] == 1
         assert agent_row["remaining"] == 0
+
+    async def test_wake_budget_reports_consumed_after_tasks_closed(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        from tinyagentos.agent_heartbeat import _heartbeat_tick
+
+        agent = next(a for a in app.state.config.agents if a["name"] == "test-agent")
+        agent["id"] = "test-agent"
+        agent["status"] = "running"
+        app.state.config.server["agent_heartbeat_enabled"] = True
+
+        project_a = await app.state.project_store.create_project(
+            name="proj-a", slug="proj-a", created_by="test",
+        )
+        project_b = await app.state.project_store.create_project(
+            name="proj-b", slug="proj-b", created_by="test",
+        )
+        task_a = await app.state.project_task_store.create_task(
+            project_id=project_a["id"],
+            title="task a",
+            created_by="test",
+            assignee_id="test-agent",
+        )
+        task_b = await app.state.project_task_store.create_task(
+            project_id=project_b["id"],
+            title="task b",
+            created_by="test",
+            assignee_id="test-agent",
+        )
+
+        async def fake_wake(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(
+            "tinyagentos.agent_heartbeat._wake_agent_with_task", fake_wake
+        )
+
+        await _heartbeat_tick(app.state)
+
+        # Close task_a so the next tick picks up task_b (proj-b)
+        await app.state.project_task_store.update_task(task_a["id"], status="closed")
+
+        await _heartbeat_tick(app.state)
+
+        # Close both tasks so held_task and list_ready_tasks both return empty
+        await app.state.project_task_store.update_task(task_b["id"], status="closed")
+
+        resp = await client.get("/api/agents/test-agent/wake-budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["consumed"] == 2
+        assert data["remaining"] == 0
+
+        resp2 = await client.get("/api/observatory/wake-budget")
+        assert resp2.status_code == 200
+        data2 = resp2.json()
+        agent_row = next(a for a in data2["agents"] if a["agent_id"] == "test-agent")
+        assert agent_row["consumed"] == 2
+        assert agent_row["remaining"] == 0
+
+    async def test_wake_budget_enforces_per_agent_total_across_projects(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        from tinyagentos.agent_heartbeat import _heartbeat_tick
+
+        agent = next(a for a in app.state.config.agents if a["name"] == "test-agent")
+        agent["id"] = "test-agent"
+        agent["status"] = "running"
+        app.state.config.server["agent_heartbeat_enabled"] = True
+        app.state.config.wake_budget = {
+            "global_default": 2,
+            "per_agent": {},
+            "per_project": {},
+        }
+
+        project_a = await app.state.project_store.create_project(
+            name="proj-a", slug="proj-a", created_by="test",
+        )
+        project_b = await app.state.project_store.create_project(
+            name="proj-b", slug="proj-b", created_by="test",
+        )
+        task_a = await app.state.project_task_store.create_task(
+            project_id=project_a["id"],
+            title="task a",
+            created_by="test",
+            assignee_id="test-agent",
+        )
+        task_b = await app.state.project_task_store.create_task(
+            project_id=project_b["id"],
+            title="task b",
+            created_by="test",
+            assignee_id="test-agent",
+        )
+
+        async def fake_wake(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(
+            "tinyagentos.agent_heartbeat._wake_agent_with_task", fake_wake
+        )
+
+        await _heartbeat_tick(app.state)
+
+        # Close task_a so the next tick picks up task_b instead of re-debouncing
+        await app.state.project_task_store.update_task(task_a["id"], status="closed")
+
+        await _heartbeat_tick(app.state)
+
+        # Third tick: budget exhausted, no more wakes regardless of ready tasks
+        await _heartbeat_tick(app.state)
+
+        resp = await client.get("/api/agents/test-agent/wake-budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["consumed"] == 2
+        assert data["remaining"] == 0
 
     async def test_get_wake_budget_not_found(self, client):
         resp = await client.get("/api/agents/no-such-agent/wake-budget")

--- a/tests/test_wake_budget.py
+++ b/tests/test_wake_budget.py
@@ -4,11 +4,13 @@ from pathlib import Path
 import pytest
 
 from tinyagentos.wake_budget import (
+    _agent_daily_keys,
     _coerce_budget,
     _read_state,
     _write_state,
     _today,
     can_wake,
+    get_agent_consumption,
     get_consumption,
     get_fleet_wake_info,
     get_next_scheduled_wake,
@@ -99,37 +101,37 @@ class TestRecordAndConsume:
 class TestCanWake:
     def test_allowed_when_under_budget(self, tmp_path):
         cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
-        assert can_wake(tmp_path, "a1", "a1", None, cfg) is True
+        assert can_wake(tmp_path, "a1", "a1", "proj-1", cfg) is True
 
     def test_blocked_when_exhausted(self, tmp_path):
         data_dir = tmp_path
-        record_scheduled_wake(data_dir, "a1", None)
-        record_scheduled_wake(data_dir, "a1", None)
+        record_scheduled_wake(data_dir, "a1", "proj-1")
+        record_scheduled_wake(data_dir, "a1", "proj-1")
         cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
-        assert can_wake(data_dir, "a1", "a1", None, cfg) is False
+        assert can_wake(data_dir, "a1", "a1", "proj-1", cfg) is False
 
     def test_zero_budget_blocks(self, tmp_path):
         cfg = _FakeConfig({"global_default": 0, "per_agent": {}, "per_project": {}})
-        assert can_wake(tmp_path, "a1", "a1", None, cfg) is False
+        assert can_wake(tmp_path, "a1", "a1", "proj-1", cfg) is False
 
 
 class TestNextScheduledWake:
     def test_returns_epoch_when_available(self, tmp_path):
         cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
-        nxt = get_next_scheduled_wake(tmp_path, "a1", None, cfg)
+        nxt = get_next_scheduled_wake(tmp_path, "a1", "proj-1", cfg)
         assert nxt is not None
         assert nxt > 0
 
     def test_none_when_exhausted(self, tmp_path):
         data_dir = tmp_path
-        record_scheduled_wake(data_dir, "a1", None)
-        record_scheduled_wake(data_dir, "a1", None)
+        record_scheduled_wake(data_dir, "a1", "proj-1")
+        record_scheduled_wake(data_dir, "a1", "proj-1")
         cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
-        assert get_next_scheduled_wake(data_dir, "a1", None, cfg) is None
+        assert get_next_scheduled_wake(data_dir, "a1", "proj-1", cfg) is None
 
     def test_none_when_zero_budget(self, tmp_path):
         cfg = _FakeConfig({"global_default": 0, "per_agent": {}, "per_project": {}})
-        assert get_next_scheduled_wake(tmp_path, "a1", None, cfg) is None
+        assert get_next_scheduled_wake(tmp_path, "a1", "proj-1", cfg) is None
 
 
 @pytest.mark.asyncio
@@ -147,6 +149,98 @@ class TestFleetWakeInfo:
         assert rows[0]["agent_id"] == "a1"
         assert rows[0]["budget"] == 2
         assert rows[0]["consumed"] == 0
+        assert rows[0]["remaining"] == 2
+
+
+class TestPerAgentConsumption:
+    def test_sums_all_project_keys_for_agent(self, tmp_path):
+        _write_state(tmp_path / "wake_budget.json", {
+            "daily": {
+                "a1:proj-x": {_today(): 1},
+                "a1:proj-y": {_today(): 2},
+                "a2:proj-x": {_today(): 3},
+            }
+        })
+        c = get_agent_consumption(tmp_path, "a1")
+        assert c["scheduled"] == 3
+        assert c["date"] == _today()
+
+    def test_zero_when_no_project_keys(self, tmp_path):
+        _write_state(tmp_path / "wake_budget.json", {
+            "daily": {
+                "a1:proj-x": {"1999-01-01": 5},
+            }
+        })
+        c = get_agent_consumption(tmp_path, "a1")
+        assert c["scheduled"] == 0
+        assert c["date"] == _today()
+
+    def test_missing_file_is_zero(self, tmp_path):
+        c = get_agent_consumption(tmp_path, "a1")
+        assert c["scheduled"] == 0
+        assert c["date"] == _today()
+
+
+class TestPerAgentCanWake:
+    def test_sums_across_projects(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-x")
+        record_scheduled_wake(data_dir, "a1", "proj-y")
+        cfg = _FakeConfig({"global_default": 3, "per_agent": {}, "per_project": {}})
+        assert can_wake(data_dir, "a1", "a1", "proj-x", cfg) is True
+
+    def test_blocks_when_agent_total_exhausted_across_projects(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-x")
+        record_scheduled_wake(data_dir, "a1", "proj-y")
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert can_wake(data_dir, "a1", "a1", "proj-x", cfg) is False
+
+    def test_per_agent_override_applies_to_total(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-x")
+        record_scheduled_wake(data_dir, "a1", "proj-y")
+        cfg = _FakeConfig({
+            "global_default": 10,
+            "per_agent": {"a1": 2},
+            "per_project": {},
+        })
+        assert can_wake(data_dir, "a1", "a1", "proj-x", cfg) is False
+
+
+class TestPerAgentNextScheduledWake:
+    def test_uses_agent_total_consumption(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-x")
+        cfg = _FakeConfig({"global_default": 3, "per_agent": {}, "per_project": {}})
+        nxt = get_next_scheduled_wake(data_dir, "a1", "proj-x", cfg)
+        assert nxt is not None
+
+    def test_none_when_agent_total_exhausted(self, tmp_path):
+        data_dir = tmp_path
+        record_scheduled_wake(data_dir, "a1", "proj-x")
+        record_scheduled_wake(data_dir, "a1", "proj-y")
+        cfg = _FakeConfig({"global_default": 2, "per_agent": {}, "per_project": {}})
+        assert get_next_scheduled_wake(data_dir, "a1", "proj-x", cfg) is None
+
+
+@pytest.mark.asyncio
+class TestPerAgentFleetInfo:
+    async def test_sums_across_projects(self, tmp_path):
+        _write_state(tmp_path / "wake_budget.json", {
+            "daily": {
+                "a1:proj-x": {_today(): 1},
+                "a1:proj-y": {_today(): 2},
+            }
+        })
+        cfg = _FakeConfig(
+            wake_budget={"global_default": 5, "per_agent": {}, "per_project": {}},
+            agents=[{"id": "a1", "name": "agent-1", "status": "running"}],
+        )
+        rows = await get_fleet_wake_info(tmp_path, cfg)
+        assert len(rows) == 1
+        assert rows[0]["agent_id"] == "a1"
+        assert rows[0]["consumed"] == 3
         assert rows[0]["remaining"] == 2
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1636,36 +1636,23 @@ async def reset_agent_budget(request: Request, name: str):
 @router.get("/api/agents/{name}/wake-budget")
 async def get_agent_wake_budget(request: Request, name: str):
     """Return an agent's resolved wake budget, today's consumption, and next
-    scheduled wake epoch."""
+    scheduled wake epoch.
+
+    Consumption is summed across all of the agent's project keys (per-agent
+    semantics) so the reported figures are accurate even when the agent holds
+    no current task.
+    """
     from pathlib import Path
-    from tinyagentos.wake_budget import resolve_budget, get_consumption, get_next_scheduled_wake
+    from tinyagentos.wake_budget import get_agent_consumption, get_next_scheduled_wake, resolve_budget
     config = request.app.state.config
     agent = find_agent(config, name)
     if not agent:
         return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
     agent_id = agent.get("id") or name
     data_dir = Path(request.app.state.data_dir)
-    project_task_store = getattr(request.app.state, "project_task_store", None)
-    project_id = None
-    if project_task_store is not None:
-        try:
-            held = await project_task_store.held_task(agent_id)
-            if held is not None:
-                task = await project_task_store.get_task(held)
-                if task is not None:
-                    project_id = task.get("project_id")
-            else:
-                ready = await project_task_store.list_ready_tasks_for_assignee(agent_id)
-                if ready:
-                    project_id = ready[0].get("project_id")
-        except Exception:
-            logger.warning(
-                "wake budget: project_task_store lookup failed for agent %s",
-                agent_id, exc_info=True,
-            )
-    budget = resolve_budget(agent_id, project_id, config)
-    consumption = get_consumption(data_dir, agent_id, project_id)
-    next_wake = get_next_scheduled_wake(data_dir, agent_id, project_id, config)
+    budget = resolve_budget(agent_id, None, config)
+    consumption = get_agent_consumption(data_dir, agent_id)
+    next_wake = get_next_scheduled_wake(data_dir, agent_id, None, config)
     return {
         "agent": name,
         "budget": budget,

--- a/tinyagentos/wake_budget.py
+++ b/tinyagentos/wake_budget.py
@@ -125,6 +125,29 @@ def get_consumption(data_dir: Path, agent_id: str, project_id: str | None) -> di
     return {"scheduled": scheduled, "date": today}
 
 
+def _agent_daily_keys(data_dir: Path, agent_id: str, today: str) -> list[str]:
+    """Return all ``{agent_id}:*`` keys that have an entry for ``today``."""
+    state = _read_state(_budget_path(data_dir))
+    prefix = f"{agent_id}:"
+    return [
+        key for key, dates in state.get("daily", {}).items()
+        if key.startswith(prefix) and today in dates
+    ]
+
+
+def get_agent_consumption(data_dir: Path, agent_id: str) -> dict:
+    """Return the agent's total scheduled wake count across all projects today."""
+    today = _today()
+    path = _budget_path(data_dir)
+    state = _read_state(path)
+    scheduled = 0
+    prefix = f"{agent_id}:"
+    for key, dates in state.get("daily", {}).items():
+        if key.startswith(prefix):
+            scheduled += int(dates.get(today, 0))
+    return {"scheduled": scheduled, "date": today}
+
+
 def can_wake(
     data_dir: Path,
     agent_id: str,
@@ -137,12 +160,16 @@ def can_wake(
     Fails closed (returns False) when the state file is damaged: a corrupted
     ``wake_budget.json`` must not silently restore a full budget and let
     enforcement cease fleet-wide.
+
+    Consumption is summed across all of the agent's project keys (per-agent
+    semantics): ``global_default`` and ``per_agent`` caps apply to the total
+    number of scheduled wakes for the agent, not per-project.
     """
-    budget = resolve_budget(agent_id, project_id, config)
+    budget = resolve_budget(agent_id, None, config)
     if budget <= 0:
         return False
     try:
-        consumption = get_consumption(data_dir, agent_id, project_id)
+        consumption = get_agent_consumption(data_dir, agent_id)
     except WakeBudgetStateError:
         logger.exception(
             "wake budget state damaged, refusing wake for agent %s", agent_id
@@ -157,11 +184,15 @@ def get_next_scheduled_wake(
     project_id: str | None,
     config: Any,
 ) -> float | None:
-    """Return the epoch of the next scheduled wake, or None if exhausted."""
-    budget = resolve_budget(agent_id, project_id, config)
+    """Return the epoch of the next scheduled wake, or None if exhausted.
+
+    Consumption is summed across all of the agent's project keys (per-agent
+    semantics).
+    """
+    budget = resolve_budget(agent_id, None, config)
     if budget <= 0:
         return None
-    consumption = get_consumption(data_dir, agent_id, project_id)
+    consumption = get_agent_consumption(data_dir, agent_id)
     remaining = budget - consumption["scheduled"]
     if remaining <= 0:
         return None
@@ -171,7 +202,12 @@ def get_next_scheduled_wake(
 
 
 async def get_fleet_wake_info(data_dir: Path, config: Any, project_task_store: Any = None) -> list[dict]:
-    """Return wake info for every running agent in config."""
+    """Return wake info for every running agent in config.
+
+    Consumption is summed across all of each agent's project keys (per-agent
+    semantics), so the reported consumed/remaining figures reflect the agent's
+    total daily usage regardless of which project the current task belongs to.
+    """
     rows: list[dict] = []
     agents = getattr(config, "agents", None) or []
     for agent in agents:
@@ -180,25 +216,8 @@ async def get_fleet_wake_info(data_dir: Path, config: Any, project_task_store: A
         agent_id = agent.get("id") or agent.get("name") or ""
         if not agent_id:
             continue
-        project_id = None
-        if project_task_store is not None:
-            try:
-                held = await project_task_store.held_task(agent_id)
-                if held is not None:
-                    task = await project_task_store.get_task(held)
-                    if task is not None:
-                        project_id = task.get("project_id")
-                else:
-                    ready = await project_task_store.list_ready_tasks_for_assignee(agent_id)
-                    if ready:
-                        project_id = ready[0].get("project_id")
-            except Exception:
-                logger.warning(
-                    "wake budget: project_task_store lookup failed for agent %s",
-                    agent_id, exc_info=True,
-                )
-        budget = resolve_budget(agent_id, project_id, config)
-        consumption = get_consumption(data_dir, agent_id, project_id)
+        budget = resolve_budget(agent_id, None, config)
+        consumption = get_agent_consumption(data_dir, agent_id)
         remaining = max(0, budget - consumption["scheduled"])
         rows.append({
             "agent_id": agent_id,
@@ -206,6 +225,6 @@ async def get_fleet_wake_info(data_dir: Path, config: Any, project_task_store: A
             "budget": budget,
             "consumed": consumption["scheduled"],
             "remaining": remaining,
-            "next_wake_epoch": get_next_scheduled_wake(data_dir, agent_id, project_id, config),
+            "next_wake_epoch": get_next_scheduled_wake(data_dir, agent_id, None, config),
         })
     return rows


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): wake-budget read reports consumed=0 the moment the charged tasks close; and enforcement quietly grants global_default per PROJECT per day, not per day

Autonomous build of board card tsk-jgz4kr.

Defect 1 (reader blindness): get_agent_wake_budget and get_fleet_wake_info
resolved project_id from held_task or first ready task. When all tasks were
closed they fell through to an untouched agent:global key, reporting
consumed=0 while the enforcer had charged under project keys. Fixed by
summing all the agent's project keys via new get_agent_consumption helper.

Defect 2 (semantics fork): can_wake compared per-project consumption to the
resolved budget, making global_default:2 mean 2 wakes per project per day.
TOKEN-DISCIPLINE rule 6 requires 2 scheduled checks/day per agent. Changed
can_wake and get_next_scheduled_wake to sum across all project keys and
resolve the budget at agent level (per_agent override then global_default).
Reader and enforcer now implement the same per-agent semantics.

Tests added: test_wake_budget_reports_consumed_after_tasks_closed pins the
cross-project read after task close; test_wake_budget_enforces_per_agent_total_across_projects
pins that the enforcer blocks at the agent total, not per-project. Existing
28 unit tests and 6 route tests stay green.

Docs-Reviewed: wake-budget docs updated to reflect per-agent semantics; route interface unchanged

Files:
 changelog.d/tsk-jgz4kr-wake-budget-per-agent.md |   3 +
 docs/design/wake-budget.md                      |  47 +++++----
 tests/test_routes_agents.py                     | 122 +++++++++++++++++++++++-
 tests/test_wake_budget.py                       | 114 ++++++++++++++++++++--
 tinyagentos/routes/agents.py                    |  33 ++-----
 tinyagentos/wake_budget.py                      |  71 +++++++++-----
 6 files changed, 309 insertions(+), 81 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wake budgets are now enforced per agent across all projects.
  * Consumption totals include scheduled wakes from every project, preventing additional wakes after an agent reaches its daily limit.
  * Global defaults and per-agent overrides are applied consistently across wake-budget checks and scheduling information.

* **Documentation**
  * Updated wake-budget documentation to reflect the implemented per-agent behavior and revised consumption reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->