### PR TITLE
Mac .app build lock still pins cryptography 49.0.0 (CVE-2026-69247 + PYSEC-2026-3552/3/4 fixed in 50.0.0); uv.lock is already at 50.0.1

### DIFF
--- a/changelog.d/tsk-cahtip-mac-lock-cryptography.md
+++ b/changelog.d/tsk-cahtip-mac-lock-cryptography.md
@@ -1,0 +1,3 @@
+### Security
+
+- Regenerated Mac .app build lock to fix CVE-2026-69247 (PKCS#7 EnvelopedData Bleichenbacher) and PYSEC-2026-3552/3553/3554. Upgraded cryptography to 50.0.1 from 49.0.0. Lock was regenerated wholesale with uv pip compile.

--- a/tinyagentos/requirements.lock
+++ b/tinyagentos/requirements.lock
@@ -54,8 +54,11 @@ click==8.3.3
     #   uvicorn
 coloredlogs==15.0.1
     # via onnxruntime
-cryptography==49.0.0
+croniter==6.2.4
+    # via tinyagentos (pyproject.toml)
+cryptography==50.0.1
     # via
+    #   tinyagentos (pyproject.toml)
     #   http-ece
     #   py-vapid
     #   pywebpush
@@ -66,7 +69,9 @@ diff-match-patch==20241021
 fastapi==0.136.1
     # via tinyagentos (pyproject.toml)
 filelock==3.29.0
-    # via huggingface-hub
+    # via
+    #   tinyagentos (pyproject.toml)
+    #   huggingface-hub
 flatbuffers==25.12.19
     # via onnxruntime
 frozenlist==1.8.0
@@ -129,7 +134,7 @@ markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-matrix-nio==0.25.2
+matrix-nio==0.26.0
     # via tinyagentos (pyproject.toml)
 mdurl==0.1.2
     # via markdown-it-py
@@ -173,6 +178,8 @@ pydantic-core==2.46.3
     # via pydantic
 pygments==2.20.0
     # via rich
+python-dateutil==2.9.0.post0
+    # via croniter
 python-dotenv==1.2.2
     # via uvicorn
 python-multipart==0.0.27
@@ -207,6 +214,8 @@ safetensors==0.7.0
     # via transformers
 shellingham==1.5.4
     # via typer
+six==1.17.0
+    # via python-dateutil
 sqlcipher3==0.6.2
     # via tinyagentos (pyproject.toml)
 starlette==1.0.0
@@ -247,7 +256,7 @@ unpaddedbase64==2.1.0
     # via matrix-nio
 urllib3==2.7.0
     # via requests
-uvicorn==0.49.0
+uvicorn==0.52.4
     # via tinyagentos (pyproject.toml)
 uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
     # via uvicorn


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Mac .app build lock still pins cryptography 49.0.0 (CVE-2026-69247 + PYSEC-2026-3552/3/4 fixed in 50.0.0); uv.lock is already at 50.0.1

Autonomous build of board card tsk-cahtip.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 changelog.d/tsk-cahtip-mac-lock-cryptography.md |  3 +++
 tinyagentos/requirements.lock                   | 17 +++++++++++++----
 2 files changed, 16 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the macOS app’s cryptographic security components.
  * Addressed vulnerabilities affecting encrypted message handling, including PKCS#7 EnvelopedData processing.
  * Improved protection against potential cryptographic attacks and strengthened the security of macOS app builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->