### PR TITLE
fold CodeRabbit findings on #2701 (tsk-wkah3z): ready_tasks view is blind to blocked-on: labels AND its limit param is inert

### DIFF
--- a/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
+++ b/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
@@ -1,3 +1,4 @@
 ### Fixed
 - `/api/projects/{pid}/tasks/ready` now honours `blocked-on:<id>` labels alongside `task_relationships` edges: a task carrying a `blocked-on:<id>` label whose target is OPEN in the same project is excluded from the ready set; closing the target re-surfaces it
 - The route's `?limit` query param is now honoured: clamped to `[1, 500]`, so `?limit=0` and `?limit=-1` no longer silently widen to unbounded or fall back to the default 50
+- `ready_tasks` (and its migration twin) now scope `blocked-on:<id>` label joins to the same project as the labelled task, so a cross-project `blocked-on:<id>` label can no longer hide a task in the wrong project

--- a/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
+++ b/changelog.d/tsk-wkah3z-ready-blocked-on-and-limit.md
@@ -1,0 +1,3 @@
+### Fixed
+- `/api/projects/{pid}/tasks/ready` now honours `blocked-on:<id>` labels alongside `task_relationships` edges: a task carrying a `blocked-on:<id>` label whose target is OPEN in the same project is excluded from the ready set; closing the target re-surfaces it
+- The route's `?limit` query param is now honoured: clamped to `[1, 500]`, so `?limit=0` and `?limit=-1` no longer silently widen to unbounded or fall back to the default 50

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -885,3 +885,106 @@ async def test_create_claimable_with_empty_body_returns_422(client):
     )
     assert resp.status_code == 200
 
+
+# ---------------------------------------------------------------------------
+# tsk-wkah3z: ready view honour blocked-on:<id> labels and the limit param
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ready_excludes_open_blocked_on_label(client):
+    """Arm A: a task labelled blocked-on:<id> with <id> OPEN is excluded.
+
+    Hits the real HTTP route with the real auth dependency (the shared
+    ``client`` fixture signs in as the test admin via the session cookie
+    path), not a fixture that bypasses the router.
+    """
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "bo"})).json()["id"]
+    blocker = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "Blocker"}
+    )).json()
+    blocked = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "Blocked"}
+    )).json()
+
+    patch_resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{blocked['id']}",
+        json={"labels": [f"blocked-on:{blocker['id']}"]},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert f"blocked-on:{blocker['id']}" in patch_resp.json()["labels"]
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids = [t["id"] for t in resp.json()["items"]]
+    assert blocked["id"] not in ids, (
+        f"ready returned {blocked['id']} carrying an open blocked-on:{blocker['id']} label"
+    )
+    assert blocker["id"] in ids
+
+    close_resp = await client.post(
+        f"/api/projects/{pid}/tasks/{blocker['id']}/close",
+        json={"closed_by": "admin", "reason": "done"},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+
+    resp_after = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids_after = [t["id"] for t in resp_after.json()["items"]]
+    assert blocked["id"] in ids_after, (
+        "un-blocking direction: closing the blocker must re-surface the blocked task"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_stale_blocked_on_label_is_ready(client):
+    """Arm B: a blocked-on:<id> label pointing at a CLOSED task is stale -> ready."""
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "stale"})).json()["id"]
+    gone = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "AlreadyClosed"}
+    )).json()
+    close_resp = await client.post(
+        f"/api/projects/{pid}/tasks/{gone['id']}/close",
+        json={"closed_by": "admin"},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+
+    stale = (await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "Stale", "labels": [f"blocked-on:{gone['id']}"]},
+    )).json()
+    assert f"blocked-on:{gone['id']}" in stale["labels"]
+
+    resp = await client.get(f"/api/projects/{pid}/tasks/ready")
+    ids = [t["id"] for t in resp.json()["items"]]
+    assert stale["id"] in ids, (
+        f"stale blocked-on label (target {gone['id']} is closed) must not exclude {stale['id']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_limit_param_honoured_and_clamped(client):
+    """Arm C: ?limit is honoured, 0/-1 clamp to the floor, >500 clamps to 500."""
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "lim"})).json()["id"]
+    for i in range(10):
+        r = await client.post(
+            f"/api/projects/{pid}/tasks", json={"title": f"T{i}"}
+        )
+        assert r.status_code == 200
+
+    five = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": 5})
+    assert five.status_code == 200
+    assert len(five.json()["items"]) == 5
+
+    zero = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": 0})
+    assert zero.status_code == 200
+    assert len(zero.json()["items"]) >= 1, "?limit=0 must NOT return unbounded / 0 items"
+
+    neg = await client.get(f"/api/projects/{pid}/tasks/ready", params={"limit": -1})
+    assert neg.status_code == 200
+    assert len(neg.json()["items"]) >= 1, "?limit=-1 must NOT return unbounded"
+
+    huge = await client.get(
+        f"/api/projects/{pid}/tasks/ready", params={"limit": 99999}
+    )
+    assert huge.status_code == 200
+    assert len(huge.json()["items"]) <= 500
+

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -988,3 +988,57 @@ async def test_ready_limit_param_honoured_and_clamped(client):
     assert huge.status_code == 200
     assert len(huge.json()["items"]) <= 500
 
