### PR TITLE
create_scope_request pending-cap is count-then-insert (TOCTOU) — enforce atomically (tsk-ki4p42)

### DIFF
--- a/changelog.d/tsk-ki4p42-atomic-pending-cap.md
+++ b/changelog.d/tsk-ki4p42-atomic-pending-cap.md
@@ -1,0 +1,3 @@
+### Security
+
+- Agent access requests and scope requests now enforce their per-identity pending cap atomically, inside the insert. A burst of concurrent requests could previously all read the same pre-insert count, all pass the check and all be stored, letting one agent flood the approver's queue past the cap that exists to stop it.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -676,7 +676,11 @@ that SAME canonical_id instead:
   never escalate an existing identity. The middleware allowlist exposes only the
   create path and the two READ paths below to a registry JWT -- approve/deny are
   POST with an extra trailing segment and match no pattern, so an agent can
-  never self-approve; the routes re-check identity == canonical_id.
+  never self-approve; the routes re-check identity == canonical_id. At most
+  `_SCOPE_REQUEST_PENDING_CAP` (10) requests may be pending per canonical_id;
+  further creates are 429. The cap is compared INSIDE the store's INSERT, not
+  counted by the route first, so a burst of concurrent self-requests cannot
+  slip past it and flood the approver's queue.
 - `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/approve`
   `{granted_scopes, project_id?}`: owner/admin only. The admin may narrow but
   never widen the requested scopes; each granted scope is added via
@@ -717,10 +721,9 @@ directions, and that is the point:
 - **Pending** rows are taken oldest-first and ahead of everything else. The
   oldest pending request is the one whose notification is long gone and whose
   id nobody holds any more -- the row these reads exist to recover -- so it is
-  the LAST thing a full page drops. This holds even if the ten-per-agent
-  pending cap is exceeded (that cap is a count-then-insert, so concurrent
-  creates can pass it together; the read path deliberately does not depend on
-  it holding).
+  the LAST thing a full page drops. The read path deliberately does not
+  depend on the ten-per-agent pending cap holding, so a page stays correct
+  however many pending rows an agent has.
 - **Decided** rows fill whatever is left of the page, newest-first, so a caller
   checking on a recent approval still sees it.
 

--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -9,6 +9,8 @@ routes and middleware.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -20,6 +22,7 @@ from tinyagentos.agent_registry_store import (
 )
 from tinyagentos.agent_grants_store import AgentGrantsStore
 from tinyagentos.agent_scope_requests_store import AgentScopeRequestsStore
+from tinyagentos.base_store import PendingCapExceeded
 from taos_test_csrf import csrf_event_hooks
 
 
