### PR TITLE
fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server: first boot timed out on :6969 while only the :6970 proxy came up (community: taOS#2)

### DIFF
--- a/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
+++ b/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 30 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).

--- a/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
+++ b/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Added `--max-time 5` per-attempt timeout to both health and cluster/workers curl probes, preventing a single stuck iteration from stalling the installer indefinitely
+- Increased `_PORT_WAIT` from 30 to 60 seconds, providing a safety margin above the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5
+- Added elapsed-time deadline tracking to both the port-open and ready wait loops, ensuring configured phase limits are enforced as wall-clock time rather than just attempt counts

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2182,14 +2182,15 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     #   1. port open  -- the process is alive and uvicorn is listening.
     #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
     #                    init chain has completed.
-    _PORT_WAIT=30
+    _PORT_WAIT=60
     _READY_WAIT=240
 
     log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
     _port_tries=0
     _port_open=0
-    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+    _port_start=$(( SECONDS ))
+    while [[ $_port_tries -lt $_PORT_WAIT && $(( SECONDS - _port_start )) -lt $_PORT_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
@@ -2209,8 +2210,9 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
 
     _ready_tries=0
     _ready_ok=0
-    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+    _ready_start=$(( SECONDS ))
+    while [[ $_ready_tries -lt $_READY_WAIT && $(( SECONDS - _ready_start )) -lt $_READY_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2172,33 +2172,62 @@ fi
 # --- wait for controller to come up -------------------------------------
 
 if [[ "$SERVICE_MODE" != "skip" ]]; then
-    # 120s ceiling: cold-boot on a Pi 5 / Orange Pi 5 lands around 55-65s
-    # (issue #337) so 60s was racing the actual ready state and printing
-    # a false "controller did not respond" warning even on successful
-    # installs. Doubling the cap keeps the safety net while removing the
-    # false alarm. Loop continues to early-exit the moment /api/cluster/workers
-    # answers, so this is just a higher ceiling, not slower steady state.
-    log "waiting for controller to be ready on port $TAOS_PORT (up to 120 s)..."
-    ctrl_tries=0
-    ctrl_up=0
-    while [[ $ctrl_tries -lt 120 ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
-            ctrl_up=1
+    # Cold-boot on a fresh install runs a lot of first-run init (litellm
+    # prisma migration, store creation, backend catalog probing) that can
+    # exceed the old 120 s cap and make the installer print "controller did
+    # not respond" when the app was actually still starting. A re-run then
+    # succeeds because everything is already initialised (taOS#2).
+    #
+    # We wait in two phases so the message names exactly what is happening:
+    #   1. port open  -- the process is alive and uvicorn is listening.
+    #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
+    #                    init chain has completed.
+    _PORT_WAIT=30
+    _READY_WAIT=240
+
+    log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
+    _port_tries=0
+    _port_open=0
+    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+            _port_open=1
             break
         fi
         sleep 1
-        ctrl_tries=$((ctrl_tries + 1))
+        _port_tries=$((_port_tries + 1))
     done
 
-    if [[ $ctrl_up -eq 0 ]]; then
-        warn "controller did not respond within 120 seconds"
+    if [[ $_port_open -eq 0 ]]; then
+        warn "controller did not open port $TAOS_PORT within $_PORT_WAIT seconds"
         if command -v journalctl >/dev/null 2>&1; then
             warn "latest journal output:"
             journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
         fi
-        die "controller failed to start — check the journal above and fix before continuing"
+        die "controller process did not start — check the journal above and fix before continuing"
     fi
-    log "controller is up"
+    log "controller port $TAOS_PORT is open, waiting for first-boot init to finish..."
+
+    _ready_tries=0
+    _ready_ok=0
+    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+            _ready_ok=1
+            break
+        fi
+        sleep 1
+        _ready_tries=$((_ready_tries + 1))
+    done
+
+    if [[ $_ready_ok -eq 0 ]]; then
+        warn "controller did not become ready within $_READY_WAIT seconds"
+        warn "first-boot init may still be running (litellm migration, store creation, backend catalog probing)"
+        if command -v journalctl >/dev/null 2>&1; then
+            warn "latest journal output:"
+            journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
+        fi
+        die "controller cluster/workers endpoint did not respond — check the journal above and fix before continuing"
+    fi
+    log "controller is ready"
 fi
 
 # --- post-install hardware capability verification -----------------------

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -119,4 +119,21 @@ grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
 echo "test: verification only runs when SERVICE_MODE != skip"
 grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
 
+# ── Controller readiness wait (taOS#2) ─────────────────────────────────
+
+echo "test: controller wait uses a 240 s ready timeout"
+grep -q "_READY_WAIT=240" "$SCRIPT"
+
+echo "test: controller wait uses a 30 s port-open timeout"
+grep -q "_PORT_WAIT=30" "$SCRIPT"
+
+echo "test: controller wait checks /api/health for port-open phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"
+
+echo "test: controller wait checks /api/cluster/workers for ready phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/cluster/workers" "$SCRIPT"
+
+echo "test: controller wait names first-boot init in the timeout message"
+grep -q "first-boot init may still be running" "$SCRIPT"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -124,8 +124,8 @@ grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabili
 echo "test: controller wait uses a 240 s ready timeout"
 grep -q "_READY_WAIT=240" "$SCRIPT"
 
-echo "test: controller wait uses a 30 s port-open timeout"
-grep -q "_PORT_WAIT=30" "$SCRIPT"
+echo "test: controller wait uses a 60 s port-open timeout"
+grep -q "_PORT_WAIT=60" "$SCRIPT"
 
 echo "test: controller wait checks /api/health for port-open phase"
 grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server: first boot timed out on :6969 while only the :6970 proxy came up (community: taOS#2)

Autonomous build of board card tsk-wgsns5.

REVISION: built on `exec/tsk-lda5ta` (cut at `c210e513a517a51de6f9f517a89ea49388500284`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

- Add --max-time 5 to health and cluster/workers curl probes (prevents stuck iteration)
- Increase _PORT_WAIT from 30 to 60 s (safety margin above 55-65 s cold-boot bind time)
- Add elapsed-time deadline to both wait loops (enforce wall-clock limits)
- Update tests for new _PORT_WAIT=60 value
Docs-Reviewed: installer wait loop fixes - no doc changes needed since changes are under scripts/, not tinyagentos/routes/

Files:
 .../tsk-lda5ta-installer-first-boot-wait.md        |  3 +
 .../tsk-wgsns5-install-server-wait-fixes.md        |  5 ++
 scripts/install-server.sh                          | 65 ++++++++++++++++------
 tests/test_install_server.sh                       | 17 ++++++
 4 files changed, 73 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer startup checks by separately confirming that the service is reachable and fully ready.
  * Increased wait time for slower first boots, reducing false installation failure reports.
  * Added clearer timeout messages when first-boot initialization is still in progress.
  * Added per-attempt request timeouts to make readiness checks more reliable.

* **Tests**
  * Added regression coverage for service availability and first-boot readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->