+
+@pytest.mark.asyncio
+async def test_ready_limit_clamp_500_enforced_with_501_tasks(client):
+    """tsk-cifqsh finding 1: with 501+ ready tasks, ?limit=99999 must clamp to 500.
+
+    Previous test only created 10 tasks, so an unclamped limit also returned
+    10 and the assertion passed without enforcing the cap. Seed 501 ready
+    tasks and assert the upper cap returns exactly 500.
+    """
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "cap"})).json()["id"]
+    for i in range(501):
+        r = await client.post(
+            f"/api/projects/{pid}/tasks", json={"title": f"T{i}"}
+        )
+        assert r.status_code == 200, r.text
+
+    huge = await client.get(
+        f"/api/projects/{pid}/tasks/ready", params={"limit": 99999}
+    )
+    assert huge.status_code == 200
+    assert len(huge.json()["items"]) == 500, (
+        f"?limit=99999 must clamp to 500 even when more than 500 ready tasks exist, "
+        f"got {len(huge.json()['items'])}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ready_blocked_on_label_does_not_match_across_projects(client):
+    """tsk-cifqsh finding 2: a blocked-on:<id> label must only match same-project tasks.
+
+    A task in project A labelled blocked-on:<blocker-in-project-B> must remain
+    ready; the label is meaningless across project boundaries. The schema view
+    join (and its migration twin) must constrain on ``bt.project_id = t.project_id``.
+    """
+    pid_a = (await client.post("/api/projects", json={"name": "A", "slug": "xpa"})).json()["id"]
+    pid_b = (await client.post("/api/projects", json={"name": "B", "slug": "xpb"})).json()["id"]
+
+    blocker_b = (await client.post(
+        f"/api/projects/{pid_b}/tasks", json={"title": "BlockerInB"}
+    )).json()
+
+    foreign_labeled = (await client.post(
+        f"/api/projects/{pid_a}/tasks",
+        json={"title": "ForeignLabeled", "labels": [f"blocked-on:{blocker_b['id']}"]},
+    )).json()
+    assert f"blocked-on:{blocker_b['id']}" in foreign_labeled["labels"]
+
+    resp = await client.get(f"/api/projects/{pid_a}/tasks/ready")
+    ids = [t["id"] for t in resp.json()["items"]]
+    assert foreign_labeled["id"] in ids, (
+        f"cross-project blocked-on:{blocker_b['id']} label must not exclude "
+        f"{foreign_labeled['id']} in project {pid_a}"
+    )
+

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -84,6 +84,7 @@ WHERE t.status = 'open'
       SELECT 1 FROM json_each(t.labels) je
       JOIN project_tasks bt
         ON 'blocked-on:' || bt.id = je.value
+       AND bt.project_id = t.project_id
       WHERE bt.status NOT IN ('closed', 'cancelled')
   );
 
@@ -229,6 +230,7 @@ class ProjectTaskStore(BaseStore):
             "AND NOT EXISTS ("
             "SELECT 1 FROM json_each(t.labels) je "
             "JOIN project_tasks bt ON 'blocked-on:' || bt.id = je.value "
