### PR TITLE
tinyagentos-rebuild-desktop fires a full npm rebuild right after a fresh bundle fetch (mtime false positive)

### DIFF
--- a/changelog.d/tsk-zvb4yz-provenance-rebuild-trigger.md
+++ b/changelog.d/tsk-zvb4yz-provenance-rebuild-trigger.md
@@ -1,0 +1,2 @@
+### Fixed
+- Desktop rebuild trigger now compares the fetched bundle against the recorded provenance (desktop/ tree SHA) instead of raw file mtimes, preventing a false-positive full npm rebuild on fresh bundle installs when source mtimes are misleading.

--- a/scripts/rebuild-desktop.sh
+++ b/scripts/rebuild-desktop.sh
@@ -30,6 +30,18 @@ fi
 #
 # Using -print -quit so find stops at the first hit (no need to scan everything).
 if [ -f static/desktop/index.html ]; then
+    # Provenance check: if a fetched bundle matches current source, skip
+    # regardless of filesystem mtimes (which can be misleading after a fetch).
+    _provenance_file="static/desktop/.taos-bundle-provenance"
+    if [ -f "$_provenance_file" ]; then
+        _current_tree="$(git rev-parse HEAD:desktop 2>/dev/null || echo "")"
+        _recorded_tree="$(cat "$_provenance_file" 2>/dev/null || echo "")"
+        if [ -n "$_current_tree" ] && [ "$_current_tree" = "$_recorded_tree" ]; then
+            echo "[taos-rebuild-desktop] desktop bundle provenance is current — skipping rebuild"
+            exit 0
+        fi
+    fi
+
     _stale_src="$(find desktop/src -type f -not -path '*/node_modules/*' -newer static/desktop/index.html -print -quit 2>/dev/null)"
     _stale_cfg="$(find desktop \( -name 'package.json' -o -name '*-lock.*' -o -name 'vite.config.*' -o -name 'tsconfig*.json' \) -type f -newer static/desktop/index.html -print -quit 2>/dev/null)"
     if [ -z "$_stale_src" ] && [ -z "$_stale_cfg" ]; then
@@ -50,6 +62,10 @@ fi
 
 if (cd desktop && npm install && npm run build); then
     echo "[taos-rebuild-desktop] desktop rebuild succeeded"
+    _current_tree="$(git rev-parse HEAD:desktop 2>/dev/null || echo "")"
+    if [ -n "$_current_tree" ]; then
+        echo "$_current_tree" > static/desktop/.taos-bundle-provenance
+    fi
 elif [ -f static/desktop/index.html ]; then
     echo "[taos-rebuild-desktop] desktop rebuild FAILED -- keeping the existing bundle (see journalctl -u tinyagentos-rebuild-desktop)"
 else

--- a/tests/test_desktop_rebuild.py
+++ b/tests/test_desktop_rebuild.py
@@ -61,6 +61,25 @@ def test_is_bundle_stale_returns_false_when_no_src_dir(tmp_path):
     assert _is_bundle_stale(tmp_path) is False
 
 
