### PR TITLE
fold CodeRabbit findings on #2763 (tsk-u2z3mh): fold CodeRabbit findings on #2752 (tsk-wgsns5): fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server

### DIFF
--- a/changelog.d/tsk-3twiky-install-server-coderabbit-folds.md
+++ b/changelog.d/tsk-3twiky-install-server-coderabbit-folds.md
@@ -1,3 +1,4 @@
 ### Fixed
 
-- Folded CodeRabbit findings on #2763: consolidated duplicate deadline checks in the port-open and ready wait loops, floored `curl --max-time` at 1 s so a future guard edit cannot disable the per-attempt timeout, anchored the test assertions to each phase, and corrected the `tsk-wgsns5` changelog wording (per-probe timeout and cold-boot timing)
+- Folded CodeRabbit findings on #2763: collapsed the duplicated deadline checks in the port-open and ready wait loops down to one guard before each probe and one after, floored `curl --max-time` at 1 s so a future guard edit cannot disable the per-attempt timeout, anchored the test assertions to each phase, and corrected the `tsk-wgsns5` changelog wording (per-probe timeout and cold-boot timing)
+- Anchored each installer wait phase to an absolute deadline (`_port_deadline` / `_ready_deadline`) and re-read the clock after every probe, so a slow `curl` can no longer let the follow-up `sleep` carry the port-open or ready phase about a second past `_PORT_WAIT` / `_READY_WAIT`

--- a/changelog.d/tsk-3twiky-install-server-coderabbit-folds.md
+++ b/changelog.d/tsk-3twiky-install-server-coderabbit-folds.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Folded CodeRabbit findings on #2763: consolidated duplicate deadline checks in the port-open and ready wait loops, floored `curl --max-time` at 1 s so a future guard edit cannot disable the per-attempt timeout, anchored the test assertions to each phase, and corrected the `tsk-wgsns5` changelog wording (per-probe timeout and cold-boot timing)

--- a/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
+++ b/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 30 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).
+- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 60 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).

--- a/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
+++ b/changelog.d/tsk-lda5ta-installer-first-boot-wait.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installer no longer gives up on the controller after 120 s on first boot. The wait is split into a 30 s port-open phase (using `/api/health`) and a 240 s readiness phase (using `/api/cluster/workers`), with an error message that names first-boot init when the port is open but the app is still starting. This prevents the false "install failed" report on slow first boots where a re-run would succeed (taOS#2).

--- a/changelog.d/tsk-u2z3mh-installer-wait-hard-deadline.md
+++ b/changelog.d/tsk-u2z3mh-installer-wait-hard-deadline.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Installer wait loops now cap curl probe time and the follow-up sleep by the remaining phase deadline, preventing a stuck probe from pushing the port-open or readiness phase past `_PORT_WAIT` / `_READY_WAIT`.

--- a/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
+++ b/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
@@ -1,5 +1,5 @@
 ### Fixed
 
-- Added `--max-time 5` per-attempt timeout to both health and cluster/workers curl probes, preventing a single stuck iteration from stalling the installer indefinitely
-- Increased `_PORT_WAIT` from 30 to 60 seconds, providing a safety margin above the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5
+- Capped installer wait probes by the remaining phase time (`curl --max-time "$_curl_timeout"`), so a probe can run for up to 60 s during port-open and 240 s during ready instead of the full phase budget
+- Increased `_PORT_WAIT` from 30 to 60 seconds, matching the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5 (no margin added; the new value sits inside that range)
 - Added elapsed-time deadline tracking to both the port-open and ready wait loops, ensuring configured phase limits are enforced as wall-clock time rather than just attempt counts

--- a/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
+++ b/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
@@ -1,5 +1,5 @@
 ### Fixed
 
-- Capped installer wait probes by the remaining phase time (`curl --max-time "$_curl_timeout"`), so a probe can run for up to 60 s during port-open and 240 s during ready instead of the full phase budget
+- Capped installer wait probes by the remaining phase time (`curl --max-time "$_curl_timeout"`), so no probe can run past its phase deadline: the first probe may get the full budget (60 s port-open, 240 s ready) and every later probe only the time still left in the phase
 - Increased `_PORT_WAIT` from 30 to 60 seconds, matching the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5 (no margin added; the new value sits inside that range)
 - Added elapsed-time deadline tracking to both the port-open and ready wait loops, ensuring configured phase limits are enforced as wall-clock time rather than just attempt counts

--- a/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
+++ b/changelog.d/tsk-wgsns5-install-server-wait-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Added `--max-time 5` per-attempt timeout to both health and cluster/workers curl probes, preventing a single stuck iteration from stalling the installer indefinitely
+- Increased `_PORT_WAIT` from 30 to 60 seconds, providing a safety margin above the documented 55–65 s cold-boot bind time on Pi 5 / Orange Pi 5
+- Added elapsed-time deadline tracking to both the port-open and ready wait loops, ensuring configured phase limits are enforced as wall-clock time rather than just attempt counts

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2190,14 +2190,17 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _port_open=0
     _port_start=$(( SECONDS ))
     while [[ $_port_tries -lt $_PORT_WAIT ]]; do
-        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
+        # Compute remaining phase time once per iteration. The `max(1, ...)`
+        # floor keeps curl's --max-time strictly positive even if a future
+        # edit weakens the deadline guard above; curl --max-time 0 means
+        # "no timeout" and would hang the installer forever.
         _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
-        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+        [[ $_remaining -le 0 ]] && break
+        _curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))
+        if curl -sf --max-time "$_curl_timeout" "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
-        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
-        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
         [[ $_remaining -le 1 ]] && break
         sleep 1
         _port_tries=$((_port_tries + 1))
