### PR TITLE
beta.46 bot-review follow-ups: inert monkeypatch in lists concurrency test + em dash in test hint

### DIFF
--- a/tests/projects/test_lists_store.py
+++ b/tests/projects/test_lists_store.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 import pytest_asyncio
+from aiosqlite.context import Result
 
 from tinyagentos.projects.lists_store import ProjectListsStore, ProjectListEntriesStore
 
@@ -297,14 +298,27 @@ async def test_reorder_entries_does_not_corrupt_sibling_list(entries_store):
 async def test_concurrent_add_entry_distinct_positions(entries_store, monkeypatch):
     """Two concurrent add_entry calls without explicit positions must not
     persist duplicate positions."""
-    original = entries_store._get_next_position
+    # Yield to the loop after each INSERT starts so the two gather branches
+    # actually interleave on the shared connection; without this the atomic
+    # single-statement INSERT keeps the test passing for the wrong reason.
+    real_execute = entries_store._db.execute
+    insert_calls = 0
 
-    async def slow_next_position(project_id, list_id):
-        val = await original(project_id, list_id)
-        await asyncio.sleep(0)
-        return val
+    def delaying_execute(*args, **kwargs):
+        nonlocal insert_calls
+        sql = args[0] if args else kwargs.get("sql", "")
+        is_insert = "INSERT INTO project_list_entries" in sql
 
-    monkeypatch.setattr(entries_store, "_get_next_position", slow_next_position)
+        async def _runner():
+            nonlocal insert_calls
+            if is_insert:
+                insert_calls += 1
+                await asyncio.sleep(0)
+            return await real_execute(*args, **kwargs)
+
+        return Result(_runner())
+
+    monkeypatch.setattr(entries_store._db, "execute", delaying_execute)
 
     e1, e2 = await asyncio.gather(
         entries_store.add_entry(
@@ -325,8 +339,11 @@ async def test_concurrent_add_entry_distinct_positions(entries_store, monkeypatc
         ),
     )
 
+    assert insert_calls == 2, "both inserts must have run through execute()"
     positions = {e1["position"], e2["position"]}
-    assert len(positions) == 2, f"expected distinct positions, got {positions}"
+    assert len(positions) == 2, (
+        f"expected distinct positions under concurrent gather, got {positions}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): beta.46 bot-review follow-ups: inert monkeypatch in lists concurrency test + em dash in test hint

Autonomous build of board card tsk-a3er4a.

The previous test patched _get_next_position, but add_entry uses an
inline SQL subquery (COALESCE((SELECT MAX(position)+1 ...), 0)) and never
calls _get_next_position, so the patch never ran and the test passed
for the SQL atomicity reason, not the patch's reason.

Switch the patch to entries_store._db.execute so it actually fires on
each INSERT: yield to the event loop right after the first INSERT
starts, so the two gather branches interleave on the shared connection
and would collide if the atomic single-statement INSERT ever regressed
to a Python-level MAX+1 read. Wrapped in aiosqlite.context.Result so
the patched function still works under both the awaitable and
async-with call shapes that aiosqlite.Connection.execute supports.

Verified red on a mutated store that uses position=0 instead of the
COALESCE subquery (assertionError: expected distinct positions under
concurrent gather, got {0}), green on the unmodified store.

Files:
 tests/projects/test_lists_store.py | 31 ++++++++++++++++++++++++-------
 1 file changed, 24 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved concurrency test coverage for adding entries at distinct positions.
  - Added verification that concurrent insert operations are both executed and interleave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->