### PR TITLE
fold CodeRabbit findings on #2737 (tsk-nk5ojm): fold CodeRabbit findings on #2727 (tsk-7fxlgp): AUDIT [observatory-audit]: deep read-only security+correctness

### DIFF
--- a/changelog.d/tsk-7fxlgp-security-audit-observatory-exceptions.md
+++ b/changelog.d/tsk-7fxlgp-security-audit-observatory-exceptions.md
@@ -1,0 +1,2 @@
+### Fixed
+- Reduced exception handling granularity in `tinyagentos/routes/observatory.py` to follow secure coding best practices

--- a/changelog.d/tsk-kwdlb4-observatory-fleet-registry-exceptions.md
+++ b/changelog.d/tsk-kwdlb4-observatory-fleet-registry-exceptions.md
@@ -1,0 +1,2 @@
+### Fixed
+- Broadened registry exception handling in `GET /api/observatory/fleet` so that any registry failure is logged and gracefully skipped instead of propagating as a 500 error.

--- a/changelog.d/tsk-nk5ojm-fix-tmp-cleanup.md
+++ b/changelog.d/tsk-nk5ojm-fix-tmp-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Ensure temporary file cleanup always runs in `_atomic_write` function in `tinyagentos/routes/observatory.py`. Added `finally` block to delete temporary file even when `json.dumps()` raises an exception, preventing orphaned temporary files.

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -1,4 +1,5 @@
 from httpx import ASGITransport, AsyncClient
+from unittest.mock import patch
 
 import pytest
 
@@ -434,6 +435,16 @@ async def test_fleet_unregistered_working_agent_has_empty_framework(app, client)
     mine = [a for a in agents if a["handle"] == "@lane-unregistered"]
     assert len(mine) == 1
     assert mine[0]["framework"] == ""
+
+
+@pytest.mark.asyncio
+async def test_fleet_does_not_break_when_registry_raises_non_runtime_error(app, client):
+    reg = app.state.agent_registry
+    if reg._db is None:
+        await reg.init()
+    with patch.object(reg, "list_all", side_effect=ValueError("registry boom")):
+        resp = await client.get("/api/observatory/fleet")
+    assert resp.status_code == 200
 
 
 class TestObservatoryAgentAuth:

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -69,16 +69,24 @@ def _atomic_write(p: Path, state: dict) -> None:
     # mid-write or a concurrent writer can never leave a truncated/corrupt file
     # (a reader always sees either the old or the new complete state).
     fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix="." + p.stem + ".", suffix=".tmp")
+    tmp_path = Path(tmp)
     try:
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(state))
         os.replace(tmp, p)
-    except (OSError, ValueError):
+        tmp = None
+    except (OSError, ValueError, TypeError):
         try:
             os.unlink(tmp)
         except OSError:
             pass
         raise
+    finally:
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
 
 
 def _write_state(request: Request, state: dict) -> None:

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -73,7 +73,7 @@ def _atomic_write(p: Path, state: dict) -> None:
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(state))
         os.replace(tmp, p)
-    except Exception:
+    except (OSError, ValueError):
         try:
             os.unlink(tmp)
         except OSError:
@@ -412,7 +412,7 @@ async def get_fleet(request: Request):
                 registered = await registry.list_all(status="active")
             else:
                 registered = await registry.list_for_user(user_id, status="active") if user_id else []
-        except Exception:
+        except RuntimeError:
             registered = []
         for rec in registered:
             handle = (rec.get("handle") or "").strip()

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -14,6 +14,7 @@ import json
 import os
 import tempfile
 import time
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from tinyagentos.agent_token_auth import (
 )
 
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE: dict = {"global": False, "lanes": {}}
 
@@ -69,17 +72,12 @@ def _atomic_write(p: Path, state: dict) -> None:
     # mid-write or a concurrent writer can never leave a truncated/corrupt file
     # (a reader always sees either the old or the new complete state).
     fd, tmp = tempfile.mkstemp(dir=str(p.parent), prefix="." + p.stem + ".", suffix=".tmp")
-    tmp_path = Path(tmp)
     try:
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(state))
         os.replace(tmp, p)
         tmp = None
     except (OSError, ValueError, TypeError):
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
         raise
     finally:
         if tmp is not None:
@@ -411,7 +409,8 @@ async def get_fleet(request: Request):
 
     # Registered agents holding no card are idle; surface them so the fleet
     # shows the full active roster, not just the busy lanes. Best-effort: a
-    # missing or erroring registry must not break the working view.
+    # missing or erroring registry must not break the working view. Any
+    # registry exception is caught and logged; the working view still renders.
     registry = getattr(request.app.state, "agent_registry", None)
     registered: list[dict] = []
     if registry is not None:
@@ -420,7 +419,8 @@ async def get_fleet(request: Request):
                 registered = await registry.list_all(status="active")
             else:
                 registered = await registry.list_for_user(user_id, status="active") if user_id else []
-        except RuntimeError:
+        except Exception:
+            logger.exception("registry lookup failed for fleet view")
             registered = []
         for rec in registered:
             handle = (rec.get("handle") or "").strip()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2737 (tsk-nk5ojm): fold CodeRabbit findings on #2727 (tsk-7fxlgp): AUDIT [observatory-audit]: deep read-only security+correctness

Autonomous build of board card tsk-kwdlb4.

REVISION: built on `exec/tsk-nk5ojm` (cut at `c5cd608fe780113d0de604363a21e59ea86b9702`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

1. Remove dead tmp_path = Path(tmp) assignment in _atomic_write; it was
   never referenced after the prior fix-forward.
2. Drop the redundant inner try/except OSError: pass unlink in the
   _atomic_write except branch; the finally block already handles all
   cleanup in one place.
3. Widen the get_fleet registry exception handler from RuntimeError to
   Exception and add structured logging; the documented intent is that a
   missing or erroring registry must not break the working view.
4. Update the nearby comment to describe the broader exception boundary.

Test: test_fleet_does_not_break_when_registry_raises_non_runtime_error
fails on exec/tsk-nk5ojm (ValueError propagates as 500) and passes after
the fix (returns 200).

Docs-Reviewed: Modified observatory routes module for internal robustness;
no user-facing API change, no doc update needed

Files:
 ...k-7fxlgp-security-audit-observatory-exceptions.md |  2 ++
 ...k-kwdlb4-observatory-fleet-registry-exceptions.md |  2 ++
 changelog.d/tsk-nk5ojm-fix-tmp-cleanup.md            |  3 +++
 tests/test_routes_observatory.py                     | 11 +++++++++++
 tinyagentos/routes/observatory.py                    | 20 ++++++++++++++------
 5 files changed, 32 insertions(+), 6 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Observatory fleet reliability by gracefully handling and logging registry lookup failures instead of returning server errors.
  * Ensured temporary files are cleaned up even when serialization or file operations fail.
  * Strengthened exception handling for Observatory file operations.
* **Tests**
  * Added coverage confirming the fleet endpoint remains available when registry lookup encounters an unexpected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->