@@ -2217,14 +2220,16 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _ready_ok=0
     _ready_start=$(( SECONDS ))
     while [[ $_ready_tries -lt $_READY_WAIT ]]; do
-        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
+        # Same timeout invariant as the port-open loop above: cap curl's
+        # --max-time by remaining phase time and floor at 1 s so it can
+        # never silently disable curl's per-attempt timeout.
         _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
-        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+        [[ $_remaining -le 0 ]] && break
+        _curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))
+        if curl -sf --max-time "$_curl_timeout" "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi
-        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
-        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
         [[ $_remaining -le 1 ]] && break
         sleep 1
         _ready_tries=$((_ready_tries + 1))

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2188,19 +2188,25 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
     _port_tries=0
     _port_open=0
-    _port_start=$(( SECONDS ))
+    _port_deadline=$(( SECONDS + _PORT_WAIT ))
     while [[ $_port_tries -lt $_PORT_WAIT ]]; do
-        # Compute remaining phase time once per iteration. The `max(1, ...)`
-        # floor keeps curl's --max-time strictly positive even if a future
-        # edit weakens the deadline guard above; curl --max-time 0 means
-        # "no timeout" and would hang the installer forever.
-        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
+        # `_port_deadline` is an absolute wall-clock deadline, so every guard
+        # below reads the clock at the moment it runs instead of a value
+        # captured earlier in the iteration. The `max(1, ...)` floor keeps
+        # curl's --max-time strictly positive even if a future edit weakens
+        # the deadline guard above; curl --max-time 0 means "no timeout" and
+        # would hang the installer forever.
+        _remaining=$(( _port_deadline - SECONDS ))
         [[ $_remaining -le 0 ]] && break
         _curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))
         if curl -sf --max-time "$_curl_timeout" "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
+        # Re-read the clock after the probe: curl may have burned the whole
+        # remaining budget, so the pre-probe `_remaining` is stale here and
+        # would let the follow-up sleep run past the phase deadline.
+        _remaining=$(( _port_deadline - SECONDS ))
         [[ $_remaining -le 1 ]] && break
         sleep 1
         _port_tries=$((_port_tries + 1))
