### PR TITLE
fix-forward #2722 (tsk-7uxooi): resolve the notification user from request.state.user_id, not the cookie-only dependency (tsk-47baqy)

### DIFF
--- a/changelog.d/tsk-7uxooi-notifications-user-scope.md
+++ b/changelog.d/tsk-7uxooi-notifications-user-scope.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - Cross-user notification read and mutation: `list`, `list_archived`, `unread_count`, `mark_read`, `archive`, and `mark_all_read` now scope to the authenticated user (`user_id IS NULL OR user_id = ?`), so a user can only see and modify their own notifications plus broadcasts. Previously these endpoints returned every user's rows and allowed cross-user mutations (CWE-862).
+- Notification routes resolve the caller from `request.state.user_id` instead of a cookie-only dependency, so local-token (`taosctl notifications`) callers resolve to the primary user and keep working instead of returning 401.

--- a/changelog.d/tsk-7uxooi-notifications-user-scope.md
+++ b/changelog.d/tsk-7uxooi-notifications-user-scope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Cross-user notification read and mutation: `list`, `list_archived`, `unread_count`, `mark_read`, `archive`, and `mark_all_read` now scope to the authenticated user (`user_id IS NULL OR user_id = ?`), so a user can only see and modify their own notifications plus broadcasts. Previously these endpoints returned every user's rows and allowed cross-user mutations (CWE-862).

--- a/tests/test_notifications_user_scope.py
+++ b/tests/test_notifications_user_scope.py
@@ -1,5 +1,3 @@
-import secrets
-
 import pytest
 import pytest_asyncio
 import yaml
@@ -202,7 +200,8 @@ class TestNotificationRoutesUserScope:
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.get("/api/notifications/count")
             assert resp.status_code == 200
-            assert "1" in resp.text
+            assert "data-count='1'" in resp.text
+            assert "<span class='notif-badge' data-count='1'>1</span>" == resp.text
 
     async def test_mark_read_other_user_returns_404(self, two_user_app):
         app, alice_id, alice_token, bob_id, bob_token = two_user_app

--- a/tests/test_notifications_user_scope.py
+++ b/tests/test_notifications_user_scope.py
@@ -10,6 +10,24 @@ from tinyagentos.notifications import NotificationStore
 from taos_test_csrf import csrf_event_hooks
 
 
