### PR TITLE
check_bot_review.py: a COMPLETED CodeRabbit review with zero findings reads as "scaffolding only" (exit 1) — every clean PR needs a hand-applied bot-review-allow

### DIFF
--- a/changelog.d/tsk-mdgep3-bot-review-zero-finding.md
+++ b/changelog.d/tsk-mdgep3-bot-review-zero-finding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **bot-review-gate false-red on clean CodeRabbit reviews**: `scripts/check_bot_review.py` now recognises a completed CodeRabbit review that found zero findings. An auto-summary comment carrying both the `No actionable comments were generated in the recent review` marker and the quota-consumed `Included review availability:` line is classified as a real review outcome and exits 0 with the Run ID printed, instead of being merged with scaffolding stubs and forcing a hand-applied `bot-review-allow` on every clean PR.

--- a/scripts/check_bot_review.py
+++ b/scripts/check_bot_review.py
@@ -89,6 +89,25 @@ CODERABBIT_SCAFFOLDING_RE = re.compile(
     re.IGNORECASE,
 )
 
+# A CodeRabbit auto-summary comment that reports a completed review with zero
+# findings carries BOTH of the following markers:
+#   (a) "No actionable comments were generated in the recent review"
+#   (b) an "Included review availability:" line that says N remain after this
+#       review (quota was consumed, so a review actually ran).
+# Together these identify a real completed review that found nothing, not a stub.
+CODERABBIT_ZERO_FINDING_PHRASE_RE = re.compile(
+    r"No actionable comments were generated in the recent review",
+    re.IGNORECASE,
+)
+CODERABBIT_QUOTA_RE = re.compile(
+    r"Included review availability:.*?remain after this review",
+    re.DOTALL | re.IGNORECASE,
+)
+CODERABBIT_RUN_ID_RE = re.compile(
+    r"\*\*Run ID\*\*:\s*(\S+)",
+    re.IGNORECASE,
+)
+
 EXIT_OK = 0
 EXIT_STUB = 1
 EXIT_ERROR = 2
@@ -223,6 +242,28 @@ def is_coderabbit_auto_summary(body: str | None) -> bool:
     if not body:
         return False
     return bool(CODERABBIT_AUTO_SUMMARY_RE.search(body))
+
+
+def is_coderabbit_zero_finding_review(body: str | None) -> tuple[bool, str | None]:
+    """Return (True, run_id) if a body is a CodeRabbit auto-summary comment
+    reporting a completed review with zero findings, else (False, None).
+
+    A completed zero-finding review is an auto-summary comment whose body
+    contains BOTH the "no actionable comments" marker and the quota-consumed
+    marker ("Included review availability:" ... "remain after this review"),
+    plus a Run ID. This distinguishes a real completed review from a merge/
+    close stub that carries no review metadata at all.
+    """
+    if not body:
+        return False, None
+    if not is_coderabbit_auto_summary(body):
+        return False, None
+    if not CODERABBIT_ZERO_FINDING_PHRASE_RE.search(body):
+        return False, None
+    if not CODERABBIT_QUOTA_RE.search(body):
+        return False, None
+    run_id_match = CODERABBIT_RUN_ID_RE.search(body)
+    return True, (run_id_match.group(1) if run_id_match else None)
 
 
 def is_real_item(item: CRItem) -> bool:
@@ -370,12 +411,15 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
     Returns (exit_code, message):
     - (0, "PASS ...")            -- a real CodeRabbit review exists.
     - (0, "PASS (absent, ...)")  -- CodeRabbit is entirely absent.
+    - (0, "PASS ...")            -- a completed zero-finding CodeRabbit review
+                                   exists (auto-summary with both no-findings
+                                   marker and quota-consumed marker).
     - (1, "FAIL ...")            -- only stubs exist, i.e. rate-limit stubs
-                                  or CodeRabbit auto-generated scaffolding
-                                  (acknowledgement / auto-summary), neither
-                                  of which is review content.
+                                   or CodeRabbit auto-generated scaffolding
+                                   (acknowledgement / auto-summary), neither
+                                   of which is review content.
     - (0, "PASS ...")            -- CR output exists but is neither a stub