@@ -2218,18 +2224,21 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
 
     _ready_tries=0
     _ready_ok=0
-    _ready_start=$(( SECONDS ))
+    _ready_deadline=$(( SECONDS + _READY_WAIT ))
     while [[ $_ready_tries -lt $_READY_WAIT ]]; do
         # Same timeout invariant as the port-open loop above: cap curl's
-        # --max-time by remaining phase time and floor at 1 s so it can
-        # never silently disable curl's per-attempt timeout.
-        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
+        # --max-time by remaining phase time, floor it at 1 s so it can
+        # never silently disable curl's per-attempt timeout, and re-read
+        # the clock after the probe so a slow probe cannot push the sleep
+        # past the phase deadline.
+        _remaining=$(( _ready_deadline - SECONDS ))
         [[ $_remaining -le 0 ]] && break
         _curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))
         if curl -sf --max-time "$_curl_timeout" "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi
+        _remaining=$(( _ready_deadline - SECONDS ))
         [[ $_remaining -le 1 ]] && break
         sleep 1
         _ready_tries=$((_ready_tries + 1))

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2182,14 +2182,15 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     #   1. port open  -- the process is alive and uvicorn is listening.
     #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
     #                    init chain has completed.
-    _PORT_WAIT=30
+    _PORT_WAIT=60
     _READY_WAIT=240
 
     log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
     _port_tries=0
     _port_open=0
-    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+    _port_start=$(( SECONDS ))
+    while [[ $_port_tries -lt $_PORT_WAIT && $(( SECONDS - _port_start )) -lt $_PORT_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
@@ -2209,8 +2210,9 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
 
     _ready_tries=0
     _ready_ok=0
-    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+    _ready_start=$(( SECONDS ))
+    while [[ $_ready_tries -lt $_READY_WAIT && $(( SECONDS - _ready_start )) -lt $_READY_WAIT ]]; do
+        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2189,11 +2189,16 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _port_tries=0
     _port_open=0
     _port_start=$(( SECONDS ))
-    while [[ $_port_tries -lt $_PORT_WAIT && $(( SECONDS - _port_start )) -lt $_PORT_WAIT ]]; do
-        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
+        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
+        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
+        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
             _port_open=1
             break
         fi
+        [[ $(( SECONDS - _port_start )) -ge $_PORT_WAIT ]] && break
+        _remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))
+        [[ $_remaining -le 1 ]] && break
         sleep 1
         _port_tries=$((_port_tries + 1))
     done
@@ -2211,11 +2216,16 @@ if [[ "$SERVICE_MODE" != "skip" ]]; then
     _ready_tries=0
     _ready_ok=0
     _ready_start=$(( SECONDS ))
-    while [[ $_ready_tries -lt $_READY_WAIT && $(( SECONDS - _ready_start )) -lt $_READY_WAIT ]]; do
-        if curl -sf --max-time 5 "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
+        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
+        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
+        if curl -sf --max-time "$_remaining" "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
             _ready_ok=1
             break
         fi
+        [[ $(( SECONDS - _ready_start )) -ge $_READY_WAIT ]] && break
+        _remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))
+        [[ $_remaining -le 1 ]] && break
         sleep 1
         _ready_tries=$((_ready_tries + 1))
     done

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2172,33 +2172,62 @@ fi
 # --- wait for controller to come up -------------------------------------
 
 if [[ "$SERVICE_MODE" != "skip" ]]; then