+def test_is_bundle_stale_returns_true_despite_fresh_bundle_with_future_mtime(tmp_path):
+    """Mtime check can falsely report stale when source files carry future mtimes
+    (e.g., from clock-skewed CI commits) even though the bundle was just fetched
+    and index.html was touched fresh.  The provenance check below rescues this."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    bundle = static_dir / "index.html"
+    bundle.write_text("<html />")
+    src_file = src_dir / "App.tsx"
+    src_file.write_text("// app")
+    # Simulate: bundle was just installed (touched 10 s ago), but source has a
+    # future mtime (clock skew during the original commit).
+    os.utime(bundle, (time.time() - 10, time.time() - 10))
+    os.utime(src_file, (time.time() + 3600, time.time() + 3600))
+    assert _is_bundle_stale(tmp_path) is True
+
+
 # ---------------------------------------------------------------------------
 # rebuild_desktop_bundle_if_stale
 # ---------------------------------------------------------------------------
@@ -238,6 +257,47 @@ async def test_rebuild_falls_back_to_npm_install_when_ci_fails(tmp_path, monkeyp
     assert ("git", "checkout") in cmds  # lockfile restored after install
 
 
+@pytest.mark.asyncio
+async def test_rebuild_skips_when_provenance_matches_despite_mtime(tmp_path, monkeypatch):
+    """A provenance marker matching current tree SHA should skip rebuild
+    even when the mtime check would falsely report stale (e.g. future-mtime
+    source files from clock-skewed commits after a fresh bundle fetch)."""
+    src_dir = tmp_path / "desktop" / "src"
+    src_dir.mkdir(parents=True)
+    static_dir = tmp_path / "static" / "desktop"
+    static_dir.mkdir(parents=True)
+    bundle = static_dir / "index.html"
+    bundle.write_text("<html />")
+    src_file = src_dir / "App.tsx"
+    src_file.write_text("// app")
+    # False-positive mtime scenario: source file is 1 h in the future.
+    os.utime(bundle, (time.time() - 10, time.time() - 10))
+    os.utime(src_file, (time.time() + 3600, time.time() + 3600))
+    # Provenance marker says the bundle matches current source.
+    (static_dir / ".taos-bundle-provenance").write_text("MATCHING_SHA")
+
+    called = []
+
+    async def fake_exec(*args, **kwargs):
+        called.append(args)
+        if args[0] == "git":
+            class Proc:
+                returncode = 0
+                async def communicate(self):
+                    return b"MATCHING_SHA\n", b""
+            return Proc()
+        raise AssertionError("subprocess should NOT be called when provenance matches")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    result = await rebuild_desktop_bundle_if_stale(tmp_path)
+    assert result.rebuilt is False
+    assert result.success is True
+    assert "provenance" in result.message.lower()
+    # Only the provenance-check git call is expected; no npm/build subprocesses.
+    assert all(c[0] == "git" for c in called)
+
+
 # ---------------------------------------------------------------------------
 # npm-install gate: only reinstall when package-lock.json changes
 # ---------------------------------------------------------------------------
@@ -345,6 +405,7 @@ async def test_prebuilt_bundle_installed_on_tree_match(tmp_path, monkeypatch):
 
     assert await _try_prebuilt_desktop_bundle(tmp_path) is True
     assert (tmp_path / "static" / "desktop" / "index.html").read_text() == "<html>ok</html>"
+    assert (tmp_path / "static" / "desktop" / ".taos-bundle-provenance").read_text() == "SHA123"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/desktop_rebuild.py
+++ b/tinyagentos/desktop_rebuild.py
@@ -95,6 +95,55 @@ def _record_deps_install(desktop_dir: Path) -> None:
         logger.warning("Could not write deps marker (%s) — next update reinstalls.", exc)
 
 
+async def _get_desktop_tree_sha(project_root: Path) -> str | None:
+    """Return the git tree SHA of desktop/, or None if git is unavailable."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(project_root),
+            "rev-parse",
+            "HEAD:desktop",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        out, _ = await proc.communicate()
+        if proc.returncode == 0:
+            return out.decode(errors="replace").strip()
+    except FileNotFoundError:
+        pass
+    return None
+
+
+async def _is_bundle_provenance_current(project_root: Path) -> bool:
+    """Return True if the bundle provenance marker matches the current desktop tree.
+
+    A marker written by a successful prebuilt-bundle install or local build
+    records the ``git rev-parse HEAD:desktop`` SHA at build time.  If the
+    current tree SHA matches, the bundle is known-good regardless of
+    filesystem mtimes (which can be misleading after a fetch or on hosts
+    with clock skew).
+    """
+    marker = project_root / "static" / "desktop" / ".taos-bundle-provenance"
+    if not marker.is_file():
+        return False
+    try:
+        recorded = marker.read_text().strip()
+    except OSError:
+        return False
+    current = await _get_desktop_tree_sha(project_root)
+    return bool(current and current == recorded)
+
+
+def _record_bundle_provenance(project_root: Path, tree_sha: str) -> None:
+    """Record the desktop tree SHA that the current bundle was built from."""
+    marker = project_root / "static" / "desktop" / ".taos-bundle-provenance"
+    try:
+        marker.write_text(tree_sha)
+    except OSError:
+        pass
+
+
 _BUNDLE_BASE = "https://github.com/jaylfc/taOS/releases/download/bundle-latest"
 
 
