### PR TITLE
Dispatcher: park a card PERMANENTLY after N cumulative failed dispatches, not per-48h window

### DIFF
--- a/changelog.d/tsk-6uueaz-park-permanent-failed-dispatches.md
+++ b/changelog.d/tsk-6uueaz-park-permanent-failed-dispatches.md
@@ -1,0 +1,3 @@
+### Added
+
+- Dispatcher now permanently parks a card after `STRIKE_THRESHOLD` cumulative failed dispatches (releases), instead of quarantining it. Strikes are cumulative with no time window.

--- a/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardColumn.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import styles from "./BoardColumn.module.css";
 
 export interface BoardColumnProps {
-  status: "ready" | "claimed" | "closed" | "quarantined";
+  status: "ready" | "claimed" | "closed" | "quarantined" | "parked";
   count: number;
   showAllClosed?: boolean;
   onShowAllClosed?: () => void;
@@ -10,7 +10,7 @@ export interface BoardColumnProps {
   children: ReactNode;
 }
 
-const NAME = { ready: "Ready", claimed: "Claimed", closed: "Closed · 7d", quarantined: "Quarantined" } as const;
+const NAME = { ready: "Ready", claimed: "Claimed", closed: "Closed · 7d", quarantined: "Quarantined", parked: "Parked" } as const;
 
 export function BoardColumn(p: BoardColumnProps) {
   const onDropTask = p.onDropTask;

--- a/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardLane.tsx
@@ -2,11 +2,11 @@ import type { DragEvent, ReactNode } from "react";
 import styles from "./BoardLane.module.css";
 import type { LaneHeader } from "./types";
 
-type CellStatus = "ready" | "claimed" | "closed" | "quarantined";
+type CellStatus = "ready" | "claimed" | "closed" | "quarantined" | "parked";
 
 export interface BoardLaneProps {
   header: LaneHeader;
-  cells: { ready: ReactNode; claimed: ReactNode; closed: ReactNode; quarantined: ReactNode };
+  cells: { ready: ReactNode; claimed: ReactNode; closed: ReactNode; quarantined: ReactNode; parked: ReactNode };
   onDropTask: (taskId: string, status: CellStatus, laneKey: string) => void;
 }
 
@@ -31,6 +31,7 @@ export function BoardLane({ header, cells, onDropTask }: BoardLaneProps) {
       <div data-testid="lane-cell-claimed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("claimed")}>{cells.claimed}</div>
       <div data-testid="lane-cell-closed" className={styles.cell} onDragOver={dragOver} onDrop={onCellDrop("closed")}>{cells.closed}</div>
       <div data-testid="lane-cell-quarantined" className={styles.cell}>{cells.quarantined}</div>
+      <div data-testid="lane-cell-parked" className={styles.cell}>{cells.parked}</div>
     </div>
   );
 }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -38,8 +38,9 @@ const MOBILE_COLUMNS: ReadonlyArray<MobileBoardColumn> = [
   { id: "claimed", label: "Claimed" },
   { id: "closed", label: "Closed" },
   { id: "quarantined", label: "Quarantined" },
+  { id: "parked", label: "Parked" },
 ];
-type ColStatus = "ready" | "claimed" | "closed" | "quarantined";
+type ColStatus = "ready" | "claimed" | "closed" | "quarantined" | "parked";
 
 export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, elementId }: ProjectBoardProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("lanes");
@@ -90,6 +91,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
     claimed: filtered.filter((t) => t.status === "claimed"),
     closed: filtered.filter((t) => t.status === "closed"),
     quarantined: filtered.filter((t) => t.status === "quarantined"),
