### PR TITLE
install-server: Docker Engine + Compose install fails on Armbian/Debian trixie (community: taOS#2)

### DIFF
--- a/changelog.d/tsk-fhc6vj-docker-trixie-fallback.md
+++ b/changelog.d/tsk-fhc6vj-docker-trixie-fallback.md
@@ -1,0 +1,2 @@
+### Fixed
+- install-server.sh now installs Docker Engine + Compose v2 on Debian trixie / Armbian trixie, whose distro apt has neither docker-compose-plugin nor docker-compose-v2 (taOS#2). When both names are missing it falls back to Docker's official apt repo (download.docker.com) after verifying the signing key fingerprint, installing docker-ce + docker-ce-cli + containerd.io + docker-buildx-plugin + docker-compose-plugin. Air-gapped hosts that can't reach download.docker.com still complete the install with a "Store Docker apps will be unavailable" warning.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1002,6 +1002,10 @@ PY
 # it docker-compose-plugin; Ubuntu's universe archive calls it
 # docker-compose-v2. Trying only the Ubuntu name broke Debian Bookworm
 # (vendor Pi images included) with "Unable to locate package" (#1541).
+# Debian trixie (and Armbian trixie, reported in taOS#2) ships NEITHER
+# name in the distro archive, so both madison lookups come back empty. The
+# caller detects that "both miss" case and falls back to Docker's official
+# apt repo via _apt_install_docker_official_repo below.
 _apt_install_compose() {
     # Probe availability with apt-cache madison instead of grepping apt's
     # stderr: the error text is locale-dependent (so string matching broke
@@ -1011,9 +1015,102 @@ _apt_install_compose() {
     # from the single install attempt itself.
     if [[ -n "$(apt-cache madison docker-compose-plugin 2>/dev/null)" ]]; then
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin
-    else
+    elif [[ -n "$(apt-cache madison docker-compose-v2 2>/dev/null)" ]]; then
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
+    else
+        # Neither name is in this distro's apt archive (trixie, some
+        # armbian releases, vendor-stripped images). Leave Docker Engine
+        # un-installed so the caller's fallback path can try Docker's
+        # official repo; if that also fails the install still exits 0
+        # with a "Store Docker apps will be unavailable" warning.
+        return 1
     fi
+}
+
+# Docker Engine + Compose v2 plugin from Docker's official apt repo
+# (download.docker.com). Used as a fallback when neither
+# docker-compose-plugin nor docker-compose-v2 are present in the distro
+# archive (taOS#2 — Debian trixie / Armbian trixie). Mirrors the
+# GPG-verify pattern used by the Zabbly Incus fallback above so a
+# rotated docker.com signing key fails closed instead of silently
+# trusting whatever a MITM serves. Returns 0 on success, 1 on any
+# failure (network blocked, missing codename, fingerprint mismatch,
+# install error). Air-gapped hosts must still let the installer
+# finish, so every caller treats 1 as "give up gracefully".
+_apt_install_docker_official_repo() {
+    local codename=""
+    if command -v lsb_release >/dev/null 2>&1; then
+        codename=$(lsb_release -cs 2>/dev/null)
+    elif [[ -f /etc/os-release ]]; then
+        codename=$(. /etc/os-release && echo "${VERSION_CODENAME:-}")
+    fi
+    if [[ -z "$codename" ]]; then
+        warn "couldn't detect distro codename — skipping Docker official-repo fallback"
+        return 1
+    fi
+
+    # Docker publishes the Debian archive at /linux/debian and the
+    # Ubuntu archive at /linux/ubuntu — the same codename is used as
+    # the suite (bookworm, trixie, jammy, noble, ...). Match on
+    # ID_LIKE so derivatives (raspbian, armbian) route to the right
+    # archive: armbian trixie reports ID=armbian / ID_LIKE=debian.
+    local docker_os="debian"
+    if [[ -f /etc/os-release ]]; then
+        local os_id
+        os_id=$(. /etc/os-release && echo "${ID:-}")
+        case "$os_id" in
+            ubuntu) docker_os="ubuntu" ;;
+            raspbian) docker_os="debian" ;;
+        esac
+        if [[ "$docker_os" == "debian" ]]; then
+            local id_like
+            id_like=$(. /etc/os-release && echo "${ID_LIKE:-}")
+            case ",$id_like," in
+                *,ubuntu,*) docker_os="ubuntu" ;;
+            esac
+        fi
+    fi
+
+    sudo install -d -m 0755 /etc/apt/keyrings
+
+    local _docker_key_tmp
+    _docker_key_tmp="$(mktemp /tmp/docker-key.XXXXXX.asc)"
+    # shellcheck disable=SC2064
+    trap "rm -f '$_docker_key_tmp'" RETURN
+    if ! curl -fsSL "https://download.docker.com/linux/$docker_os/gpg" -o "$_docker_key_tmp"; then
+        warn "failed to fetch Docker apt key — skipping Docker official-repo fallback"
+        return 1
+    fi
+    # Expected key fingerprint (verified against https://download.docker.com/linux/debian/gpg
+    # — "Docker Release (CE deb) <docker@docker.com>", primary key
+    # 9DC8 5822 9FC7 DD38 854A  E2D8 8D81 803C 0EBF CD88). Update here
+    # if Docker rotates the signing key.
+    local _docker_expected_fp="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+    local _docker_actual_fp
+    _docker_actual_fp="$(gpg --with-colons --import-options show-only \
+        --import "$_docker_key_tmp" 2>/dev/null \
+        | awk -F: '/^fpr:/{gsub(/ /,"",$10); print $10}' | head -1)"
+    _docker_actual_fp="${_docker_actual_fp//[[:space:]]/}"
+    if [[ "$_docker_actual_fp" != "$_docker_expected_fp" ]]; then
+        warn "Docker apt key fingerprint mismatch: expected $_docker_expected_fp, got '$_docker_actual_fp'"
+        warn "  Refusing to add Docker's repo — skipping Docker official-repo fallback"
+        return 1
+    fi
+    log "Docker apt key fingerprint ok (${_docker_actual_fp:0:16}…)"
+    sudo cp "$_docker_key_tmp" /etc/apt/keyrings/docker.asc
+    echo "deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/$docker_os $codename stable" \
+        | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    if ! sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq; then
+        warn "apt-get update failed after adding Docker's repo — skipping Docker official-repo fallback"
+        return 1
+    fi
+    if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin; then
+        warn "apt install from Docker's repo failed — see /var/log/apt/term.log"
+        return 1
+    fi
+    log "Docker Engine + Compose v2 plugin installed via Docker's official repo"
+    return 0
 }
 
 ensure_docker_for_apps() {
@@ -1060,8 +1157,20 @@ ensure_docker_for_apps() {
             # left the box without Docker at all (#1541).
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
                 || warn "apt install docker.io failed — Store Docker apps will be unavailable"
-            _apt_install_compose \
-                || warn "apt install of the compose plugin failed — Store Docker apps will be unavailable"
+            if ! _apt_install_compose; then
+                # Neither docker-compose-plugin nor docker-compose-v2 is in
+                # this distro's apt archive — Debian trixie / Armbian
+                # trixie (taOS#2) are the known case. Fall back to Docker's
+                # official apt repo, which ships docker-ce +
+                # docker-compose-plugin. If `docker` still isn't on PATH
+                # after that (e.g. the host is air-gapped), warn and let
+                # the rest of the installer continue — Store Docker apps
+                # will simply be unavailable.
+                log "compose plugin not in distro apt — trying Docker's official apt repo"
+                if ! _apt_install_docker_official_repo; then
+                    warn "Docker Engine + Compose plugin are unavailable on this host (Store Docker apps will be unavailable)"
+                fi
+            fi
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y -q moby-engine docker-compose \
                 || warn "dnf install moby-engine/docker-compose failed — Store Docker apps will be unavailable"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -119,4 +119,39 @@ grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
 echo "test: verification only runs when SERVICE_MODE != skip"
 grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
 
+# ── Docker install fallback for Debian trixie / Armbian trixie (taOS#2) ──
+
+echo "test: trixie fallback defines _apt_install_docker_official_repo"
+grep -q "_apt_install_docker_official_repo()" "$SCRIPT"
+
+echo "test: _apt_install_compose probes both docker-compose-plugin and docker-compose-v2"
+grep -q "apt-cache madison docker-compose-plugin" "$SCRIPT"
+grep -q "apt-cache madison docker-compose-v2" "$SCRIPT"
+
+echo "test: _apt_install_compose returns non-zero when neither name is in apt"
+grep -A12 'apt-cache madison docker-compose-plugin' "$SCRIPT" \
+    | grep -q "return 1"
+
+echo "test: trixie fallback uses Docker's official apt repo (download.docker.com)"
+grep -q "download.docker.com/linux" "$SCRIPT"
+
+echo "test: trixie fallback verifies Docker apt key fingerprint before importing"
+grep -q "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" "$SCRIPT"
+grep -q "Docker apt key fingerprint mismatch" "$SCRIPT"
+
+echo "test: trixie fallback installs docker-ce + plugin from Docker's repo"
+grep -q "docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin" "$SCRIPT"
+
+echo "test: trixie fallback is gated on _apt_install_compose failing, not on docker.io"
+grep -A10 "if ! _apt_install_compose" "$SCRIPT" \
+    | grep -q "_apt_install_docker_official_repo"
+
+echo "test: trixie fallback degrades gracefully (warn, no abort) when the repo is unreachable"
+grep -B1 -A2 "_apt_install_docker_official_repo" "$SCRIPT" \
+    | grep -q "Docker Engine + Compose plugin are unavailable"
+
+echo "test: ensure_docker_for_apps call site tolerates fallback failure (no set -e abort)"
+ensure_docker_call_line=$(grep -n "ensure_docker_for_apps || warn" "$SCRIPT" | head -1 | cut -d: -f1)
+(( ensure_docker_call_line > 0 ))
+
 echo "all tests passed"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): install-server: Docker Engine + Compose install fails on Armbian/Debian trixie (community: taOS#2)

Autonomous build of board card tsk-fhc6vj.

Debian trixie and Armbian trixie ship neither docker-compose-plugin nor
docker-compose-v2 in the distro apt archive, so the existing
_apt_install_compose helper warned 'Store Docker apps will be
unavailable' and the surrounding code then bailed with 'docker not on
PATH after install - skipping daemon/group setup', leaving Docker
Engine itself un-installed (taOS#2).

Teach _apt_install_compose to probe both names with apt-cache madison
and return 1 when neither is present, and add a new
_apt_install_docker_official_repo helper that, when invoked from the
apt branch of ensure_docker_for_apps, adds Docker's official apt repo
(download.docker.com) for the detected distro + codename after
verifying the signing key fingerprint, then installs docker-ce,
docker-ce-cli, containerd.io, docker-buildx-plugin and
docker-compose-plugin. The fingerprint check mirrors the Zabbly
Incus fallback above so a rotated docker.com signing key fails
closed instead of trusting whatever a MITM serves.

The fallback only fires when _apt_install_compose returns 1, so
existing Debian/Ubuntu/Fedora/Arch/Alpine paths take the same code
they always did. Air-gapped hosts whose curl/apt calls fail still
finish the installer with the existing 'Store Docker apps will be
unavailable' warning, satisfying the degrade contract.

Tests: tests/test_install_server.sh covers (1) the new function
exists, (2) _apt_install_compose probes both names and returns 1 on
both-miss, (3) the fallback uses download.docker.com, (4) it
verifies the fingerprint before importing, (5) it installs
docker-ce + plugin, (6) the fallback is gated on
_apt_install_compose failing (not on docker.io), (7) it degrades
gracefully when the repo is unreachable, (8) the ensure_docker_for_apps
call site still tolerates a non-zero return. All 42 tests pass.

Doc gate: scripts/install* is in the doc-gate installers rule;
README.md does not document the Docker install mechanic (only 'Docker
apps, auto-detected'), so a Docs-Reviewed trailer is the right
escape rather than rewriting README.
Docs-Reviewed: README.md's install section only mentions Docker at the
product level ('Docker apps, auto-detected'); the Docker install
mechanic isn't documented there, and the user-visible change is
captured by changelog.d/tsk-fhc6vj-docker-trixie-fallback.md.

Files:
 changelog.d/tsk-fhc6vj-docker-trixie-fallback.md |   2 +
 scripts/install-server.sh                        | 115 ++++++++++++++++++++++-
 tests/test_install_server.sh                     |  35 +++++++
 3 files changed, 149 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker installation on Debian trixie and Armbian trixie systems when distribution repositories do not provide Docker Compose.
  * Added a secure fallback to Docker’s official repository for installing Docker Engine and Compose v2.
  * Installations now complete with a warning when the official repository is unreachable; Store Docker apps may be unavailable in that case.
* **Tests**
  * Added coverage for repository fallback, package detection, signing-key verification, and graceful failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->