### PR TITLE
Scope approval: server publishes the project-scope vocabulary the consent picker renders from (tsk-rf6kwc)

### DIFF
--- a/changelog.d/tsk-rf6kwc-consent-scope-vocabulary.md
+++ b/changelog.d/tsk-rf6kwc-consent-scope-vocabulary.md
@@ -1,0 +1,3 @@
+### Fixed
+- The consent approve surface no longer keeps its own copy of the "needs a project" scope list. `GET /api/agents/scope-vocabulary` now publishes the server's grantable scopes and the subset that must be bound to a project, and `ConsentActions` renders the project picker from that response, so a scope added server-side can no longer silently reintroduce the unfixable 400 on Approve.
+- If that vocabulary cannot be loaded, Allow is disabled and the failure is shown, instead of falling back to a stale local list and approving with the wrong shape.

--- a/desktop/src/apps/DecisionsApp.test.tsx
+++ b/desktop/src/apps/DecisionsApp.test.tsx
@@ -10,13 +10,29 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { DecisionsApp } from "./DecisionsApp";
 import { useDecisionEventsStore } from "@/stores/decision-events-store";
 
-function mockFetch(
-  responses: Record<string, { ok: boolean; status?: number; body: unknown }>,
-) {
+/** ConsentActions reads the server's project-scope vocabulary before it will
+ *  enable Allow, so any surface embedding it needs this route answered. It is a
+ *  fixed server-side constant, so the harness answers it by default rather than
+ *  every test restating it; a test may still override the key. */
+const SCOPE_VOCABULARY_RESPONSE = {
+  ok: true,
+  body: {
+    valid_scopes: ["a2a_send", "canvas_read", "files_write", "memory_read", "project_tasks"],
+    project_scopes: ["canvas_read", "files_write", "project_tasks"],
+  },
+};
+
+type MockResponse = { ok: boolean; status?: number; body: unknown };
+
+function mockFetch(responses: Record<string, MockResponse>) {
+  const withDefaults: Record<string, MockResponse> = {
+    "GET /api/agents/scope-vocabulary": SCOPE_VOCABULARY_RESPONSE,
+    ...responses,
+  };
   return vi.fn().mockImplementation((input: string, init?: RequestInit) => {
     const method = (init?.method ?? "GET").toUpperCase();
     const key = `${method} ${input}`;
-    const hit = responses[key] ?? responses[input] ?? responses["*"];
+    const hit = withDefaults[key] ?? withDefaults[input] ?? withDefaults["*"];
     if (!hit) throw new Error(`Unmocked fetch: ${key}`);
     return Promise.resolve({
       ok: hit.ok,
@@ -265,6 +281,10 @@ describe("DecisionsApp", () => {
     await waitFor(() => expect(screen.getByText("owl@lab")).toBeTruthy());
     expect(screen.getByText(/access requests/i)).toBeTruthy();
 
+    // Allow stays disabled until the scope vocabulary is in hand.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
     await flush();
 

--- a/desktop/src/components/ConsentActions.test.tsx
+++ b/desktop/src/components/ConsentActions.test.tsx
@@ -2,17 +2,46 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConsentActions, computeScopeDiff, consentPayload } from "./ConsentActions";
 
-function okFetch() {
-  return vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    json: () => Promise.resolve({ status: "ok" }),
+/** The server's project-scope vocabulary, as GET /api/agents/scope-vocabulary
+ *  reports it. Tests serve this rather than relying on any list baked into the
+ *  component -- the component must not have one. */
+const SERVER_PROJECT_SCOPES = [
+  "canvas_read",
+  "canvas_write",
+  "files_read",
+  "files_write",
+  "project_lists",
+  "project_notes",
+  "project_tasks",
+  "project_tasks_create",
+  "project_tasks_update",
+];
+
+function okJson(body: unknown, status = 200) {
+  return Promise.resolve({ ok: true, status, json: () => Promise.resolve(body) });
+}
+
+/** Answer the scope-vocabulary request, or null when `url` is something else.
+ *  Every fetch mock in this file delegates to it first so the component under
+ *  test always has a server to read the vocabulary from. */
+function vocabHit(url: unknown, projectScopes: string[] = SERVER_PROJECT_SCOPES) {
+  if (!String(url).startsWith("/api/agents/scope-vocabulary")) return null;
+  return okJson({
+    valid_scopes: [...projectScopes, "memory_read", "memory_write", "a2a_send"].sort(),
+    project_scopes: projectScopes,
   });
+}
+
+function okFetch() {
+  return vi.fn((url: string) => vocabHit(url) ?? okJson({ status: "ok" }));
 }
 
 describe("ConsentActions", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // Baseline: a server that publishes the scope vocabulary. Tests needing
+    // other endpoints stub their own fetch over this one.
+    vi.stubGlobal("fetch", okFetch());
   });
 
   it("renders Allow and Deny buttons", () => {
@@ -65,10 +94,14 @@ describe("ConsentActions", () => {
   });
 
   it("surfaces an error and does not call onResolved on a failed request", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 403,
-      json: () => Promise.resolve({ detail: "forbidden" }),
+    const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
+      return Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({ detail: "forbidden" }),
+      });
     });
     vi.stubGlobal("fetch", fetchMock);
     const onResolved = vi.fn();
@@ -82,6 +115,8 @@ describe("ConsentActions", () => {
 
   it("shows a project picker for a project_tasks request and sends the chosen project_id", async () => {
     const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       if (String(url).startsWith("/api/projects")) {
         return Promise.resolve({
           ok: true,
@@ -112,6 +147,8 @@ describe("ConsentActions", () => {
 
   it("gates Allow until a project is chosen when several projects exist", async () => {
     const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       if (String(url).startsWith("/api/projects")) {
         return Promise.resolve({
           ok: true,
@@ -134,6 +171,8 @@ describe("ConsentActions", () => {
 
   it("creates a project inline and grants project_tasks against the new project", async () => {
     const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       const u = String(url);
       if (u === "/api/projects?status=active") {
         return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ items: [] }) });
@@ -169,6 +208,8 @@ describe("ConsentActions", () => {
 
   it("preselects and labels the requested project when it resolves", async () => {
     const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       if (String(url).startsWith("/api/projects")) {
         return Promise.resolve({
           ok: true,
@@ -230,6 +271,8 @@ describe("ConsentActions", () => {
 
   it("shows an explicit red not-found message and disables Allow when the requested project does not resolve", async () => {
     const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       if (String(url).startsWith("/api/projects")) {
         return Promise.resolve({
           ok: true,
@@ -354,6 +397,8 @@ describe("ConsentActions", () => {
     "renders the project picker for scope %s and sends project_id on approve",
     async (scope) => {
       const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
         if (String(url).startsWith("/api/projects")) {
           return Promise.resolve({
             ok: true,
@@ -395,6 +440,8 @@ describe("ConsentActions", () => {
 
   it("allows recovery when the requested project does not resolve", async () => {
     const fetchMock = vi.fn((url: string) => {
+      const vocab = vocabHit(url);
+      if (vocab) return vocab;
       if (String(url).startsWith("/api/projects")) {
         return Promise.resolve({
           ok: true,
@@ -430,6 +477,135 @@ describe("ConsentActions", () => {
     fireEvent.change(select, { target: { value: "p1" } });
     expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled();
     expect(select).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  // ---------------------------------------------------------------------
+  // The picker's gate is the SERVER's vocabulary, not a list kept here.
+  //
+  // Mirroring the server list in this component is what made Approve 400 with
+  // no remedy: the copy fell behind, the picker never rendered, and approve was
+  // POSTed without the project_id the server demands. Re-listing today's nine
+  // scopes only postpones that -- the tenth breaks it again. These tests pin
+  // the property that actually prevents it: the component must render from
+  // whatever the server says, including scopes it has never heard of, and must
+  // not render for scopes the server does not classify as project-bound.
+  // ---------------------------------------------------------------------
+
+  function projectsAnd(projectScopes: string[]) {
+    return vi.fn((url: string) => {
+      const vocab = vocabHit(url, projectScopes);
+      if (vocab) return vocab;
+      if (String(url).startsWith("/api/projects")) {
+        return okJson({ items: [{ id: "p1", name: "Alpha" }] });
+      }
+      return okJson({ status: "ok" });
+    });
+  }
+
+  it("renders the project picker for a project scope the client has never heard of", async () => {
+    // A scope added to the server's _PROJECT_SCOPES after this build shipped.
+    const fetchMock = projectsAnd([...SERVER_PROJECT_SCOPES, "project_ledger_write"]);
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions
+        requestId="req-future"
+        scopes={["project_ledger_write"]}
+        onResolved={onResolved}
+      />,
+    );
+
+    await screen.findByLabelText(/Grant project access for/i);
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    const approve = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    expect(JSON.parse((approve![1] as RequestInit).body as string)).toEqual({
+      granted_scopes: ["project_ledger_write"],
+      project_id: "p1",
+    });
+  });
+
+  it("renders the project picker for files_write and sends the chosen project_id", async () => {
+    const fetchMock = projectsAnd(SERVER_PROJECT_SCOPES);
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions
+        requestId="req-fw"
+        scopes={["files_read", "files_write"]}
+        onResolved={onResolved}
+      />,
+    );
+
+    await screen.findByLabelText(/Grant project access for/i);
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    const approve = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    expect(JSON.parse((approve![1] as RequestInit).body as string)).toEqual({
+      granted_scopes: ["files_read", "files_write"],
+      project_id: "p1",
+    });
+  });
+
+  it("does not render the picker for a scope the server no longer treats as project-bound", async () => {
+    // The refusing direction: a scope this component used to hardcode, which
+    // the server has since dropped from _PROJECT_SCOPES. A local copy would
+    // still demand a project and block Allow on a grant that needs none.
+    const fetchMock = projectsAnd(
+      SERVER_PROJECT_SCOPES.filter((s) => s !== "canvas_write"),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions requestId="req-dropped" scopes={["canvas_write"]} onResolved={onResolved} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
+    expect(screen.queryByLabelText(/Grant project access for/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    const approve = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    expect(JSON.parse((approve![1] as RequestInit).body as string)).toEqual({
+      granted_scopes: ["canvas_write"],
+    });
+  });
+
+  it("blocks Allow and says so when the scope vocabulary cannot be loaded", async () => {
+    // Fail closed. Falling back to a built-in list here is exactly the state
+    // this card removes, and a silent fallback would be indistinguishable from
+    // a correct answer.
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).startsWith("/api/agents/scope-vocabulary")) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          json: () => Promise.resolve({}),
+        });
+      }
+      return okJson({ status: "ok" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions requestId="req-vocab-down" scopes={["files_write"]} onResolved={onResolved} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/scope vocabulary/i),
+    );
+    expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/approve"))).toBe(false),
+    );
+    expect(onResolved).not.toHaveBeenCalled();
   });
 });
 

--- a/desktop/src/components/ConsentActions.test.tsx
+++ b/desktop/src/components/ConsentActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConsentActions, computeScopeDiff, consentPayload } from "./ConsentActions";
 
@@ -620,6 +620,72 @@ describe("ConsentActions", () => {
     });
   });
 
+  it("treats a vocabulary array with a non-string entry as a failure, not a shorter list", async () => {
+    // Filtering the bad entry out would yield a list that still looks valid
+    // while missing a project scope -- the picker-never-renders bug again, now
+    // with no error to point at.
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).startsWith("/api/agents/scope-vocabulary")) {
+        return okJson({ project_scopes: ["files_write", null, "project_tasks"] });
+      }
+      return okJson({ status: "ok" });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions requestId="req-bad-vocab" scopes={["files_write"]} onResolved={onResolved} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/malformed/i),
+    );
+    expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+    expect(screen.queryByLabelText(/Grant project access for/i)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/approve"))).toBe(false),
+    );
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+
+  it("times the vocabulary request out rather than leaving Allow disabled with no reason", async () => {
+    vi.useFakeTimers();
+    try {
+      // A request that never settles unless aborted -- the hang case.
+      const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).startsWith("/api/agents/scope-vocabulary")) {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError")),
+            );
+          });
+        }
+        return okJson({ status: "ok" });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      render(<ConsentActions requestId="req-hang" scopes={["files_write"]} />);
+
+      // Before the deadline: disabled, but nothing is claimed either way.
+      expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+      expect(screen.queryByRole("alert")).toBeNull();
+
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      expect(screen.getByRole("alert")).toHaveTextContent(/no answer within 10s/i);
+      expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+      // The signal was actually passed, so the socket is released too.
+      const vocabCall = fetchMock.mock.calls.find((c) =>
+        String(c[0]).startsWith("/api/agents/scope-vocabulary"),
+      );
+      expect((vocabCall![1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("blocks Allow and says so when the scope vocabulary cannot be loaded", async () => {
     // Fail closed. Falling back to a built-in list here is exactly the state
     // this card removes, and a silent fallback would be indistinguishable from
@@ -641,7 +707,9 @@ describe("ConsentActions", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent(/scope vocabulary/i),
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Could not confirm which scopes need a project \(the server answered 503\)/i,
+      ),
     );
     expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
 

--- a/desktop/src/components/ConsentActions.test.tsx
+++ b/desktop/src/components/ConsentActions.test.tsx
@@ -32,6 +32,15 @@ function vocabHit(url: unknown, projectScopes: string[] = SERVER_PROJECT_SCOPES)
   });
 }
 
+/** Resolve once the project list has landed: the picker shows "Loading..." as
+ *  its placeholder option until then, and asserting on the selection or on
+ *  Allow before that is a race. */
+async function projectListLoaded() {
+  await waitFor(() =>
+    expect(screen.queryByRole("option", { name: /Loading/i })).toBeNull(),
+  );
+}
+
 function okFetch() {
   return vi.fn((url: string) => vocabHit(url) ?? okJson({ status: "ok" }));
 }
@@ -63,6 +72,10 @@ describe("ConsentActions", () => {
       />,
     );
 
+    // Allow stays disabled until the server's scope vocabulary is in hand.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
 
     await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
@@ -70,7 +83,8 @@ describe("ConsentActions", () => {
       "/api/agents/auth-requests/req-1/approve",
       expect.objectContaining({ method: "POST" }),
     );
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const approve = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    const init = approve![1] as RequestInit;
     expect(JSON.parse(init.body as string)).toEqual({
       granted_scopes: ["memory_read", "a2a_send"],
     });
@@ -107,6 +121,9 @@ describe("ConsentActions", () => {
     const onResolved = vi.fn();
     render(<ConsentActions requestId="req-3" scopes={[]} onResolved={onResolved} />);
 
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("forbidden"));
@@ -133,6 +150,10 @@ describe("ConsentActions", () => {
     );
     // The picker appears and the single project is auto-selected.
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
     await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
@@ -163,6 +184,9 @@ describe("ConsentActions", () => {
     render(<ConsentActions requestId="req-m" scopes={["project_tasks"]} />);
 
     const select = await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
+    // With two projects none is auto-selected, so Allow is still gated.
+    expect(screen.getByRole("option", { name: "Bravo" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
 
     fireEvent.change(select, { target: { value: "p2" } });
@@ -191,6 +215,7 @@ describe("ConsentActions", () => {
     render(<ConsentActions requestId="req-c" scopes={["project_tasks"]} onResolved={onResolved} />);
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
     expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: /new/i }));
@@ -241,6 +266,7 @@ describe("ConsentActions", () => {
     );
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
     // The resolved requested project is shown by NAME, not just id.
     const requestLine = screen.getByText(/Requesting access for/i);
     expect(requestLine).toHaveTextContent("BTRDRL");
@@ -299,6 +325,7 @@ describe("ConsentActions", () => {
     );
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
     // Explicit not-found message naming the unresolved project id.
     const msg = screen.getByText(/Requested project prj-btrdrl not found/i);
     expect(msg).toBeInTheDocument();
@@ -424,6 +451,10 @@ describe("ConsentActions", () => {
       );
 
       await screen.findByLabelText(/Grant project access for/i);
+      await projectListLoaded();
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+      );
       fireEvent.click(screen.getByRole("button", { name: /allow/i }));
       await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
 
@@ -468,6 +499,7 @@ describe("ConsentActions", () => {
     );
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
     // Initially, Allow is disabled and the select is marked invalid.
     expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
     const select = screen.getByLabelText(/Grant project access for/i);
@@ -516,6 +548,12 @@ describe("ConsentActions", () => {
     );
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
+    // The picker renders before the project list lands; Allow unlocks only once
+    // a project is actually selected.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
     await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
 
@@ -539,6 +577,12 @@ describe("ConsentActions", () => {
     );
 
     await screen.findByLabelText(/Grant project access for/i);
+    await projectListLoaded();
+    // The picker renders before the project list lands; Allow unlocks only once
+    // a project is actually selected.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
     await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
 

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -49,6 +49,11 @@ import { withCsrf } from "@/lib/csrf";
  *  tinyagentos/routes/agent_auth_requests.py. */
 const SCOPE_VOCABULARY_URL = "/api/agents/scope-vocabulary";
 
+/** How long to wait for the vocabulary before treating silence as a failure.
+ *  A hung request must become a visible error, not an Allow button that is
+ *  disabled forever for no stated reason. */
+const VOCAB_TIMEOUT_MS = 10_000;
+
 interface ProjectOption {
   id: string;
   name: string;
@@ -177,16 +182,30 @@ export function ConsentActions({
 
   useEffect(() => {
     let cancelled = false;
-    fetch(SCOPE_VOCABULARY_URL, { credentials: "include" })
+    // A request that never settles would leave Allow disabled forever with
+    // nothing on screen saying why -- the same "no remedy on screen" shape as
+    // the 400 this card removes. Bound it and report the timeout.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), VOCAB_TIMEOUT_MS);
+    fetch(SCOPE_VOCABULARY_URL, {
+      credentials: "include",
+      signal: controller.signal,
+    })
       .then(async (r) => {
         if (!r.ok) {
-          throw new Error(`scope vocabulary unavailable (${r.status})`);
+          throw new Error(`the server answered ${r.status}`);
         }
         const d = (await r.json()) as { project_scopes?: unknown };
-        if (!Array.isArray(d?.project_scopes)) {
-          throw new Error("scope vocabulary response was malformed");
+        // Every entry must be a string. Filtering the bad ones out instead
+        // would hand back a SHORTER list that still looks valid, silently
+        // dropping a project scope and reopening the picker-never-renders bug.
+        if (
+          !Array.isArray(d?.project_scopes) ||
+          !d.project_scopes.every((v): v is string => typeof v === "string")
+        ) {
+          throw new Error("the server's answer was malformed");
         }
-        return d.project_scopes.filter((s): s is string => typeof s === "string");
+        return d.project_scopes;
       })
       .then((list) => {
         if (cancelled) return;
@@ -197,13 +216,18 @@ export function ConsentActions({
         if (cancelled) return;
         setProjectScopes(null);
         setVocabError(
-          e instanceof Error
-            ? e.message
-            : "Could not read the scope vocabulary from the server.",
+          controller.signal.aborted
+            ? `no answer within ${Math.round(VOCAB_TIMEOUT_MS / 1000)}s`
+            : e instanceof Error
+              ? e.message
+              : "the request failed",
         );
-      });
+      })
+      .finally(() => clearTimeout(timer));
     return () => {
       cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
     };
   }, []);
 
@@ -379,8 +403,8 @@ export function ConsentActions({
     <div className="mt-2" role="group" aria-label="Consent actions">
       {vocabError && (
         <p role="alert" className="mb-2 text-[11px] text-red-300">
-          Could not load the scope vocabulary ({vocabError}), so it is not known
-          whether these scopes need a project. Reload before approving.
+          Could not confirm which scopes need a project ({vocabError}), so this
+          request cannot be approved safely. Reload and try again.
         </p>
       )}
       {scopes.length > 0 && (

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -34,18 +34,20 @@ import { withCsrf } from "@/lib/csrf";
  * so a request that named no project (or the wrong one) can still be assigned
  * the right project at approval time. The chosen project id is passed to the
  * approve endpoint, which mints the token bound to it.
+ *
+ * WHICH scopes those are is the server's answer, never ours. This file used to
+ * carry its own Set of them, and it fell six scopes behind the backend's
+ * `_PROJECT_SCOPES`: for `files_write` (and five others) the picker never
+ * rendered, approve was POSTed with no project_id, and the operator got a 400
+ * with no control on screen that could fix it. A refreshed copy would only
+ * postpone that until the next scope is added, so there is no copy here at all
+ * -- the vocabulary is fetched below and the picker renders from the response.
  */
-const PROJECT_SCOPES = new Set([
-  "project_tasks",
-  "canvas_read",
-  "canvas_write",
-  "project_tasks_create",
-  "project_tasks_update",
-  "project_lists",
-  "project_notes",
-  "files_read",
-  "files_write",
-]);
+
+/** Server-published scope vocabulary: every grantable scope, plus the subset
+ *  that is meaningless without a project binding. See
+ *  tinyagentos/routes/agent_auth_requests.py. */
+const SCOPE_VOCABULARY_URL = "/api/agents/scope-vocabulary";
 
 interface ProjectOption {
   id: string;
@@ -145,12 +147,19 @@ export function ConsentActions({
   // asked) is unchanged; the prop exists so the Requested vs Granted contrast
   // is always explicit and a narrowing can never be silent.
   const granted = grantedScopes ?? scopes;
-  const needsProject = granted.some((s) => PROJECT_SCOPES.has(s));
   const { dropped, added } = computeScopeDiff(scopes, granted);
   const hasScopeDiff = dropped.length > 0 || added.length > 0;
 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // null until the server's vocabulary has been read. There is deliberately no
+  // default value to fall back on: not knowing which scopes need a project is
+  // exactly the state that produced the unfixable 400, so it blocks Allow and
+  // says why rather than guessing from a stale list.
+  const [projectScopes, setProjectScopes] = useState<string[] | null>(null);
+  const [vocabError, setVocabError] = useState<string | null>(null);
+  const needsProject =
+    projectScopes !== null && granted.some((s) => projectScopes.includes(s));
   const [projects, setProjects] = useState<ProjectOption[]>([]);
   const [loadingProjects, setLoadingProjects] = useState(false);
   // Start empty on purpose: a requestedProjectId is only adopted after it is
@@ -165,6 +174,38 @@ export function ConsentActions({
     useState<boolean>(false);
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(SCOPE_VOCABULARY_URL, { credentials: "include" })
+      .then(async (r) => {
+        if (!r.ok) {
+          throw new Error(`scope vocabulary unavailable (${r.status})`);
+        }
+        const d = (await r.json()) as { project_scopes?: unknown };
+        if (!Array.isArray(d?.project_scopes)) {
+          throw new Error("scope vocabulary response was malformed");
+        }
+        return d.project_scopes.filter((s): s is string => typeof s === "string");
+      })
+      .then((list) => {
+        if (cancelled) return;
+        setProjectScopes(list);
+        setVocabError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setProjectScopes(null);
+        setVocabError(
+          e instanceof Error
+            ? e.message
+            : "Could not read the scope vocabulary from the server.",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!needsProject) return;
@@ -258,6 +299,17 @@ export function ConsentActions({
   async function decide(approved: boolean) {
     setBusy(true);
     setError(null);
+    // Approving without knowing whether these scopes are project-bound is the
+    // defect this surface exists to prevent; refuse rather than guess. Denying
+    // needs no vocabulary, so it is never blocked.
+    if (approved && projectScopes === null) {
+      setError(
+        vocabError ??
+          "Still reading the scope vocabulary from the server; try again in a moment.",
+      );
+      setBusy(false);
+      return;
+    }
     let projectId = selectedProjectId;
     // If approving with a project scope while mid-create, create the project first.
     if (approved && needsProject && creating && newName.trim()) {
@@ -319,11 +371,18 @@ export function ConsentActions({
 
   const allowDisabled =
     busy ||
+    projectScopes === null ||
     (needsProject &&
       (creating ? !newName.trim() : !selectedProjectId));
 
   return (
     <div className="mt-2" role="group" aria-label="Consent actions">
+      {vocabError && (
+        <p role="alert" className="mb-2 text-[11px] text-red-300">
+          Could not load the scope vocabulary ({vocabError}), so it is not known
+          whether these scopes need a project. Reload before approving.
+        </p>
+      )}
       {scopes.length > 0 && (
         <div className="mb-2">
           <div className="flex flex-wrap items-baseline gap-1">

--- a/desktop/src/components/NotificationCentre.test.tsx
+++ b/desktop/src/components/NotificationCentre.test.tsx
@@ -172,9 +172,20 @@ describe("NotificationCentre click routing", () => {
   });
 
   it("archives (not just removes) the notification when a consent decision is made", async () => {
+    // ConsentActions will not enable Allow until the server has told it which
+    // scopes need a project, so the stub has to answer that route like the
+    // real one does -- an empty {} is a malformed vocabulary, not a no-op.
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) }),
+      vi.fn().mockImplementation((url: string) => {
+        const body = String(url).startsWith("/api/agents/scope-vocabulary")
+          ? {
+              valid_scopes: ["memory_read", "project_tasks"],
+              project_scopes: ["project_tasks"],
+            }
+          : {};
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) });
+      }),
     );
     notifications = [
       notif({
@@ -186,6 +197,9 @@ describe("NotificationCentre click routing", () => {
     ];
     render(<NotificationCentre />);
 
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled(),
+    );
     fireEvent.click(screen.getByRole("button", { name: /allow/i }));
 
     // Resolution archives + reads (lands in History), it is NOT a plain dismiss.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -711,7 +711,20 @@ previously grantable without a `project_id`, which minted an inert note grant
 the operator believed was usable; it now follows the same rule as
 `project_tasks`. `decisions_read` /
 `decisions_write` (and the other global scopes) may be granted globally
-(`project_id=None`) or per-project. Creation
+(`project_id=None`) or per-project.
+
+`_PROJECT_SCOPES` is published, not duplicated. `GET /api/agents/scope-vocabulary`
+(authenticated) returns `{"valid_scopes": [...], "project_scopes": [...]}`, and the
+desktop consent surface renders the project picker from that response rather than
+from any list of its own. Adding a scope to `_PROJECT_SCOPES` therefore needs no
+client change; keeping a second copy anywhere is the bug that made Approve answer
+400 for `files_write` with no picker on screen to supply the `project_id`. If the
+vocabulary cannot be read, the consent surface disables Allow and says so — it
+does not fall back to a built-in list. The route lives in `agent_auth_requests.py`
+and must stay ahead of `/api/agents/{name}` in the router include order in
+`tinyagentos/routes/__init__.py`, or that path parameter captures it.
+
+Creation
 surfaces a bell notification (`source: agent_scope_requests`) to the owner/admin,
 retired when the request is decided.
 

--- a/tests/test_consent_actions_scopes.py
+++ b/tests/test_consent_actions_scopes.py
@@ -1,20 +1,79 @@
-"""Verify the frontend ConsentActions PROJECT_SCOPES set stays in sync with the
-backend _PROJECT_SCOPES. A drift here silently reintroduces the 400 bug the
-consent picker fix is meant to close."""
+"""The consent picker's "this scope needs a project" list has exactly one home:
+the server.
+
+It used to have two -- ``_PROJECT_SCOPES`` here and a ``PROJECT_SCOPES`` Set in
+``desktop/src/components/ConsentActions.tsx`` -- and the copy fell six scopes
+behind, so approving ``files_write`` (and five others) rendered no project
+picker, POSTed no ``project_id``, and got back a 400 the operator could not act
+on. Pinning the two lists to each other only narrows the window; the mechanism
+that produced the drift is the copy itself.
+
+So this module asserts the durable shape instead:
+
+  * the server PUBLISHES the vocabulary at ``GET /api/agents/scope-vocabulary``,
+    and what it publishes is ``_PROJECT_SCOPES`` itself, not a restatement;
+  * the route is reachable under that exact path (``/api/agents/{name}`` in
+    routes/agents.py would happily swallow it if the routers were reordered);
+  * the client holds NO local copy to drift, and does read the published one.
+"""
+
+from __future__ import annotations
 
 import re
 from pathlib import Path
 
-from tinyagentos.routes.agent_auth_requests import _PROJECT_SCOPES
+import pytest
+
+from tinyagentos.routes.agent_auth_requests import (
+    VALID_SCOPES,
+    _PROJECT_SCOPES,
+)
+
+_CONSENT_ACTIONS = Path("desktop/src/components/ConsentActions.tsx")
+_VOCABULARY_PATH = "/api/agents/scope-vocabulary"
 
 
-def test_consent_actions_project_scopes_match_backend():
-    ts_file = Path("desktop/src/components/ConsentActions.tsx").read_text()
-    match = re.search(r"const PROJECT_SCOPES = new Set\(\[(.*?)\]\)", ts_file, re.DOTALL)
-    assert match, "PROJECT_SCOPES constant not found in ConsentActions.tsx"
-    scopes_str = match.group(1)
-    ts_scopes = {s.strip().strip('"').strip("'") for s in scopes_str.split(",") if s.strip()}
-    assert ts_scopes == _PROJECT_SCOPES, (
-        f"ConsentActions.tsx PROJECT_SCOPES drifted from backend _PROJECT_SCOPES: "
-        f"TS={sorted(ts_scopes)}, Python={sorted(_PROJECT_SCOPES)}"
+@pytest.mark.asyncio
+async def test_scope_vocabulary_publishes_the_server_project_scopes(client):
+    """The endpoint the picker reads returns the server's own set, verbatim."""
+    resp = await client.get(_VOCABULARY_PATH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["project_scopes"] == sorted(_PROJECT_SCOPES)
+    assert body["valid_scopes"] == sorted(VALID_SCOPES)
+    # Every project scope is a grantable scope; a typo in one list would
+    # otherwise publish a scope that can never be granted.
+    assert set(body["project_scopes"]) <= set(body["valid_scopes"])
+
+
+@pytest.mark.asyncio
+async def test_scope_vocabulary_is_not_shadowed_by_the_agent_name_route(client):
+    """``/api/agents/{name}`` must not capture the vocabulary path.
+
+    Both routes live under ``/api/agents/``; which one wins depends on router
+    include order in routes/__init__.py. A 404 (or an agent-shaped body) here
+    means a reorder silently took the picker's data source away.
+    """
+    resp = await client.get(_VOCABULARY_PATH)
+    assert resp.status_code == 200, resp.text
+    assert "project_scopes" in resp.json()
+
+
+def test_consent_actions_keeps_no_local_project_scope_list():
+    """No second copy of the list may exist in the client."""
+    ts = _CONSENT_ACTIONS.read_text()
+    stale = re.search(r"PROJECT_SCOPES\s*=\s*new Set\(", ts)
+    assert stale is None, (
+        "ConsentActions.tsx declares its own PROJECT_SCOPES set again. That copy "
+        "is what drifted from the backend _PROJECT_SCOPES and made Approve 400 "
+        f"with no remedy; render the picker from {_VOCABULARY_PATH} instead."
+    )
+
+
+def test_consent_actions_reads_the_published_vocabulary():
+    """...and it reads the server's, so a new server scope needs no client edit."""
+    ts = _CONSENT_ACTIONS.read_text()
+    assert _VOCABULARY_PATH in ts, (
+        f"ConsentActions.tsx never requests {_VOCABULARY_PATH}; the project "
+        "picker is being gated by something other than the server's vocabulary."
     )

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -236,7 +236,9 @@ def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:
 # ---------------------------------------------------------------------------
 
 @router.get("/api/agents/scope-vocabulary")
-async def get_scope_vocabulary(user: CurrentUser = Depends(current_user)):
+# The dependency is the point: it is what makes this route authenticated. The
+# handler needs nothing from the user -- the vocabulary is the same for all.
+async def get_scope_vocabulary(_user: CurrentUser = Depends(current_user)):
     """Publish the grantable scope vocabulary and the project-bound subset.
 
     The consent surface (desktop/src/components/ConsentActions.tsx) has to know

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -7,6 +7,7 @@ GET    /api/agents/auth-requests/{request_id}          — poll request status (
 POST   /api/agents/auth-requests/{request_id}/approve  — approve + mint identity (admin only)
 POST   /api/agents/auth-requests/{request_id}/deny     — deny the request (admin only)
 GET    /api/agents/auth-requests                       — list pending requests (admin only)
+GET    /api/agents/scope-vocabulary                    — grantable scopes + the project-bound subset
 
 The two public endpoints (create + status poll) are added to auth_middleware.EXEMPT_PATHS
 so unauthenticated external agents can reach them.  The opaque UUID request_id acts as a
@@ -228,6 +229,33 @@ def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:
     if request_id not in locks:
         locks[request_id] = asyncio.Lock()
     return locks[request_id]
+
+
+# ---------------------------------------------------------------------------
+# Routes — scope vocabulary (authenticated)
+# ---------------------------------------------------------------------------
+
+@router.get("/api/agents/scope-vocabulary")
+async def get_scope_vocabulary(user: CurrentUser = Depends(current_user)):
+    """Publish the grantable scope vocabulary and the project-bound subset.
+
+    The consent surface (desktop/src/components/ConsentActions.tsx) has to know
+    which scopes cannot be granted without a project_id, because that is what
+    decides whether it renders the project picker at all. It used to know by
+    keeping its own copy of `_PROJECT_SCOPES`, which fell six scopes behind:
+    approving `files_write` rendered no picker, POSTed no project_id, and the
+    approve handler answered 400 with nothing on screen the operator could act
+    on. Every scope added below would have re-broken it the same silent way.
+
+    So the list is written down once, here, and the client reads it. Note this
+    route must stay ahead of `/api/agents/{name}` (routes/agents.py) in the
+    include order in routes/__init__.py, or that path parameter swallows it —
+    tests/test_consent_actions_scopes.py pins that.
+    """
+    return {
+        "valid_scopes": sorted(VALID_SCOPES),
+        "project_scopes": sorted(_PROJECT_SCOPES),
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Scope approval is unusable for files/project_tasks_create/update: client PROJECT_SCOPES has drifted from the server's, so Approve 400s with no way to supply project_id

Autonomous build of board card tsk-rf6kwc.

## What changed

The card's durable fix, not the constant patch.

- **Server publishes the vocabulary.** New `GET /api/agents/scope-vocabulary`
  (authenticated) in `tinyagentos/routes/agent_auth_requests.py` returns
  `{"valid_scopes": [...], "project_scopes": [...]}` straight from `VALID_SCOPES`
  and `_PROJECT_SCOPES` — not a restatement of them.
- **The client reads it and keeps no copy.** `desktop/src/components/ConsentActions.tsx`
  fetches the vocabulary and computes `needsProject` from the response. The
  local `const PROJECT_SCOPES = new Set([...])` is **deleted**. A scope added to
  `_PROJECT_SCOPES` now needs no client change at all.
- **Fails closed and loudly.** Not knowing the vocabulary is the exact state that
  produced the unfixable 400, so it is not papered over with a built-in fallback:
  while the response is outstanding, or if it fails, Allow is disabled and the
  reason is rendered. Deny never depends on it.
- **Route ordering is pinned.** `/api/agents/{name}` (routes/agents.py) will happily
  capture this path — it did, before the route existed, returning
  `{"error":"Agent 'scope-vocabulary' not found"}`. A test asserts the resolved
  path, not just the handler function.
- `docs/agent-coordination.md` documents the published vocabulary and the
  no-second-copy rule; changelog fragment at `changelog.d/tsk-rf6kwc-consent-scope-vocabulary.md`.

### Note on the card's stated reds

The card's first red — "given a scope request for `files_write`, assert the project
picker RENDERS; today it does not" — **passes on current `origin/dev`**. `e776eef61`
(fix-forward #2607, merged 2026-08-29) had already resynced the client constant to
all nine server scopes, and added a regex drift test. That is precisely the
"patch the constant, leave the mechanism" outcome the card's Fix section warns
about, so the card's reds as literally written can no longer fail. Both are kept as
regression coverage, and the reds below are built on the mechanism that *is* still
broken: the client deciding this from a list of its own.

## RED FIRST (pasted)

Frontend, on the pre-fix component (`npx vitest run src/components/ConsentActions.test.tsx`):

```
     × renders the project picker for a project scope the client has never heard of 2090ms (retry x1)
     × does not render the picker for a scope the server no longer treats as project-bound 202ms (retry x1)
     × blocks Allow and says so when the scope vocabulary cannot be loaded 2102ms (retry x1)

 FAIL  src/components/ConsentActions.test.tsx > ConsentActions > renders the project picker for a project scope the client has never heard of
TestingLibraryElementError: Unable to find a label with the text of: /Grant project access for/i
 FAIL  src/components/ConsentActions.test.tsx > ConsentActions > does not render the picker for a scope the server no longer treats as project-bound
AssertionError: expected <select …(3)>…(2)</select> to be null
 FAIL  src/components/ConsentActions.test.tsx > ConsentActions > blocks Allow and says so when the scope vocabulary cannot be loaded
TestingLibraryElementError: Unable to find role="alert"

 Test Files  1 failed (1)
      Tests  3 failed | 27 passed (30)
EXIT=1
```

Contract, on the pre-fix server + client (`python -m pytest tests/test_consent_actions_scopes.py -q`):

```
FFFF                                                                     [100%]
__________ test_scope_vocabulary_publishes_the_server_project_scopes ___________
        resp = await client.get(_VOCABULARY_PATH)
>       assert resp.status_code == 200, resp.text
E       AssertionError: {"error":"Agent 'scope-vocabulary' not found"}
E       assert 404 == 200

__________ test_consent_actions_keeps_no_local_project_scope_list ______________
E       AssertionError: ConsentActions.tsx declares its own PROJECT_SCOPES set again. That copy is what drifted from the backend _PROJECT_SCOPES and made Approve 400 with no remedy; render the picker from /api/agents/scope-vocabulary instead.
E       assert <re.Match object; span=(1976, 2001), match='PROJECT_SCOPES = new Set('> is None

__________ test_consent_actions_reads_the_published_vocabulary _________________
E       AssertionError: ConsentActions.tsx never requests /api/agents/scope-vocabulary; the project picker is being gated by something other than the server's vocabulary.

FAILED tests/test_consent_actions_scopes.py::test_scope_vocabulary_publishes_the_server_project_scopes
FAILED tests/test_consent_actions_scopes.py::test_scope_vocabulary_is_not_shadowed_by_the_agent_name_route
FAILED tests/test_consent_actions_scopes.py::test_consent_actions_keeps_no_local_project_scope_list
FAILED tests/test_consent_actions_scopes.py::test_consent_actions_reads_the_published_vocabulary
4 failed in 16.14s
EXIT=1
```

The 404 body is worth reading twice: `/api/agents/{name}` was already answering that
path, which is why the ordering test exists.

## GREEN

```
$ npx vitest run src/components/ConsentActions.test.tsx
 Test Files  1 passed (1)
      Tests  30 passed (30)                                    EXIT=0

$ npm run build                                                EXIT=0  (✓ built in 39.94s)

$ python -m pytest tests/test_consent_actions_scopes.py -q
4 passed in 10.11s                                             EXIT=0

$ python -m pytest tests/ -q -k "scope or agent_auth"
262 passed, 1 skipped, 12425 deselected in 902.38s             EXIT=0

$ python -m pytest tests/test_auth_requests.py tests/test_agent_scope_requests.py \
      tests/test_consent_actions_scopes.py tests/test_routes_agent_auth_requests.py -q
99 passed in 188.74s                                           EXIT=0

$ npx vitest run src/apps/NotificationsApp.test.tsx src/apps/__tests__ src/components/__tests__
 Test Files  36 passed (36)
      Tests  221 passed (221)                                  EXIT=0

$ python scripts/check_doc_gate.py diff-gate --base origin/dev
doc-gate: clean                                                EXIT=0
```

## Gate

@taOS-dev reviews before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a server-provided scope vocabulary for the consent screen.
  * Project scope options now reflect scopes supported by the server.
  * Added an endpoint for authenticated clients to retrieve available scopes.

* **Bug Fixes**
  * The Allow action is disabled when scope information is unavailable.
  * Added an error alert when scope vocabulary loading fails, preventing approval submission.

* **Documentation**
  * Documented the scope vocabulary endpoint and consent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Removes-Intentionally: tests/test_consent_actions_scopes.py:test_consent_actions_project_scopes_match_backend

That test asserted the client-side PROJECT_SCOPES mirror matches the server set. This PR deletes the mirror itself (the server vocabulary endpoint is the only copy), so the regex has nothing to match; its no-drift intent is enforced by the four stronger tests in tests/test_consent_actions_scopes.py and the ConsentActions frontend tests.
