### PR TITLE
startup probes unreachable model backends SEQUENTIALLY with long timeouts - :6969 takes 100s+ to answer

### DIFF
--- a/changelog.d/tsk-xjwolt-non-blocking-startup-probe.md
+++ b/changelog.d/tsk-xjwolt-non-blocking-startup-probe.md
@@ -1,0 +1,2 @@
+### Fixed
+- Backend catalog startup no longer blocks the :6969 main app on the first probe pass, so a cold boot with unreachable configured model backends serves the first request immediately instead of waiting the full per-backend connect timeout (tsk-xjwolt; measured at 100s+ on a Pi 4 with three unreachable local backends). The catalog still reconciles every configured backend in the background, and callers that need the post-probe view can await `BackendCatalog.wait_initial_probe()` explicitly.

--- a/tests/test_backend_catalog_lifecycle.py
+++ b/tests/test_backend_catalog_lifecycle.py
@@ -26,6 +26,7 @@ async def test_disabled_backend_excluded_from_routing():
     ]
     catalog = BackendCatalog(backends=backends, probe_fn=probe, interval_seconds=3600)
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         results = catalog.backends_with_capability("llm-chat")
         assert len(results) == 1
@@ -48,6 +49,7 @@ async def test_lifecycle_state_in_to_dict():
     ]
     catalog = BackendCatalog(backends=backends, probe_fn=probe, interval_seconds=3600)
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         entries = catalog.backends()
         assert len(entries) == 1
@@ -75,6 +77,7 @@ async def test_stopped_backend_in_backends_startable():
     catalog = BackendCatalog(backends=backends, probe_fn=probe, interval_seconds=3600)
     catalog._lifecycle_states["b1"] = "stopped"
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         startable = catalog.backends_startable_for_capability("image-generation")
         assert len(startable) == 1
@@ -105,6 +108,7 @@ async def test_backends_startable_cold_start():
     # Mark stopped BEFORE start so the poll sees the state but the probe fails
     catalog._lifecycle_states["cold-sd"] = "stopped"
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         startable = catalog.backends_startable_for_capability("image-generation")
         assert len(startable) == 1
@@ -126,9 +130,56 @@ async def test_set_and_get_lifecycle_state():
     backends = [{"name": "b1", "type": "rkllama", "url": "http://b1", "priority": 1}]
     catalog = BackendCatalog(backends=backends, probe_fn=probe, interval_seconds=3600)
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         assert catalog.get_lifecycle_state("b1") == "running"
         catalog.set_lifecycle_state("b1", "stopped")
         assert catalog.get_lifecycle_state("b1") == "stopped"
     finally:
         await catalog.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_block_on_unreachable_backends():
+    """tsk-xjwolt: BackendCatalog.start() must return promptly even when
+    every configured backend's probe is slow/unreachable. The previous
+    implementation awaited the first probe pass with a 15s cap, which
+    meant a single :6969 boot could take the full per-backend connect
+    timeout (measured at 100s+ on a Pi 4 with three unreachable local
+    model-backend URLs). After the fix, the main app serves requests
+    while the catalog reconciles in the background.
+    """
+    import time
+
+    # Each probe sleeps for a very long time. If start() blocked on the
+    # initial probe, this would take the same wall-clock to return. The
+    # bound is generous on purpose (1.0s) to avoid flakiness while still
+    # being a few orders of magnitude smaller than the old 100s+ boot.
+    SLOW_PROBE_SECONDS = 30.0
+    TIGHT_BOUND_SECONDS = 1.0
+
+    async def slow_probe(backend: dict) -> dict:
+        await asyncio.sleep(SLOW_PROBE_SECONDS)
+        return {"status": "ok", "response_ms": int(SLOW_PROBE_SECONDS * 1000), "models": []}
+
+    backends = [
+        {"name": f"slow-{i}", "type": "ollama", "url": f"http://10.255.255.{i+1}:11434",
+         "priority": i + 1, "enabled": True}
+        for i in range(3)
+    ]
+    catalog = BackendCatalog(
+        backends=backends, probe_fn=slow_probe, interval_seconds=3600,
+    )
+
+    t0 = time.monotonic()
+    await catalog.start()
+    elapsed = time.monotonic() - t0
+    assert elapsed < TIGHT_BOUND_SECONDS, (
+        f"start() took {elapsed:.2f}s with 3 unreachable backends; "
+        f"expected < {TIGHT_BOUND_SECONDS}s (tsk-xjwolt)"
+    )
+    # First probe hasn't completed yet, so backends() is empty.
+    assert catalog.backends() == []
+    # The poll task is still running in the background.
+    assert catalog._task is not None
+    await catalog.stop()

