### PR TITLE
fold CodeRabbit findings on #2752 (tsk-wgsns5): fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server: first boot timed out on :6969 while only the :

### DIFF
--- a/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
+++ b/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 30 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).
+- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 60 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).

--- a/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
+++ b/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 30 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).

--- a/changelog.d/tsk-u2z3mh-installer-wait-hard-deadline.md
+++ b/changelog.d/tsk-u2z3mh-installer-wait-hard-deadline.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installer wait loops now cap curl probe time and the follow-up sleep by the remaining phase deadline, preventing a stuck probe from pushing the port-open or readiness phase past `_PORT_WAIT` / `_READY_WAIT`.

--- a/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
+++ b/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Added `--max-time 5` per-attempt timeout to both health and cluster/workers curl probes, preventing a single stuck iteration from stalling the installer indefinitely
+- Increased `_PORT_WAIT` from 30 to 60 seconds, providing a safety margin above the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5
+- Added elapsed-time deadline tracking to both the port-open and ready wait loops, ensuring configured phase limits are enforced as wall-clock time rather than just attempt counts

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2182,14 +2182,15 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     #   1. port open  -- the process is alive and uvicorn is listening.
     #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
     #                    init chain has completed.
-    _PORT_WAIT=30
+    _PORT_WAIT=60
     _READY_WAIT=240
 
     log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
     _port_tries=0
     _port_open=0
