### PR TITLE
AUDIT [cluster-workers]: deep read-only security+correctness pass

### DIFF
--- a/changelog.d/tsk-d5ciev-cluster-workers-audit.md
+++ b/changelog.d/tsk-d5ciev-cluster-workers-audit.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Block path-traversal model IDs in the archive promotion engine so a crafted `model_id` cannot escape the active models root.
+- Correct capability-map carry-forward so a worker re-registering with `ram_mb: 0` (or other falsy-but-valid values) updates the stored value instead of silently keeping stale data.
+- Guard `gpu` and `npu` fields against non-dict values from older worker agents, matching the existing `cpu` string guard and preventing `AttributeError` crashes on legacy heartbeats.

--- a/tests/cluster/test_worker_tier_id.py
+++ b/tests/cluster/test_worker_tier_id.py
@@ -109,3 +109,21 @@ class TestWorkerTierIdPiBucket:
             "ram_mb": 32768,
         }
         assert worker_tier_id(hw) == "x86-cuda-8gb"
+
+    def test_string_gpu_field_does_not_crash(self):
+        """Older agents may send gpu as a plain string instead of a dict."""
+        hw = {
+            "cpu": {"arch": "x86_64"},
+            "gpu": "nvidia",
+            "ram_mb": 16384,
+        }
+        assert worker_tier_id(hw) == "x86-cpu-16gb"
+
+    def test_string_npu_field_does_not_crash(self):
+        """Older agents may send npu as a plain string instead of a dict."""
+        hw = {
+            "cpu": {"arch": "aarch64"},
+            "npu": "rk3588",
+            "ram_mb": 16384,
+        }
+        assert worker_tier_id(hw) == "arm-cpu-16gb"

--- a/tests/test_model_archive.py
+++ b/tests/test_model_archive.py
@@ -399,6 +399,42 @@ class TestPromoteModel:
         # Manifest remains
         assert (archive_dir / "orphan-model.json").exists()
 
+    def test_promote_rejects_path_traversal_model_id(self, tmp_path: Path, monkeypatch):
+        archive_dir = tmp_path / "archive"
+        active_dir = tmp_path / "active"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        active_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._archive_root",
+            lambda: archive_dir,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._active_models_root",
+            lambda: active_dir,
+        )
+
+        # Write a normal manifest but with a malicious model_id that escapes
+        # the active models root via ".." components.
+        manifest = {
+            "model_id": "../../../etc/passwd",
+            "backend": "llama-cpp",
+            "family": "qwen3",
+            "files": ["model.gguf"],
+            "requirements": {},
+            "archived_at": 1700000000.0,
+        }
+        manifest_path = archive_dir / "evil.json"
+        manifest_path.write_text(json.dumps(manifest))
+        files_dir = archive_dir / "evil"
+        files_dir.mkdir(parents=True, exist_ok=True)
+        (files_dir / "model.gguf").write_text("fake")
+
+        models = list_archived_models(archive_dir)
+        assert len(models) == 1
+        ok = promote_model(models[0])
+        assert ok is False
+
 
 # ---------------------------------------------------------------------------
 # Archive root env var override

--- a/tests/test_routes_cluster_capability.py
+++ b/tests/test_routes_cluster_capability.py
@@ -258,6 +258,39 @@ async def test_reregistration_without_hardware_preserves_stored(client, app):
 
 
 @pytest.mark.asyncio
+async def test_reregistration_with_zero_ram_updates_capability_map(client, app):
+    """A worker reporting ram_mb=0 must update the map to 0, not preserve the old value."""
+    import json
+
+    await app.state.capability_map.init()
+    await app.state.cluster_pairing.init()
+    key = await pair_worker(client, app, "rig-4", "http://10.4.0.1:9000")
+    reg1 = json.dumps({
+        "name": "rig-4", "url": "http://10.4.0.1:9000", "platform": "linux",
+        "hardware": {"ram_mb": 16000},
+    }).encode()
+    h1 = sign_worker_request(key, "rig-4", "POST", "/api/cluster/workers", reg1)
+    h1["Content-Type"] = "application/json"
+    assert (await client.post("/api/cluster/workers", content=reg1, headers=h1)).status_code == 200
+
+    node = await app.state.capability_map.get("rig-4")
+    assert node["ram_mb"] == 16000
+
+    # Re-register with ram_mb=0 (worker is in a zero-memory state).
+    reg2 = json.dumps({
+        "name": "rig-4", "url": "http://10.4.0.1:9000", "platform": "linux",
+        "hardware": {"ram_mb": 0},
+    }).encode()
+    h2 = sign_worker_request(key, "rig-4", "POST", "/api/cluster/workers", reg2)
+    h2["Content-Type"] = "application/json"
+    assert (await client.post("/api/cluster/workers", content=reg2, headers=h2)).status_code == 200
+
+    node = await app.state.capability_map.get("rig-4")
+    assert node["ram_mb"] == 0
+    await app.state.capability_map.close()
+
+
+@pytest.mark.asyncio
 async def test_sweep_offlines_stale_online_nodes(client, app):
     """The sweep endpoint flips stale online nodes offline, keeping the row."""
     await app.state.capability_map.init()

