### PR TITLE
fix-forward #2690: RECONCILE_403_OCCURRED is never global, so main() raises UnboundLocalError on every --head-sha invocation

### DIFF
--- a/changelog.d/tsk-ks6i3c-reconcile-403-flag-removed.md
+++ b/changelog.d/tsk-ks6i3c-reconcile-403-flag-removed.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `scripts/check_bot_review.py` no longer crashes with `UnboundLocalError` on
+  every `--head-sha` run. The `RECONCILE_403_OCCURRED` module-level flag was
+  both read and assigned inside `main()` without a `global` declaration, so
+  the read at the verified-stub check raised before the reset assignment
+  could run. The reconcile path now signals a 403-during-PATCH via the
+  return value of `reconcile_head_sha_check_run` and the gate still keeps
+  the verdict red when a stale FAILURE survives, instead of waiving it.

--- a/changelog.d/tsk-shh2en-distinguish-403-error.md
+++ b/changelog.d/tsk-shh2en-distinguish-403-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- reconcile now distinguishes HTTP 403 Forbidden from other infrastructure errors when PATCHing stale bot-review-gate check runs; a distinct "override could not be applied" message is printed on 403 rather than the generic "stale FAILURE survived reconcile" line, making permission faults visible and distinguishable from genuinely unwaived PRs

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -123,10 +123,6 @@ VERDICT_TO_CONCLUSION = {
     EXIT_STUB: "failure",
 }
 
-# Track whether reconcile encountered a 403 Forbidden during PATCH,
-# to distinguish it from genuine infrastructure failure in main().
-RECONCILE_403_OCCURRED = False
-
 
 @dataclass
 class CRItem:
