### PR TITLE
Light theme: bg-white/8 maps to 0.08, colliding with /15 and exceeding /10 (0.06), breaking the overlay scale's monotonicity

### DIFF
--- a/changelog.d/tsk-k7dhkp-light-theme-bg-white-8-alpha-collision.md
+++ b/changelog.d/tsk-k7dhkp-light-theme-bg-white-8-alpha-collision.md
@@ -3,5 +3,7 @@
   instead of `0.08`, restoring the strictly increasing scale `/5 (0.04) < /8 (0.05)
   < /10 (0.06) < /15 (0.08) < /20 (0.10)`. Previously `/8` collided with `/15` and
   exceeded `/10`, so surfaces using `bg-white/8` for a subtler affordance than
-  `bg-white/15` rendered identically, and darker than `bg-white/10`. The `hover:`
-  and `focus:` variant mirrors were fixed alongside the base utility.
+  `bg-white/15` rendered identically, and darker than `bg-white/10`. The `focus:`
+  mirror follows the base value; the `hover:` mirror uses its own ramp
+  (`/5 (0.05) < /8 (0.06) < /10 (0.07) < /15 (0.08) < /20 (0.10)`), so `hover:bg-white/8`
+  is `0.06` rather than tying with `hover:bg-white/5`.

--- a/changelog.d/tsk-k7dhkp-light-theme-bg-white-8-alpha-collision.md
+++ b/changelog.d/tsk-k7dhkp-light-theme-bg-white-8-alpha-collision.md
@@ -1,0 +1,7 @@
+### Fixed
+- The light-theme compatibility layer now inverts `bg-white/8` to `rgba(0, 0, 0, 0.05)`
+  instead of `0.08`, restoring the strictly increasing scale `/5 (0.04) < /8 (0.05)
+  < /10 (0.06) < /15 (0.08) < /20 (0.10)`. Previously `/8` collided with `/15` and
+  exceeded `/10`, so surfaces using `bg-white/8` for a subtler affordance than
+  `bg-white/15` rendered identically, and darker than `bg-white/10`. The `hover:`
+  and `focus:` variant mirrors were fixed alongside the base utility.

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -196,7 +196,7 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
       ["hover:bg-white/[0.1]", "background-color", "rgba(0, 0, 0, 0.1)"],
       ["hover:border-white/[0.06]", "border-color", "rgba(0, 0, 0, 0.06)"],
       ["hover:bg-white/3", "background-color", "rgba(0, 0, 0, 0.03)"],
-      ["hover:bg-white/8", "background-color", "rgba(0, 0, 0, 0.08)"],
+      ["hover:bg-white/8", "background-color", "rgba(0, 0, 0, 0.05)"],
       ["hover:bg-white/15", "background-color", "rgba(0, 0, 0, 0.08)"],
       ["hover:bg-white/20", "background-color", "rgba(0, 0, 0, 0.10)"],
       ["hover:border-white/15", "border-color", "rgba(0, 0, 0, 0.14)"],
@@ -256,7 +256,7 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     const cases: Array<[string, string]> = [
       ["bg-white/3", "rgba(0, 0, 0, 0.03)"],
       ["bg-white/5", "rgba(0, 0, 0, 0.04)"],
-      ["bg-white/8", "rgba(0, 0, 0, 0.08)"],
+      ["bg-white/8", "rgba(0, 0, 0, 0.05)"],
       ["bg-white/10", "rgba(0, 0, 0, 0.06)"],
       ["bg-white/15", "rgba(0, 0, 0, 0.08)"],
       ["bg-white/20", "rgba(0, 0, 0, 0.1)"],
@@ -264,6 +264,31 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     setScheme("light");
     for (const [className, expected] of cases) {
       expect(bgColor(className), className).toBe(expected);
+    }
+  });
+
+  it("keeps the light-scheme bg-white/N plain-fraction alpha scale strictly increasing", () => {
+    // N = 5, 8, 10, 15, 20 are the plain-fraction white-overlay steps emitted by
+    // Tailwind. Their light-scheme inverted alphas must climb without ties or
+    // backsteps: /8 sits between /5 (0.04) and /10 (0.06), so it must not collide
+    // with /15 (0.08) or exceed /10 — both violations happened with the old 0.08.
+    const steps = [5, 8, 10, 15, 20] as const;
+    const alphaOf: Record<number, number> = {};
+    const re =
+      /\[class~="bg-white\/(\d+)"\]\s*\{[^}]*background-color:\s*rgba\(\s*0,\s*0,\s*0,\s*([\d.]+)\s*\)/g;
+    for (const m of TOKENS_CSS.matchAll(re)) {
+      alphaOf[Number(m[1])] = parseFloat(m[2]);
+    }
+    for (const n of steps) {
+      expect(alphaOf[n], `bg-white/${n} has no light-scheme rule`).toBeDefined();
+    }
+    const vals = steps.map((n) => alphaOf[n]);
+    expect(vals).toEqual([0.04, 0.05, 0.06, 0.08, 0.1]);
+    for (let i = 0; i < vals.length - 1; i++) {
+      expect(
+        vals[i],
+        `bg-white/${steps[i]} alpha ${vals[i]} must be less than bg-white/${steps[i + 1]} alpha ${vals[i + 1]}`,
+      ).toBeLessThan(vals[i + 1]);
     }
   });
 

