### PR TITLE
observatory.py nits from #2750: dead `except (OSError, ValueError, TypeError): raise` in _atomic_write; tsk-kwdlb4 fragment records a registry 'broadening' that never happened

### DIFF
--- a/changelog.d/tsk-kwdlb4-observatory-fleet-registry-exceptions.md
+++ b/changelog.d/tsk-kwdlb4-observatory-fleet-registry-exceptions.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Broadened registry exception handling in `GET /api/observatory/fleet` so that any registry failure is logged and gracefully skipped instead of propagating as a 500 error.
+- Registry lookup failures in `GET /api/observatory/fleet` are now logged (they were already swallowed, so the fleet view kept rendering).

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -77,8 +77,6 @@ def _atomic_write(p: Path, state: dict) -> None:
             f.write(json.dumps(state))
         os.replace(tmp, p)
         tmp = None
-    except (OSError, ValueError, TypeError):
-        raise
     finally:
         if tmp is not None:
             try:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): observatory.py nits from #2750: dead `except (OSError, ValueError, TypeError): raise` in _atomic_write; tsk-kwdlb4 fragment records a registry 'broadening' that never happened

Autonomous build of board card tsk-fool65.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

observatory.py _atomic_write removed the bare
    except (OSError, ValueError, TypeError):
        raise
clause -- it caught exactly the same exceptions that the surrounding code
already raised and re-raised them unchanged, so every other exception type
propagated anyway. The finally clause (which sets tmp = None after the
successful os.replace so the cleanup branch leaves the replaced path alone)
stays.

changelog.d/tsk-kwdlb4-... was rewritten to match what #2750 actually
changed: registry lookup failures in GET /api/observatory/fleet are now
logged. Proof they were already swallowed: the bare
    except Exception:
around the registry calls was present before #2750 (e.g. commit
1ed2e4b29 tinyagentos/routes/observatory.py line 415); the diff only added
logger.exception(...).

No behaviour change. 45 tests pass (tests/test_routes_observatory.py).

Docs-Reviewed: no user-visible behaviour change; dead-code removal and a
changelog fragment correction only.

Files:
 changelog.d/tsk-kwdlb4-observatory-fleet-registry-exceptions.md | 2 +-
 tinyagentos/routes/observatory.py                               | 2 --
 2 files changed, 1 insertion(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Observatory fleet views continue rendering when registry lookups fail, while recording the failure for troubleshooting.
  - Registry exception handling documentation now accurately reflects the existing behavior, clarifying that lookup failures are logged and do not cause a server error.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->