### PR TITLE
installer: Zabbly keyring written 0600 breaks every subsequent apt-get update

### DIFF
--- a/docs/changelog.d/tsk-h7ngh2-zabbly-keyring.md
+++ b/docs/changelog.d/tsk-h7ngh2-zabbly-keyring.md
@@ -1,0 +1,2 @@
+### Fixed
+- Zabbly keyring written 0600 breaks every subsequent apt-get update: changed `cp` to `install -m 0644` in scripts/install-server.sh

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -892,7 +892,7 @@ ensure_container_runtime() {
                     return 0
                 fi
                 log "Zabbly key fingerprint ok (${_zabbly_actual_fp:0:16}…)"
-                sudo cp "$_zabbly_key_tmp" /etc/apt/keyrings/zabbly.asc
+                sudo install -m 0644 "$_zabbly_key_tmp" /etc/apt/keyrings/zabbly.asc
                 echo "deb [signed-by=/etc/apt/keyrings/zabbly.asc] https://pkgs.zabbly.com/incus/stable $codename main" \
                     | sudo tee /etc/apt/sources.list.d/zabbly-incus-stable.list > /dev/null
                 sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -119,4 +119,7 @@ grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
 echo "test: verification only runs when SERVICE_MODE != skip"
 grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
 
+echo "test: Zabbly keyring installed with world-readable permissions"
+grep -q "install -m 0644.*zabbly.asc" "$SCRIPT"
+
 echo "all tests passed"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): installer: Zabbly keyring written 0600 breaks every subsequent apt-get update

Autonomous build of board card tsk-h7ngh2.



Files:
 docs/changelog.d/tsk-h7ngh2-zabbly-keyring.md | 2 ++
 scripts/install-server.sh                     | 2 +-
 tests/test_install_server.sh                  | 3 +++
 3 files changed, 6 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected permissions for the Zabbly package keyring so it is readable by required system processes.

* **Tests**
  * Added regression coverage to verify the keyring is installed with the expected permissions.

* **Documentation**
  * Documented the keyring permission correction in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->