@@ -137,6 +140,48 @@ async def test_agent_can_self_request_with_own_token(client, monkeypatch, tmp_pa
         assert resp.status_code == 200, resp.text
         assert resp.json()["status"] == "pending"
         assert await env.scope_store.count_pending_for(cid) == 1
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_self_requests_cannot_bypass_pending_cap(
+    client, monkeypatch, tmp_path
+):
+    """A burst from ONE agent must not push it past the per-agent pending cap.
+
+    A count-then-insert cap is bypassable by exactly the traffic it exists to
+    stop: every request in a concurrent burst reads the same pre-insert count,
+    every one of them passes the check, and every one of them inserts — so the
+    agent floods the approver's queue with as many pending rows as it can open
+    connections for.
+    """
+    from tinyagentos.routes.agent_auth_requests import _SCOPE_REQUEST_PENDING_CAP as cap
+
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = client._transport.app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            async def _create():
+                return await bare.post(
+                    f"/api/agents/registry/{cid}/scope-requests",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json={"requested_scopes": ["a2a_send"]},
+                )
+
+            # No return_exceptions: a server-side crash must fail the test, not
+            # shrink the status list into a vacuous pass.
+            results = await asyncio.gather(*[_create() for _ in range(2 * cap)])
+
+        statuses = sorted(r.status_code for r in results)
+        assert statuses == [200] * cap + [429] * cap, (
+            f"cap race: expected exactly {cap} accepted, got {statuses}"
+        )
+        assert await env.scope_store.count_pending_for(cid) == cap
     finally:
         await env.close()
 
@@ -1201,9 +1246,8 @@ async def test_list_scope_requests_status_filter_is_case_insensitive(
 async def test_list_keeps_the_oldest_pending_even_past_the_route_cap(tmp_path):
     """A full page drops the NEWEST pending rows, never the oldest.
 
-    The route's ten-per-agent pending cap is enforced with a count-then-insert,
-    so concurrent creates can push an agent past it. The read path must not
-    depend on that cap holding: the oldest pending request is the one whose
+    The read path must not depend on the ten-per-agent pending cap holding,
+    however that cap is enforced: the oldest pending request is the one whose
     notification is long gone and whose id nobody has any more, so it is the
     last row a full page may drop. Newer pending rows are the ones the caller
     just created and still holds ids for.
@@ -1270,5 +1314,50 @@ async def test_list_for_page_does_not_sort_the_whole_history(tmp_path, monkeypat
             assert "idx_scope_requests_canonical_created" in plan, (
                 f"{sql!r} does not use the ordered index: {plan}"
             )
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_store_create_enforces_pending_cap_atomically(tmp_path):
+    """``create(pending_cap=N)`` admits exactly N pending rows under a burst.
+
+    The guard lives in the INSERT itself, so it holds no matter how the
+    caller's awaits interleave — a caller that checked the count first would
+    hand every racer the same stale answer.
+    """
+    store = AgentScopeRequestsStore(tmp_path / "scope.db")
+    await store.init()
+    try:
+        results = await asyncio.gather(
+            *[
+                store.create(
+                    canonical_id="agent-1",
+                    requested_scopes=["memory_read"],
+                    pending_cap=3,
+                )
+                for _ in range(9)
+            ],
+            return_exceptions=True,
+        )
+        created = [r for r in results if isinstance(r, dict)]
+        refused = [r for r in results if isinstance(r, PendingCapExceeded)]
+        assert len(created) == 3, f"expected 3 inserts, got {results}"
+        assert len(refused) == 6, f"expected 6 refusals, got {results}"
+        assert await store.count_pending_for("agent-1") == 3
+        assert refused[0].cap == 3
+
+        # The cap counts PENDING rows only: deciding one frees a slot.
+        await store.set_decision(created[0]["id"], "refused", decided_by="u1")
+        rec = await store.create(
+            canonical_id="agent-1", requested_scopes=["a2a_send"], pending_cap=3
+        )
+        assert rec["status"] == "pending"
+
+        # A different agent has its own budget.
+        other = await store.create(
+            canonical_id="agent-2", requested_scopes=["a2a_send"], pending_cap=3
+        )
+        assert other["canonical_id"] == "agent-2"
     finally:
         await store.close()

--- a/tests/test_auth_requests.py
+++ b/tests/test_auth_requests.py
@@ -19,11 +19,13 @@ Covers:
     - Approve already-decided → 409
     - Deny → refused
     - Deny already-decided → 409
-    - Abuse cap → 429
+    - Abuse cap → 429 (including under a concurrent burst)
     - List pending (admin) → returns pending records
     - List pending (non-admin) → 403
 """
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 import pytest_asyncio
@@ -31,6 +33,7 @@ from httpx import ASGITransport, AsyncClient
 from taos_test_csrf import csrf_event_hooks
 
 from tinyagentos.auth_requests_store import AuthRequestsStore
+from tinyagentos.base_store import PendingCapExceeded
 from tinyagentos.agent_grants_store import AgentGrantsStore
 
 
@@ -169,6 +172,45 @@ class TestAuthRequestsStore:
             assert await store.count_pending_for("agent-x", "hermes") == 2
             assert await store.count_pending_for("agent-y", "hermes") == 1
             assert await store.count_pending_for("nobody", "hermes") == 0
+        finally:
+            await store.close()
+
+    async def test_create_enforces_pending_cap_atomically(self, tmp_path):
+        """``create(pending_cap=N)`` admits exactly N pending rows under a burst.
+
+        The guard lives in the INSERT itself, so it holds however the caller's
+        awaits interleave; a caller that counted first would hand every racer
+        the same stale answer. ``pending_cap=None`` keeps the store uncapped
+        for the callers that mint one row per freshly-deduped identity.
+        """
+        store = await self._make_store(tmp_path / "ar.db")
+        try:
+            results = await asyncio.gather(
+                *[
+                    store.create(
+                        identity_claim="agent-x",
+                        framework="hermes",
+                        requested_scopes=[],
+                        pending_cap=2,
+                    )
+                    for _ in range(6)
+                ],
+                return_exceptions=True,
+            )
+            created = [r for r in results if isinstance(r, dict)]
+            refused = [r for r in results if isinstance(r, PendingCapExceeded)]
+            assert len(created) == 2, f"expected 2 inserts, got {results}"
+            assert len(refused) == 4, f"expected 4 refusals, got {results}"
+            assert await store.count_pending_for("agent-x", "hermes") == 2
+
+            # The cap is per (identity_claim, framework), not global.
+            other = await store.create(
+                identity_claim="agent-x",
+                framework="claude",
+                requested_scopes=[],
+                pending_cap=2,
+            )
+            assert other["framework"] == "claude"
         finally:
             await store.close()
 
@@ -527,6 +569,39 @@ class TestAuthRequestRoutes:
                 json={**_CREATE_BODY, "identity_claim": "flood-agent"},
             )
             assert r.status_code == 429
+
+    async def test_concurrent_creates_cannot_bypass_abuse_cap(self, consent_client):
+        """A concurrent burst from one identity must not exceed _PENDING_CAP.
+
+        The route is unauthenticated, so this is the cheapest flood there is:
+        with a count-then-insert cap every request in the burst reads the same
+        pre-insert count, passes, and inserts.
+        """
+        from tinyagentos.routes.agent_auth_requests import _PENDING_CAP
+
+        app = consent_client._transport.app
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as bare:
+            async def _create():
+                return await bare.post(
+                    "/api/agents/auth-requests",
+                    json={**_CREATE_BODY, "identity_claim": "burst-agent"},
+                )
+
+            # No return_exceptions: a server-side crash must fail the test, not
+            # shrink the status list into a vacuous pass.
+            results = await asyncio.gather(
+                *[_create() for _ in range(2 * _PENDING_CAP)]
+            )
+
+        statuses = sorted(r.status_code for r in results)
+        assert statuses == [200] * _PENDING_CAP + [429] * _PENDING_CAP, (
+            f"cap race: expected exactly {_PENDING_CAP} accepted, got {statuses}"
+        )
+        pending = await app.state.auth_requests.count_pending_for(
+            "burst-agent", _CREATE_BODY["framework"]
+        )
+        assert pending == _PENDING_CAP
 
     async def test_list_pending_admin(self, consent_client):
         transport = ASGITransport(app=consent_client._transport.app)

--- a/tinyagentos/agent_scope_requests_store.py
+++ b/tinyagentos/agent_scope_requests_store.py
@@ -11,7 +11,9 @@ never registers a second identity.
 The state machine mirrors ``auth_requests``: pending → accepted | refused
 (terminal).  ``set_decision`` is atomic — a conditional UPDATE that only
 matches rows still in ``pending`` status, so two concurrent approvals cannot
-both win a read-check-then-write race.
+both win a read-check-then-write race.  ``create`` is atomic the same way: the
+per-agent pending cap is a condition ON the INSERT, so a burst of concurrent
+requests from one agent cannot all pass a stale count and all insert.
 """
 
 import json
@@ -21,7 +23,7 @@ from typing import Optional
 
 import aiosqlite
 
-from tinyagentos.base_store import BaseStore
+from tinyagentos.base_store import BaseStore, PendingCapExceeded
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS agent_scope_requests (
@@ -48,6 +50,20 @@ CREATE INDEX IF NOT EXISTS idx_scope_requests_canonical_created
 """
 
 _VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})
