### PR TITLE
[lib-audit] MCP supervisor pipes stdout and never drains it: deadlock (tsk-j3m3bm)

### DIFF
--- a/changelog.d/tsk-j3m3bm-mcp-stdout-drain.md
+++ b/changelog.d/tsk-j3m3bm-mcp-stdout-drain.md
@@ -1,0 +1,16 @@
+- `mcp`: the supervisor now drains an MCP server's **stdout** as well as its
+  stderr. Both pipes were captured but only stderr was ever read, so any server
+  writing more than the 64 KiB pipe buffer to stdout blocked in `write()`
+  forever while the supervisor kept reporting it healthy — and for a
+  stdio-transport server stdout is the JSON-RPC channel, so that was the
+  primary data path, not an edge case. Log entries now carry a `stream` field
+  (`stdout`/`stderr`), and the Logs tab tails both.
+- `mcp`: both drains read the pipes in fixed-size chunks instead of iterating
+  lines. `async for line in reader` raises `ValueError` once a single line
+  exceeds `StreamReader`'s 64 KiB limit, which killed the drain task and
+  re-opened the same deadlock — a JSON-RPC frame is one line and routinely
+  larger than that.
+- `mcp`: `POST /api/mcp/call` answers `501 not_implemented` while the JSON-RPC
+  transport is unwired. It used to answer `200` with
+  `{"ok": true, "result": "stub ..."}`, which no caller could tell apart from a
+  real tool result.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -989,6 +989,37 @@ Python**, so an agent holding grants on several projects and carrying more than
 500 decisions in total can still lose allowed-project rows to the limit. Same
 shape as the original bug, narrower blast radius.
 
+## MCP tool calls (`POST /api/mcp/call`)
+
+Route module `tinyagentos/routes/mcp.py`, backed by `tinyagentos/mcp/proxy.py`.
+Body: `{"server_id", "tool", "agent_name", "agent_groups"?, "arguments"?,
+"resource"?}`.
+
+**The JSON-RPC transport is NOT wired yet, and the route says so.** Three
+answers are possible today:
+
+| status | body | meaning |
+|---|---|---|
+| `403` | `{"error": "permission_denied", "reason": ...}` | the attachment does not grant this agent that tool/resource |
+| `503` | `{"error": "server_unavailable", ...}` | the server is not running and could not be started |
+| `501` | `{"error": "not_implemented", "reason": "MCP JSON-RPC transport is not wired yet; no tool call was made"}` | permissions passed, the server is up, and nothing was called |
+
+Until issue-time this route answered `200` with
+`{"ok": true, "result": "stub — MCP JSON-RPC call not yet wired"}`, which no
+caller could tell apart from a real tool result. **Do not write a caller that
+treats a 2xx from this route as proof a tool ran** — there is no success shape
+on this path yet. When the transport lands, the 501 becomes a real result; the
+403 and 503 arms keep their meaning.
+
+`MCPSupervisor` spawns stdio servers with both pipes captured and **drains
+both**. `GET /api/mcp/servers/{id}/logs` and its `/logs/stream` SSE tail carry
+entries tagged `"stream": "stdout"` or `"stream": "stderr"` so the two can be
+told apart; `level` stays `"error"`/`"info"` for the colour-coded tail. A
+server that writes more than a pipe buffer to stdout used to block in `write()`
+forever while `get_status()` still reported it `running` — for a
+stdio-transport server stdout is the JSON-RPC channel, so that was the primary
+data path, not an edge case.
+
 ## Config save and restore (`/api/config`, session-only)
 
 Route module `tinyagentos/routes/settings.py`. Owner routes behind the session

