### PR TITLE
fix-forward #2622: archive_checklist_item still publishes under task_id in its fallback, contradicting its own docstring (tsk-s5pif2)

### DIFF
--- a/changelog.d/tsk-s5pif2-checklist-orphan-task-publish.md
+++ b/changelog.d/tsk-s5pif2-checklist-orphan-task-publish.md
@@ -1,0 +1,9 @@
+### Fixed
+- Checklist item create and archive now refuse a task that no longer exists
+  instead of publishing their broker event under a topic no project subscriber
+  listens to. `task_checklist_items.task_id` declares a foreign key but the
+  task store never enables `PRAGMA foreign_keys = ON`, so a checklist item can
+  outlive its task; the previous fallback resolved the publish topic to an
+  empty string and the `checklist.item.created` / `checklist.item.archived`
+  event was silently lost. Both paths now resolve the parent task before they
+  mutate, so a refusal leaves no orphan row and no half-applied archive.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1174,6 +1174,15 @@ Route module `tinyagentos/routes/projects.py`.
   another project is existence-hiding rather than merely forbidden.
 - Creating an item logs `checklist.item.created` to the project activity feed
   with the actor, task id, item id and text.
+- Both `checklist.item.created` and `checklist.item.archived` are published on
+  the broker under the task's **`project_id`**, because project subscribers
+  subscribe at project scope. The store therefore resolves the parent task
+  first and raises `ValueError: task not found: <task_id>` when it is gone —
+  create refuses before inserting the row, archive refuses before flipping
+  `archived`. `task_checklist_items.task_id` declares a foreign key but the
+  store never sets `PRAGMA foreign_keys = ON`, so an item can outlive its task;
+  without the guard the event went to a topic nobody listens to and was
+  silently lost.
 - Archiving is store-level only and refuses unless the item is both **verified**
   and **reported**; there is no archive route.
 - `DELETE` and per-item subpaths (`.../checklist-items/{item_id}`) stay

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -464,6 +464,80 @@ async def test_checklist_item_event_delivered_at_project_scope(store_with_broker
     assert checklist_events[0].payload["task_id"] == t["id"]
 
 
+async def _delete_task_row(store, task_id: str) -> None:
+    """Drop a task row out from under its checklist items.
+
+    ``task_checklist_items.task_id`` declares ``REFERENCES project_tasks(id)``
+    but ProjectTaskStore never issues ``PRAGMA foreign_keys = ON``, so SQLite
+    does not enforce it and a live checklist item can outlive its task.
+    """
+    await store._db.execute("DELETE FROM project_tasks WHERE id = ?", (task_id,))
+    await store._db.commit()
+
+
+@pytest.mark.asyncio
+async def test_archive_checklist_item_refuses_when_task_is_gone(store_with_broker):
+    """Archiving an orphaned item must raise, not publish off-topic.
+
+    The fallback resolved the publish topic to something that is not a
+    project_id, so ``checklist.item.archived`` landed on a channel no
+    project subscriber listens to and the mutation was silently lost.
+    """
+    store, broker = store_with_broker
+    t = await store.create_task(project_id="proj-orphan", title="Objective", created_by="u")
+    item = await store.create_checklist_item(task_id=t["id"], text="step one", created_by="u")
+    await store.update_checklist_item(item_id=item["id"], verified=True, reported=True)
+    await _delete_task_row(store, t["id"])
+
+    # Captured rather than asserted with pytest.raises so the topic assertion
+    # below is the one that reports the defect, not an unreached line after it.
+    raised: ValueError | None = None
+    try:
+        await store.archive_checklist_item(item_id=item["id"])
+    except ValueError as exc:
+        raised = exc
+
+    # Nothing may reach a non-project channel: "" is the current fallback
+    # topic, the task_id is the pre-#2622 one. Both are dead letter boxes.
+    for dead_topic in ("", t["id"]):
+        queue = await broker.subscribe(dead_topic)
+        stray = []
+        while not queue.empty():
+            stray.append(queue.get_nowait().kind)
+        assert not stray, f"event published to dead topic {dead_topic!r}: {stray}"
+
+    assert raised is not None and "task not found" in str(raised), (
+        f"archive must refuse an item whose task is gone, raised: {raised!r}"
+    )
+    # The refused archive must not have mutated the row either.
+    again = await store.get_checklist_item(item["id"])
+    assert again["archived"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_checklist_item_refuses_when_task_is_missing(store_with_broker):
+    """Same defect on the sibling create path — it must refuse, not orphan a row."""
+    store, broker = store_with_broker
+
+    raised: ValueError | None = None
+    try:
+        await store.create_checklist_item(task_id="tsk-ghost", text="step one", created_by="u")
+    except ValueError as exc:
+        raised = exc
+
+    for dead_topic in ("", "tsk-ghost"):
+        queue = await broker.subscribe(dead_topic)
+        stray = []
+        while not queue.empty():
+            stray.append(queue.get_nowait().kind)
+        assert not stray, f"event published to dead topic {dead_topic!r}: {stray}"
+
+    assert raised is not None and "task not found" in str(raised), (
+        f"create must refuse a missing task, raised: {raised!r}"
+    )
+    assert await store.list_checklist_items(task_id="tsk-ghost", include_archived=True) == []
+
+
 @pytest.mark.asyncio
 async def test_checklist_item_created_by_persists(store):
     """Acceptance 1: Round-trip test: create_checklist_item(created_by="u") -> list_checklist_items returns created_by == "u". RED on origin/dev (column absent), green on the fix."""

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -917,6 +917,16 @@ class ProjectTaskStore(BaseStore):
         text: str,
         created_by: str,
     ) -> dict:
+        """Create a checklist item on a task.
+
+        Raises ValueError if the task does not exist: the item's only route to
+        a project subscriber is the task's ``project_id``, so a missing task
+        leaves nothing to publish under. Resolved before the INSERT so a refusal
+        never leaves an orphan row behind.
+        """
+        task = await self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"task not found: {task_id}")
         cid = new_id("cki")
         now = time.time()
         await self._db.execute(
@@ -932,9 +942,7 @@ class ProjectTaskStore(BaseStore):
         row = await cur.fetchone()
         desc = cur.description
         item = _row_to_checklist_item(row, desc)
-        task = await self.get_task(task_id)
-        project_id = task["project_id"] if task is not None else ""
-        await self._publish(project_id, "checklist.item.created", {"id": item["id"], "text": item["text"], "task_id": task_id})
+        await self._publish(task["project_id"], "checklist.item.created", {"id": item["id"], "text": item["text"], "task_id": task_id})
         return item
 
     async def list_checklist_items(
@@ -989,7 +997,10 @@ class ProjectTaskStore(BaseStore):
         """Archive a checklist item. Only valid if verified=1 and reported=1.
 
         Raises ValueError if the item cannot be archived because it lacks
-        verification or a report.
+        verification or a report, or because its task is gone — the task
+        carries the ``project_id`` that ``checklist.item.archived`` is
+        published under, and project subscribers listen at project scope only.
+        Resolved before the UPDATE so a refusal leaves the item untouched.
         """
         item = await self.get_checklist_item(item_id)
         if item is None:
@@ -998,15 +1009,16 @@ class ProjectTaskStore(BaseStore):
             raise ValueError("item cannot be archived: not verified")
         if item["reported"] != 1:
             raise ValueError("item cannot be archived: not reported")
+        task = await self.get_task(item["task_id"])
+        if task is None:
+            raise ValueError(f"task not found: {item['task_id']}")
         now = time.time()
         await self._db.execute(
             "UPDATE task_checklist_items SET archived = 1, updated_at = ? WHERE id = ?",
             (now, item_id),
         )
         await self._db.commit()
-        task = await self.get_task(item["task_id"])
-        project_id = task["project_id"] if task is not None else ""
-        await self._publish(project_id, "checklist.item.archived", {"id": item_id, "task_id": item["task_id"], "archived": True})
+        await self._publish(task["project_id"], "checklist.item.archived", {"id": item_id, "task_id": item["task_id"], "archived": True})
         return await self.get_checklist_item(item_id)
 
     async def get_checklist_item(self, item_id: str) -> dict | None:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2622: archive_checklist_item still publishes under task_id in its fallback, contradicting its own docstring
Autonomous build of board card tsk-s5pif2.

BASE: exec/tsk-pa2zau
Supersedes #2622

## Base correction (please read first)

The card's `BASE: exec/tsk-pa2zau` is dead. PR #2622 was **closed unmerged**
(`mergedAt: null`), and its head `237dcd37f` is **not** an ancestor of `dev`.
The checklist feature reached `dev` through a different carry (#2674, `79a5f12e5`),
so the create-path fix #2622 was cut to make never landed. Building on
`exec/tsk-pa2zau` would have replayed a stale tree against a base that has moved
147 commits on. This branch is therefore cut from `origin/dev` (`b8f7726ea`).

That changes what the defect looks like, but not that it is real:

| | card / `exec/tsk-pa2zau` | current `dev` |
|---|---|---|
| `create_checklist_item` fallback | raises (the #2622 fix) | `project_id = ... else ""` |
| `archive_checklist_item` fallback | `else item["task_id"]` | `else ""` |

So on `dev` **both** siblings still resolve the publish topic to something that
is not a `project_id`. The card's premise ("create was fixed to raise, archive
kept the fallback") does not hold on `dev` — neither was fixed — and the card's
FIX ("make the archive path raise, exactly as create does") cannot be satisfied
by copying create, because create does not raise either. Both are fixed here.

The reachability the card asserts is confirmed verbatim on `dev`:
`task_checklist_items.task_id` declares `REFERENCES project_tasks(id)`, and
`ProjectTaskStore` never issues `PRAGMA foreign_keys = ON` (grep for the pragma
hits `mcp/registry.py`, `shared_folders.py`, `relationships.py`,
`library_store.py`, `secrets.py` — never `projects/task_store.py`). A checklist
item can outlive its task, and `ProjectEventBroker` keys one channel per
`project_id`, so the event lands where nobody is subscribed and is silently lost.

## What changed

`tinyagentos/projects/task_store.py`
- `create_checklist_item` resolves the parent task **before** the INSERT and
  raises `ValueError: task not found: <task_id>` when it is missing, so a
  refusal cannot leave an orphan row behind. The publish now uses
  `task["project_id"]` unconditionally — the `else ""` fallback is gone.
- `archive_checklist_item` resolves the parent task **before** the UPDATE, with
  the same raise, so a refusal leaves the item un-archived rather than
  half-applying the mutation and then losing its event. Same fallback removal.
- Both docstrings now state why the task is required (it carries the only
  `project_id` a project subscriber can be reached at) instead of asserting a
  guarantee the code did not have.

`tests/projects/test_task_store.py`
- Two mutating acceptance tests. The archive one deletes the parent row out from
  under a live, verified+reported checklist item (`_delete_task_row`, which is
  only possible *because* the FK is unenforced), then asserts no event reached
  either dead topic — `""` (the `dev` fallback) or the `task_id` (the
  pre-#2622 one) — that the call raised, and that `archived` stayed `False`.
  The create one does the same against a task id that never existed and asserts
  no row was inserted.
- The raise is captured into a variable rather than wrapped in `pytest.raises`
  on purpose: with `pytest.raises` first, the topic assertion is unreachable on
  a red run and the failure reads "DID NOT RAISE", which is exactly the
  "asserting archive returns 200 cannot fail" shape the card rules out. In this
  order the assertion that goes red is the one naming the wrong topic and the
  event that went to it.

## RED FIRST (pasted)

Run at the base source (`git checkout origin/dev -- tinyagentos/projects/task_store.py`,
new tests in place):

```
$ .venv/bin/python -m pytest tests/projects/test_task_store.py -q -p no:cacheprovider -k "refuses_when_task"
FF                                                                       [100%]
=================================== FAILURES ===================================
____________ test_archive_checklist_item_refuses_when_task_is_gone _____________

    store, broker = store_with_broker
    t = await store.create_task(project_id="proj-orphan", title="Objective", created_by="u")
    item = await store.create_checklist_item(task_id=t["id"], text="step one", created_by="u")
    await store.update_checklist_item(item_id=item["id"], verified=True, reported=True)
    await _delete_task_row(store, t["id"])

    # Captured rather than asserted with pytest.raises so the topic assertion
    # below is the one that reports the defect, not an unreached line after it.
    raised: ValueError | None = None
    try:
        await store.archive_checklist_item(item_id=item["id"])
    except ValueError as exc:
        raised = exc

    # Nothing may reach a non-project channel: "" is the current fallback
    # topic, the task_id is the pre-#2622 one. Both are dead letter boxes.
    for dead_topic in ("", t["id"]):
        queue = await broker.subscribe(dead_topic)
        stray = []
        while not queue.empty():
            stray.append(queue.get_nowait().kind)
>           assert not stray, f"event published to dead topic {dead_topic!r}: {stray}"
E           AssertionError: event published to dead topic '': ['checklist.item.archived']
E           assert not ['checklist.item.archived']

tests/projects/test_task_store.py:507: AssertionError
___________ test_create_checklist_item_refuses_when_task_is_missing ____________

    store, broker = store_with_broker

    raised: ValueError | None = None
    try:
        await store.create_checklist_item(task_id="tsk-ghost", text="step one", created_by="u")
    except ValueError as exc:
        raised = exc

    for dead_topic in ("", "tsk-ghost"):
        queue = await broker.subscribe(dead_topic)
        stray = []
        while not queue.empty():
            stray.append(queue.get_nowait().kind)
>           assert not stray, f"event published to dead topic {dead_topic!r}: {stray}"
E           AssertionError: event published to dead topic '': ['checklist.item.created']
E           assert not ['checklist.item.created']

tests/projects/test_task_store.py:533: AssertionError
=========================== short test summary info ============================
FAILED tests/projects/test_task_store.py::test_archive_checklist_item_refuses_when_task_is_gone
FAILED tests/projects/test_task_store.py::test_create_checklist_item_refuses_when_task_is_missing
2 failed, 44 deselected in 1.99s
```

The failing assertion is the topic one, and it names the event and the channel
it was misrouted to — the mutation is what makes it fail, per the card's
"ACCEPTANCE MUST MUTATE".

## GREEN

```
$ .venv/bin/python -m pytest tests/projects/test_task_store.py tests/test_routes_task_checklist.py -q -p no:cacheprovider
......................................................                   [100%]
54 passed in 102.01s (0:01:42)
```

Also run on the fix:

```
$ .venv/bin/python -m pytest tests/projects/ -q -p no:cacheprovider
412 passed in 400.61s (0:06:40)

$ .venv/bin/python -m pytest tests/test_project_task_store.py tests/test_project_events.py \
    tests/test_routes_project_tasks_aggregate.py tests/test_routes_task_checklist.py \
    tests/test_auth_middleware.py -q -p no:cacheprovider
153 passed in 204.70s (0:03:24)
```

## Docs

- `docs/agent-coordination.md` — the "Task checklist items" section under the
  Bearer-allowlist surface documented the routes and the verified+reported
  archive precondition but said nothing about the publish topic. It now records
  that both `checklist.item.created` and `checklist.item.archived` go out under
  the task's `project_id`, that the store raises `task not found` when the task
  is gone, and why the unenforced foreign key makes that state reachable.
- `changelog.d/tsk-s5pif2-checklist-orphan-task-publish.md` — new fragment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checklist items can no longer be created for or archived under tasks that no longer exist.
  * Invalid operations now return a clear “task not found” error without creating orphaned records, changing existing items, or publishing unusable events.
  * Checklist events are now routed using the parent task’s project information.

* **Documentation**
  * Updated task checklist documentation to describe validation behavior and event routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->