+
+# The insert's column list, shared by both ``create`` shapes so the capped and
+# uncapped writes can never drift apart on which columns they set.
+_CREATE_COLUMNS = (
+    "(id, canonical_id, requested_scopes, project_id, reason, status, created_ts)"
+)
+
+# Makes the pending cap atomic with the insert: SQLite evaluates the count and
+# performs the insert in ONE statement, so no interleaved caller can slip a row
+# in between them. Served by ``idx_scope_requests_canonical``.
+_CAP_GUARD = (
+    "(SELECT COUNT(*) FROM agent_scope_requests "
+    " WHERE canonical_id = ? AND status = 'pending') < ?"
+)
 
 # Hard ceiling on a single ``list_for`` page. Decided rows accumulate forever,
 # so the read routes must never return a response whose size tracks an agent's
@@ -91,30 +107,56 @@ class AgentScopeRequestsStore(BaseStore):
         requested_scopes: list[str],
         project_id: Optional[str] = None,
         reason: str = "",
+        pending_cap: Optional[int] = None,
     ) -> dict:
-        """Create a new pending scope request. Returns the full record."""
+        """Create a new pending scope request. Returns the full record.
+
+        ``pending_cap`` caps how many PENDING rows this canonical_id may hold.
+        The comparison happens inside the INSERT (see ``_CAP_GUARD``), so it is
+        atomic with the write: the caller must NOT count first and decide, as
+        every request in a concurrent burst would read the same pre-insert
+        count, pass, and insert — which is how the abuse cap became bypassable
+        by exactly the flood it exists to stop. Raises ``PendingCapExceeded``
+        when the cap is already full; ``None`` leaves the store uncapped.
+        """
         if self._db is None:
             raise RuntimeError("AgentScopeRequestsStore not initialised — call init() first")
 
         request_id = uuid.uuid4().hex
         now = datetime.now(timezone.utc).isoformat()