--- a/tests/mcp/test_supervisor_stdout.py
+++ b/tests/mcp/test_supervisor_stdout.py
@@ -1,0 +1,224 @@
+"""The MCP supervisor must drain the child's stdout, and the proxy must not lie.
+
+Two defects, one subsystem:
+
+* ``MCPSupervisor.start`` spawns with ``stdout=PIPE`` but only ever reads
+  stderr.  Once the OS pipe buffer (64 KiB on Linux) fills, the child blocks in
+  ``write()`` forever while ``get_status()`` keeps reporting ``running: True``
+  — a hang indistinguishable from a working server.  For a stdio-transport MCP
+  server stdout *is* the JSON-RPC channel, so this is the primary data path,
+  not an edge case.
+* ``proxy.call_tool`` returned ``{"ok": True, "result": "stub ..."}``, which is
+  indistinguishable from a real result to any caller.
+
+The quiet-server tests that already live in ``tests/test_mcp.py`` pass today;
+only a chatty server exposes the deadlock, so these are deliberately chatty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.mcp.proxy import call_tool
+from tinyagentos.mcp.registry import MCPServerStore
+from tinyagentos.mcp.supervisor import MCPSupervisor
+
+# Well over the 64 KiB Linux pipe buffer: a child that gets no reader blocks
+# after the first ~64 KiB and never reaches the sentinel.
+STDOUT_BYTES = 1024 * 1024
+
+# The sentinel is written to *stderr* after the stdout write completes.  stderr
+# is drained today, so its arrival is a positive signal that the child got past
+# its stdout write, rather than an inference from the absence of a crash.
+SENTINEL = "DRAINED-OK"
+
+# Generous enough that a slow CI box cannot fail it, short enough that a real
+# deadlock is reported in seconds rather than at the 120 s pytest timeout.
+DRAIN_TIMEOUT_S = 10.0
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path: Path):
+    s = MCPServerStore(tmp_path / "mcp.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def supervisor(store):
+    sup = MCPSupervisor(store=store, catalog=None, notif_store=None)
+    yield sup
+    await sup.stop_all()
+
+
+def _chatty_cmd(script: str) -> list[str]:
+    """Unbuffered python -c, so the child's writes hit the pipe immediately."""
+    return [sys.executable, "-u", "-c", script]
+
+
+async def _wait_for_sentinel(supervisor: MCPSupervisor, server_id: str) -> bool:
+    """Poll the log buffer for the stderr sentinel until DRAIN_TIMEOUT_S."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + DRAIN_TIMEOUT_S
+    while loop.time() < deadline:
+        if any(SENTINEL in e["line"] for e in supervisor.logs(server_id, limit=10_000)):
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_chatty_stdout_does_not_deadlock(store, supervisor):
+    """1 MiB of short lines on stdout must not wedge the child.
+
+    Without a stdout reader the child fills the pipe buffer and blocks, so the
+    stderr sentinel that follows the write never arrives — while ``get_status``
+    still claims the server is running.
+    """
+    script = (
+        "import sys\n"
+        "line = 'x' * 63 + '\\n'\n"
+        f"for _ in range({STDOUT_BYTES} // 64):\n"
+        "    sys.stdout.write(line)\n"
+        "sys.stdout.flush()\n"
+        f"sys.stderr.write({SENTINEL!r} + '\\n')\n"
+        "sys.stderr.flush()\n"
+        "import time; time.sleep(30)\n"
+    )
+    await store.register_server(
+        "chatty-srv", "1.0", "stdio", config={"cmd": _chatty_cmd(script)}
+    )
+    assert await supervisor.start("chatty-srv") is True
+
+    drained = await _wait_for_sentinel(supervisor, "chatty-srv")
+    status = supervisor.get_status("chatty-srv")
+    assert drained, (
+        f"child never got past its {STDOUT_BYTES}-byte stdout write within "
+        f"{DRAIN_TIMEOUT_S}s — blocked on a full pipe buffer, while "
+        f"get_status() reports {status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_oversized_stdout_line_does_not_deadlock(store, supervisor):
+    """One line larger than StreamReader's 64 KiB limit must still drain.
+
+    ``async for line in reader`` raises ValueError once a line exceeds the
+    stream limit, which aborts the drain task and re-opens exactly the deadlock
+    a stdout reader is meant to close.  A JSON-RPC frame on a stdio-transport
+    server is a single line and is routinely larger than the limit, so this is
+    the shape of the real traffic.
+    """
+    script = (
+        "import sys\n"
+        f"sys.stdout.write('y' * {STDOUT_BYTES} + '\\n')\n"
+        "sys.stdout.flush()\n"
+        f"sys.stderr.write({SENTINEL!r} + '\\n')\n"
+        "sys.stderr.flush()\n"
+        "import time; time.sleep(30)\n"
+    )
+    await store.register_server(
+        "jumbo-srv", "1.0", "stdio", config={"cmd": _chatty_cmd(script)}
+    )
+    assert await supervisor.start("jumbo-srv") is True
+
+    drained = await _wait_for_sentinel(supervisor, "jumbo-srv")
+    status = supervisor.get_status("jumbo-srv")
+    assert drained, (
+        f"child never got past its single {STDOUT_BYTES}-byte stdout line "
+        f"within {DRAIN_TIMEOUT_S}s, while get_status() reports {status}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdout_lines_are_tagged_and_tailable(store, supervisor):
+    """Drained stdout has to reach the log tail, tagged apart from stderr.
+
+    The MCP app's Logs tab is specified as a live stdout/stderr tail, so
+    draining stdout into a black hole would trade one defect for another.
+    """
+    script = (
+        "import sys\n"
+        "sys.stdout.write('hello-from-stdout\\n')\n"
+        "sys.stdout.flush()\n"
+        f"sys.stderr.write({SENTINEL!r} + '\\n')\n"
+        "sys.stderr.flush()\n"
+        "import time; time.sleep(30)\n"
+    )
+    await store.register_server(
+        "tagged-srv", "1.0", "stdio", config={"cmd": _chatty_cmd(script)}
+    )
+    assert await supervisor.start("tagged-srv") is True
+    assert await _wait_for_sentinel(supervisor, "tagged-srv")
+
+    entries = supervisor.logs("tagged-srv", limit=10_000)
+    stdout_lines = [e for e in entries if e.get("stream") == "stdout"]
+    stderr_lines = [e for e in entries if e.get("stream") == "stderr"]
+    assert any("hello-from-stdout" in e["line"] for e in stdout_lines), (
+        f"stdout never reached the log tail: {entries}"
+    )
+    assert any(SENTINEL in e["line"] for e in stderr_lines), (
+        f"stderr lost its stream tag: {entries}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_stdout_drain(store, supervisor):
+    """stop() must reap the stdout drain the way it already reaps stderr's.
+
+    An un-cancelled drain task outlives the server it was reading for and is
+    reported by the event loop as a pending task at shutdown.
+    """
+    script = (
+        "import sys, time\n"
+        "sys.stdout.write('tick\\n')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(30)\n"
+    )
+    await store.register_server(
+        "reap-srv", "1.0", "stdio", config={"cmd": _chatty_cmd(script)}
+    )
+    assert await supervisor.start("reap-srv") is True
+    sp = supervisor._processes["reap-srv"]
+    stdout_task = sp.stdout_task
+    assert stdout_task is not None, "start() never created a stdout drain task"
+
+    assert await supervisor.stop("reap-srv") is True
+    assert stdout_task.done(), "stop() left the stdout drain task running"
+
+
+@pytest.mark.asyncio
+async def test_proxy_call_does_not_return_success_shaped_stub(store, supervisor):
+    """The proxy must report an explicit error, never a fake success.
+
+    A caller cannot tell ``{"ok": True, "result": "stub ..."}`` from a real
+    tool result, so a stub that reports success is worse than one that errors.
+    """
+    await store.register_server(
+        "sleep-srv", "1.0", "stdio", config={"cmd": ["sleep", "infinity"]}
+    )
+    await store.add_attachment("sleep-srv", "all", None)
+
+    result = await call_tool(
+        supervisor=supervisor,
+        store=store,
+        agent_name="bot1",
+        agent_groups=[],
+        server_id="sleep-srv",
+        tool="fetch_url",
+        arguments={"url": "https://example.invalid"},
+    )
+
+    assert result.get("ok") is not True, (
+        f"proxy returned a success-shaped result with no call made: {result}"
+    )
+    assert "error" in result, f"proxy returned neither a result nor an error: {result}"
+    assert result.get("status") == 501, (
+        f"an unwired transport must surface as 501 Not Implemented, got {result}"
+    )

--- a/tests/test_routes_mcp.py
+++ b/tests/test_routes_mcp.py
@@ -185,6 +185,56 @@ class TestMCPGetConfig:
 
 
 @pytest.mark.asyncio
+class TestMCPProxyCall:
+    """`POST /api/mcp/call` is the real caller of `proxy.call_tool`.
+
+    The JSON-RPC transport is not wired yet, so the route has to surface that
+    as an explicit failure.  It used to answer 200 with `{"ok": true, "result":
+    "stub ..."}`, which no caller could tell from a real tool result.
+    """
+
+    async def test_call_without_transport_returns_501_not_a_stub(self, app_client):
+        client, app = app_client
+        mcp_store = app.state.mcp_store
+        await mcp_store.register_server(
+            "mcp-fetch", "1.0.0", "stdio", config={"cmd": ["sleep", "infinity"]}
+        )
+        await mcp_store.add_attachment("mcp-fetch", "all", None)
+
+        resp = await client.post(
+            "/api/mcp/call",
+            json={
+                "server_id": "mcp-fetch",
+                "tool": "fetch_url",
+                "agent_name": "weatherbot",
+                "arguments": {"url": "https://example.invalid"},
+            },
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert data["error"] == "not_implemented"
+        assert data.get("ok") is not True
+        assert "stub" not in str(data.get("result", ""))
+
+    async def test_call_denied_by_permissions_still_returns_403(self, app_client):
+        """The new 501 must not shadow the permission check that runs first."""
+        client, app = app_client
+        mcp_store = app.state.mcp_store
+        await mcp_store.register_server("mcp-fetch", "1.0.0", "stdio")
+
+        resp = await client.post(
+            "/api/mcp/call",
+            json={
+                "server_id": "mcp-fetch",
+                "tool": "fetch_url",
+                "agent_name": "weatherbot",
+            },
+        )
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "permission_denied"
+
+
+@pytest.mark.asyncio
 class TestMCPGetEnv:
     async def test_env_empty_when_no_secrets(self, app_client):
         client, app = app_client

--- a/tinyagentos/mcp/proxy.py
+++ b/tinyagentos/mcp/proxy.py
@@ -30,16 +30,23 @@ async def call_tool(
         if not started:
             return {"error": "server_unavailable", "reason": f"could not start {server_id}", "status": 503}
 
+    # The JSON-RPC transport is not wired yet.  Fail explicitly rather than
+    # returning a success-shaped stub: a caller cannot tell `{"ok": True, ...}`
+    # from a real tool result, so a stub that reports success silently feeds
+    # made-up data into whatever asked for the call.
     logger.warning(
-        "mcp proxy: actual MCP JSON-RPC call not yet wired — returning stub "
+        "mcp proxy: MCP JSON-RPC transport not wired — refusing call "
         "(server=%s tool=%s agent=%s)",
         server_id,
         tool,
         agent_name,
     )
     return {
-        "ok": True,
-        "result": "stub — MCP JSON-RPC call not yet wired",
+        "error": "not_implemented",
+        "reason": (
+            "MCP JSON-RPC transport is not wired yet; no tool call was made"
+        ),
+        "server_id": server_id,
         "tool": tool,
-        "arguments": arguments,
+        "status": 501,
     }

--- a/tinyagentos/mcp/supervisor.py
+++ b/tinyagentos/mcp/supervisor.py
@@ -12,6 +12,41 @@ from tinyagentos.mcp.registry import MCPServerStore
 
 logger = logging.getLogger(__name__)
 
+# How much we pull off a child's pipe per read.  Both pipes are read in
+# fixed-size chunks rather than with `async for line in reader`, because that
+# iterator raises ValueError as soon as a single line exceeds StreamReader's
+# 64 KiB limit — which would kill the drain task and re-open the very deadlock
+# the drain exists to close.  A JSON-RPC frame on a stdio-transport server is
+# one line and routinely larger than that.
+_READ_CHUNK = 65536
+
+# A run of bytes this long with no newline is flushed to the log buffer as its
+# own entry, so a child emitting an unbounded newline-free stream cannot grow
+# the partial-line buffer without limit.
+_MAX_PARTIAL_LINE = 65536
+
+
+async def _iter_lines(reader: asyncio.StreamReader) -> AsyncIterator[str]:
+    """Yield decoded lines from `reader` with no per-line size limit."""
+    buf = bytearray()
+    while True:
+        chunk = await reader.read(_READ_CHUNK)
+        if not chunk:
+            break
+        buf.extend(chunk)
+        while True:
+            nl = buf.find(b"\n")
+            if nl < 0:
+                break
+            line = bytes(buf[:nl])
+            del buf[: nl + 1]
+            yield line.decode(errors="replace").rstrip()
+        if len(buf) >= _MAX_PARTIAL_LINE:
+            yield bytes(buf).decode(errors="replace").rstrip()
+            buf.clear()
+    if buf:
+        yield bytes(buf).decode(errors="replace").rstrip()
+
 
 @dataclass
 class ServerProcess:
@@ -22,6 +57,7 @@ class ServerProcess:
     )
     started_at: float = field(default_factory=time.time)
     stderr_task: asyncio.Task | None = None
+    stdout_task: asyncio.Task | None = None
 
 
 class MCPSupervisor:
@@ -64,6 +100,16 @@ class MCPSupervisor:
             self._drain_stderr(server_id, sp),
             name=f"mcp-stderr-{server_id}",
         )
+        # stdout is piped too, so it MUST have a reader.  Without one the child
+        # blocks in write() as soon as the OS pipe buffer fills and never makes
+        # progress again, while mark_running()/get_status() keep reporting it
+        # healthy — a hang indistinguishable from a working server.  For a
+        # stdio-transport server stdout is the JSON-RPC channel, so that is the
+        # primary data path, not an edge case.
+        sp.stdout_task = asyncio.create_task(
+            self._drain_stdout(server_id, sp),
+            name=f"mcp-stdout-{server_id}",
+        )
 
         await self._store.mark_running(server_id, proc.pid)
         logger.info("mcp: started %s pid=%s", server_id, proc.pid)
@@ -90,12 +136,13 @@ class MCPSupervisor:
             await proc.wait()
 
         exit_code = proc.returncode
-        if sp.stderr_task and not sp.stderr_task.done():
-            sp.stderr_task.cancel()
-            try:
-                await sp.stderr_task
-            except asyncio.CancelledError:
-                pass
+        for task in (sp.stderr_task, sp.stdout_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
         self._processes.pop(server_id, None)
         await self._store.mark_stopped(server_id, exit_code=exit_code)
@@ -191,11 +238,35 @@ class MCPSupervisor:
             pass
         return None
 
+    async def _drain_stdout(self, server_id: str, sp: ServerProcess) -> None:
+        """Read the child's stdout so it can never block on a full pipe buffer.
+
+        Until the JSON-RPC layer is wired the frames land in the same ring
+        buffer as stderr — the MCP app's Logs tab is specified as a live
+        stdout/stderr tail — tagged with ``stream`` so a reader can tell the
+        two apart.  Teardown stays in `_drain_stderr`: a child that closes
+        stdout early is still alive, and cancelling here would restore the
+        deadlock.
+        """
+        assert sp.process.stdout is not None
+        try:
+            async for line in _iter_lines(sp.process.stdout):
+                sp.log_buffer.append({
+                    "idx": len(sp.log_buffer),
+                    "ts": time.time(),
+                    "level": "info",
+                    "stream": "stdout",
+                    "line": line,
+                })
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("mcp stdout drain error for %s", server_id)
+
     async def _drain_stderr(self, server_id: str, sp: ServerProcess) -> None:
         assert sp.process.stderr is not None
         try:
-            async for raw_line in sp.process.stderr:
-                line = raw_line.decode(errors="replace").rstrip()
+            async for line in _iter_lines(sp.process.stderr):
                 level = "error" if any(
                     kw in line.lower() for kw in ("error", "exception", "traceback", "fatal")
                 ) else "info"
@@ -203,6 +274,7 @@ class MCPSupervisor:
                     "idx": len(sp.log_buffer),
                     "ts": time.time(),
                     "level": level,
+                    "stream": "stderr",
                     "line": line,
                 }
                 sp.log_buffer.append(entry)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] MCP supervisor pipes stdout and never drains it: deadlock
Autonomous build of board card tsk-j3m3bm.

## What changed

**1. `tinyagentos/mcp/supervisor.py` — stdout is now drained.**

`start()` spawned with `stdout=PIPE` and `stderr=PIPE` but only ever created a
reader for stderr. Once the 64 KiB OS pipe buffer filled, the child blocked in
`write()` forever while `mark_running()` / `get_status()` kept reporting it
healthy. For a stdio-transport MCP server stdout **is** the JSON-RPC channel,
so this is the primary data path, not an edge case.

- New `_drain_stdout` mirroring `_drain_stderr`, wired to a `ServerProcess.stdout_task`.
- `stop()` now reaps **both** drain tasks (it only cancelled stderr's).
- Log entries carry a `"stream": "stdout" | "stderr"` tag. The MCP app's Logs
  tab is specified as a live stdout/stderr tail, so draining stdout into a
  black hole would have traded one defect for another. `level` is unchanged, so
  the colour-coded tail keeps working.
- Teardown (`mark_stopped`) deliberately stays in `_drain_stderr`'s `finally`:
  a child that closes stdout early is still alive, and cancelling the stdout
  drain there would restore the deadlock.

**2. Same file — the drain no longer dies on a long line.** Both drains now
read fixed-size chunks through a shared `_iter_lines` helper instead of
`async for line in reader`. That iterator raises `ValueError` as soon as a
single line exceeds `StreamReader`'s 64 KiB limit, which kills the drain task
and re-opens exactly the deadlock the drain exists to close — and a JSON-RPC
frame is one line, routinely larger than the limit. Fixing only the missing
reader would have left the same hang reachable through the real traffic shape,
so the class is fixed on both pipes. The second RED test below is the one that
proves it.

**3. `tinyagentos/mcp/proxy.py` — no more success-shaped stub.** `call_tool`
returned `{"ok": True, "result": "stub — MCP JSON-RPC call not yet wired"}` for
a call it never made, which no caller can tell from a real tool result. It now
returns `{"error": "not_implemented", "reason": ..., "status": 501}`; the route
already maps `status` onto the HTTP code, so `POST /api/mcp/call` answers
**501**. The `403 permission_denied` and `503 server_unavailable` arms are
unchanged and are covered by a test so the new 501 cannot shadow them.

### Scoped out, with reason

The card's "durable half" — adopting the official `mcp` SDK and re-hosting the
supervisor lifecycle under `stdio_client` — is **not** in this PR. The card
carries its own escape hatch for that (*"If that is unacceptable for the 4 GB
core, gate it behind an `mcp` extra ... but still drain stdout"*), and the
weight caveat is decisive: 19 `requires_dist`, including `httpx2>=2.5.0`, which
is a **separate distribution** from the pinned `httpx>=0.27`, so both would be
installed on the low-RAM core. Both DONE-WHEN conditions are met without it.
Adopting the SDK is a dependency decision for the lead, not a builder's to make
inside a defect card.

## RED FIRST (pasted)

Verbatim at the base ref (`origin/dev` @ `b8f7726ea`), before any source change:

```
$ .venv/bin/python -m pytest tests/mcp/test_supervisor_stdout.py -q -p no:cacheprovider

FFFFF                                                                    [100%]
=================================== FAILURES ===================================
_____________________ test_chatty_stdout_does_not_deadlock _____________________
E       AssertionError: child never got past its 1048576-byte stdout write within 10.0s — blocked on a full pipe buffer, while get_status() reports {'running': True, 'pid': 3195133, 'uptime_s': 10.019613265991211, 'log_count': 0}
E       assert False

tests/mcp/test_supervisor_stdout.py:101: AssertionError
_____________ test_single_oversized_stdout_line_does_not_deadlock ______________
E       AssertionError: child never got past its single 1048576-byte stdout line within 10.0s, while get_status() reports {'running': True, 'pid': 3196828, 'uptime_s': 10.011690855026245, 'log_count': 0}
E       assert False

tests/mcp/test_supervisor_stdout.py:133: AssertionError
__________________ test_stdout_lines_are_tagged_and_tailable ___________________
E       assert False
tests/mcp/test_supervisor_stdout.py:159: AssertionError
____________________ test_stop_cancels_the_stdout_drain ________________________
>       stdout_task = sp.stdout_task
                      ^^^^^^^^^^^^^^
E       AttributeError: 'ServerProcess' object has no attribute 'stdout_task'. Did you mean: 'stderr_task'?

tests/mcp/test_supervisor_stdout.py:189: AttributeError
_____________ test_proxy_call_does_not_return_success_shaped_stub ______________
E       AssertionError: proxy returned a success-shaped result with no call made: {'ok': True, 'result': 'stub — MCP JSON-RPC call not yet wired', 'tool': 'fetch_url', 'arguments': {'url': 'https://example.invalid'}}
E       assert True is not True

tests/mcp/test_supervisor_stdout.py:218: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  tinyagentos.mcp.proxy:proxy.py:33 mcp proxy: actual MCP JSON-RPC call not yet wired — returning stub (server=sleep-srv tool=fetch_url agent=bot1)
=========================== short test summary info ============================
FAILED tests/mcp/test_supervisor_stdout.py::test_chatty_stdout_does_not_deadlock
FAILED tests/mcp/test_supervisor_stdout.py::test_single_oversized_stdout_line_does_not_deadlock
FAILED tests/mcp/test_supervisor_stdout.py::test_stdout_lines_are_tagged_and_tailable
FAILED tests/mcp/test_supervisor_stdout.py::test_stop_cancels_the_stdout_drain
FAILED tests/mcp/test_supervisor_stdout.py::test_proxy_call_does_not_return_success_shaped_stub
5 failed in 42.35s
```

`log_count: 0` alongside `running: True` is the whole defect in one line: not a
single byte was read off the pipe, and the supervisor called it healthy. The
42 s runtime is the two 10 s deadlock timeouts.

The card's note that a quiet server passes today is confirmed —
`tests/test_mcp.py::test_supervisor_start_stop` and
`::test_supervisor_log_buffer_bounds` were green at this same ref.

## GREEN

```
$ .venv/bin/python -m pytest tests/mcp/test_supervisor_stdout.py -q -p no:cacheprovider
.....                                                                    [100%]
5 passed in 1.81s
```

42 s of deadlock timeouts collapses to 1.81 s of real work.

Also run, all green:

```
$ .venv/bin/python -m pytest tests/mcp/ tests/test_routes_mcp.py tests/test_mcp.py \
    tests/test_permissions.py tests/test_agent_manual_compiled.py tests/test_agent_manual.py \
    -q -p no:cacheprovider
94 passed in 49.80s

$ .venv/bin/python -m pytest tests/test_doc_gate.py tests/test_check_doc_gate.py \
    tests/test_collate_changelog.py -q -p no:cacheprovider
142 passed in 25.42s

$ python scripts/check_doc_gate.py invariants   -> doc-gate: clean
$ python scripts/check_doc_gate.py diff-gate --staged -> doc-gate: clean
$ python -m compileall tinyagentos/mcp -q       -> clean
```

New tests: `tests/mcp/test_supervisor_stdout.py` (5) plus
`tests/test_routes_mcp.py::TestMCPProxyCall` (2), which exercises the **real
caller** — `POST /api/mcp/call` — rather than only `call_tool` directly, and
pins the 403 permission arm so the new 501 cannot swallow it.

## Docs

- `docs/agent-coordination.md` — new **"MCP tool calls (`POST /api/mcp/call`)"**
  section: the 403 / 503 / 501 answer table, an explicit warning not to treat a
  2xx from this route as proof a tool ran (there is no success shape on this
  path yet), and the `stream`-tagged log entries on
  `GET /api/mcp/servers/{id}/logs` and its SSE tail. This is the doc the
  `agent-manual` doc-gate rule requires for a `tinyagentos/mcp/**` change.
- `changelog.d/tsk-j3m3bm-mcp-stdout-drain.md` — three user-visible entries.
- Swept `docs/`, `README.md`, `CONTRIBUTING.md` and `AGENTS.md` for the old
  behaviour: no stale mention found. `docs/superpowers/specs/2026-04-14-mcp-app-design.md`
  needs no edit — it already specifies the Logs tab as a "live stdout/stderr
  tail" (which the drain now actually delivers) and still lists "proxy wiring
  into the agent tool-call path" as pending work, which remains true.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP servers no longer stall when producing large amounts of output.
  * Very large output lines are handled without errors.
  * Server logs now clearly identify whether entries came from standard output or standard error.
  * Stopping an MCP server now reliably cleans up output processing.

* **API Changes**
  * Unavailable MCP tool calls now return a clear `501 Not Implemented` response instead of a misleading success result.

* **Documentation**
  * Documented MCP tool-call responses and server output logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->