-                                  nor substantive (edge case, not fake-green).
+                                   nor substantive (edge case, not fake-green).
     """
     if not items:
         return EXIT_OK, "PASS (absent, not stubbed): no CodeRabbit output on this PR"
@@ -386,6 +430,19 @@ def classify(items: list[CRItem]) -> tuple[int, str]:
             f"PASS: {len(real_items)} real CodeRabbit review item(s) "
             f"(exit {EXIT_OK})"
         )
+
+    # Check for a completed zero-finding review before falling through to the
+    # stub verdict. An auto-summary comment carrying both the "no actionable
+    # comments" marker and the quota-consumed marker means CodeRabbit ran and
+    # found nothing -- that is a real review outcome, not fake-green.
+    for item in items:
+        is_zf, run_id = is_coderabbit_zero_finding_review(item.body)
+        if is_zf:
+            run_id_str = f" (run {run_id})" if run_id else ""
+            return EXIT_OK, (
+                f"PASS: real CodeRabbit review, 0 findings{run_id_str} "
+                f"(exit {EXIT_OK})"
+            )
 
     # No real review threads. A trigger was accepted but produced no review
     # content: that is the fake-green condition. This covers both the

--- a/tests/scripts/test_check_bot_review.py
+++ b/tests/scripts/test_check_bot_review.py
@@ -1113,6 +1113,126 @@ class TestDetectorIsolation:
             assert check_mod.is_real_item(summary) is True
 
 
+class TestIsCoderabbitZeroFindingReview:
+    """The zero-finding detector: an auto-summary comment carrying both the
+    no-findings marker and the quota-consumed marker is a completed review
+    that found nothing, not a stub."""
+
+    ZERO_FINDING_BODY = (
+        "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+        "**Run ID**: abc123-def456\n"
+        "📒 Files selected for processing (3)\n"
+        "No actionable comments were generated in the recent review.\n"
+        "**Included review availability:** Your plan provides up to 4 included reviews per hour; 2 remain after this review."
+    )
+
+    def test_both_markers_returns_true_and_run_id(self, check_mod) -> None:
+        is_zf, run_id = check_mod.is_coderabbit_zero_finding_review(self.ZERO_FINDING_BODY)
+        assert is_zf is True
+        assert run_id == "abc123-def456"
+
+    def test_without_auto_summary_marker_returns_false(self, check_mod) -> None:
+        body = "No actionable comments were generated in the recent review.\n" \
+               "**Included review availability:** Your plan provides up to 4 included reviews per hour; 2 remain after this review."
+        is_zf, run_id = check_mod.is_coderabbit_zero_finding_review(body)
+        assert is_zf is False
+        assert run_id is None
+
+    def test_without_phrase_a_returns_false(self, check_mod) -> None:
+        body = (
+            "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+            "**Run ID**: abc123-def456\n"
+            "**Included review availability:** Your plan provides up to 4 included reviews per hour; 2 remain after this review."
+        )
+        is_zf, run_id = check_mod.is_coderabbit_zero_finding_review(body)
+        assert is_zf is False
+        assert run_id is None
+
+    def test_without_phrase_b_returns_false(self, check_mod) -> None:
+        body = (
+            "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+            "**Run ID**: abc123-def456\n"
+            "No actionable comments were generated in the recent review."
+        )
+        is_zf, run_id = check_mod.is_coderabbit_zero_finding_review(body)
+        assert is_zf is False
+        assert run_id is None
+
+    def test_empty_body_returns_false(self, check_mod) -> None:
+        assert check_mod.is_coderabbit_zero_finding_review("") == (False, None)
+        assert check_mod.is_coderabbit_zero_finding_review(None) == (False, None)
+
+    def test_run_id_missing_returns_true_without_run_id(self, check_mod) -> None:
+        body = (
+            "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+            "No actionable comments were generated in the recent review.\n"
+            "**Included review availability:** Your plan provides up to 4 included reviews per hour; 2 remain after this review."
+        )
+        is_zf, run_id = check_mod.is_coderabbit_zero_finding_review(body)
+        assert is_zf is True
+        assert run_id is None
+
+
+class TestClassifyZeroFinding:
+    """classify() treats a completed zero-finding review as PASS, not FAIL."""
+
+    ZERO_FINDING_BODY = TestIsCoderabbitZeroFindingReview.ZERO_FINDING_BODY
+
+    def test_zero_finding_only_passes(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(id=1, body=self.ZERO_FINDING_BODY, is_review=False),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "0 findings" in message
+        assert "run abc123-def456" in message
+
+    def test_zero_finding_with_run_id_in_message(self, check_mod) -> None:
+        items = [
+            check_mod.CRItem(id=1, body=self.ZERO_FINDING_BODY, is_review=False),
+        ]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == 0
+        assert "abc123-def456" in message
+
+
+RATE_LIMIT_ACK_BODY = (
+    "⚠️ Action not completed\n"
+    "Review rate limited.\n"
+    "Your included review limit is currently reached…"
+)
+A_ONLY_BODY = (
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+    "No actionable comments were generated in the recent review."
+)
+B_ONLY_BODY = (
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+    "📒 Files selected for processing (3)\n"
+    "**Included review availability:** Your plan provides up to 4 included reviews per hour; 2 remain after this review."
+)
+MERGE_CLOSE_BODY = "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"
+
+
+class TestClassifyZeroFindingControls:
+    """Parametrised per-field controls: each bullet from the task plus the
+    positive case. Deleting one half of the predicate must make the corresponding
+    case go RED."""
+
+    @pytest.mark.parametrize("body,expected_exit,expected_substring", [
+        (TestIsCoderabbitZeroFindingReview.ZERO_FINDING_BODY, 0, "0 findings"),
+        (RATE_LIMIT_ACK_BODY, 1, "FAIL"),
+        (A_ONLY_BODY, 1, "FAIL"),
+        (B_ONLY_BODY, 1, "FAIL"),
+        (MERGE_CLOSE_BODY, 1, "FAIL"),
+        (ACK_BODY, 1, "FAIL"),
+    ])
+    def test_control_cases(self, check_mod, body, expected_exit, expected_substring) -> None:
+        items = [check_mod.CRItem(id=1, body=body, is_review=False)]
+        exit_code, message = check_mod.classify(items)
+        assert exit_code == expected_exit, f"body={body!r}: expected exit {expected_exit}, got {exit_code}: {message}"
+        assert expected_substring in message, f"body={body!r}: expected {expected_substring!r} in {message!r}"
+
+
 class TestTrueGateFailure:
     """Acceptance #3: a TRUE gate failure (#2554 -- CodeRabbit scaffolding only,
     no review content) must STILL be reported red. The fix clears stale red by


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_bot_review.py: a COMPLETED CodeRabbit review with zero findings reads as "scaffolding only" (exit 1) — every clean PR needs a hand-applied bot-review-allow