-    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+    _port_start=$(( SECONDS ))
+    while [[ $_port_tries -lt $_PORT_WAIT && $(( SECONDS - _port_start )) -lt $_PORT_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
@@ -2209,8 +2210,9 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
 
     _ready_tries=0
     _ready_ok=0
-    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+    _ready_start=$(( SECONDS ))
+    while [[ $_ready_tries -lt $_READY_WAIT && $(( SECONDS - _ready_start )) -lt $_READY_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2189,11 +2189,16 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _port_tries=0
     _port_open=0
     _port_start=$(( SECONDS ))
-    while [[ $_port_tries -lt $_PORT_WAIT && $(( SECONDS - _port_start )) -lt $_PORT_WAIT ]]; do
-        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
+        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
+        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
+        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
+        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
+        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
+        [[ $_remaining -le 1 ]] && break
         sleep 1
         _port_tries=$((_port_tries + 1))
     done
@@ -2211,11 +2216,16 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _ready_tries=0
     _ready_ok=0
     _ready_start=$(( SECONDS ))
-    while [[ $_ready_tries -lt $_READY_WAIT && $(( SECONDS - _ready_start )) -lt $_READY_WAIT ]]; do
-        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
+        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
+        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
+        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi
+        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
+        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
+        [[ $_remaining -le 1 ]] && break
         sleep 1
         _ready_tries=$((_ready_tries + 1))
     done

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2172,33 +2172,62 @@ fi
 # --- wait for controller to come up -------------------------------------
 
 if [[ "$SERVICE_MODE" != "skip" ]]; then
-    # 120s ceiling: cold-boot on a Pi 5 / Orange Pi 5 lands around 55-65s
-    # (issue #337) so 60s was racing the actual ready state and printing
-    # a false "controller did not respond" warning even on successful
-    # installs. Doubling the cap keeps the safety net while removing the
-    # false alarm. Loop continues to early-exit the moment /api/cluster/workers
-    # answers, so this is just a higher ceiling, not slower steady state.
-    log "waiting for controller to be ready on port $TAOS_PORT (up to 120 s)..."
-    ctrl_tries=0
-    ctrl_up=0
-    while [[ $ctrl_tries -lt 120 ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
-            ctrl_up=1
+    # Cold-boot on a fresh install runs a lot of first-run init (litellm
+    # prisma migration, store creation, backend catalog probing) that can
+    # exceed the old 120 s cap and make the installer print "controller did
+    # not respond" when the app was actually still starting. A re-run then
+    # succeeds because everything is already initialised (taOS#2).
+    #
+    # We wait in two phases so the message names exactly what is happening:
+    #   1. port open  -- the process is alive and uvicorn is listening.
+    #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
+    #                    init chain has completed.
+    _PORT_WAIT=30
+    _READY_WAIT=240
+
+    log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
+    _port_tries=0
+    _port_open=0
+    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+            _port_open=1
             break
         fi
         sleep 1
-        ctrl_tries=$((ctrl_tries + 1))
+        _port_tries=$((_port_tries + 1))
     done
 
-    if [[ $ctrl_up -eq 0 ]]; then
-        warn "controller did not respond within 120 seconds"
+    if [[ $_port_open -eq 0 ]]; then
+        warn "controller did not open port $TAOS_PORT within $_PORT_WAIT seconds"
         if command -v journalctl >/dev/null 2>&1; then
             warn "latest journal output:"
             journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
         fi
-        die "controller failed to start — check the journal above and fix before continuing"
+        die "controller process did not start — check the journal above and fix before continuing"
     fi
-    log "controller is up"
+    log "controller port $TAOS_PORT is open, waiting for first-boot init to finish..."
+
+    _ready_tries=0
+    _ready_ok=0
+    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+            _ready_ok=1
+            break
+        fi
+        sleep 1
+        _ready_tries=$((_ready_tries + 1))
+    done
+
+    if [[ $_ready_ok -eq 0 ]]; then
+        warn "controller did not become ready within $_READY_WAIT seconds"
+        warn "first-boot init may still be running (litellm migration, store creation, backend catalog probing)"
+        if command -v journalctl >/dev/null 2>&1; then
+            warn "latest journal output:"
+            journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
+        fi
+        die "controller cluster/workers endpoint did not respond — check the journal above and fix before continuing"
+    fi
+    log "controller is ready"
 fi
 
 # --- post-install hardware capability verification -----------------------

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -136,4 +136,16 @@ grep -q "curl.*localhost:\$TAOS_PORT/api/cluster/workers" "$SCRIPT"
 echo "test: controller wait names first-boot init in the timeout message"
 grep -q "first-boot init may still be running" "$SCRIPT"
 
+echo "test: port-open loop caps curl probe by remaining phase time"
+grep -q '_remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))' "$SCRIPT"
+
+echo "test: port-open loop breaks before sleep when remaining <= 1"
+grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+
+echo "test: ready loop caps curl probe by remaining phase time"
+grep -q '_remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))' "$SCRIPT"
+
+echo "test: ready loop breaks before sleep when remaining <= 1"
+grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -119,4 +119,21 @@ grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
 echo "test: verification only runs when SERVICE_MODE != skip"
 grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
 
+# ── Controller readiness wait (taOS#2) ─────────────────────────────────
+
+echo "test: controller wait uses a 240 s ready timeout"
+grep -q "_READY_WAIT=240" "$SCRIPT"
+
+echo "test: controller wait uses a 30 s port-open timeout"
+grep -q "_PORT_WAIT=30" "$SCRIPT"
+
+echo "test: controller wait checks /api/health for port-open phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"
+
+echo "test: controller wait checks /api/cluster/workers for ready phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/cluster/workers" "$SCRIPT"
+
+echo "test: controller wait names first-boot init in the timeout message"
+grep -q "first-boot init may still be running" "$SCRIPT"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -124,8 +124,8 @@ grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabili
 echo "test: controller wait uses a 240 s ready timeout"
 grep -q "_READY_WAIT=240" "$SCRIPT"
 
-echo "test: controller wait uses a 30 s port-open timeout"
-grep -q "_PORT_WAIT=30" "$SCRIPT"
+echo "test: controller wait uses a 60 s port-open timeout"
+grep -q "_PORT_WAIT=60" "$SCRIPT"
 
 echo "test: controller wait checks /api/health for port-open phase"
 grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2752 (tsk-wgsns5): fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server: first boot timed out on :6969 while only the :

Autonomous build of board card tsk-u2z3mh.

REVISION: built on `exec/tsk-wgsns5` (cut at `a72bac57866eaafc8bb72e34a2c1010898c304d0`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

1. scripts/install-server.sh: cap curl --max-time and the follow-up sleep
   by the remaining phase time so a stuck probe cannot push port-open or
   readiness past _PORT_WAIT / _READY_WAIT
2. changelog.d/tsk-lda5ta-installer-first-boot-wait.md: update port-open
   timeout from 30 s to 60 s to match _PORT_WAIT

Docs-Reviewed: install-server.sh wait-loop hardening does not change any user-facing installer contract, available options, or documented procedure, so README.md and docs require no update.

Files:
 .../tsk-lda5ta-installer-first-boot-wait.md        |  3 +
 .../tsk-u2z3mh-installer-wait-hard-deadline.md     |  3 +
 .../tsk-wgsns5-install-server-wait-fixes.md        |  5 ++
 scripts/install-server.sh                          | 75 +++++++++++++++++-----
 tests/test_install_server.sh                       | 29 +++++++++
 5 files changed, 98 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server installation startup checks with separate phases for port availability and first-boot initialization.
  - Installer waits longer for the server to become available and complete initialization.
  - Added bounded health checks and readiness probes to prevent waits from exceeding their allotted time.
  - Added clearer timeout messages identifying whether the server failed to open its port or finish first-boot initialization.

- **Tests**
  - Added coverage for installer readiness timeouts, endpoint checks, and deadline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->