-
-        await self._db.execute(
-            """
-            INSERT INTO agent_scope_requests
-                (id, canonical_id, requested_scopes, project_id, reason, status, created_ts)
-            VALUES (?, ?, ?, ?, ?, 'pending', ?)
-            """,
-            (
-                request_id,
-                canonical_id,
-                json.dumps(requested_scopes),
-                project_id,
-                reason,
-                now,
-            ),
+        values = (
+            request_id,
+            canonical_id,
+            json.dumps(requested_scopes),
+            project_id,
+            reason,
+            now,
         )
+
+        if pending_cap is None:
+            cur = await self._db.execute(
+                f"INSERT INTO agent_scope_requests {_CREATE_COLUMNS} "
+                "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+                values,
+            )
+        else:
+            cur = await self._db.execute(
+                f"INSERT INTO agent_scope_requests {_CREATE_COLUMNS} "
+                "SELECT ?, ?, ?, ?, ?, 'pending', ? WHERE " + _CAP_GUARD,
+                (*values, canonical_id, pending_cap),
+            )
         await self._db.commit()
+
+        if cur.rowcount == 0:
+            # The guard excluded the row: nothing was written. Read the count
+            # back only to describe the refusal — the decision itself was made
+            # atomically above.
+            raise PendingCapExceeded(
+                key=canonical_id,
+                cap=pending_cap,
+                pending=await self.count_pending_for(canonical_id),
+            )
+
         record = await self.get(request_id)
         if record is None:
             raise RuntimeError(f"scope_request {request_id!r} missing immediately after insert")

--- a/tinyagentos/auth_requests_store.py
+++ b/tinyagentos/auth_requests_store.py
@@ -10,7 +10,9 @@ and retrieve them.
 The state machine is simple: pending → accepted | refused (terminal).
 ``set_decision`` is atomic — it uses a conditional UPDATE that only
 matches rows still in ``pending`` status, so two concurrent approve calls
-cannot both win a read-check-then-write race.
+cannot both win a read-check-then-write race.  ``create`` is atomic the same
+way when given a ``pending_cap``: the cap is a condition ON the INSERT, so a
+burst of concurrent submissions cannot all pass a stale count and all insert.
 """
 
 import json
@@ -20,7 +22,7 @@ from typing import Optional
 
 import aiosqlite
 
-from tinyagentos.base_store import BaseStore
+from tinyagentos.base_store import BaseStore, PendingCapExceeded
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS auth_requests (
@@ -45,6 +47,21 @@ CREATE INDEX IF NOT EXISTS idx_auth_requests_identity ON auth_requests(identity_
 """
 
 _VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})