-    # 120s ceiling: cold-boot on a Pi 5 / Orange Pi 5 lands around 55-65s
-    # (issue #337) so 60s was racing the actual ready state and printing
-    # a false "controller did not respond" warning even on successful
-    # installs. Doubling the cap keeps the safety net while removing the
-    # false alarm. Loop continues to early-exit the moment /api/cluster/workers
-    # answers, so this is just a higher ceiling, not slower steady state.
-    log "waiting for controller to be ready on port $TAOS_PORT (up to 120 s)..."
-    ctrl_tries=0
-    ctrl_up=0
-    while [[ $ctrl_tries -lt 120 ]]; do
-        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
-            ctrl_up=1
+    # Cold-boot on a fresh install runs a lot of first-run init (litellm
+    # prisma migration, store creation, backend catalog probing) that can
+    # exceed the old 120 s cap and make the installer print "controller did
+    # not respond" when the app was actually still starting. A re-run then
+    # succeeds because everything is already initialised (taOS#2).
+    #
+    # We wait in two phases so the message names exactly what is happening:
+    #   1. port open  -- the process is alive and uvicorn is listening.
+    #   2. ready      -- /api/cluster/workers answers, meaning the lifespan
+    #                    init chain has completed.
+    _PORT_WAIT=30
+    _READY_WAIT=240
+
+    log "waiting for controller port $TAOS_PORT to open (up to $_PORT_WAIT s)..."
+    _port_tries=0
+    _port_open=0
+    while [[ $_port_tries -lt $_PORT_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/health" >/dev/null 2>&1; then
+            _port_open=1
             break
         fi
         sleep 1
-        ctrl_tries=$((ctrl_tries + 1))
+        _port_tries=$((_port_tries + 1))
     done
 
-    if [[ $ctrl_up -eq 0 ]]; then
-        warn "controller did not respond within 120 seconds"
+    if [[ $_port_open -eq 0 ]]; then
+        warn "controller did not open port $TAOS_PORT within $_PORT_WAIT seconds"
         if command -v journalctl >/dev/null 2>&1; then
             warn "latest journal output:"
             journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
         fi
-        die "controller failed to start — check the journal above and fix before continuing"
+        die "controller process did not start — check the journal above and fix before continuing"
     fi
-    log "controller is up"
+    log "controller port $TAOS_PORT is open, waiting for first-boot init to finish..."
+
+    _ready_tries=0
+    _ready_ok=0
+    while [[ $_ready_tries -lt $_READY_WAIT ]]; do
+        if curl -sf "http://localhost:$TAOS_PORT/api/cluster/workers" >/dev/null 2>&1; then
+            _ready_ok=1
+            break
+        fi
+        sleep 1
+        _ready_tries=$((_ready_tries + 1))
+    done
+
+    if [[ $_ready_ok -eq 0 ]]; then
+        warn "controller did not become ready within $_READY_WAIT seconds"
+        warn "first-boot init may still be running (litellm migration, store creation, backend catalog probing)"
+        if command -v journalctl >/dev/null 2>&1; then
+            warn "latest journal output:"
+            journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
+        fi
+        die "controller cluster/workers endpoint did not respond — check the journal above and fix before continuing"
+    fi
+    log "controller is ready"
 fi
 
 # --- post-install hardware capability verification -----------------------

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -136,4 +136,16 @@ grep -q "curl.*localhost:\$TAOS_PORT/api/cluster/workers" "$SCRIPT"
 echo "test: controller wait names first-boot init in the timeout message"
 grep -q "first-boot init may still be running" "$SCRIPT"
 
+echo "test: port-open loop caps curl probe by remaining phase time"
+grep -q '_remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))' "$SCRIPT"
+
+echo "test: port-open loop breaks before sleep when remaining <= 1"
+grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+
+echo "test: ready loop caps curl probe by remaining phase time"
+grep -q '_remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))' "$SCRIPT"
+
+echo "test: ready loop breaks before sleep when remaining <= 1"
+grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -137,15 +137,41 @@ echo "test: controller wait names first-boot init in the timeout message"
 grep -q "first-boot init may still be running" "$SCRIPT"
 
 echo "test: port-open loop caps curl probe by remaining phase time"
-grep -q '_remaining=$(( _PORT_WAIT - (SECONDS - _port_start) ))' "$SCRIPT"
+grep -q '_PORT_WAIT - (SECONDS - _port_start)' "$SCRIPT"
+
+echo "test: port-open loop passes a positive timeout to curl --max-time"
+# Scoped to the /api/health curl so a regression on the ready loop cannot
+# satisfy this assertion (and vice versa).
+awk '/_PORT_WAIT.*\(SECONDS.*_port_start\)/{port=1} port && /--max-time/{print; exit}' "$SCRIPT" \
+    | grep -q -- '--max-time "[^"]*"'
 
 echo "test: port-open loop breaks before sleep when remaining <= 1"
-grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+awk '/while.*_port_tries.*do/{port=1; next} port && /curl.*api.health/{health=1; next} port && health && /_remaining -le 1/{print; exit}' "$SCRIPT" \
+    | grep -q '_remaining -le 1'
+
+echo "test: port-open loop computes remaining phase time once per iteration"
+# Catches the duplicated deadline check refactor regression; the original
+# branch recomputed `_PORT_WAIT - (SECONDS - _port_start)` twice per loop.
+[[ $(grep -c '_PORT_WAIT - (SECONDS - _port_start)' "$SCRIPT") -eq 1 ]]
+
+echo "test: port-open loop floors curl --max-time at 1 s"
+# Ensures a future edit cannot weaken the deadline guard and silently
+# disable curl's per-attempt timeout (finding #3 / #4 invariant).
+grep -q '_curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))' "$SCRIPT"
 
 echo "test: ready loop caps curl probe by remaining phase time"
-grep -q '_remaining=$(( _READY_WAIT - (SECONDS - _ready_start) ))' "$SCRIPT"
+grep -q '_READY_WAIT - (SECONDS - _ready_start)' "$SCRIPT"
+
+echo "test: ready loop passes a positive timeout to curl --max-time"
+awk '/_READY_WAIT.*\(SECONDS.*_ready_start\)/{ready=1} ready && /--max-time/{print; exit}' "$SCRIPT" \
+    | grep -q -- '--max-time "[^"]*"'
 
 echo "test: ready loop breaks before sleep when remaining <= 1"
-grep -q '\[\[ $_remaining -le 1 \]\] && break' "$SCRIPT"
+awk '/while.*_ready_tries.*do/{ready=1; next} ready && /curl.*cluster.workers/{workers=1; next} ready && workers && /_remaining -le 1/{print; exit}' "$SCRIPT" \
+    | grep -q '_remaining -le 1'
+
+echo "test: ready loop computes remaining phase time once per iteration"
+# Same as port-open: original branch recomputed twice per loop.
+[[ $(grep -c '_READY_WAIT - (SECONDS - _ready_start)' "$SCRIPT") -eq 1 ]]
 
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -151,8 +151,14 @@ awk '/_port_deadline - SECONDS/{port=1} port && /--max-time/{print; exit}' "$SCR
     | grep -q -- '--max-time "[^"]*"'
 
 echo "test: port-open loop breaks before sleep when remaining <= 1"
-awk '/while.*_port_tries.*do/{port=1; next} port && /curl.*api.health/{health=1; next} port && health && /_remaining -le 1/{print; exit}' "$SCRIPT" \
-    | grep -q '_remaining -le 1'
+# Ordering matters: whichever of the guard or the sleep comes first ends the
+# scan, so a future edit that moves `_remaining -le 1` below `sleep 1` fails
+# here instead of matching it further down the loop.
+awk '/while.*_port_tries.*do/{p=1; next}
+     p && /curl.*api.health/{c=1; next}
+     p && c && /_remaining -le 1/{found=1; exit}
+     p && c && /sleep 1/{exit}
+     END{exit !found}' "$SCRIPT"
 
 echo "test: port-open loop re-reads the clock after the probe, before sleeping"
 # A slow curl can consume the whole remaining budget, so reusing the
@@ -167,8 +173,14 @@ awk '/while.*_port_tries.*do/{p=1; next}
 
 echo "test: port-open loop floors curl --max-time at 1 s"
 # Ensures a future edit cannot weaken the deadline guard and silently
-# disable curl's per-attempt timeout (finding #3 / #4 invariant).
-grep -q '_curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))' "$SCRIPT"
+# disable curl's per-attempt timeout (finding #3 / #4 invariant). Scoped to
+# the port-open loop and stopped at its curl so the ready loop's copy of the
+# floor cannot satisfy this assertion, and so the floor must be set before
+# the probe that uses it.
+awk '/while.*_port_tries.*do/{p=1; next}
+     p && index($0, "_curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))"){found=1}
+     p && /curl.*api.health/{exit}
+     END{exit !found}' "$SCRIPT"
 
 echo "test: ready loop caps curl probe by remaining phase time"
 grep -q '_remaining=$(( _ready_deadline - SECONDS ))' "$SCRIPT"
@@ -181,8 +193,12 @@ awk '/_ready_deadline - SECONDS/{ready=1} ready && /--max-time/{print; exit}' "$
     | grep -q -- '--max-time "[^"]*"'
 
 echo "test: ready loop breaks before sleep when remaining <= 1"
-awk '/while.*_ready_tries.*do/{ready=1; next} ready && /curl.*cluster.workers/{workers=1; next} ready && workers && /_remaining -le 1/{print; exit}' "$SCRIPT" \
-    | grep -q '_remaining -le 1'
+# Same ordering enforcement as the port-open loop.
+awk '/while.*_ready_tries.*do/{r=1; next}
+     r && /curl.*cluster.workers/{c=1; next}
+     r && c && /_remaining -le 1/{found=1; exit}
+     r && c && /sleep 1/{exit}
+     END{exit !found}' "$SCRIPT"
 
 echo "test: ready loop re-reads the clock after the probe, before sleeping"
 # Same stale-value regression as the port-open loop.
@@ -190,6 +206,14 @@ awk '/while.*_ready_tries.*do/{r=1; next}
      r && /curl.*cluster.workers/{c=1; next}
      r && c && index($0, "_remaining=$(( _ready_deadline - SECONDS ))"){found=1}
      r && c && /sleep 1/{exit}
+     END{exit !found}' "$SCRIPT"
+
+echo "test: ready loop floors curl --max-time at 1 s"
+# Same invariant, asserted independently inside the ready loop so a
+# regression that drops the floor from one loop cannot hide behind the other.
+awk '/while.*_ready_tries.*do/{r=1; next}
+     r && index($0, "_curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))"){found=1}
+     r && /curl.*cluster.workers/{exit}
      END{exit !found}' "$SCRIPT"
 
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -137,22 +137,33 @@ echo "test: controller wait names first-boot init in the timeout message"
 grep -q "first-boot init may still be running" "$SCRIPT"
 
 echo "test: port-open loop caps curl probe by remaining phase time"
-grep -q '_PORT_WAIT - (SECONDS - _port_start)' "$SCRIPT"
+grep -q '_remaining=$(( _port_deadline - SECONDS ))' "$SCRIPT"
+
+echo "test: port-open phase deadline is anchored once, before the loop"
+# One absolute deadline per phase; every guard inside the loop reads the
+# clock against it rather than re-deriving the phase budget.
+[[ $(grep -c '_port_deadline=$(( SECONDS + _PORT_WAIT ))' "$SCRIPT") -eq 1 ]]
 
 echo "test: port-open loop passes a positive timeout to curl --max-time"
 # Scoped to the /api/health curl so a regression on the ready loop cannot
 # satisfy this assertion (and vice versa).
-awk '/_PORT_WAIT.*\(SECONDS.*_port_start\)/{port=1} port && /--max-time/{print; exit}' "$SCRIPT" \
+awk '/_port_deadline - SECONDS/{port=1} port && /--max-time/{print; exit}' "$SCRIPT" \
     | grep -q -- '--max-time "[^"]*"'
 
 echo "test: port-open loop breaks before sleep when remaining <= 1"
 awk '/while.*_port_tries.*do/{port=1; next} port && /curl.*api.health/{health=1; next} port && health && /_remaining -le 1/{print; exit}' "$SCRIPT" \
     | grep -q '_remaining -le 1'
 
-echo "test: port-open loop computes remaining phase time once per iteration"
-# Catches the duplicated deadline check refactor regression; the original
-# branch recomputed `_PORT_WAIT - (SECONDS - _port_start)` twice per loop.
-[[ $(grep -c '_PORT_WAIT - (SECONDS - _port_start)' "$SCRIPT") -eq 1 ]]
+echo "test: port-open loop re-reads the clock after the probe, before sleeping"
+# A slow curl can consume the whole remaining budget, so reusing the
+# pre-probe `_remaining` for the post-probe guard lets the follow-up
+# sleep run past _PORT_WAIT. Assert the recompute sits between the curl
+# and the sleep.
+awk '/while.*_port_tries.*do/{p=1; next}
+     p && /curl.*api.health/{c=1; next}
+     p && c && index($0, "_remaining=$(( _port_deadline - SECONDS ))"){found=1}
+     p && c && /sleep 1/{exit}
+     END{exit !found}' "$SCRIPT"
 
 echo "test: port-open loop floors curl --max-time at 1 s"
 # Ensures a future edit cannot weaken the deadline guard and silently
@@ -160,18 +171,25 @@ echo "test: port-open loop floors curl --max-time at 1 s"
 grep -q '_curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))' "$SCRIPT"
 
 echo "test: ready loop caps curl probe by remaining phase time"
-grep -q '_READY_WAIT - (SECONDS - _ready_start)' "$SCRIPT"
+grep -q '_remaining=$(( _ready_deadline - SECONDS ))' "$SCRIPT"
+
+echo "test: ready phase deadline is anchored once, before the loop"
+[[ $(grep -c '_ready_deadline=$(( SECONDS + _READY_WAIT ))' "$SCRIPT") -eq 1 ]]
 
 echo "test: ready loop passes a positive timeout to curl --max-time"
-awk '/_READY_WAIT.*\(SECONDS.*_ready_start\)/{ready=1} ready && /--max-time/{print; exit}' "$SCRIPT" \
+awk '/_ready_deadline - SECONDS/{ready=1} ready && /--max-time/{print; exit}' "$SCRIPT" \
     | grep -q -- '--max-time "[^"]*"'
 
 echo "test: ready loop breaks before sleep when remaining <= 1"
 awk '/while.*_ready_tries.*do/{ready=1; next} ready && /curl.*cluster.workers/{workers=1; next} ready && workers && /_remaining -le 1/{print; exit}' "$SCRIPT" \
     | grep -q '_remaining -le 1'
 
-echo "test: ready loop computes remaining phase time once per iteration"
-# Same as port-open: original branch recomputed twice per loop.
-[[ $(grep -c '_READY_WAIT - (SECONDS - _ready_start)' "$SCRIPT") -eq 1 ]]
+echo "test: ready loop re-reads the clock after the probe, before sleeping"
+# Same stale-value regression as the port-open loop.
+awk '/while.*_ready_tries.*do/{r=1; next}
+     r && /curl.*cluster.workers/{c=1; next}
+     r && c && index($0, "_remaining=$(( _ready_deadline - SECONDS ))"){found=1}
+     r && c && /sleep 1/{exit}
+     END{exit !found}' "$SCRIPT"
 
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -119,4 +119,21 @@ grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"
 echo "test: verification only runs when SERVICE_MODE != skip"
 grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabilities"
 
+# ── Controller readiness wait (taOS#2) ─────────────────────────────────
+
+echo "test: controller wait uses a 240 s ready timeout"
+grep -q "_READY_WAIT=240" "$SCRIPT"
+
+echo "test: controller wait uses a 30 s port-open timeout"
+grep -q "_PORT_WAIT=30" "$SCRIPT"
+
+echo "test: controller wait checks /api/health for port-open phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"
+
+echo "test: controller wait checks /api/cluster/workers for ready phase"
+grep -q "curl.*localhost:\$TAOS_PORT/api/cluster/workers" "$SCRIPT"
+
+echo "test: controller wait names first-boot init in the timeout message"
+grep -q "first-boot init may still be running" "$SCRIPT"
+
 echo "all tests passed"

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -124,8 +124,8 @@ grep -A 3 'SERVICE_MODE.*!=.*skip' "$SCRIPT" | grep -q "verify_hardware_capabili
 echo "test: controller wait uses a 240 s ready timeout"
 grep -q "_READY_WAIT=240" "$SCRIPT"
 
-echo "test: controller wait uses a 30 s port-open timeout"
-grep -q "_PORT_WAIT=30" "$SCRIPT"
+echo "test: controller wait uses a 60 s port-open timeout"
+grep -q "_PORT_WAIT=60" "$SCRIPT"
 
 echo "test: controller wait checks /api/health for port-open phase"
 grep -q "curl.*localhost:\$TAOS_PORT/api/health" "$SCRIPT"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fold CodeRabbit findings on #2763 (tsk-u2z3mh): fold CodeRabbit findings on #2752 (tsk-wgsns5): fold CodeRabbit findings on #2744 (tsk-lda5ta): install-server

Autonomous build of board card tsk-3twiky.

REVISION: built on `exec/tsk-u2z3mh` (cut at `7477bdf2e614d42a5f7ab3c384a38fc3e8e7c7b8`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Consolidates the duplicate deadline checks in the port-open and ready
wait loops (findings #1, #2, #4), floors curl --max-time at 1 s so a
future guard edit cannot silently disable the per-attempt timeout
(findings #3, #4), anchors each test assertion to its phase so the
two loops are verified independently (findings #5, #9), and corrects
the tsk-wgsns5 changelog wording (per-probe timeout description and
cold-boot timing claim, findings #7, #8) and adds a trailing newline
(finding #6).

Findings refuted:
- none.

Tests: tests/test_install_server.sh passes on this commit and FAILS
on exec/tsk-u2z3mh at 'port-open loop computes remaining phase time
once per iteration' (proves the duplicate-deadline-check consolidation
is actually enforced).

Docs-Reviewed: this PR only consolidates loop internals and tightens
test coverage; the external behavior (60 s port-open + 240 s ready
phase budgets, curl per-attempt timeout bounded by remaining phase
time) is unchanged from exec/tsk-u2z3mh, so README.md and the
installer docs already reflect the contracted behavior.

Files:
 .../tsk-3twiky-install-server-coderabbit-folds.md  |  3 +
 .../tsk-lda5ta-installer-first-boot-wait.md        |  3 +
 .../tsk-u2z3mh-installer-wait-hard-deadline.md     |  3 +
 .../tsk-wgsns5-install-server-wait-fixes.md        |  5 ++
 scripts/install-server.sh                          | 80 +++++++++++++++++-----
 tests/test_install_server.sh                       | 55 +++++++++++++++
 6 files changed, 132 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installer startup now checks server availability in two phases: port opening within 60 seconds, followed by first-boot readiness within 240 seconds.
  - Readiness checks use health and worker-status endpoints, with clearer initialization timeout errors.

- **Bug Fixes**
  - Improved reliability during slow or cold server startups.
  - Timeout calculations now account for each connection attempt and avoid extending phase deadlines with probes or sleeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->