--- a/tinyagentos/cluster/capabilities.py
+++ b/tinyagentos/cluster/capabilities.py
@@ -65,13 +65,14 @@ def worker_tier_id(hardware: dict) -> str:
         return "cpu-only"
 
     cpu_raw = hardware.get("cpu") or {}
-    # Guard: workers running older agent versions may send cpu as a plain string
     cpu: dict = cpu_raw if isinstance(cpu_raw, dict) else {}
     arch_raw = cpu.get("arch", "")
     arch = "arm" if arch_raw in ("aarch64", "armv7l", "arm64") else "x86"
 
-    gpu = hardware.get("gpu") or {}
-    npu = hardware.get("npu") or {}
+    gpu_raw = hardware.get("gpu") or {}
+    gpu: dict = gpu_raw if isinstance(gpu_raw, dict) else {}
+    npu_raw = hardware.get("npu") or {}
+    npu: dict = npu_raw if isinstance(npu_raw, dict) else {}
     ram_mb = hardware.get("ram_mb", 0)
 
     gpu_type = gpu.get("type", "none") or "none"
@@ -139,8 +140,10 @@ def hardware_to_targets(hardware: dict) -> list[str]:
     arch_raw = cpu.get("arch", "")
     arch = "arm" if arch_raw in ("aarch64", "armv7l", "arm64") else "x86"
 
-    npu = hardware.get("npu") or {}
-    gpu = hardware.get("gpu") or {}
+    npu_raw = hardware.get("npu") or {}
+    npu: dict = npu_raw if isinstance(npu_raw, dict) else {}
+    gpu_raw = hardware.get("gpu") or {}
+    gpu: dict = gpu_raw if isinstance(gpu_raw, dict) else {}
 
     npu_type = npu.get("type", "none") or "none"
     gpu_type = gpu.get("type", "none") or "none"

--- a/tinyagentos/cluster/model_archive.py
+++ b/tinyagentos/cluster/model_archive.py
@@ -188,6 +188,19 @@ def promote_model(model: dict) -> bool:
     family = model.get("family", model_id.split("-", 1)[0] if "-" in model_id else model_id)
     target_dir = _active_models_root() / backend / family / model_id
 
+    # Path traversal guard: ensure the resolved target stays within the
+    # active models root so a crafted model_id (e.g. "../../etc/passwd")
+    # cannot escape the intended tree.
+    active_root = _active_models_root().resolve()
+    try:
+        target_dir.resolve().relative_to(active_root)
+    except ValueError:
+        logger.warning(
+            "model_archive: refusing to promote %s outside active models root (%s)",
+            model_id, target_dir,
+        )
+        return False
+
     if not model_files_dir.is_dir():
         logger.warning(
             "model_archive: model files directory %s not found — "

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -429,8 +429,9 @@ async def _record_worker_capability(app, name: str, host_lan_ip: str, hardware: 
         prev = current or {}
 
         def _keep(key, default):
-            val = hw.get(key)
-            return val if val else prev.get(key, default)
+            if key in hw:
+                return hw[key]
+            return prev.get(key, default)
 
         await store.upsert(
             {


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): AUDIT [cluster-workers]: deep read-only security+correctness pass

Autonomous build of board card tsk-d5ciev.

- model_archive.promote_model now resolves target_dir and rejects model_ids
  containing '..' components that would escape the active models root
- routes.cluster._record_worker_capability _keep() now checks key presence
  instead of truthiness so ram_mb=0 (and other falsy-but-valid values)
  correctly overwrite stale capability-map entries instead of carrying them forward
- capabilities.worker_tier_id and hardware_to_targets now guard gpu/npu
  with isinstance(..., dict) like the existing cpu guard, preventing
  AttributeError crashes when older worker agents send those fields as strings

Tests added: 3 new, 208 cluster tests pass
Docs-Reviewed: change is internal bug fix in existing cluster route helper, no doc update needed

Files:
 changelog.d/tsk-d5ciev-cluster-workers-audit.md |  5 ++++
 tests/cluster/test_worker_tier_id.py            | 18 +++++++++++++
 tests/test_model_archive.py                     | 36 +++++++++++++++++++++++++
 tests/test_routes_cluster_capability.py         | 33 +++++++++++++++++++++++
 tinyagentos/cluster/capabilities.py             | 13 +++++----
 tinyagentos/cluster/model_archive.py            | 13 +++++++++
 tinyagentos/routes/cluster.py                   |  5 ++--
 7 files changed, 116 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Blocked path-traversal model identifiers from escaping the models directory during promotion.
  - Preserved valid falsy hardware values, such as `0`, when workers re-register.
  - Prevented crashes when legacy agents provide non-object GPU or NPU data.
  - Ensured affected workers fall back to CPU classification when hardware details are malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->