--- a/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
+++ b/desktop/src/theme/__tests__/light-scheme-arbitrary-values.test.ts
@@ -196,7 +196,7 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
       ["hover:bg-white/[0.1]", "background-color", "rgba(0, 0, 0, 0.1)"],
       ["hover:border-white/[0.06]", "border-color", "rgba(0, 0, 0, 0.06)"],
       ["hover:bg-white/3", "background-color", "rgba(0, 0, 0, 0.03)"],
-      ["hover:bg-white/8", "background-color", "rgba(0, 0, 0, 0.05)"],
+      ["hover:bg-white/8", "background-color", "rgba(0, 0, 0, 0.06)"],
       ["hover:bg-white/15", "background-color", "rgba(0, 0, 0, 0.08)"],
       ["hover:bg-white/20", "background-color", "rgba(0, 0, 0, 0.10)"],
       ["hover:border-white/15", "border-color", "rgba(0, 0, 0, 0.14)"],
@@ -267,28 +267,45 @@ describe("light-scheme arbitrary-value overlay inversion", () => {
     }
   });
 
-  it("keeps the light-scheme bg-white/N plain-fraction alpha scale strictly increasing", () => {
+  describe("light-scheme bg-white/N plain-fraction alpha scales stay strictly increasing", () => {
     // N = 5, 8, 10, 15, 20 are the plain-fraction white-overlay steps emitted by
     // Tailwind. Their light-scheme inverted alphas must climb without ties or
-    // backsteps: /8 sits between /5 (0.04) and /10 (0.06), so it must not collide
-    // with /15 (0.08) or exceed /10 — both violations happened with the old 0.08.
+    // backsteps on BOTH the base scale and the hover mirror: /8 sits between /5
+    // and /10, so it must not collide with a neighbour or exceed /10. The base
+    // scale had /8 = 0.08 (tied /15, exceeded /10); the hover mirror then had
+    // /8 = 0.05 (tied /5). The two scales use different alpha ramps, so each is
+    // asserted against its own expected values.
     const steps = [5, 8, 10, 15, 20] as const;
-    const alphaOf: Record<number, number> = {};
-    const re =
-      /\[class~="bg-white\/(\d+)"\]\s*\{[^}]*background-color:\s*rgba\(\s*0,\s*0,\s*0,\s*([\d.]+)\s*\)/g;
-    for (const m of TOKENS_CSS.matchAll(re)) {
-      alphaOf[Number(m[1])] = parseFloat(m[2]);
-    }
-    for (const n of steps) {
-      expect(alphaOf[n], `bg-white/${n} has no light-scheme rule`).toBeDefined();
-    }
-    const vals = steps.map((n) => alphaOf[n]);
-    expect(vals).toEqual([0.04, 0.05, 0.06, 0.08, 0.1]);
-    for (let i = 0; i < vals.length - 1; i++) {
-      expect(
-        vals[i],
-        `bg-white/${steps[i]} alpha ${vals[i]} must be less than bg-white/${steps[i + 1]} alpha ${vals[i + 1]}`,
-      ).toBeLessThan(vals[i + 1]);
+    const cases: Array<[string, RegExp, number[]]> = [
+      [
+        "base",
+        /\[class~="bg-white\/(\d+)"\]\s*\{[^}]*background-color:\s*rgba\(\s*0,\s*0,\s*0,\s*([\d.]+)\s*\)/g,
+        [0.04, 0.05, 0.06, 0.08, 0.1],
+      ],
+      [
+        "hover",
+        /\[class~="hover:bg-white\/(\d+)"\]:hover\s*\{[^}]*background-color:\s*rgba\(\s*0,\s*0,\s*0,\s*([\d.]+)\s*\)/g,
+        [0.05, 0.06, 0.07, 0.08, 0.1],
+      ],
+    ];
+    for (const [label, re, expected] of cases) {
+      it(`${label} scale`, () => {
+        const alphaOf: Record<number, number> = {};
+        for (const m of TOKENS_CSS.matchAll(re)) {
+          alphaOf[Number(m[1])] = parseFloat(m[2]);
+        }
+        for (const n of steps) {
+          expect(alphaOf[n], `${label} bg-white/${n} has no light-scheme rule`).toBeDefined();
+        }
+        const vals = steps.map((n) => alphaOf[n]);
+        expect(vals).toEqual(expected);
+        for (let i = 0; i < vals.length - 1; i++) {
+          expect(
+            vals[i],
+            `${label} bg-white/${steps[i]} alpha ${vals[i]} must be less than bg-white/${steps[i + 1]} alpha ${vals[i + 1]}`,
+          ).toBeLessThan(vals[i + 1]);
+        }
+      });
     }
   });
 

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -87,7 +87,7 @@
 :root[data-scheme="light"] [class~="bg-white/10"] { background-color: rgba(0, 0, 0, 0.06); }
 :root[data-scheme="light"] [class~="bg-white/15"] { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="bg-white/20"] { background-color: rgba(0, 0, 0, 0.10); }
-:root[data-scheme="light"] [class~="bg-white/8"]  { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="bg-white/8"]  { background-color: rgba(0, 0, 0, 0.05); }
 
 :root[data-scheme="light"] [class~="border-white/5"]  { border-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="border-white/8"]  { border-color: rgba(0, 0, 0, 0.10); }
@@ -175,7 +175,7 @@
 :root[data-scheme="light"] [class~="hover:bg-white/5"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="hover:bg-white/10"]:hover { background-color: rgba(0, 0, 0, 0.07); }
 :root[data-scheme="light"] [class~="hover:bg-white/3"]:hover  { background-color: rgba(0, 0, 0, 0.03); }
-:root[data-scheme="light"] [class~="hover:bg-white/8"]:hover  { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="hover:bg-white/8"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="hover:bg-white/15"]:hover { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="hover:bg-white/20"]:hover { background-color: rgba(0, 0, 0, 0.10); }
 /* Arbitrary-value hover overlays — same 1:1 inversion as the base rules above,
@@ -195,7 +195,7 @@
 /* Focus and active overlays: re-assert the inverted fill on :focus/:active so
    the affordance survives the light-scheme flip. */
 :root[data-scheme="light"] [class~="focus:bg-white/5"]:focus { background-color: rgba(0, 0, 0, 0.04); }
-:root[data-scheme="light"] [class~="focus:bg-white/8"]:focus { background-color: rgba(0, 0, 0, 0.08); }
+:root[data-scheme="light"] [class~="focus:bg-white/8"]:focus { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="focus:border-white/25"]:focus { border-color: rgba(0, 0, 0, 0.16); }
 :root[data-scheme="light"] [class~="focus:border-white/30"]:focus { border-color: rgba(0, 0, 0, 0.18); }
 :root[data-scheme="light"] [class~="focus:ring-white/20"]:focus { --tw-ring-color: rgba(0, 0, 0, 0.2); }

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -175,7 +175,7 @@
 :root[data-scheme="light"] [class~="hover:bg-white/5"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
 :root[data-scheme="light"] [class~="hover:bg-white/10"]:hover { background-color: rgba(0, 0, 0, 0.07); }
 :root[data-scheme="light"] [class~="hover:bg-white/3"]:hover  { background-color: rgba(0, 0, 0, 0.03); }
-:root[data-scheme="light"] [class~="hover:bg-white/8"]:hover  { background-color: rgba(0, 0, 0, 0.05); }
+:root[data-scheme="light"] [class~="hover:bg-white/8"]:hover  { background-color: rgba(0, 0, 0, 0.06); }
 :root[data-scheme="light"] [class~="hover:bg-white/15"]:hover { background-color: rgba(0, 0, 0, 0.08); }
 :root[data-scheme="light"] [class~="hover:bg-white/20"]:hover { background-color: rgba(0, 0, 0, 0.10); }
 /* Arbitrary-value hover overlays — same 1:1 inversion as the base rules above,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Light theme: bg-white/8 maps to 0.08, colliding with /15 and exceeding /10 (0.06), breaking the overlay scale's monotonicity

Autonomous build of board card tsk-k7dhkp.

bg-white/8 mapped to rgba(0, 0, 0, 0.08) in the light scheme, colliding
with bg-white/15 (also 0.08) and exceeding bg-white/10 (0.06), which
broke the plain-fraction overlay scale's strict monotonicity. Change the
base, hover, and focus rules from 0.08 to 0.05, restoring
/5 < /8 < /10 < /15 < /20.

Add a monotonicity assertion to light-scheme-arbitrary-values.test.ts
that reads all five bg-white/N alpha values from tokens.css and
asserts strict increasing order.

Proof: red before fix (values were [0.04, 0.08, 0.06, 0.08, 0.1])
  toEqual [0.04, 0.05, 0.06, 0.08, 0.1] failed
  green after fix (values are [0.04, 0.05, 0.06, 0.08, 0.1])
  15/15 tests pass

Files:
 ...7dhkp-light-theme-bg-white-8-alpha-collision.md |  7 ++++++
 .../light-scheme-arbitrary-values.test.ts          | 29 ++++++++++++++++++++--
 desktop/src/theme/tokens.css                       |  6 ++---
 3 files changed, 37 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected light-theme rendering for `bg-white/8` backgrounds and focus states.
  * Adjusted hover-state opacity to provide the intended visual contrast and preserve the correct overlay progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->