+
+# The insert's column list, shared by both ``create`` shapes so the capped and
+# uncapped writes can never drift apart on which columns they set.
+_CREATE_COLUMNS = (
+    "(id, identity_claim, framework, requested_scopes, requested_skills,"
+    " reason, duration_secs, project_id, status, created_ts)"
+)
+
+# Makes the pending cap atomic with the insert: SQLite evaluates the count and
+# performs the insert in ONE statement, so no interleaved caller can slip a row
+# in between them. Served by ``idx_auth_requests_identity``.
+_CAP_GUARD = (
+    "(SELECT COUNT(*) FROM auth_requests "
+    " WHERE identity_claim = ? AND framework = ? AND status = 'pending') < ?"
+)
 
 
 def _row_to_dict(row: aiosqlite.Row) -> dict:
@@ -85,34 +102,63 @@ class AuthRequestsStore(BaseStore):
         reason: str = "",
         duration_secs: Optional[int] = None,
         project_id: Optional[str] = None,
+        pending_cap: Optional[int] = None,
     ) -> dict:
-        """Create a new pending auth request. Returns the full record."""
+        """Create a new pending auth request. Returns the full record.
+
+        ``pending_cap`` caps how many PENDING rows this (identity_claim,
+        framework) pair may hold. The comparison happens inside the INSERT (see
+        ``_CAP_GUARD``), so it is atomic with the write: the caller must NOT
+        count first and decide, as every request in a concurrent burst would
+        read the same pre-insert count, pass, and insert — and this route takes
+        no credentials, so that burst is free. Raises ``PendingCapExceeded``
+        when the cap is already full.
+
+        ``None`` leaves the store uncapped, for callers that mint exactly one
+        row per freshly-deduped identity (invite redemption) rather than
+        accepting whatever identity_claim a stranger sends.
+        """
         if self._db is None:
             raise RuntimeError("AuthRequestsStore not initialised — call init() first")
 
         request_id = uuid.uuid4().hex
         now = datetime.now(timezone.utc).isoformat()