--- a/tests/test_backend_catalog_subscribe.py
+++ b/tests/test_backend_catalog_subscribe.py
@@ -36,6 +36,9 @@ async def test_subscriber_fires_on_status_change():
     )
     catalog.subscribe(subscriber)
     await catalog.start()
+    # tsk-xjwolt: start() no longer blocks on the first probe; tests
+    # that need the post-probe view await wait_initial_probe().
+    await catalog.wait_initial_probe()
     try:
         # Initial probe fired once on start
         assert call_count["n"] == 1

--- a/tests/test_resource_scheduler.py
+++ b/tests/test_resource_scheduler.py
@@ -399,6 +399,7 @@ async def test_backend_catalog_capability_routing():
 
     catalog = BackendCatalog(backends=backends, probe_fn=probe, interval_seconds=3600)
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         entries = catalog.backends_with_capability("image-generation")
         assert [e.name for e in entries] == ["a", "b"]  # priority order
@@ -437,6 +438,7 @@ async def test_backend_catalog_marks_unhealthy_stale():
         stale_after_seconds=3600,  # long grace period
     )
     await catalog.start()
+    await catalog.wait_initial_probe()
     try:
         assert catalog.backends_with_capability("image-generation")
         state["healthy"] = False

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1083,6 +1083,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         )
         # Start the live backend catalog — everything that asks "what's
         # available?" reads from this rather than the filesystem.
+        # tsk-xjwolt: start() does NOT block on the first probe anymore.
+        # Unreachable backends would otherwise stack their connect timeouts
+        # before :6969 can accept a single request. Probes run in the
+        # background; the lifecycle-state reconcile below fires on the
+        # first probe pass via a one-shot subscriber.
         try:
             await backend_catalog.start()
         except Exception:
@@ -1135,12 +1140,24 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # After the first probe, mark auto-managed backends that are not
         # currently reachable as "stopped" so the scheduler knows to start
         # them on demand rather than treating them as permanently broken.
-        for _entry in backend_catalog.backends():
-            _b_conf = next(
-                (b for b in config.backends if b["name"] == _entry.name), {}
-            )
-            if _b_conf.get("auto_manage") and _entry.status != "ok":
-                backend_catalog.set_lifecycle_state(_entry.name, "stopped")
+        # tsk-xjwolt: BackendCatalog.start() no longer blocks on the first
+        # probe, so this reconcile runs once via a one-shot subscriber
+        # instead of reading the (empty) entries dict immediately after
+        # start() returns.
+        _lifecycle_reconciled = {"done": False}
+
+        async def _reconcile_auto_manage_lifecycle() -> None:
+            if _lifecycle_reconciled["done"]:
+                return
+            _lifecycle_reconciled["done"] = True
+            for _entry in backend_catalog.backends():
+                _b_conf = next(
+                    (b for b in config.backends if b["name"] == _entry.name), {}
+                )
+                if _b_conf.get("auto_manage") and _entry.status != "ok":
+                    backend_catalog.set_lifecycle_state(_entry.name, "stopped")
+
+        backend_catalog.subscribe(_reconcile_auto_manage_lifecycle)
 
         # Joined view of the registry cache + live catalog probes.
         # Used by the Store / Dashboard / Models routes instead of

--- a/tinyagentos/scheduler/backend_catalog.py
+++ b/tinyagentos/scheduler/backend_catalog.py
@@ -177,11 +177,33 @@ class BackendCatalog:
         return repr(parts)
 
     async def start(self) -> None:
-        """Kick off the background polling task and wait for the first pass."""
+        """Kick off the background polling task and return immediately.
+
+        The first probe pass runs concurrently in the background so the
+        main app starts serving requests without waiting for backends to
+        be reachable. Misconfigured or unreachable backends would
+        otherwise block the lifespan for the full connect timeout per
+        backend (tsk-xjwolt). Subscribers and ``backends()`` consumers
+        are guaranteed to see a consistent post-probe view once
+        ``wait_initial_probe()`` resolves.
+        """
         if self._task is not None:
             return
         self._task = asyncio.create_task(self._poll_loop(), name="backend-catalog-poll")
-        await asyncio.wait_for(self._initial_probe_done.wait(), timeout=15.0)
+
+    async def wait_initial_probe(self, timeout: float | None = None) -> None:
+        """Await the first probe pass, used by tests and by callers that
+        genuinely need the post-probe view before proceeding. The main
+        server boot path should NOT call this — it is the fix for
+        tsk-xjwolt that probing backends sequentially with long timeouts
+        delayed :6969 from accepting traffic.
+        """
+        if self._initial_probe_done.is_set():
+            return
+        if timeout is None:
+            await self._initial_probe_done.wait()
+        else:
+            await asyncio.wait_for(self._initial_probe_done.wait(), timeout=timeout)
 
     async def stop(self) -> None:
         if self._task is not None:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): startup probes unreachable model backends SEQUENTIALLY with long timeouts - :6969 takes 100s+ to answer

Autonomous build of board card tsk-xjwolt.

BackendCatalog.start() previously awaited the first probe pass with a 15s
cap, so a cold boot of the controller with N unreachable model-backend
URLs in config would stack the per-backend connect timeout before
uvicorn could accept its first request. Measured live on a Pi 4
restart with three unreachable local backends: :6970 bound quickly but
:6969 took 100+ seconds to answer (tsk-hhpm4m).

Defer the initial probe off the serving path:
- BackendCatalog.start() now spawns the poll task and returns
  immediately. The poll loop still runs _probe_all on its first
  iteration and sets the existing _initial_probe_done event, so all
  downstream consumers behave the same once the probe completes.
- Add BackendCatalog.wait_initial_probe() for the (test) callers that
  genuinely need the post-probe view synchronously.
- Move the post-start auto_manage -> stopped lifecycle reconcile in
  app.py into a one-shot subscriber so it still runs exactly once,
  after the first probe rather than after start() returns.
- Existing tests that asserted the synchronous-start contract now
  await wait_initial_probe() explicitly.

Red test: test_start_does_not_block_on_unreachable_backends configures
three slow probes (30s each) and asserts start() returns in under
1s. Verified to fail on the prior code (15s TimeoutError) and pass
on the new code (~0.4s). 25 tests in the backend_catalog_subscribe,
backend_catalog_lifecycle, and resource_scheduler suites stay green;
broader app/test_app_startup_* sweep (33 tests) also green.

Docs-Reviewed: no routes/* or doc/* file changed; the user-visible
behaviour change (cold-boot latency on :6969) is captured in the new
changelog.d/tsk-xjwolt-non-blocking-startup-probe.md fragment.

Files:
 .../tsk-xjwolt-non-blocking-startup-probe.md       |  2 +
 tests/test_backend_catalog_lifecycle.py            | 51 ++++++++++++++++++++++
 tests/test_backend_catalog_subscribe.py            |  3 ++
 tests/test_resource_scheduler.py                   |  2 +
 tinyagentos/app.py                                 | 29 +++++++++---
 tinyagentos/scheduler/backend_catalog.py           | 26 ++++++++++-
 6 files changed, 105 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application startup no longer waits for backend connectivity checks to complete.
  * The app can serve its first request promptly even when configured backends are unreachable.
  * Backend discovery and lifecycle reconciliation continue in the background after startup.

* **Improvements**
  * Backend status becomes available as probes complete, while callers that need the initial complete view can explicitly wait for it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->