+            "AND bt.project_id = t.project_id "
             "WHERE bt.status NOT IN ('closed', 'cancelled')"
             ")"
         )

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -79,6 +79,12 @@ WHERE t.status = 'open'
       WHERE r.from_task_id = t.id
         AND r.kind = 'blocks'
         AND bt.status NOT IN ('closed', 'cancelled')
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM json_each(t.labels) je
+      JOIN project_tasks bt
+        ON 'blocked-on:' || bt.id = je.value
+      WHERE bt.status NOT IN ('closed', 'cancelled')
   );
 
 CREATE TABLE IF NOT EXISTS task_checklist_items (
@@ -197,6 +203,34 @@ class ProjectTaskStore(BaseStore):
         await self._db.execute(
             "CREATE INDEX IF NOT EXISTS idx_tasks_element "
             "ON project_tasks(project_id, element_id)"
+        )
+        await self._db.commit()
+        # Ready-view migration: re-create ready_tasks so it honours the
+        # ``blocked-on:<id>`` label mechanism (defect tsk-wkah3z). SQLite's
+        # ``CREATE VIEW IF NOT EXISTS`` is a no-op when the view already
+        # exists, so databases created before this change keep the old view
+        # body and silently keep returning tasks whose blocker is still
+        # open. Drop + recreate is safe here: the view is a derived
+        # projection of project_tasks, so a rebuild after the drop picks up
+        # the new WHERE clause with no data movement.
+        await self._db.execute("DROP VIEW IF EXISTS ready_tasks")
+        await self._db.execute(
+            "CREATE VIEW ready_tasks AS "
+            "SELECT t.* FROM project_tasks t "
+            "WHERE t.status = 'open' "
+            "AND t.claimed_by IS NULL "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM task_relationships r "
+            "JOIN project_tasks bt ON bt.id = r.to_task_id "
+            "WHERE r.from_task_id = t.id "
+            "AND r.kind = 'blocks' "
+            "AND bt.status NOT IN ('closed', 'cancelled')"
+            ") "
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM json_each(t.labels) je "
+            "JOIN project_tasks bt ON 'blocked-on:' || bt.id = je.value "
+            "WHERE bt.status NOT IN ('closed', 'cancelled')"
+            ")"
         )
         await self._db.commit()
         # Add created_by column for checklist items (defect tsk-6xymzj).
@@ -608,7 +642,11 @@ class ProjectTaskStore(BaseStore):
     async def list_ready_tasks(
         self, project_id: str, limit: int = 50, element_id: str | None = None
     ) -> list[dict]:
-        limit = max(1, min(limit, 200))
+        # Clamp to [1, 500]. The floor stops ``limit=0`` / negative inputs from
+        # being silently widened to ``unbounded`` or the default 50, and the
+        # cap protects the route from a caller asking for an unreasonable
+        # window (defect tsk-wkah3z).
+        limit = max(1, min(limit, 500))
         conds = ["project_id = ?"]
         params: list = [project_id]
         if element_id is not None:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -917,13 +917,25 @@ async def ready_tasks(
     project_id: str,
     request: Request,
     element_id: str | None = None,
+    limit: int = 50,
 ):
+    """List ready (open, unclaimed, unblocked) tasks for the project.
+
+    ``limit`` is clamped to ``[1, 500]`` in the store: a floor of 1 stops
+    ``?limit=0`` / negative inputs from being silently widened to unbounded
+    or the default 50 (the LIMIT -1 SQLite trap, see taosmd #415), and the
+    500 cap keeps the route from streaming an unreasonable window back to a
+    caller.  The view honours the ``blocked-on:<id>`` label convention
+    alongside ``task_relationships`` edges (defect tsk-wkah3z).
+    """
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(request, pstore, project_id)
     if isinstance(auth, JSONResponse):
         return auth
     store = request.app.state.project_task_store
-    return {"items": await store.list_ready_tasks(project_id=project_id, element_id=element_id)}
+    return {"items": await store.list_ready_tasks(
+        project_id=project_id, element_id=element_id, limit=limit
+    )}
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2701 (tsk-wkah3z): ready_tasks view is blind to blocked-on: labels AND its limit param is inert

Autonomous build of board card tsk-cifqsh.

REVISION: built on `exec/tsk-wkah3z` (cut at `0147775995d3ad274b0c5c21ff87aa95d7a55d77`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

1. tests/test_routes_projects.py:989 -- Arm C created 10 ready tasks, so an
   unclamped ?limit=99999 also returned 10 and the <= 500 assertion passed
   without ever proving the cap. Add test_ready_limit_clamp_500_enforced_with_501_tasks
   which seeds 501 ready tasks and asserts ?limit=99999 returns exactly 500
   (the store's max(1, min(limit, 500)) clamp is what enforces it).

2. tinyagentos/projects/task_store.py:86 and :231 -- both label-blocker
   joins matched any active task with the labelled id, regardless of
   project, so a task in project A could be hidden by a blocked-on:<id>
   label whose target lives in project B. Add bt.project_id = t.project_id
   to both the schema view and the migration view definition so the join
   stays inside one project. Add test_ready_blocked_on_label_does_not_match_across_projects
   which creates an active task in project B, a task in project A carrying
   a blocked-on:<B-task> label, and asserts the project-A task is still
   ready.

Failing run on exec/tsk-wkah3z (pre-fix, with the new test):
  pytest tests/test_routes_projects.py::test_ready_blocked_on_label_does_not_match_across_projects
  FAILED AssertionError: cross-project blocked-on:tsk-7wlsta label must not
  exclude tsk-sd65yo in project prj-ogukwj

After the fix in task_store.py both new tests pass; the 62 tests in
tests/test_routes_projects.py stay green.

Changelog: tsk-wkah3z-ready-blocked-on-and-limit.md gains a third Fixed
bullet for the cross-project scope fix.

Files:
 .../tsk-wkah3z-ready-blocked-on-and-limit.md       |   4 +
 tests/test_routes_projects.py                      | 157 +++++++++++++++++++++
 tinyagentos/projects/task_store.py                 |  42 +++++-
 tinyagentos/routes/projects.py                     |  14 +-
 4 files changed, 215 insertions(+), 2 deletions(-)