Autonomous build of board card tsk-mdgep3.

An auto-summary comment carrying both the 'no actionable comments' marker
and the quota-consumed 'Included review availability:' line is a real
completed review that found nothing, not scaffolding. classify() now
detects this via a separate is_coderabbit_zero_finding_review predicate
and exits 0 with the Run ID printed, instead of merging it with stubs
and forcing a hand-applied bot-review-allow on every clean PR.

Controls remain exit 1: rate-limit ack, (a)-only auto-summary, (b)-only
auto-summary, merge/close auto-summary, and acknowledgement reply are all
still stubs.

Tests added: TestIsCoderabbitZeroFindingReview, TestClassifyZeroFinding,
and parametrised TestClassifyZeroFindingControls with one case per task
bullet plus the positive case.

Fixes the false-red on clean CodeRabbit reviews described in tsk-mdgep3.

Files:
 changelog.d/tsk-mdgep3-bot-review-zero-finding.md |   3 +
 scripts/check_bot_review.py                       |  65 +++++++++++-
 tests/scripts/test_check_bot_review.py            | 120 ++++++++++++++++++++++
 3 files changed, 184 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Completed CodeRabbit reviews with no actionable findings are now recognized as valid review outcomes.
  - Clean reviews now pass automatically with the review Run ID displayed, eliminating the need for manual approval overrides.
  - Review detection remains strict for incomplete, rate-limited, or non-review messages.

- **Tests**
  - Added coverage for zero-finding reviews, missing metadata, and related control cases to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->