+    parked: filtered.filter((t) => t.status === "parked"),
   }), [filtered]);
 
   const lanes = useMemo(() => {
@@ -103,6 +105,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
     claimed: filtered.filter(t => t.status === "claimed").length,
     closed: filtered.filter(t => t.status === "closed").length,
     quarantined: filtered.filter(t => t.status === "quarantined").length,
+    parked: filtered.filter(t => t.status === "parked").length,
   }), [filtered]);
 
   const elementNameById = useMemo(
@@ -116,7 +119,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
   };
 
   const dispatchDnd = async (taskId: string, columnStatus: ColStatus, laneKey?: string) => {
-    if (columnStatus === "quarantined") return;
+    if (columnStatus === "quarantined" || columnStatus === "parked") return;
     const task = tasks.find(t => t.id === taskId);
     if (!task) return;
     const result = dndAction({
@@ -170,9 +173,9 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
         onOpen={(id) => onOpenTask?.(id)}
         onMove={(id) => setMovePopover(id)}
         justClaimed={justClaimed === t.id}
-        draggable={drag && t.status !== "quarantined"}
+        draggable={drag && t.status !== "quarantined" && t.status !== "parked"}
         elementName={showElementBadge && t.element_id ? (elementNameById[t.element_id] ?? null) : null}
-        onDragStart={drag && t.status !== "quarantined" ? onCardDragStart : undefined}
+        onDragStart={drag && t.status !== "quarantined" && t.status !== "parked" ? onCardDragStart : undefined}
         isLead={isLead}
         onUnquarantine={t.status === "quarantined" && isLead ? handleUnquarantine : undefined}
       />
@@ -219,11 +222,11 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
       />
       {viewMode === "kanban" ? (
         <div className={styles.cols}>
-          {(["ready", "claimed", "closed", "quarantined"] as ColStatus[]).map(s => {
+          {(["ready", "claimed", "closed", "quarantined", "parked"] as ColStatus[]).map(s => {
             const dataStatus = s === "ready" ? "open" : s;
             const cards = filtered.filter(t => t.status === dataStatus);
             return (
-              <BoardColumn key={s} status={s} count={cards.length} onDropTask={s === "quarantined" ? undefined : (id) => dispatchDnd(id, s)}>
+              <BoardColumn key={s} status={s} count={cards.length} onDropTask={s === "quarantined" || s === "parked" ? undefined : (id) => dispatchDnd(id, s)}>
                 {cards.map(t => renderCard(t))}
               </BoardColumn>
             );
@@ -237,6 +240,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
             <span>Claimed · {counts.claimed}</span>
             <span>Closed · {counts.closed}</span>
             <span>Quarantined · {counts.quarantined}</span>
+            <span>Parked · {counts.parked}</span>
           </div>
           {lanes!.map(lane => (
             <BoardLane
@@ -247,6 +251,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask, isLead, ele
                 claimed: lane.cards.filter(t => t.status === "claimed").map(t => renderCard(t)),
                 closed: lane.cards.filter(t => t.status === "closed").map(t => renderCard(t, false)),
                 quarantined: lane.cards.filter(t => t.status === "quarantined").map(t => renderCard(t, false)),
+                parked: lane.cards.filter(t => t.status === "parked").map(t => renderCard(t, false)),
               }}
               onDropTask={(id, status, laneKey) => dispatchDnd(id, status, laneKey)}
             />

--- a/desktop/src/apps/ProjectsApp/board/types.ts
+++ b/desktop/src/apps/ProjectsApp/board/types.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = "open" | "claimed" | "closed" | "quarantined";
+export type TaskStatus = "open" | "claimed" | "closed" | "quarantined" | "parked";
 
 export interface Task {
   id: string;

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -31,7 +31,7 @@ export type ProjectTask = {
   parent_task_id: string | null;
   title: string;
   body: string;
-  status: "open" | "claimed" | "closed" | "cancelled" | "quarantined";
+  status: "open" | "claimed" | "closed" | "cancelled" | "quarantined" | "parked";
   priority: number;
   labels: string[];
   assignee_id: string | null;

--- a/tests/projects/test_strike_wiring.py
+++ b/tests/projects/test_strike_wiring.py
@@ -131,3 +131,27 @@ async def test_unquarantine_route_lead_success_and_noauth_failure(app):
             assert body["status"] == "open"
 
             assert await strikes.count_strikes(task_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_release_parks_after_threshold_strikes(app):
+    """Releasing a claimed task records a strike; after STRIKE_THRESHOLD
+    cumulative releases the task is permanently parked."""
+    async with app.router.lifespan_context(app):
+        async with _auth_client(app) as c:
+            project_id, task_id = await _make_project_and_task(c, "strike-park")
+
+            task_store = app.state.project_task_store
+            strikes = app.state.task_strikes
+
+            for i in range(strikes.STRIKE_THRESHOLD):
+                await task_store.claim_task(task_id, "worker-1")
+                ok = await task_store.release_task(task_id, "worker-1")
+                assert ok is True
+                count = await strikes.count_strikes(task_id)
+                if i < strikes.STRIKE_THRESHOLD - 1:
+                    assert count == i + 1
+
+            fetched = await task_store.get_task(task_id)
+            assert fetched["status"] == "parked"
+            assert await strikes.count_strikes(task_id) == strikes.STRIKE_THRESHOLD

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -610,3 +610,31 @@ async def test_close_unclaimed_unchanged(store):
     again = await store.get_task(t["id"])
     assert again["status"] == "closed"
     assert again["closed_by"] == "reviewer"
+
+
+@pytest.mark.asyncio
+async def test_park_task(store):
+    """park_task sets status to parked and records audit."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    ok = await store.park_task(t["id"], actor="system")
+    assert ok is True
+    back = await store.get_task(t["id"])
+    assert back["status"] == "parked"
+
+
+@pytest.mark.asyncio
+async def test_park_already_parked_is_noop(store):
+    """park_task on an already-parked task returns False."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.park_task(t["id"], actor="system")
+    ok = await store.park_task(t["id"], actor="system")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_park_closed_task_is_noop(store):
+    """park_task on a closed task returns False."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.close_task(t["id"], closed_by="u")
+    ok = await store.park_task(t["id"], actor="system")
+    assert ok is False

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -728,3 +728,91 @@ async def test_quarantine_event_payload_carries_strike_metadata(tmp_path):
     finally:
         await s.close()
         await strikes.close()
+
+
+@pytest.mark.asyncio
+async def test_park_open_task(tmp_path):
+    s = await _store(tmp_path)
+    task = await s.create_task("prj-1", "Task", "alice")
+    ok = await s.park_task(task["id"], "system")
+    assert ok is True
+    fetched = await s.get_task(task["id"])
+    assert fetched["status"] == "parked"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_park_claimed_task_records_from_status_claimed(tmp_path):
+    audit = BoardAuditLog(tmp_path / "audit.db")
+    await audit.init()
+    s = ProjectTaskStore(tmp_path / "tasks.db", audit=audit)
+    await s.init()
+    try:
+        task = await s.create_task("prj-1", "Task", "alice")
+        await s.claim_task(task["id"], "worker-1")
+        ok = await s.park_task(task["id"], "system")
+        assert ok is True
+        history = await audit.history(task["id"])
+        parked = [h for h in history if h["event"] == "task.parked"]
+        assert len(parked) == 1
+        assert parked[0]["from_status"] == "claimed"
+    finally:
+        await s.close()
+        await audit.close()
+
+
+@pytest.mark.asyncio
+async def test_park_is_permanent(tmp_path):
+    s = await _store(tmp_path)
+    task = await s.create_task("prj-1", "Task", "alice")
+    ok = await s.park_task(task["id"], "system")
+    assert ok is True
+    fetched = await s.get_task(task["id"])
+    assert fetched["status"] == "parked"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_parked_task_cannot_be_claimed(tmp_path):
+    s = await _store(tmp_path)
+    task = await s.create_task("prj-1", "Task", "alice")
+    await s.park_task(task["id"], "system")
+    ok = await s.claim_task(task["id"], "agent-1")
+    assert ok is False
+    fetched = await s.get_task(task["id"])
+    assert fetched["status"] == "parked"
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_release_records_strike_and_parks_after_threshold(tmp_path):
+    from tinyagentos.projects.strike_store import StrikeStore
+
+    strikes = StrikeStore(tmp_path / "strikes.db")
+    await strikes.init()
+    s = ProjectTaskStore(tmp_path / "tasks.db", strikes=strikes)
+    await s.init()
+    try:
+        task = await s.create_task("prj-1", "Task", "alice")
+        for _ in range(StrikeStore.STRIKE_THRESHOLD):
+            await s.claim_task(task["id"], "worker-1")
+            ok = await s.release_task(task["id"], "worker-1")
+            assert ok is True
+        fetched = await s.get_task(task["id"])
+        assert fetched["status"] == "parked"
+        assert await strikes.count_strikes(task["id"]) == StrikeStore.STRIKE_THRESHOLD
+    finally:
+        await s.close()
+        await strikes.close()
+
+
+@pytest.mark.asyncio
+async def test_release_without_strikes_store_does_not_record(tmp_path):
+    s = await _store(tmp_path)
+    task = await s.create_task("prj-1", "Task", "alice")
+    await s.claim_task(task["id"], "worker-1")
+    ok = await s.release_task(task["id"], "worker-1")
+    assert ok is True
+    fetched = await s.get_task(task["id"])
+    assert fetched["status"] == "open"
+    await s.close()

--- a/tinyagentos/projects/strike_store.py
+++ b/tinyagentos/projects/strike_store.py
@@ -26,16 +26,15 @@ def _row(r) -> dict:
 class StrikeStore(BaseStore):
     """Append-only log of verification strikes per task.
 
-    The dispatch host (taOS-dev) records a strike each time a card fails
-    verification.  When the count reaches ``STRIKE_THRESHOLD`` the task is
-    quarantined (see ``ProjectTaskStore.quarantine_task``) and the lead is
-    notified.  Strikes are auto-cleared when the task closes or its PR
-    merges (see ``ProjectTaskStore.close_task`` and the unquarantine route).
+    The dispatch host records a strike each time a card fails verification.
+    When the cumulative count reaches ``STRIKE_THRESHOLD`` the task is
+    permanently parked (see ``ProjectTaskStore.park_task``).  Strikes are
+    auto-cleared when the task closes (see ``ProjectTaskStore.close_task``).
     """
 
     SCHEMA = STRIKE_SCHEMA
 
-    # Number of failed verifications before a card is quarantined.
+    # Number of cumulative failed dispatches before a card is permanently parked.
     STRIKE_THRESHOLD = 3
 
     async def record_strike(

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -4,16 +4,16 @@ import json
 import logging
 import time
 
-from typing import TYPE_CHECKING
-
 from tinyagentos.base_store import BaseStore
 from tinyagentos.projects.ids import new_id
+from tinyagentos.projects.strike_store import StrikeStore
+
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from tinyagentos.board_audit import BoardAuditLog
     from tinyagentos.projects.events import ProjectEventBroker
     from tinyagentos.projects.project_store import ProjectStore
-    from tinyagentos.projects.strike_store import StrikeStore
 
 logger = logging.getLogger(__name__)
 
@@ -439,6 +439,48 @@ class ProjectTaskStore(BaseStore):
                 )
             await self._record_audit(
                 task_id, "task.released", releaser_id, "claimed", "open",
+                project_id=existing["project_id"] if existing else "",
+            )
+            if self._strikes is not None:
+                try:
+                    count = await self._strikes.record_strike(
+                        task_id, "dispatch_failed", actor=releaser_id
+                    )
+                    if count >= StrikeStore.STRIKE_THRESHOLD:
+                        await self.park_task(task_id, "system")
+                except Exception:
+                    logger.warning(
+                        "strike recording failed for task %s on release", task_id, exc_info=True
+                    )
+        return changed
+
+    async def park_task(self, task_id: str, actor: str) -> bool:
+        """Permanently park a task.
+
+        A parked task is removed from the ready pool permanently.  Unlike
+        quarantine there is no un-park operation.  Only acts on a task that is
+        not already closed, cancelled, or parked; returns False otherwise.
+        """
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'parked', updated_at = ?
+               WHERE id = ? AND status NOT IN ('closed', 'cancelled', 'parked')""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(
+                    existing["project_id"],
+                    "task.parked",
+                    {"id": task_id, "actor": actor},
+                )
+            from_status = "claimed" if existing and existing.get("claimed_by") else "open"
+            await self._record_audit(
+                task_id, "task.parked", actor, from_status, "parked",
                 project_id=existing["project_id"] if existing else "",
             )
         return changed


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Dispatcher: park a card PERMANENTLY after N cumulative failed dispatches, not per-48h window

Autonomous build of board card tsk-6uueaz.

Add park_task to ProjectTaskStore and wire auto-park into release_task.
When a claimed task is released back to the pool a strike is recorded.
After STRIKE_THRESHOLD cumulative releases the task is permanently parked
and removed from the ready pool. Strikes remain cumulative with no time
window. Frontend board gains a Parked column.

Docs-Reviewed: no route changes

Files:
 desktop/src/apps/ProjectsApp/board/types.ts        |  2 +-
 desktop/src/lib/projects.ts                        |  2 +-
 tests/projects/test_strike_wiring.py               | 24 ++++++
 tests/projects/test_task_store.py                  | 30 +++++++-
 tests/test_task_store.py                           | 88 ++++++++++++++++++++++
 tinyagentos/projects/strike_store.py               | 11 ++-
 tinyagentos/projects/task_store.py                 | 48 +++++++++++-
 11 files changed, 212 insertions(+), 22 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Parked** status and column to project boards.
  - Parked tasks display dedicated counts and cannot be claimed, dragged, or moved.
  - Tasks are permanently parked after reaching the cumulative failed-dispatch strike threshold.
  - Added safeguards to prevent parking closed, cancelled, or already parked tasks.

- **Bug Fixes**
  - Failed dispatch strikes now accumulate consistently and trigger parking at the configured threshold.

- **Tests**
  - Added coverage for parking behavior, audit records, task restrictions, and strike-threshold handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->