@@ -182,8 +231,13 @@ async def _try_prebuilt_desktop_bundle(project_root: Path) -> bool:
         staged.rename(target)  # atomic rename (same filesystem)
         # The tarball preserves the CI build mtime, which can predate the local
         # source and make _is_bundle_stale treat the bundle as perpetually stale
-        # (re-downloading on every check). Stamp index.html fresh.
+        # (re-downloading on every check). Stamp index.html fresh and record
+        # provenance so the rebuild trigger can compare content hashes instead.
         (target / "index.html").touch()
+        try:
+            (target / ".taos-bundle-provenance").write_text(local_tree)
+        except OSError:
+            pass
         logger.info("Prebuilt desktop bundle installed into static/desktop/.")
         return True
     except Exception as exc:
@@ -213,12 +267,22 @@ async def rebuild_desktop_bundle_if_stale(
     staleness heuristic isn't trustworthy — committed bundles can lie about
     their freshness when a PR landed source-only.
     """
-    if not force and not _is_bundle_stale(project_root):
-        return RebuildResult(
-            rebuilt=False,
-            success=True,
-            message="Desktop bundle is current — skipping rebuild.",
-        )
+    if not force:
+        # Provenance check first: a fetched (or locally built) bundle whose
+        # recorded tree SHA matches the current desktop/ source is always
+        # current, regardless of filesystem mtimes.
+        if await _is_bundle_provenance_current(project_root):
+            return RebuildResult(
+                rebuilt=False,
+                success=True,
+                message="Desktop bundle provenance is current — skipping rebuild.",
+            )
+        if not _is_bundle_stale(project_root):
+            return RebuildResult(
+                rebuilt=False,
+                success=True,
+                message="Desktop bundle is current — skipping rebuild.",
+            )
 
     desktop_dir = project_root / "desktop"
     if not (desktop_dir / "package.json").is_file():
@@ -312,6 +376,13 @@ async def rebuild_desktop_bundle_if_stale(
             return RebuildResult(rebuilt=True, success=False, message=msg)
 
         logger.info("Desktop bundle rebuilt successfully.")
+        # Record provenance so future checks use content hash, not mtime.
+        try:
+            tree_sha = await _get_desktop_tree_sha(project_root)
+            if tree_sha:
+                _record_bundle_provenance(project_root, tree_sha)
+        except Exception:
+            pass
         return RebuildResult(rebuilt=True, success=True, message="Desktop bundle rebuilt successfully.")
 
     except asyncio.TimeoutError:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tinyagentos-rebuild-desktop fires a full npm rebuild right after a fresh bundle fetch (mtime false positive)

Autonomous build of board card tsk-zvb4yz.

tinyagentos-rebuild-desktop.service fired a redundant npm rebuild after a
fresh bundle-latest fetch because find -newer compared raw mtimes against
static/desktop/index.html. Source files with future mtimes (e.g. clock-
skewed CI commits) triggered the false positive on the Pi 4.

Fix: write a .taos-bundle-provenance marker containing the desktop/ tree
SHA on every successful prebuilt-bundle install or local build. The rebuild
trigger now checks this marker first and skips npm when the recorded SHA
matches git rev-parse HEAD:desktop, falling back to mtime only when no
marker exists. Same fix applied to the shell script used by the systemd
service.

Tests: added a fresh-bundle scenario with future-mtime source proving the
mtime check wrongly reports stale, and an integration test proving the
provenance check now skips rebuild. Updated the prebuilt-bundle test to
assert the marker is written.

Files:
 .../tsk-zvb4yz-provenance-rebuild-trigger.md       |  2 +
 scripts/rebuild-desktop.sh                         | 16 ++++
 tests/test_desktop_rebuild.py                      | 61 ++++++++++++++++
 tinyagentos/desktop_rebuild.py                     | 85 ++++++++++++++++++++--
 4 files changed, 157 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary full desktop rebuilds after fresh bundle installations when source file timestamps are inaccurate.
  * Desktop bundles now use recorded source provenance to determine whether rebuilding is needed.
  * Rebuild checks continue to fall back to file timestamps when provenance is unavailable or does not match.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->