+def _row_by_title(items: list[dict], title: str) -> dict:
+    """Pick a notification by title, never by list position.
+
+    Every row added in a test shares the same whole-second ``timestamp``, so the
+    ORDER BY on ties is whatever the index happens to yield. Selecting by title
+    also keeps route-scoping setups off the scoped store API, so the red these
+    tests produce on unfixed code is the leak, not a signature TypeError.
+    """
+    for item in items:
+        if item["title"] == title:
+            return item
+    raise AssertionError(f"no notification titled {title!r}")
+
+
+def _id_by_title(items: list[dict], title: str) -> int:
+    return _row_by_title(items, title)["id"]
+
+
 def _make_config(tmp_path) -> dict:
     return {
         "server": {"host": "0.0.0.0", "port": 6969},
@@ -48,9 +66,9 @@ class TestNotificationStoreUserScope:
         await notif_store.add("a", "a msg", user_id="u1")
         await notif_store.add("b", "b msg", user_id="u2")
         await notif_store.add("c", "c msg")
-        items = await notif_store.list()
-        await notif_store.archive(items[0]["id"], user_id="u1")
-        await notif_store.archive(items[1]["id"], user_id="u2")
+        by_title = {i["title"]: i["id"] for i in await notif_store.list()}
+        await notif_store.archive(by_title["a"], user_id="u1")
+        await notif_store.archive(by_title["b"], user_id="u2")
         history = await notif_store.list_archived(user_id="u1")
         titles = {h["title"] for h in history}
         assert titles == {"a"}
@@ -96,35 +114,37 @@ class TestNotificationStoreUserScope:
         assert len(await notif_store.list_archived(user_id="u1")) == 1
 
 
+@pytest_asyncio.fixture
+async def two_user_app(tmp_path):
+    """A started app with alice (primary/admin) and bob, plus a session each."""
+    config = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+
+    notif_store = app.state.notifications
+    if notif_store._db is not None:
+        await notif_store.close()
+    await notif_store.init()
+
+    auth = app.state.auth
+    auth.setup_user("alice", "Alice", "", "alicepass123")
+    alice_rec = auth.find_user("alice")
+    alice_token = auth.create_session(user_id=alice_rec["id"], long_lived=True)
+
+    bob_invite = auth.add_user_invite("bob", "alice")
+    auth.complete_invite("bob", bob_invite, "Bob", "", "bobpass123")
+    bob_rec = auth.find_user("bob")
+    bob_token = auth.create_session(user_id=bob_rec["id"], long_lived=True)
+
+    app.state._startup_complete = True
+
+    return app, alice_rec["id"], alice_token, bob_rec["id"], bob_token
+
+
 @pytest.mark.asyncio
 class TestNotificationRoutesUserScope:
-    @pytest_asyncio.fixture
-    async def two_user_app(self, tmp_path):
-        config = _make_config(tmp_path)
-        (tmp_path / "config.yaml").write_text(yaml.dump(config))
-        (tmp_path / ".setup_complete").touch()
-
-        app = create_app(data_dir=tmp_path)
-
-        notif_store = app.state.notifications
-        if notif_store._db is not None:
-            await notif_store.close()
-        await notif_store.init()
-
-        auth = app.state.auth
-        auth.setup_user("alice", "Alice", "", "alicepass123")
-        alice_rec = auth.find_user("alice")
-        alice_token = auth.create_session(user_id=alice_rec["id"], long_lived=True)
-
-        bob_invite = auth.add_user_invite("bob", "alice")
-        auth.complete_invite("bob", bob_invite, "Bob", "", "bobpass123")
-        bob_rec = auth.find_user("bob")
-        bob_token = auth.create_session(user_id=bob_rec["id"], long_lived=True)
-
-        app.state._startup_complete = True
-
-        return app, alice_rec["id"], alice_token, bob_rec["id"], bob_token
-
     async def _alice_client(self, app, alice_token):
         transport = ASGITransport(app=app)
         return AsyncClient(
@@ -163,10 +183,9 @@ class TestNotificationRoutesUserScope:
         store = app.state.notifications
         await store.add("alice-notif", "for alice", user_id=alice_id)
         await store.add("bob-notif", "for bob", user_id=bob_id)
-        alice_items = await store.list(user_id=alice_id)
-        bob_items = await store.list(user_id=bob_id)
-        await store.archive(alice_items[0]["id"], user_id=alice_id)
-        await store.archive(bob_items[0]["id"], user_id=bob_id)
+        by_title = {i["title"]: i["id"] for i in await store.list()}
+        await store.archive(by_title["alice-notif"])
+        await store.archive(by_title["bob-notif"])
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.get("/api/notifications/archived")
             assert resp.status_code == 200
@@ -189,8 +208,7 @@ class TestNotificationRoutesUserScope:
         app, alice_id, alice_token, bob_id, bob_token = two_user_app
         store = app.state.notifications
         await store.add("bob-notif", "for bob", user_id=bob_id)
-        bob_items = await store.list(user_id=bob_id)
-        bob_notif_id = bob_items[0]["id"]
+        bob_notif_id = _id_by_title(await store.list(), "bob-notif")
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{bob_notif_id}/read")
             assert resp.status_code == 404
@@ -200,8 +218,7 @@ class TestNotificationRoutesUserScope:
         app, alice_id, alice_token, bob_id, bob_token = two_user_app
         store = app.state.notifications
         await store.add("bob-notif", "for bob", user_id=bob_id)
-        bob_items = await store.list(user_id=bob_id)
-        bob_notif_id = bob_items[0]["id"]
+        bob_notif_id = _id_by_title(await store.list(), "bob-notif")
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{bob_notif_id}/archive")
             assert resp.status_code == 404
@@ -211,9 +228,119 @@ class TestNotificationRoutesUserScope:
         app, alice_id, alice_token, bob_id, bob_token = two_user_app
         store = app.state.notifications
         await store.add("alice-notif", "for alice", user_id=alice_id)
-        alice_items = await store.list(user_id=alice_id)
-        alice_notif_id = alice_items[0]["id"]
+        alice_notif_id = _id_by_title(await store.list(), "alice-notif")
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{alice_notif_id}/read")
             assert resp.status_code == 200
             assert (await store.list(user_id=alice_id))[0]["read"] is True
+
+
+@pytest.mark.asyncio
+class TestNotificationRoutesLocalToken:
+    """The local token (``Authorization: Bearer <token>``, no cookie) must work.
+
+    AuthMiddleware accepts the local token and maps it to the primary user by
+    setting ``request.state.user_id``; it never sets a session cookie. Every
+    ``taosctl notifications`` subcommand authenticates exactly that way, so a
+    cookie-only route dependency (``Depends(get_current_user)``) turns all of
+    them into 401s while the browser keeps working.
+    """
+
+    def _token_client(self, app):
+        """A local-token caller: Bearer header, and deliberately NO cookie."""
+        return AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers={"Authorization": f"Bearer {app.state.auth.get_local_token()}"},
+            event_hooks=csrf_event_hooks(),
+        )
+
+    async def test_list_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        await store.add("broadcast", "for everyone")
+        async with self._token_client(app) as c:
+            resp = await c.get("/api/notifications")
+            assert resp.status_code == 200, resp.text
+            titles = {i["title"] for i in resp.json()}
+        # The token resolves to the PRIMARY user, not to "everyone".
+        assert titles == {"alice-notif", "broadcast"}
+
+    async def test_count_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        async with self._token_client(app) as c:
+            resp = await c.get("/api/notifications/count")
+            assert resp.status_code == 200, resp.text
+            assert "data-count='1'" in resp.text
+
+    async def test_archived_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        rows = await store.list()
+        await store.archive(_id_by_title(rows, "alice-notif"))
+        await store.archive(_id_by_title(rows, "bob-notif"))
+        async with self._token_client(app) as c:
+            resp = await c.get("/api/notifications/archived")
+            assert resp.status_code == 200, resp.text
+            titles = {i["title"] for i in resp.json()}
+        assert titles == {"alice-notif"}
+
+    async def test_mark_read_own_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, _bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        own_id = _id_by_title(await store.list(), "alice-notif")
+        async with self._token_client(app) as c:
+            resp = await c.post(f"/api/notifications/{own_id}/read")
+            assert resp.status_code == 200, resp.text
+        assert _row_by_title(await store.list(), "alice-notif")["read"] is True
+
+    async def test_mark_read_other_user_with_local_token_returns_404(self, two_user_app):
+        app, _alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        bob_notif_id = _id_by_title(await store.list(), "bob-notif")
+        async with self._token_client(app) as c:
+            resp = await c.post(f"/api/notifications/{bob_notif_id}/read")
+            assert resp.status_code == 404, resp.text
+        assert _row_by_title(await store.list(), "bob-notif")["read"] is False
+
+    async def test_archive_own_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, _bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        own_id = _id_by_title(await store.list(), "alice-notif")
+        async with self._token_client(app) as c:
+            resp = await c.post(f"/api/notifications/{own_id}/archive")
+            assert resp.status_code == 200, resp.text
+        assert len(await store.list_archived(user_id=alice_id)) == 1
+
+    async def test_read_all_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        async with self._token_client(app) as c:
+            resp = await c.post("/api/notifications/read-all")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["marked"] == 1
+        rows = await store.list()
+        assert _row_by_title(rows, "alice-notif")["read"] is True
+        assert _row_by_title(rows, "bob-notif")["read"] is False
+
+    async def test_mark_all_read_with_local_token_is_not_401(self, two_user_app):
+        app, alice_id, _alice_token, bob_id, _bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        async with self._token_client(app) as c:
+            resp = await c.post("/api/notifications/mark-all-read")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["marked"] == 1

--- a/tests/test_notifications_user_scope.py
+++ b/tests/test_notifications_user_scope.py
@@ -212,7 +212,7 @@ class TestNotificationRoutesUserScope:
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{bob_notif_id}/read")
             assert resp.status_code == 404
-            assert (await store.list(user_id=bob_id))[0]["read"] is False
+        assert _row_by_title(await store.list(), "bob-notif")["read"] is False
 
     async def test_archive_other_user_returns_404(self, two_user_app):
         app, alice_id, alice_token, bob_id, bob_token = two_user_app
@@ -222,7 +222,9 @@ class TestNotificationRoutesUserScope:
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{bob_notif_id}/archive")
             assert resp.status_code == 404
-            assert len(await store.list_archived(user_id=bob_id)) == 0
+        # list() filters archived = 0, so finding the row proves it stayed active.
+        assert _row_by_title(await store.list(), "bob-notif")
+        assert not [i for i in await store.list_archived() if i["title"] == "bob-notif"]
 
     async def test_mark_own_notification_succeeds(self, two_user_app):
         app, alice_id, alice_token, bob_id, bob_token = two_user_app
@@ -232,7 +234,7 @@ class TestNotificationRoutesUserScope:
         async with await self._alice_client(app, alice_token) as c:
             resp = await c.post(f"/api/notifications/{alice_notif_id}/read")
             assert resp.status_code == 200
-            assert (await store.list(user_id=alice_id))[0]["read"] is True
+        assert _row_by_title(await store.list(), "alice-notif")["read"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_notifications_user_scope.py
+++ b/tests/test_notifications_user_scope.py
@@ -1,0 +1,219 @@
+import secrets
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.notifications import NotificationStore
+from taos_test_csrf import csrf_event_hooks
+
+
+def _make_config(tmp_path) -> dict:
+    return {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+
+
+@pytest_asyncio.fixture
+async def notif_store(tmp_path):
+    store = NotificationStore(tmp_path / "notifications.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+@pytest.mark.asyncio
+class TestNotificationStoreUserScope:
+    async def test_list_returns_own_and_broadcast(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        await notif_store.add("c", "c msg")
+        items = await notif_store.list(user_id="u1")
+        titles = {i["title"] for i in items}
+        assert titles == {"a", "c"}
+
+    async def test_list_excludes_other_users(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        items = await notif_store.list(user_id="u1")
+        assert all(i["user_id"] != "u2" for i in items)
+
+    async def test_list_archived_returns_own_only(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        await notif_store.add("c", "c msg")
+        items = await notif_store.list()
+        await notif_store.archive(items[0]["id"], user_id="u1")
+        await notif_store.archive(items[1]["id"], user_id="u2")
+        history = await notif_store.list_archived(user_id="u1")
+        titles = {h["title"] for h in history}
+        assert titles == {"a"}
+
+    async def test_unread_count_counts_own_and_broadcast(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        await notif_store.add("c", "c msg")
+        assert await notif_store.unread_count(user_id="u1") == 2
+
+    async def test_none_user_id_returns_unfiltered(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        items = await notif_store.list(user_id=None)
+        assert len(items) == 2
+
+    async def test_mark_read_scoped_to_user(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        u1_items = await notif_store.list(user_id="u1")
+        u2_items = await notif_store.list(user_id="u2")
+        u1_id = u1_items[0]["id"]
+        u2_id = u2_items[0]["id"]
+        affected = await notif_store.mark_read(u2_id, user_id="u1")
+        assert affected == 0
+        assert (await notif_store.list(user_id="u2"))[0]["read"] is False
+        affected = await notif_store.mark_read(u1_id, user_id="u1")
+        assert affected == 1
+        assert (await notif_store.list(user_id="u1"))[0]["read"] is True
+
+    async def test_archive_scoped_to_user(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+        u1_items = await notif_store.list(user_id="u1")
+        u2_items = await notif_store.list(user_id="u2")
+        u1_id = u1_items[0]["id"]
+        u2_id = u2_items[0]["id"]
+        affected = await notif_store.archive(u2_id, user_id="u1")
+        assert affected == 0
+        assert len(await notif_store.list_archived(user_id="u2")) == 0
+        affected = await notif_store.archive(u1_id, user_id="u1")
+        assert affected == 1
+        assert len(await notif_store.list_archived(user_id="u1")) == 1
+
+
+@pytest.mark.asyncio
+class TestNotificationRoutesUserScope:
+    @pytest_asyncio.fixture
+    async def two_user_app(self, tmp_path):
+        config = _make_config(tmp_path)
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+        (tmp_path / ".setup_complete").touch()
+
+        app = create_app(data_dir=tmp_path)
+
+        notif_store = app.state.notifications
+        if notif_store._db is not None:
+            await notif_store.close()
+        await notif_store.init()
+
+        auth = app.state.auth
+        auth.setup_user("alice", "Alice", "", "alicepass123")
+        alice_rec = auth.find_user("alice")
+        alice_token = auth.create_session(user_id=alice_rec["id"], long_lived=True)
+
+        bob_invite = auth.add_user_invite("bob", "alice")
+        auth.complete_invite("bob", bob_invite, "Bob", "", "bobpass123")
+        bob_rec = auth.find_user("bob")
+        bob_token = auth.create_session(user_id=bob_rec["id"], long_lived=True)
+
+        app.state._startup_complete = True
+
+        return app, alice_rec["id"], alice_token, bob_rec["id"], bob_token
+
+    async def _alice_client(self, app, alice_token):
+        transport = ASGITransport(app=app)
+        return AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            cookies={"taos_session": alice_token},
+            event_hooks=csrf_event_hooks(),
+        )
+
+    async def _bob_client(self, app, bob_token):
+        transport = ASGITransport(app=app)
+        return AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            cookies={"taos_session": bob_token},
+            event_hooks=csrf_event_hooks(),
+        )
+
+    async def test_list_excludes_other_user(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        await store.add("broadcast", "for everyone")
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.get("/api/notifications")
+            assert resp.status_code == 200
+            data = resp.json()
+            titles = {i["title"] for i in data}
+            assert "alice-notif" in titles
+            assert "bob-notif" not in titles
+            assert "broadcast" in titles
+
+    async def test_archived_excludes_other_user(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        alice_items = await store.list(user_id=alice_id)
+        bob_items = await store.list(user_id=bob_id)
+        await store.archive(alice_items[0]["id"], user_id=alice_id)
+        await store.archive(bob_items[0]["id"], user_id=bob_id)
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.get("/api/notifications/archived")
+            assert resp.status_code == 200
+            data = resp.json()
+            titles = {i["title"] for i in data}
+            assert "alice-notif" in titles
+            assert "bob-notif" not in titles
+
+    async def test_count_excludes_other_user(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.get("/api/notifications/count")
+            assert resp.status_code == 200
+            assert "1" in resp.text
+
+    async def test_mark_read_other_user_returns_404(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        bob_items = await store.list(user_id=bob_id)
+        bob_notif_id = bob_items[0]["id"]
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.post(f"/api/notifications/{bob_notif_id}/read")
+            assert resp.status_code == 404
+            assert (await store.list(user_id=bob_id))[0]["read"] is False
+
+    async def test_archive_other_user_returns_404(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("bob-notif", "for bob", user_id=bob_id)
+        bob_items = await store.list(user_id=bob_id)
+        bob_notif_id = bob_items[0]["id"]
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.post(f"/api/notifications/{bob_notif_id}/archive")
+            assert resp.status_code == 404
+            assert len(await store.list_archived(user_id=bob_id)) == 0
+
+    async def test_mark_own_notification_succeeds(self, two_user_app):
+        app, alice_id, alice_token, bob_id, bob_token = two_user_app
+        store = app.state.notifications
+        await store.add("alice-notif", "for alice", user_id=alice_id)
+        alice_items = await store.list(user_id=alice_id)
+        alice_notif_id = alice_items[0]["id"]
+        async with await self._alice_client(app, alice_token) as c:
+            resp = await c.post(f"/api/notifications/{alice_notif_id}/read")
+            assert resp.status_code == 200
+            assert (await store.list(user_id=alice_id))[0]["read"] is True

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -211,47 +211,86 @@ class NotificationStore(BaseStore):
             except Exception:
                 logger.warning("NotificationStore: could not schedule web-push", exc_info=True)
 
-    async def list(self, limit: int = 20, unread_only: bool = False) -> list[dict]:
+    async def list(
+        self,
+        limit: int = 20,
+        unread_only: bool = False,
+        user_id: str | None = None,
+    ) -> list[dict]:
         # Active feed: archived (dismissed) notifications are excluded.
         conds = ["archived = 0"]
+        if user_id is not None:
+            conds.append("(user_id IS NULL OR user_id = ?)")
         if unread_only:
             conds.append("read = 0")
+        params: tuple = (user_id, limit) if user_id is not None else (limit,)
         sql = (
             "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
             f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?"
         )
-        async with self._db.execute(sql, (limit,)) as cursor:
+        async with self._db.execute(sql, params) as cursor:
             rows = await cursor.fetchall()
         return [_serialize_row(r) for r in rows]
 
-    async def list_archived(self, limit: int = 50) -> list[dict]:
+    async def list_archived(
+        self,
+        limit: int = 50,
+        user_id: str | None = None,
+    ) -> list[dict]:
         # History view: the dismissed notifications, newest first. Nothing is
         # deleted, so this is the durable record (#62 / append-only #103).
+        conds = ["archived = 1"]
+        if user_id is not None:
+            conds.append("(user_id IS NULL OR user_id = ?)")
+        params: tuple = (user_id, limit) if user_id is not None else (limit,)
         async with self._db.execute(
             "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
-            " WHERE archived = 1 ORDER BY timestamp DESC LIMIT ?",
-            (limit,),
+            f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?",
+            params,
         ) as cursor:
             rows = await cursor.fetchall()
         return [_serialize_row(r) for r in rows]
 
-    async def unread_count(self) -> int:
+    async def unread_count(self, user_id: str | None = None) -> int:
+        conds = ["read = 0", "archived = 0"]
+        if user_id is not None:
+            conds.append("(user_id IS NULL OR user_id = ?)")
+        params: tuple = (user_id,) if user_id is not None else ()
         async with self._db.execute(
-            "SELECT COUNT(*) FROM notifications WHERE read = 0 AND archived = 0"
+            f"SELECT COUNT(*) FROM notifications WHERE {' AND '.join(conds)}",
+            params,
         ) as cursor:
             row = await cursor.fetchone()
         return row[0] if row else 0
 
-    async def mark_read(self, notif_id: int) -> None:
-        await self._db.execute("UPDATE notifications SET read = 1 WHERE id = ?", (notif_id,))
+    async def mark_read(self, notif_id: int, user_id: str | None = None) -> int:
+        if user_id is not None:
+            cursor = await self._db.execute(
+                "UPDATE notifications SET read = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
+                (notif_id, user_id),
+            )
+        else:
+            # Internal/system caller: unfiltered update.
+            cursor = await self._db.execute(
+                "UPDATE notifications SET read = 1 WHERE id = ?", (notif_id,)
+            )
         await self._db.commit()
+        return cursor.rowcount
 
-    async def archive(self, notif_id: int) -> None:
+    async def archive(self, notif_id: int, user_id: str | None = None) -> int:
         # Dismiss = archive. The row stays; the History view still shows it.
-        await self._db.execute(
-            "UPDATE notifications SET archived = 1 WHERE id = ?", (notif_id,)
-        )
+        if user_id is not None:
+            cursor = await self._db.execute(
+                "UPDATE notifications SET archived = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
+                (notif_id, user_id),
+            )
+        else:
+            # Internal/system caller: unfiltered update.
+            cursor = await self._db.execute(
+                "UPDATE notifications SET archived = 1 WHERE id = ?", (notif_id,)
+            )
         await self._db.commit()
+        return cursor.rowcount
 
     async def archive_by_source_ref(self, source: str, request_id) -> int:
         """Archive active notifications whose JSON `data.request_id` matches.
@@ -262,6 +301,7 @@ class NotificationStore(BaseStore):
         (#62: nothing is deleted). Idempotent: rows already archived are
         skipped; returns the number newly archived.
         """
+        # Intentionally global: resolves by source + request_id, not by user.
         async with self._db.execute(
             "SELECT id, data FROM notifications WHERE source = ? AND archived = 0",
             (source,),
@@ -279,6 +319,8 @@ class NotificationStore(BaseStore):
             if str(payload.get("request_id")) == target:
                 ids.append(nid)
         if ids:
+            # Intentionally global: source-ref resolution applies to the row,
+            # not to a specific user.
             placeholders = ",".join("?" * len(ids))
             await self._db.execute(
                 f"UPDATE notifications SET archived = 1, read = 1 WHERE id IN ({placeholders})",
@@ -287,8 +329,15 @@ class NotificationStore(BaseStore):
             await self._db.commit()
         return len(ids)
 
-    async def mark_all_read(self) -> int:
-        cursor = await self._db.execute("UPDATE notifications SET read = 1 WHERE read = 0")
+    async def mark_all_read(self, user_id: str | None = None) -> int:
+        if user_id is not None:
+            cursor = await self._db.execute(
+                "UPDATE notifications SET read = 1 WHERE read = 0 AND (user_id IS NULL OR user_id = ?)",
+                (user_id,),
+            )
+        else:
+            # Internal/system caller: unfiltered update.
+            cursor = await self._db.execute("UPDATE notifications SET read = 1 WHERE read = 0")
         await self._db.commit()
         return cursor.rowcount
 
@@ -296,6 +345,7 @@ class NotificationStore(BaseStore):
         # Age out only old UNdismissed notifications. Archived rows are the
         # durable history a user explicitly dismissed (#62 / append-only #103),
         # so they are never GC'd here.
+        # Intentionally global: retention/prune is a system-wide operation.
         cutoff = int(time.time()) - (max_age_days * 86400)
         cursor = await self._db.execute(
             "DELETE FROM notifications WHERE timestamp < ? AND archived = 0", (cutoff,)

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -16,11 +16,20 @@ from tinyagentos.routes.auth import _require_admin
 router = APIRouter()
 
 
-def _notif_user_id(current_user: dict[str, Any]) -> str:
-    uid = str(current_user.get("id") or "")
+def _notif_user_id(request: Request) -> str:
+    """Resolve the calling user the way the rest of the app does.
+
+    AuthMiddleware sets ``request.state.user_id`` for BOTH the session cookie
+    and the local token (``Authorization: Bearer <token>``, which it maps to
+    the primary user), so browser sessions, ``taosctl`` and host scripts all
+    resolve here. A cookie-only dependency such as ``get_current_user`` would
+    401 every local-token caller. Same idiom as ``routes/event_stream.py`` and
+    ``routes/desktop_control.py``.
+    """
+    uid = getattr(request.state, "user_id", None)
     if not uid:
-        raise HTTPException(status_code=401, detail="session has no user id")
-    return uid
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return str(uid)
 
 
 def _format_ts(ts: int) -> str:
@@ -36,12 +45,8 @@ def _format_ts(ts: int) -> str:
 
 
 @router.get("/api/notifications")
-async def list_notifications(
-    request: Request,
-    unread_only: bool = False,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
-    user_id = _notif_user_id(current_user)
+async def list_notifications(request: Request, unread_only: bool = False):
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     items = await store.list(unread_only=unread_only, user_id=user_id)
     # Return HTML for HTMX requests, JSON otherwise
@@ -97,34 +102,24 @@ async def create_notification(request: Request, body: CreateNotificationRequest)
 
 
 @router.get("/api/notifications/count", response_class=HTMLResponse)
-async def notification_count(
-    request: Request,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
-    user_id = _notif_user_id(current_user)
+async def notification_count(request: Request):
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     count = await store.unread_count(user_id=user_id)
     return f"<span class='notif-badge' data-count='{count}'>{count if count else ''}</span>"
 
 
 @router.get("/api/notifications/archived")
-async def list_archived_notifications(
-    request: Request,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
+async def list_archived_notifications(request: Request):
     """History view: dismissed notifications, newest first (nothing deleted)."""
-    user_id = _notif_user_id(current_user)
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     return await store.list_archived(user_id=user_id)
 
 
 @router.post("/api/notifications/{notif_id}/read")
-async def mark_read(
-    request: Request,
-    notif_id: int,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
-    user_id = _notif_user_id(current_user)
+async def mark_read(request: Request, notif_id: int):
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     affected = await store.mark_read(notif_id, user_id=user_id)
     if affected == 0:
@@ -133,13 +128,9 @@ async def mark_read(
 
 
 @router.post("/api/notifications/{notif_id}/archive")
-async def archive_notification(
-    request: Request,
-    notif_id: int,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
+async def archive_notification(request: Request, notif_id: int):
     """Dismiss a notification by archiving it; it stays in the History view."""
-    user_id = _notif_user_id(current_user)
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     affected = await store.archive(notif_id, user_id=user_id)
     if affected == 0:
@@ -148,22 +139,16 @@ async def archive_notification(
 
 
 @router.post("/api/notifications/read-all")
-async def mark_all_read(
-    request: Request,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
-    user_id = _notif_user_id(current_user)
+async def mark_all_read(request: Request):
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     count = await store.mark_all_read(user_id=user_id)
     return {"ok": True, "marked": count}
 
 
 @router.post("/api/notifications/mark-all-read")
-async def mark_all_read_counted(
-    request: Request,
-    current_user: dict[str, Any] = Depends(get_current_user),
-):
-    user_id = _notif_user_id(current_user)
+async def mark_all_read_counted(request: Request):
+    user_id = _notif_user_id(request)
     store = request.app.state.notifications
     count = await store.mark_all_read(user_id=user_id)
     return {"marked": count}

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -16,6 +16,13 @@ from tinyagentos.routes.auth import _require_admin
 router = APIRouter()
 
 
+def _notif_user_id(current_user: dict[str, Any]) -> str:
+    uid = str(current_user.get("id") or "")
+    if not uid:
+        raise HTTPException(status_code=401, detail="session has no user id")
+    return uid
+
+
 def _format_ts(ts: int) -> str:
     """Format a unix timestamp as a relative or short date string."""
     delta = int(time.time()) - ts
@@ -29,9 +36,14 @@ def _format_ts(ts: int) -> str:
 
 
 @router.get("/api/notifications")
-async def list_notifications(request: Request, unread_only: bool = False):
+async def list_notifications(
+    request: Request,
+    unread_only: bool = False,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    items = await store.list(unread_only=unread_only)
+    items = await store.list(unread_only=unread_only, user_id=user_id)
     # Return HTML for HTMX requests, JSON otherwise
     if request.headers.get("hx-request"):
         if not items:
@@ -85,45 +97,75 @@ async def create_notification(request: Request, body: CreateNotificationRequest)
 
 
 @router.get("/api/notifications/count", response_class=HTMLResponse)
-async def notification_count(request: Request):
+async def notification_count(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    count = await store.unread_count()
+    count = await store.unread_count(user_id=user_id)
     return f"<span class='notif-badge' data-count='{count}'>{count if count else ''}</span>"
 
 
 @router.get("/api/notifications/archived")
-async def list_archived_notifications(request: Request):
+async def list_archived_notifications(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """History view: dismissed notifications, newest first (nothing deleted)."""
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    return await store.list_archived()
+    return await store.list_archived(user_id=user_id)
 
 
 @router.post("/api/notifications/{notif_id}/read")
-async def mark_read(request: Request, notif_id: int):
+async def mark_read(
+    request: Request,
+    notif_id: int,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    await store.mark_read(notif_id)
+    affected = await store.mark_read(notif_id, user_id=user_id)
+    if affected == 0:
+        raise HTTPException(status_code=404, detail="notification not found")
     return {"ok": True}
 
 
 @router.post("/api/notifications/{notif_id}/archive")
-async def archive_notification(request: Request, notif_id: int):
+async def archive_notification(
+    request: Request,
+    notif_id: int,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Dismiss a notification by archiving it; it stays in the History view."""
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    await store.archive(notif_id)
+    affected = await store.archive(notif_id, user_id=user_id)
+    if affected == 0:
+        raise HTTPException(status_code=404, detail="notification not found")
     return {"ok": True}
 
 
 @router.post("/api/notifications/read-all")
-async def mark_all_read(request: Request):
+async def mark_all_read(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    await store.mark_all_read()
-    return {"ok": True}
+    count = await store.mark_all_read(user_id=user_id)
+    return {"ok": True, "marked": count}
 
 
 @router.post("/api/notifications/mark-all-read")
-async def mark_all_read_counted(request: Request):
+async def mark_all_read_counted(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
+    user_id = _notif_user_id(current_user)
     store = request.app.state.notifications
-    count = await store.mark_all_read()
+    count = await store.mark_all_read(user_id=user_id)
     return {"marked": count}
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2722 (tsk-7uxooi): notification user scoping 401s every local-token caller — taosctl notifications list/count/read/read-all/mark-all-read all break; resolve the user from request.state.user_id, not the cookie-only dependency

Autonomous build of board card tsk-47baqy.

REVISION: built on `exec/tsk-7uxooi` rebased onto origin/dev

## What changed

Keeps everything #2722 got right — the store-side scoping (`user_id IS NULL OR user_id = ?`), the 0-rows-affected → 404 semantics, and its tests — and replaces only the route-side user resolution.

- `tinyagentos/routes/notifications.py`: `_notif_user_id()` now takes the `Request` and reads `getattr(request.state, "user_id", None)`, raising 401 when absent. The `current_user: dict = Depends(get_current_user)` parameter is gone from `list`, `count`, `archived`, `{id}/read`, `{id}/archive`, `read-all` and `mark-all-read`.

  `get_current_user` reads only the `taos_session` cookie. `AuthMiddleware` sets `request.state.user_id` for **both** the session cookie and the local token (`Authorization: Bearer <token>`, mapped to the primary user, `auth_middleware.py:566`), and the local token never sets a cookie — so gating on the cookie 401'd every `taosctl notifications` subcommand and every host script. The new form is the idiom `routes/event_stream.py:45-47` and `routes/desktop_control.py:46` already use. A local token before onboarding still has `user_id=None` and still 401s, which is the documented behaviour.

- `get_current_user` now appears only on the three pre-existing push routes:

  ```
  $ grep -n 'get_current_user' tinyagentos/routes/notifications.py
  13:from tinyagentos.auth import get_current_user
  25:    resolve here. A cookie-only dependency such as ``get_current_user`` would
  192:    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008   <- push/vapid-public-key
  234:    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008   <- push/subscribe
  260:    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008   <- push/unsubscribe
  ```

- `tests/test_notifications_user_scope.py`:
  - **L1** new `TestNotificationRoutesLocalToken` — 8 tests driving `list`, `count`, `archived`, `{id}/read` (own and another user's), `{id}/archive`, `read-all` and `mark-all-read` with `Authorization: Bearer <auth.get_local_token()>` and **no cookie**. They also assert the token resolves to the **primary user**, not to "everyone": the list is exactly `{alice-notif, broadcast}`, the count is 1, and `read-all` marks 1 row while bob's stays unread.
  - **L2** the route-scoping setups no longer call a scoped store method before the assertion. Ids are fetched from the unfiltered `store.list()` and picked by title (`_row_by_title` / `_id_by_title`), and the post-status read-backs go through the unfiltered list too, so on unfixed code these fail on the leak assertion rather than on a signature `TypeError`.
  - **L3** `test_list_archived_returns_own_only` selects by title instead of `items[0]`/`items[1]` — every row shares the same whole-second `timestamp`, so positional order was only whatever `idx_notif_ts` gave on ties.
  - The `two_user_app` fixture moved to module scope so both route classes use the same app build.

- `changelog.d/tsk-7uxooi-notifications-user-scope.md`: kept from the base branch, plus one line under `### Fixed` for the local-token resolution.

## RED FIRST (pasted)

### L1 — on the BASE branch `exec/tsk-7uxooi` (72893caa5), sources restored, final tests

```
$ python -m pytest tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken -q --tb=short
tests/test_notifications_user_scope.py:270: in test_list_with_local_token_is_not_401
    assert resp.status_code == 200, resp.text
E   AssertionError: {"detail":"Authentication required"}
E   assert 401 == 200
...
tests/test_notifications_user_scope.py:312: in test_mark_read_other_user_with_local_token_returns_404
    assert resp.status_code == 404, resp.text
E   AssertionError: {"detail":"Authentication required"}
E   assert 401 == 404
...
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_list_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_count_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_archived_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_mark_read_own_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_mark_read_other_user_with_local_token_returns_404
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_archive_own_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_read_all_with_local_token_is_not_401
FAILED tests/test_notifications_user_scope.py::TestNotificationRoutesLocalToken::test_mark_all_read_with_local_token_is_not_401
8 failed in 35.77s
EXIT=1
```

Every one of the 8 fails as `401 {"detail":"Authentication required"}` — the cookie-only gate, not a scoping mismatch.

### L2 — on origin/dev sources, final tests: assertion reds, no `TypeError`

```
$ python -m pytest tests/test_notifications_user_scope.py::TestNotificationRoutesUserScope -q --tb=short -p no:randomly
FFFFF.                                                                   [100%]
tests/test_notifications_user_scope.py:178: in test_list_excludes_other_user
    assert "bob-notif" not in titles
E   AssertionError: assert 'bob-notif' not in {'alice-notif', 'bob-notif', 'broadcast'}

tests/test_notifications_user_scope.py:195: in test_archived_excludes_other_user
    assert "bob-notif" not in titles
E   AssertionError: assert 'bob-notif' not in {'alice-notif', 'bob-notif'}

tests/test_notifications_user_scope.py:205: in test_count_excludes_other_user
    assert "1" in resp.text
E   assert '1' in "<span class='notif-badge' data-count='2'>2</span>"

tests/test_notifications_user_scope.py:214: in test_mark_read_other_user_returns_404
    assert resp.status_code == 404
E   assert 200 == 404

tests/test_notifications_user_scope.py:224: in test_archive_other_user_returns_404
    assert resp.status_code == 404
E   assert 200 == 404
5 failed, 1 passed in 18.60s
EXIT=1
```

All five leak tests now red on the leak itself (previously 2 assertion reds and 11 `TypeError: NotificationStore.list() got an unexpected keyword argument 'user_id'`). Being precise about the card's "three mutation tests": `test_mark_read_other_user_returns_404` and `test_archive_other_user_returns_404` are the cross-user ones and both now fail on `assert 200 == 404` with the row actually mutated. The third, `test_mark_own_notification_succeeds`, is the does-not-over-block control and **passes** on origin/dev — correctly, since origin/dev has no scoping at all to over-block with. It used to "fail" there only on the `store.list(user_id=...)` `TypeError` in its read-back, which was never evidence of anything; that read-back now goes through the unfiltered list. It is red on nothing and green on both, by design.

## GREEN

```
$ python -m pytest tests/test_notifications_user_scope.py -q
.....................                                                    [100%]
21 passed in 44.45s

$ python -m pytest tests/test_notifications_user_scope.py tests/ -q -k notification
155 passed, 12551 deselected, 11 warnings in 316.38s (0:05:16)

$ python -m pytest tests/test_notifications.py tests/test_notifications_mark_all.py \
    tests/test_notifications_prefs.py tests/test_notifications_push.py \
    tests/test_notifications_user_scope.py tests/test_routes_notifications.py \
    tests/test_taosctl_notifications.py tests/test_auth_middleware.py \
    tests/test_task_lifecycle_notifications.py tests/test_notify_tools.py -q
198 passed in 147.51s (0:02:27)

$ python -m pytest tests/test_taosctl_route_coverage.py tests/test_taosctl.py \
    tests/test_taosctl_client.py tests/test_routes_auth.py tests/cli -q
43 passed in 46.02s

$ python scripts/check_doc_gate.py diff-gate --base origin/dev
doc-gate: clean
```

## MANUAL PROOF — the caller the PR broke

A real app started on a throwaway data dir (one primary user "alice", two seeded rows: `manual-check` owned by alice and `other-user-notif` owned by a different user id), driven by the actual CLI with `TAOS_TOKEN` = the install's local token.

**On this branch:**

```
$ taosctl notifications list
ID  TITLE
1   manual-check
exit=0

$ taosctl notifications count
<span class='notif-badge' data-count='1'>1</span>
exit=0
```

200 output, and the other user's row is correctly invisible (count 1, not 2) — the scoping decided on tsk-7uxooi still holds for the local-token caller.

**Same app, same data dir, same token, with `routes/notifications.py` + `notifications.py` restored to `exec/tsk-7uxooi`:**

```
$ taosctl notifications list
taosctl: API error (401): Authentication required
exit=2

$ taosctl notifications count
taosctl: API error (401): Authentication required
exit=2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications are now correctly limited to the signed-in user, while broadcast notifications remain visible.
  * Users can no longer view, mark, archive, or bulk-update another user’s notifications.
  * Notification actions now work consistently for both session-based and Bearer-token sign-ins.
  * Read and archive actions now correctly report when a notification is unavailable or does not belong to the signed-in user.
  * Unread counts and archived notification lists now reflect the current user’s notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->