-
-        await self._db.execute(
-            """
-            INSERT INTO auth_requests
-                (id, identity_claim, framework, requested_scopes, requested_skills,
-                 reason, duration_secs, project_id, status, created_ts)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
-            """,
-            (
-                request_id,
-                identity_claim,
-                framework,
-                json.dumps(requested_scopes),
-                json.dumps(requested_skills or []),
-                reason,
-                duration_secs,
-                project_id,
-                now,
-            ),
+        values = (
+            request_id,
+            identity_claim,
+            framework,
+            json.dumps(requested_scopes),
+            json.dumps(requested_skills or []),
+            reason,
+            duration_secs,
+            project_id,
+            now,
         )
+
+        if pending_cap is None:
+            cur = await self._db.execute(
+                f"INSERT INTO auth_requests {_CREATE_COLUMNS} "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
+                values,
+            )
+        else:
+            cur = await self._db.execute(
+                f"INSERT INTO auth_requests {_CREATE_COLUMNS} "
+                "SELECT ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ? WHERE " + _CAP_GUARD,
+                (*values, identity_claim, framework, pending_cap),
+            )
         await self._db.commit()
+
+        if cur.rowcount == 0:
+            # The guard excluded the row: nothing was written. Read the count
+            # back only to describe the refusal — the decision itself was made
+            # atomically above.
+            raise PendingCapExceeded(
+                key=f"{identity_claim}/{framework}",
+                cap=pending_cap,
+                pending=await self.count_pending_for(identity_claim, framework),
+            )
+
         record = await self.get(request_id)
         if record is None:
             raise RuntimeError(f"auth_request {request_id!r} missing immediately after insert")

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -9,6 +9,27 @@ class Engine(Enum):
     POSTGRES = "postgres"
 
 
+class PendingCapExceeded(Exception):
+    """A store refused an insert because a per-key pending cap is already full.
+
+    Raised by a ``create()`` that enforces the cap INSIDE its INSERT statement
+    rather than leaving the caller to count first.  A count-then-insert cap is
+    bypassable by exactly the traffic caps exist to stop: every request in a
+    concurrent burst reads the same pre-insert count, every one of them passes
+    the check, and every one of them inserts.
+
+    ``pending`` is read back after the refusal, so it is a description for the
+    error message, not the value the decision was made on -- that comparison
+    happened atomically in SQL.  Routes map this to 429.
+    """
+
+    def __init__(self, *, key: str, cap: int, pending: int):
+        self.key = key
+        self.cap = cap
+        self.pending = pending
+        super().__init__(f"{pending} pending at cap {cap} for {key!r}")
+
+
 class BaseStore:
     """Base class for all SQLite-backed stores.
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -32,13 +32,16 @@ from pydantic import BaseModel
 from aiosqlite import IntegrityError
 from tinyagentos.agent_registry_store import _slugify, mint_registry_token
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
+from tinyagentos.base_store import PendingCapExceeded
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 # Maximum number of unresolved pending requests allowed from the same
-# identity_claim + framework before new submissions are rate-limited.
+# identity_claim + framework before new submissions are rate-limited. Handed to
+# the store's create(), which compares it inside the INSERT — never counted
+# here first (see create_auth_request).
 _PENDING_CAP = 5
 
 # Closed vocabulary of grantable scopes — surfaced to the user in the
@@ -284,27 +287,29 @@ async def create_auth_request(request: Request, body: CreateAuthRequest):
         )
 
     # Abuse cap: reject if too many pending requests from the same identity.
-    pending_count = await store.count_pending_for(
-        body.identity_claim, body.framework
-    )
-    if pending_count >= _PENDING_CAP:
+    # The cap is passed INTO create() and compared inside its INSERT rather
+    # than counted here first: this route takes no credentials, so a burst of
+    # concurrent posts is free, and a count-then-insert check hands every
+    # request in that burst the same pre-insert count.
+    try:
+        record = await store.create(
+            identity_claim=body.identity_claim,
+            framework=body.framework,
+            requested_scopes=body.requested_scopes,
+            requested_skills=body.requested_skills,
+            reason=body.reason,
+            duration_secs=body.duration_secs,
+            project_id=body.project_id,
+            pending_cap=_PENDING_CAP,
+        )
+    except PendingCapExceeded as exc:
         raise HTTPException(
             status_code=429,
             detail=(
                 f"too many pending requests from identity {body.identity_claim!r} "
-                f"({pending_count} pending; resolve existing requests first)"
+                f"({exc.pending} pending; resolve existing requests first)"
             ),
-        )
-
-    record = await store.create(
-        identity_claim=body.identity_claim,
-        framework=body.framework,
-        requested_scopes=body.requested_scopes,
-        requested_skills=body.requested_skills,
-        reason=body.reason,
-        duration_secs=body.duration_secs,
-        project_id=body.project_id,
-    )
+        ) from None
 
     # Surface the request as a non-blocking bell + toast notification. The
     # data payload carries everything the inline consent actions need to
@@ -1015,6 +1020,8 @@ async def list_auth_requests(
 # ---------------------------------------------------------------------------
 
 # Maximum unresolved scope requests per canonical_id before new ones are 429'd.
+# Handed to the store's create(), which compares it inside the INSERT — never
+# counted here first (see create_scope_request).
 _SCOPE_REQUEST_PENDING_CAP = 10
 
 # Closed vocabulary of scope-request lifecycle states, mirroring the store's
@@ -1113,23 +1120,27 @@ async def create_scope_request(
             detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
         )
 
+    # The cap is passed INTO create() and compared inside its INSERT rather
+    # than counted here first: an agent holds its own token, so it can fire a
+    # burst of self-requests that would all read the same pre-insert count and
+    # all insert — the approver-flood the cap exists to stop.
     store = _get_scope_requests_store(request)
-    pending_count = await store.count_pending_for(canonical_id)
-    if pending_count >= _SCOPE_REQUEST_PENDING_CAP:
+    try:
+        rec = await store.create(
+            canonical_id=canonical_id,
+            requested_scopes=body.requested_scopes,
+            project_id=body.project_id,
+            reason=body.reason,
+            pending_cap=_SCOPE_REQUEST_PENDING_CAP,
+        )
+    except PendingCapExceeded as exc:
         raise HTTPException(
             status_code=429,
             detail=(
                 f"too many pending scope requests for {canonical_id!r} "
-                f"({pending_count} pending; resolve existing requests first)"
+                f"({exc.pending} pending; resolve existing requests first)"
             ),
-        )
-
-    rec = await store.create(
-        canonical_id=canonical_id,
-        requested_scopes=body.requested_scopes,
-        project_id=body.project_id,
-        reason=body.reason,
-    )
+        ) from None
 
     # Surface the request as a bell + toast for the owner/admin. Best effort: a
     # notification failure must not fail the created request (mirrors the


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): create_scope_request pending-cap is count-then-insert (TOCTOU) — enforce atomically
Autonomous build of board card tsk-ki4p42.

## What changed

`create_scope_request` counted pending rows and then inserted as two separate
awaits, so N concurrent self-requests from one agent all read the same
pre-insert count, all passed `pending_count < _SCOPE_REQUEST_PENDING_CAP`, and
all inserted. The card's "same audit" for `auth_requests_store.count_pending_for`
confirmed the identical shape in `create_auth_request` — and that route takes no
credentials at all, so the burst is free.

- `tinyagentos/base_store.py`: new `PendingCapExceeded`, carrying `key`, `cap`
  and a `pending` count read back purely to describe the refusal.
- `tinyagentos/agent_scope_requests_store.py` and
  `tinyagentos/auth_requests_store.py`: `create()` takes `pending_cap` and
  enforces it as a condition ON the INSERT —
  `INSERT ... SELECT ... WHERE (SELECT COUNT(*) ... AND status='pending') < ?`.
  SQLite evaluates that as one statement, so no interleaved caller can slip a
  row in between the count and the write. `rowcount == 0` means the guard
  excluded the row and nothing was written, which raises `PendingCapExceeded`.
  The subquery is served by the existing `idx_scope_requests_canonical` /
  `idx_auth_requests_identity` indexes; no schema change.
- `tinyagentos/routes/agent_auth_requests.py`: both create routes drop the
  pre-count and pass their cap into `create()`, mapping `PendingCapExceeded` to
  the same 429 (same detail wording) they returned before. No API shape change.

The cap stays route policy rather than becoming a store constant, so
`pending_cap=None` leaves the store uncapped for the invite-redemption callers
in `routes/project_invites.py`, which mint one row per freshly deduped identity
rather than accepting whatever `identity_claim` a stranger sends. Making the cap
unconditional there would have silently turned a legitimate redemption into a
500 — a behaviour change the card did not ask for.

Chose the atomic-INSERT option over `BEGIN IMMEDIATE`. It is also what the
sibling store already points at: `device_pair_requests_store.py:20-24` documents
its in-process `_create_lock` as sound only for single-process serving and names
"a single transactional INSERT ... WHERE (SELECT COUNT ...) statement" as the
fix if that ever changes.

## RED FIRST (pasted)

`PendingCapExceeded` was added first (an inert symbol) so the tests could import
it and fail on the defect rather than on a collection error. The two route tests
are the card's specified RED and fail on the race itself; the two store tests
fail on the absent `pending_cap` parameter.

```
$ .venv/bin/python -m pytest \
    tests/test_agent_scope_requests.py::test_concurrent_self_requests_cannot_bypass_pending_cap \
    tests/test_agent_scope_requests.py::test_store_create_enforces_pending_cap_atomically \
    "tests/test_auth_requests.py::TestAuthRequestsStore::test_create_enforces_pending_cap_atomically" \
    "tests/test_auth_requests.py::TestAuthRequestRoutes::test_concurrent_creates_cannot_bypass_abuse_cap" \
    -q -p no:cacheprovider --tb=line

tests/test_agent_scope_requests.py:181: AssertionError: cap race: expected exactly 10 accepted, got [200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200]
E   TypeError: AgentScopeRequestsStore.create() got an unexpected keyword argument 'pending_cap'
tests/test_agent_scope_requests.py:1335: TypeError: AgentScopeRequestsStore.create() got an unexpected keyword argument 'pending_cap'
E   TypeError: AuthRequestsStore.create() got an unexpected keyword argument 'pending_cap'
tests/test_auth_requests.py:190: TypeError: AuthRequestsStore.create() got an unexpected keyword argument 'pending_cap'
E   AssertionError: cap race: expected exactly 5 accepted, got [200, 200, 200, 200, 200, 200, 200, 200, 200, 200]
    assert [200, 200, 20...200, 200, ...] == [200, 200, 20...200, 429, ...]
      At index 5 diff: 200 != 429
tests/test_auth_requests.py:598: AssertionError: cap race: expected exactly 5 accepted, got [200, 200, 200, 200, 200, 200, 200, 200, 200, 200]
=========================== short test summary info ============================
FAILED tests/test_agent_scope_requests.py::test_concurrent_self_requests_cannot_bypass_pending_cap
FAILED tests/test_agent_scope_requests.py::test_store_create_enforces_pending_cap_atomically
FAILED tests/test_auth_requests.py::TestAuthRequestsStore::test_create_enforces_pending_cap_atomically
FAILED tests/test_auth_requests.py::TestAuthRequestRoutes::test_concurrent_creates_cannot_bypass_abuse_cap
4 failed in 11.17s
```

Every one of the 20 concurrent scope requests and all 10 concurrent
auth-requests were accepted: the cap was not merely leaky, it was inert under
a burst.

## GREEN

```
$ .venv/bin/python -m pytest <the same four node ids> -q -p no:cacheprovider
....                                                                     [100%]
4 passed in 20.15s

$ .venv/bin/python -m pytest tests/test_agent_scope_requests.py tests/test_auth_requests.py \
    tests/test_auth_requests_store.py tests/test_routes_agent_auth_requests.py \
    tests/routes/test_device_pair_security.py -q -p no:cacheprovider
132 passed, 2 warnings in 719.06s (0:11:59)

$ .venv/bin/python -m pytest tests/test_routes_project_invites.py -q -p no:cacheprovider
39 passed in 374.13s (0:06:14)
```

`tests/test_routes_project_invites.py` was run because it is the only other
caller of `AuthRequestsStore.create`; it keeps the uncapped path.

New tests:

- `test_concurrent_self_requests_cannot_bypass_pending_cap` — 2x cap concurrent
  self-requests through the real route, asserting exactly cap `200`s, exactly
  cap `429`s, and exactly cap rows persisted. Gathered without
  `return_exceptions`, so a server-side crash fails the test rather than
  shrinking the status list into a vacuous pass.
- `test_concurrent_creates_cannot_bypass_abuse_cap` — the same for the
  unauthenticated `POST /api/agents/auth-requests`.
- `test_store_create_enforces_pending_cap_atomically` (both stores) — the guard
  holds at the store boundary regardless of how a caller's awaits interleave,
  a decided row frees a slot, and the budget is per key.

## Docs

- `docs/agent-coordination.md`: the scope-request create bullet now states the
  10-per-canonical_id cap and that it is compared inside the store's INSERT. Two
  stale claims that the cap "is a count-then-insert, so concurrent creates can
  pass it together" were removed; the surrounding point (the read path does not
  depend on the cap holding) is unchanged and still true.
- Module docstrings of both stores now say `create` is atomic the same way
  `set_decision` already was, and the `test_list_keeps_the_oldest_pending...`
  docstring no longer justifies itself with the removed race.
- `changelog.d/tsk-ki4p42-atomic-pending-cap.md` (`### Security`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending limits for agent access and scope requests are now enforced atomically, preventing concurrent submissions from exceeding the configured cap.
  * Requests exceeding the pending limit receive a rate-limit response.
  * Pending limits remain isolated per identity and request context.
  * New requests can be created after an existing request is resolved.

* **Documentation**
  * Clarified pending-limit behavior and pagination guarantees.

* **Tests**
  * Added coverage for concurrent submissions, per-identity isolation, and rate-limit responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->