@@ -608,7 +604,11 @@ def reconcile_head_sha_check_run(
 
     Returns the GitHub response dict on a successful write, or None if there
     was no write to make (all runs already matched) or on infrastructure
-    failure.
+    failure. A 403 Forbidden refusal on the PATCH returns
+    ``{"reconciled": False, "reason": "patch_refused_403", "head_sha": ...}``
+    so the caller can block a false-clean verdict without relying on a
+    module-level flag (which previously shadowed as a local inside main()
+    and broke with UnboundLocalError on every --head-sha run).
     """
     runs = list_check_runs(owner, repo, head_sha, token)
     if runs is None:
@@ -656,18 +656,23 @@ def reconcile_head_sha_check_run(
         # stale FAILURE survives is strictly worse than writing nothing, because
         # it leaves the SHA pinned on UNSTABLE and looks reconciled.
         if any_403:
-            RECONCILE_403_OCCURRED = True
             print(
                 f"error: override could not be applied on {head_sha}; "
                 f"the bot-review-allow label waiver could not be applied due "
                 f"to insufficient permissions", file=sys.stderr,
             )
-        else:
-            print(
-                f"error: could not PATCH one or more stale bot-review-gate runs on "
-                f"{head_sha}; refusing to publish a new run that would coexist with "
-                f"them", file=sys.stderr,
-            )
+            # Signal a 403 refusal to main() so it can keep the gate red
+            # instead of reporting a false-clean verdict. A 403 from the
+            # PATCH means a stale FAILURE survived, so the gate must not
+            # waive it; the dict return shape is distinct from the
+            # success/no-op `None` so callers can branch on it.
+            return {"reconciled": False, "reason": "patch_refused_403",
+                    "head_sha": head_sha}
+        print(
+            f"error: could not PATCH one or more stale bot-review-gate runs on "
+            f"{head_sha}; refusing to publish a new run that would coexist with "
+            f"them", file=sys.stderr,
+        )
         return None
     if patched_any:
         return {"reconciled": True, "action": "patched", "head_sha": head_sha}
@@ -777,7 +782,7 @@ def main(argv: list[str] | None = None) -> int:
     # written as a check-run conclusion: it is reported by the job failure and
     # must not self-clear a stale run, so the write is skipped.
     if head_sha and exit_code in VERDICT_TO_CONCLUSION:
-        reconcile_head_sha_check_run(
+        reconcile_result = reconcile_head_sha_check_run(
             owner, repo, head_sha, VERDICT_TO_CONCLUSION[exit_code], token,
         )
         # Read back the reconciled verdict (the read side of the #2493 fix).
@@ -789,14 +794,27 @@ def main(argv: list[str] | None = None) -> int:
         verified_code, _ = check_run_verdict(
             owner, repo, head_sha, token,
         )
-        if verified_code == EXIT_STUB and exit_code == EXIT_OK and not RECONCILE_403_OCCURRED:
+        if verified_code == EXIT_STUB and exit_code == EXIT_OK:
             print(
                 f"fail: stale bot-review-gate FAILURE on {head_sha} "
                 f"survived reconcile -- PR stays UNSTABLE "
                 f"(exit {EXIT_STUB})"
             )
             return EXIT_STUB
-    RECONCILE_403_OCCURRED = False  # reset for next run
+        # A 403 refusal on the PATCH means a stale FAILURE survived because
+        # we could not patch it; even when the latest check run now reads
+        # clean, the gate must not waive it. The reconcile_result carries the
+        # refusal signal so main() does not need a module-level flag (which
+        # previously shadowed as a local in this function and broke the read
+        # of its own reset with an UnboundLocalError on every --head-sha run).
+        if (isinstance(reconcile_result, dict)
+                and reconcile_result.get("reason") == "patch_refused_403"):
+            print(
+                f"fail: could not PATCH stale bot-review-gate run on "
+                f"{head_sha} (403 Forbidden); PR stays UNSTABLE "
+                f"(exit {EXIT_STUB})"
+            )
+            return EXIT_STUB
     return exit_code
 
 

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -123,6 +123,10 @@ VERDICT_TO_CONCLUSION = {
     EXIT_STUB: "failure",
 }
 
+# Track whether reconcile encountered a 403 Forbidden during PATCH,
+# to distinguish it from genuine infrastructure failure in main().
+RECONCILE_403_OCCURRED = False
+
 
 @dataclass
 class CRItem:
@@ -572,7 +576,16 @@ def _api_mutate(
         with urlopen(req, timeout=30) as r:
             return 200 <= r.status < 300
     except Exception as e:
-        print(f"error: {method} {url} failed: {e}", file=sys.stderr)
+        if getattr(e, "code", None) == 403:
+            print(
+                f"error: {method} {url} failed: {e}",
+                file=sys.stderr,
+            )
+            return False
+        print(
+            f"error: {method} {url} failed: {e}",
+            file=sys.stderr,
+        )
         return None
 
 
@@ -611,6 +624,7 @@ def reconcile_head_sha_check_run(
     # the stale FAILURE still pins the SHA on UNSTABLE -- while reconcile
     # returns a dict that reads as a successful write. Fail closed instead.
     mutate_failed = False
+    any_403 = False
     for run in runs:
         status = run.get("status")
         existing = run.get("conclusion")
@@ -635,15 +649,25 @@ def reconcile_head_sha_check_run(
             patched_any = True
         else:
             mutate_failed = True
+            if result is False:
+                any_403 = True
     if mutate_failed:
         # Do NOT fall through to the POST below: publishing a fresh run while a
         # stale FAILURE survives is strictly worse than writing nothing, because
         # it leaves the SHA pinned on UNSTABLE and looks reconciled.
-        print(
-            f"error: could not PATCH one or more stale bot-review-gate runs on "
-            f"{head_sha}; refusing to publish a new run that would coexist with "
-            f"them", file=sys.stderr,
-        )
+        if any_403:
+            RECONCILE_403_OCCURRED = True
+            print(
+                f"error: override could not be applied on {head_sha}; "
+                f"the bot-review-allow label waiver could not be applied due "
+                f"to insufficient permissions", file=sys.stderr,
+            )
+        else:
+            print(
+                f"error: could not PATCH one or more stale bot-review-gate runs on "
+                f"{head_sha}; refusing to publish a new run that would coexist with "
+                f"them", file=sys.stderr,
+            )
         return None
     if patched_any:
         return {"reconciled": True, "action": "patched", "head_sha": head_sha}
@@ -765,13 +789,14 @@ def main(argv: list[str] | None = None) -> int:
         verified_code, _ = check_run_verdict(
             owner, repo, head_sha, token,
         )
-        if verified_code == EXIT_STUB and exit_code == EXIT_OK:
+        if verified_code == EXIT_STUB and exit_code == EXIT_OK and not RECONCILE_403_OCCURRED:
             print(
                 f"fail: stale bot-review-gate FAILURE on {head_sha} "
                 f"survived reconcile -- PR stays UNSTABLE "
                 f"(exit {EXIT_STUB})"
             )
             return EXIT_STUB
+    RECONCILE_403_OCCURRED = False  # reset for next run
     return exit_code
 
 

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -539,6 +539,79 @@ class TestMain:
         with pytest.raises(SystemExit):
             check_mod.main([])
 
+    def test_main_head_sha_does_not_raise_unbound_local_error(
+        self, check_mod, capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Acceptance: main() with --head-sha and a terminal exit code must
+        complete without raising UnboundLocalError.
+
+        Repro from tsk-ks6i3c: `RECONCILE_403_OCCURRED` was a module-level
+        flag that `main()` both read (at the verified-stub check) and
+        assigned (at the reset for next run). Because `main()` assigned it
+        with no `global` statement, Python treated the name as local to
+        `main()` for the whole function, so the earlier read raised
+        UnboundLocalError before the assignment ran -- the reconcile path was
+        dead on every --head-sha run.
+        """
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        # Drive the terminal-exit-code branch with all network calls stubbed:
+        # check_bot_review -> EXIT_OK, reconcile_head_sha_check_run -> None,
+        # check_run_verdict -> EXIT_OK. The reconciled-verdict read happens
+        # before any 403-flag reset, which is the line that previously
+        # raised.
+        with patch.object(check_mod, "collect_coderabbit_items",
+                          return_value=items), \
+             patch.object(check_mod, "reconcile_head_sha_check_run",
+                          return_value=None), \
+             patch.object(check_mod, "check_run_verdict",
+                          return_value=(check_mod.EXIT_OK, "stub ok")):
+            rc = check_mod.main(
+                ["2366", "--owner", "jaylfc", "--repo", "taOS",
+                 "--head-sha", "abcdef0123456789" + "0" * 24],
+            )
+        assert rc == check_mod.EXIT_OK
+
+    def test_main_patch_403_refusal_blocks_false_clean_verdict(
+        self, check_mod, capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Acceptance: an infra-403-during-PATCH must STILL block a false
+        clean verdict, not waive it.
+
+        When the reconcile PATCH is refused with 403 Forbidden the stale
+        FAILURE survives; the gate must report EXIT_STUB even if the latest
+        check run on the SHA happens to read green. The pre-fix inverted
+        condition (`... and not RECONCILE_403_OCCURRED`) let the 403 path
+        WAIVE the gate; the post-fix return-value signal flips that.
+        """
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        refused = {"reconciled": False, "reason": "patch_refused_403",
+                   "head_sha": "abcdef0123456789" + "0" * 24}
+        with patch.object(check_mod, "collect_coderabbit_items",
+                          return_value=items), \
+             patch.object(check_mod, "reconcile_head_sha_check_run",
+                          return_value=refused), \
+             patch.object(check_mod, "check_run_verdict",
+                          return_value=(check_mod.EXIT_OK, "stub ok")):
+            rc = check_mod.main(
+                ["2366", "--owner", "jaylfc", "--repo", "taOS",
+                 "--head-sha", "abcdef0123456789" + "0" * 24],
+            )
+        captured = capsys.readouterr()
+        assert rc == check_mod.EXIT_STUB, (
+            "a 403-during-PATCH must keep the gate red, not waive it to OK"
+        )
+        assert "403" in captured.out
+
 
 # ---------------------------------------------------------------------------
 # collect_pr_labels(owner, repo, pr) -- API-fetched label set (mocked at _api_get)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2690: RECONCILE_403_OCCURRED is never global, so main() raises UnboundLocalError on every --head-sha invocation

Autonomous build of board card tsk-ks6i3c.

REVISION: built on `exec/tsk-shh2en` (cut at `737f4f0e9b9b9f8c27c89bd1faa8e52de176a1c3`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

scripts/check_bot_review.py crashed with UnboundLocalError on every
--head-sha run because main() both read and assigned a module-level
RECONCILE_403_OCCURRED flag without a global declaration. The
assignment at the end of main() shadowed the name as a local for the
whole function body, so the earlier read at the verified-stub check
raised before the assignment could run.

The pre-fix inverted condition (... and not RECONCILE_403_OCCURRED)
also let a 403-during-PATCH waive the gate to clean, which is the
opposite of the safety it was supposed to provide: a stale FAILURE
surviving because the PATCH was refused must keep the verdict red,
not flip it green.

Replace the module flag with a structured return value from
reconcile_head_sha_check_run:
  - success: dict {reconciled: True, action: ..., head_sha: ...}
  - no work / infra failure: None
  - 403 refusal: dict {reconciled: False, reason: patch_refused_403,
    head_sha: ...}

main() inspects the return value and treats patch_refused_403 as a
blocking failure, so the gate stays EXIT_STUB. The verified-stub
check no longer needs the third clause; it now fires whenever the
latest check run on the SHA still reads failure, matching the
intended behavior in both comments and the existing fail-closed
tests.

Tests added in tests/scripts/test_check_bot_review.py::TestMain:
  - test_main_head_sha_does_not_raise_unbound_local_error drives
    the terminal-exit-code branch with --head-sha and asserts the
    function returns EXIT_OK rather than raising. Previously this
    raised UnboundLocalError as shown in the repro.
  - test_main_patch_403_refusal_blocks_false_clean_verdict forces a
    patch_refused_403 return from reconcile and asserts main() returns
    EXIT_STUB, covering the inverted-condition regression.

Verified: uv run --group dev pytest
  tests/scripts/test_check_bot_review.py -q -> 106 passed
  tests/test_check_gate_integrity.py -q -> 71 passed

Files:
 .../tsk-ks6i3c-reconcile-403-flag-removed.md       |  9 +++
 changelog.d/tsk-shh2en-distinguish-403-error.md    |  3 +
 scripts/check_bot_review.py                        | 49 ++++++++++++++-
 tests/scripts/test_check_bot_review.py             | 73 ++++++++++++++++++++++
 4 files changed, 131 insertions(+), 3 deletions(-)