### PR TITLE
bot-review-gate pins every PR red forever once one gate run failed: reconcile PATCHes runner-owned job check-runs, which GitHub refuses, then fails closed

### DIFF
--- a/changelog.d/tsk-4h3dvk-bot-review-gate-job-runs.md
+++ b/changelog.d/tsk-4h3dvk-bot-review-gate-job-runs.md
@@ -1,0 +1,8 @@
+### Fixed
+- `scripts/check_bot_review.py` now skips runner-owned GitHub Actions job check
+  runs (those with a non-null `external_id` or a `details_url` under
+  `/actions/runs/`) during reconcile and verdict reads. The Actions API token
+  cannot PATCH these runs, so a stale job-owned FAILURE previously caused
+  reconcile to fail closed and pin every subsequent gate run red. Job-owned
+  staleness is irrelevant because GitHub's merge box keys off the latest check
+  run per name, and only the script's own runs are writable.

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -260,6 +260,22 @@ def _is_coderabbit(user: dict | None) -> bool:
     return (user.get("login") or "").lower() in CODERABBIT_LOGINS
 
 
+def _is_job_owned_run(run: dict) -> bool:
+    """Return True if a check run is runner-owned and cannot be PATCHed.
+
+    GitHub Actions creates a runner-owned check run for each job (app.slug
+    = github-actions, external_id set to the job GUID). The Actions API
+    token cannot update these runs, so they must be skipped during
+    reconcile and ignored when reading the head-SHA verdict.
+    """
+    if run.get("external_id"):
+        return True
+    details_url = run.get("details_url") or ""
+    if "/actions/runs/" in details_url:
+        return True
+    return False
+
+
 def collect_coderabbit_items(
     owner: str, repo: str, pr_number: int, token: str | None = None,
 ) -> list[CRItem] | None:
@@ -481,16 +497,19 @@ def list_check_runs(
 
 
 def filter_head_sha_check_runs(check_runs: list[dict]) -> list[dict]:
-    """Drop non-terminal runs; keep only completed bot-review-gate check runs,
-    sorted most-recent-first by (started_at, id).
+    """Drop non-terminal and job-owned runs; keep only completed bot-review-gate
+    check runs the script can actually write, sorted most-recent-first by
+    (started_at, id).
 
-    An in_progress run is never authoritative for the head-SHA verdict: the job
-    may still be writing it, so ``latest_check_run_conclusion`` must not read a
-    half-written conclusion as the verdict.
+    Runner-owned job check runs (app.slug=github-actions) cannot be PATCHed
+    via the Actions API token, so they are irrelevant to the verdict: the
+    merge box keys off the latest check run per name, and the script's own
+    runs are the only ones it can correct.
     """
     completed = [
         r for r in check_runs
         if r.get("status") == "completed" and r.get("conclusion") is not None
+        and not _is_job_owned_run(r)
     ]
     return sorted(
         completed,
@@ -620,6 +639,12 @@ def reconcile_head_sha_check_run(
             continue
         if existing == conclusion:
             continue
+        # Runner-owned job check runs (app.slug=github-actions) cannot be
+        # PATCHed via the Actions API token; skip them. Their staleness is
+        # irrelevant because mergeStateStatus keys off the latest check run
+        # per name, not any coexisting run.
+        if _is_job_owned_run(run):
+            continue
         url = f"{API}/repos/{owner}/{repo}/check-runs/{run['id']}"
         result = _api_mutate(
             url,
@@ -648,10 +673,13 @@ def reconcile_head_sha_check_run(
     if patched_any:
         return {"reconciled": True, "action": "patched", "head_sha": head_sha}
 
-    # No stale run to update. If a matching conclusion already exists, nothing
-    # to do; if none exists at all, publish a fresh terminal check run.
+    # No stale run to update. If a matching conclusion already exists on a
+    # writable run, nothing to do; if none exists at all, publish a fresh
+    # terminal check run. Job-owned runs are not writable, so they do not
+    # suppress a fresh POST.
     if any(
         r.get("status") == "completed" and r.get("conclusion") == conclusion
+        and not _is_job_owned_run(r)
         for r in runs
     ):
         return None

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -1314,3 +1314,123 @@ class TestReconcileFailsClosedOnMutateFailure:
                 "jaylfc", "taOS", self.HEAD_SHA, "success")
         methods = [c.kwargs.get("method", "POST") for c in mutate.call_args_list]
         assert "POST" in methods
+
+
+class TestJobOwnedRunsSkipped:
+    """Runner-owned job check runs are not writable and must not pin the
+    gate red or trigger a PATCH error."""
+
+    HEAD_SHA = "1baa21a" + "0" * 34
+
+    @staticmethod
+    def _job_run(run_id, conclusion, started_at):
+        return {
+            "id": run_id,
+            "name": "bot-review-gate",
+            "head_sha": "1baa21a",
+            "status": "completed",
+            "conclusion": conclusion,
+            "started_at": started_at,
+            "completed_at": started_at,
+            "external_id": "job-guid-" + str(run_id),
+        }
+
+    @staticmethod
+    def _script_run(run_id, conclusion, started_at):
+        return {
+            "id": run_id,
+            "name": "Bot review gate",
+            "head_sha": "1baa21a",
+            "status": "completed",
+            "conclusion": conclusion,
+            "started_at": started_at,
+            "completed_at": started_at,
+        }
+
+    @staticmethod
+    def _mock_list(check_runs):
+        def side_effect(url, token=None):
+            return [{"total_count": len(check_runs), "check_runs": check_runs}]
+        return side_effect
+
+    def test_job_owned_failure_older_than_job_owned_success_exits_0(
+        self, check_mod, capsys
+    ) -> None:
+        """Acceptance #1: job-owned stale FAILURE with newer job-owned SUCCESS
+        must not pin the gate red. The script makes zero PATCH calls."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        runs = [
+            self._job_run(1001, "failure", "2026-08-17T21:30:58Z"),
+            self._job_run(1002, "success", "2026-08-27T12:08:17Z"),
+        ]
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=items), \
+             patch.object(check_mod, "_api_get",
+                          side_effect=self._mock_list(runs)), \
+             patch.object(check_mod, "_api_mutate") as mutate:
+            rc = check_mod.main([
+                "2692", "--owner", "jaylfc", "--repo", "taOS",
+                "--head-sha", self.HEAD_SHA,
+            ])
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "PASS" in captured.out
+        methods = [c.kwargs.get("method", "POST") for c in mutate.call_args_list]
+        assert "PATCH" not in methods
+
+    def test_job_owned_stale_failure_no_patch_error(
+        self, check_mod, capsys
+    ) -> None:
+        """Acceptance #2: job-owned stale FAILURE must not produce a PATCH
+        error, and the exit follows the fresh verdict."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        runs = [self._job_run(1001, "failure", "2026-08-17T21:30:58Z")]
+        with patch.object(check_mod, "collect_coderabbit_items", return_value=items), \
+             patch.object(check_mod, "_api_get",
+                          side_effect=self._mock_list(runs)), \
+             patch.object(check_mod, "_api_mutate", return_value=False) as mutate:
+            rc = check_mod.main([
+                "2692", "--owner", "jaylfc", "--repo", "taOS",
+                "--head-sha", self.HEAD_SHA,
+            ])
+        captured = capsys.readouterr()
+        assert "could not PATCH" not in captured.out
+        assert "could not PATCH" not in captured.err
+        assert rc == 0
+        methods = [c.kwargs.get("method", "POST") for c in mutate.call_args_list]
+        assert "PATCH" not in methods
+
+    def test_latest_non_job_owned_failure_still_exits_1(
+        self, check_mod, capsys
+    ) -> None:
+        """Acceptance #3: a genuine writable FAILURE is still red -- fail-closed
+        is retained for the script's own runs."""
+        items = [
+            check_mod.CRItem(
+                id=1, body="## Review\n\nFound an issue.", is_review=True,
+                review_state="COMMENTED",
+            ),
+        ]
+        runs = [
+            self._job_run(1001, "failure", "2026-08-17T21:30:58Z"),
+            self._script_run(1002, "failure", "2026-08-27T12:08:17Z"),
+        ]
+        with patch.object(check_mod, "_api_get",
+                          side_effect=self._mock_list(runs)), \
+             patch.object(check_mod, "_api_mutate", return_value=False) as mutate:
+            rc = check_mod.main([
+                "2692", "--owner", "jaylfc", "--repo", "taOS",
+                "--head-sha", self.HEAD_SHA,
+            ])
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "FAIL" in captured.out or "stale" in captured.out


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): bot-review-gate pins every PR red forever once one gate run failed: reconcile PATCHes runner-owned job check-runs, which GitHub refuses, then fails closed

Autonomous build of board card tsk-4h3dvk.

runner-owned GitHub Actions job check runs (external_id set, details_url
under /actions/runs/) cannot be PATCHed via the Actions API token, so a
stale job-owned FAILURE previously caused reconcile to fail closed and
pin every subsequent gate run red.

- filter_head_sha_check_runs now drops job-owned runs; the verdict reads
  only the latest writable run
- reconcile_head_sha_check_run skips job-owned runs in both the PATCH
  loop and the existing-match check, so it no longer prints
  'could not PATCH' for them or suppress a fresh POST
- check_run_verdict continues to return the latest completed run per
  name; with job-owned runs excluded the fresh verdict is authoritative

107 tests pass, including three new ones in TestJobOwnedRunsSkipped:
job-owned stale FAILURE with newer job-owned SUCCESS exits 0 with zero
PATCH calls, a lone job-owned FAILURE produces no PATCH error and exits
0, and a writable FAILURE still exits 1 (fail-closed retained).

Files:
 changelog.d/tsk-4h3dvk-bot-review-gate-job-runs.md |   8 ++
 scripts/check_bot_review.py                        |  44 ++++++--
 tests/scripts/test_check_bot_review.py             | 120 +++++++++++++++++++++
 3 files changed, 164 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runner-owned GitHub Actions job checks are now excluded from bot review reconciliation.
  * Stale, unwritable job failures no longer block subsequent gate runs or trigger patch errors.
  * Genuine writable failures continue to fail closed as expected.

* **Documentation**
  * Added a changelog entry describing the updated job-run handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->