### PR TITLE
fold CodeRabbit findings on #2728 (tsk-oy4dte): AUDIT [a2a-comms]: deep read-only security+correctness pass

### DIFF
--- a/changelog.d/tsk-e4wi5w-a2a-bus-since-validation.md
+++ b/changelog.d/tsk-e4wi5w-a2a-bus-since-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `bus_stream` now parses `since` from query params manually instead of relying on FastAPI's `float | None = None` annotation, returning project-consistent 400 errors for non-numeric and non-finite values (matching `/api/a2a/bus/messages` behavior). Docstring updated to document `since` as a message `ts` (float), NOT an id, and that unknown query params are rejected 400.

--- a/changelog.d/tsk-oy4dte-a2a-stream-validation.md
+++ b/changelog.d/tsk-oy4dte-a2a-stream-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The A2A bus SSE stream proxy (`/api/a2a/bus/stream`) now rejects non-finite `since` cursor values (nan, inf, -inf) with a 400 error instead of forwarding them to the bus, matching the validation already present on the sibling messages endpoint. It also rejects unknown query parameters with a 400 instead of silently ignoring them, preventing the same incremental-read confusion that was fixed on `/api/a2a/bus/messages`.

--- a/tests/test_routes_a2a_bus_stream.py
+++ b/tests/test_routes_a2a_bus_stream.py
@@ -253,6 +253,42 @@ class TestBusStreamProxy:
 
 
 @pytest.mark.asyncio
+class TestStreamInputValidation:
+    async def test_stream_since_rejects_non_finite_cursors(self, agent_app, client):
+        """`since` is a message ts, not an id. A NaN/inf cursor must not be
+        forwarded to the bus -- the same silent-empty-window defect that was
+        fixed on the sibling messages endpoint must not exist here."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        for bad in ("nan", "NaN", "inf", "-inf", "Infinity"):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                params={"channel": "general", "since": bad},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 400, f"{bad} was accepted as a cursor"
+            assert "finite" in resp.json()["error"]
+
+    async def test_stream_unknown_query_param_is_400(self, agent_app, client):
+        """An ignored cursor param is indistinguishable from one that works.
+
+        Measured on the live proxy before the fix on the messages endpoint:
+        `since_id=2430` was silently dropped and returned 500 messages starting
+        at id 1890. The stream endpoint must reject unknown params for the same
+        reason."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        for bad in ("since_id", "after", "from_id"):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                params={"channel": "general", bad: "2430"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 400, f"{bad} was accepted"
+            body = resp.json()
+            assert bad in body["error"]
+            assert "since" in body["hint"]
+
+
+@pytest.mark.asyncio
 class TestMessagesSincePassthrough:
     async def test_messages_forwards_since(self, agent_app, client):
         payload = {"messages": [{"id": "m1", "ts": 1, "from": "a", "body": "hi"}]}

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -268,7 +268,6 @@ async def _channel_exists(bus: str, channel: str) -> bool:
 async def bus_stream(
     request: Request,
     channel: str = "",
-    since: float | None = None,
 ):
     """Authenticated SSE proxy to the raw bus stream.
 
@@ -281,8 +280,8 @@ async def bus_stream(
 
     ``channel`` maps to the bus ``thread`` query param. Omitting it (or passing
     ``channel=*``) subscribes to ALL threads: no ``thread`` param is forwarded
-    upstream, so the bus streams events from every thread. ``since`` maps to the
-    bus cursor.
+    upstream, so the bus streams events from every thread. ``since`` is the cursor
+    and is a message ``ts`` (a float), NOT an id -- any other query param is a 400.
     """
     await _authorize_bus_read(request)
 
@@ -297,23 +296,38 @@ async def bus_stream(
             status_code=400,
         )
 
+    params: dict = {}
+    # Manual since parsing: FastAPI's `since: float | None = None` annotation
+    # causes non-numeric values like `?since=abc` to trigger a 422 instead of
+    # the project-consistent 400 seen on /messages. Parse from query params first.
+    since_raw = request.query_params.get("since")
+    if since_raw is not None:
+        try:
+            since_val = float(since_raw)
+        except ValueError:
+            return JSONResponse(
+                {"error": "since must be a message ts (float), not an id"},
+                status_code=400,
+            )
+        # float() happily accepts "nan", "inf" and "-inf".  A NaN cursor makes
+        # every comparison on the bus side false, so the reader gets a silent
+        # empty window forever and a 200 confirming it -- the exact failure this
+        # endpoint is being fixed for, reintroduced through the validator.
+        if not math.isfinite(since_val):
+            return JSONResponse(
+                {"error": "since must be a finite message ts (float), not an id"},
+                status_code=400,
+            )
+        params["since"] = since_val
+
     # An empty channel or "*" means "all threads": omit the thread param
     # upstream so the bus streams every thread. NOTE: when per-channel bus ACLs
     # land (card tsk-dp6fyv), an all-threads subscriber must receive ONLY the
     # threads it is allowed to read, not everything -- filter here, not at the
     # bus. This is the line a future change will get wrong.
     all_threads = channel == "" or channel == "*"
-    params: dict = {}
     if not all_threads:
         params["thread"] = channel
-    if since is not None:
-        if not math.isfinite(since):
-            return JSONResponse(
-                {"error": "since must be a finite message ts (float), not an id"},
-                status_code=400,
-            )
-        params["since"] = since
-
     bus = _bus_url()
 
     async def event_stream():

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -114,6 +114,8 @@ _MESSAGES_PARAMS = frozenset({"channel", "thread", "limit", "since"})
 # the thread param", which is how the bus itself spells all-threads.
 _ALL_CHANNELS = frozenset({"all", "*"})
 
+_STREAM_PARAMS = frozenset({"channel", "since"})
+
 
 @router.get("/api/a2a/bus/messages")
 async def bus_messages(request: Request):
@@ -284,6 +286,17 @@ async def bus_stream(
     """
     await _authorize_bus_read(request)
 
+    unknown = sorted(set(request.query_params.keys()) - _STREAM_PARAMS)
+    if unknown:
+        return JSONResponse(
+            {
+                "error": f"unknown query parameter(s): {', '.join(unknown)}",
+                "accepted": sorted(_STREAM_PARAMS),
+                "hint": "the cursor is 'since' and takes a message ts (float), not an id",
+            },
+            status_code=400,
+        )
+
     # An empty channel or "*" means "all threads": omit the thread param
     # upstream so the bus streams every thread. NOTE: when per-channel bus ACLs
     # land (card tsk-dp6fyv), an all-threads subscriber must receive ONLY the
@@ -294,6 +307,11 @@ async def bus_stream(
     if not all_threads:
         params["thread"] = channel
     if since is not None:
+        if not math.isfinite(since):
+            return JSONResponse(
+                {"error": "since must be a finite message ts (float), not an id"},
+                status_code=400,
+            )
         params["since"] = since
 
     bus = _bus_url()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2728 (tsk-oy4dte): AUDIT [a2a-comms]: deep read-only security+correctness pass

Autonomous build of board card tsk-e4wi5w.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

REVISION: built on `exec/tsk-oy4dte` (cut at `23ecc907f184b755da98f07ec5aa9716c71f7613`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Docs-Reviewed: updated bus_stream docstring and since validation

Files:
 changelog.d/tsk-e4wi5w-a2a-bus-since-validation.md |  3 ++
 changelog.d/tsk-oy4dte-a2a-stream-validation.md    |  3 ++
 tests/test_routes_a2a_bus_stream.py                | 36 +++++++++++++++++
 tinyagentos/routes/a2a_bus.py                      | 46 ++++++++++++++++++----
 4 files changed, 81 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for A2A bus stream requests.
  * Invalid or non-finite `since` values now return clear HTTP 400 errors.
  * Unknown query parameters are rejected with HTTP 400 responses and guidance to use supported parameters.
  * The `since` cursor is consistently interpreted as a message timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->