### PR TITLE
fix(tasks): PATCH persists explicit clears and rejects unknown fields (tsk-5xq2mw)

### DIFF
--- a/changelog.d/tsk-5xq2mw-task-patch-inert-fields.md
+++ b/changelog.d/tsk-5xq2mw-task-patch-inert-fields.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Projects board: `PATCH /api/projects/{pid}/tasks/{tid}` no longer reports success for an edit it drops. Clearing a card's assignee, parent or element (sent as `null`, e.g. dragging a card to the board's "Unassigned" or "Orphans" lane) now persists, and a field the route cannot write — a `null` on a non-nullable field, a misspelled key, or a read-only column such as `id`/`created_by` — is rejected with 422 instead of answering 200 with the unchanged task.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -415,7 +415,15 @@ The registry-JWT surface, by scope:
   whitelisted fields (title, body, labels, priority), own-or-lead cards only.
   Also SEPARATE from project_tasks - a plain project_tasks token gets 403 on
   PATCH. The seeded internal lead (@taOS-dev) carries it by default so it can
-  edit its own board's cards; assignee_id and parent_task_id stay human-only.
+  edit its own board's cards; assignee_id and parent_task_id stay human-only -
+  the whitelist keys on which fields the body SENDS, so sending one of them as
+  `null` (a clear) is refused 403 like any other edit of it.
+  The route writes exactly the fields the body sends: an omitted field is left
+  unchanged, `assignee_id`/`parent_task_id`/`element_id` take `null` as a real
+  clear (`element_id` also takes the legacy `"none"` string), and anything the
+  route cannot write - a `null` on a non-nullable field, a misspelled key, a
+  read-only column such as `id`/`created_by`/`claimed_by` - is a 422 rather
+  than a 200 echoing a task it never changed.
 - **project_doc_review**: read and write doc-review stamps for a project.
   `GET /api/projects/{pid}/doc-reviews` (list), `GET /api/projects/{pid}/doc-review/{path}`
   (read one), and `PUT /api/projects/{pid}/doc-review/{path}` (set state).

--- a/docs/routes.d/01-project-tasks.md
+++ b/docs/routes.d/01-project-tasks.md
@@ -19,6 +19,21 @@ Access the kanban board for a project. Granting `project_tasks` also makes the a
 - `POST /api/projects/{pid}/tasks/{id}/reopen` — reopen a closed task
 - `GET /api/projects/tasks/{id}/context` — get task context
 
+### PATCH body semantics
+
+`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields the body sends
+and answers with the stored task:
+
+- an omitted field is left unchanged;
+- `assignee_id`, `parent_task_id` and `element_id` accept `null` as a real edit
+  (unassign / orphan / untag); `element_id` also accepts the legacy `"none"`
+  string for the same clear;
+- `null` on any other field is a `422` — it cannot be written, so it is not
+  silently ignored;
+- a key the route cannot write (a misspelling, or a read-only column such as
+  `id`, `created_by`, `claimed_by`) is a `422`, never a `200` that echoes back
+  an unchanged task.
+
 ### Grant requirements
 
 Granting `project_tasks` also makes the agent a project member.

--- a/docs/routes.d/01-project-tasks.md
+++ b/docs/routes.d/01-project-tasks.md
@@ -21,18 +21,11 @@ Access the kanban board for a project. Granting `project_tasks` also makes the a
 
 ### PATCH body semantics
 
-`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields the body sends
-and answers with the stored task:
-
-- an omitted field is left unchanged;
-- `assignee_id`, `parent_task_id` and `element_id` accept `null` as a real edit
-  (unassign / orphan / untag); `element_id` also accepts the legacy `"none"`
-  string for the same clear;
-- `null` on any other field is a `422` — it cannot be written, so it is not
-  silently ignored;
-- a key the route cannot write (a misspelling, or a read-only column such as
-  `id`, `created_by`, `claimed_by`) is a `422`, never a `200` that echoes back
-  an unchanged task.
+`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields sent and
+returns the stored task. Omitted = unchanged. `assignee_id`, `parent_task_id`,
+`element_id` accept `null` as a real clear (`element_id` also the legacy
+`"none"`). `null` elsewhere, an unknown key, or a read-only column (`id`,
+`created_by`, `claimed_by`) is a `422` — never a `200` echoing an unchanged task.
 
 ### Grant requirements
 

--- a/docs/routes.d/02-agent-api.md
+++ b/docs/routes.d/02-agent-api.md
@@ -16,7 +16,7 @@ Granting `project_tasks` also makes the agent a project member.
 
 ### project_tasks_update
 
-`PATCH /api/projects/{pid}/tasks/{tid}` — whitelisted fields (title, body, labels, priority). own-or-lead cards only. SEPARATE from `project_tasks`; plain project_tasks token gets 403.
+`PATCH /api/projects/{pid}/tasks/{tid}` — whitelisted fields (title, body, labels, priority). own-or-lead cards only. SEPARATE from `project_tasks`; plain project_tasks token gets 403. The whitelist keys on which fields the body SENDS, so `{"assignee_id": null}` is a 403 like any other assignee edit.
 
 ### canvas_read & canvas_write
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -18,6 +18,21 @@ Access the kanban board for a project. Granting `project_tasks` also makes the a
 - `POST /api/projects/{pid}/tasks/{id}/reopen` — reopen a closed task
 - `GET /api/projects/tasks/{id}/context` — get task context
 
+### PATCH body semantics
+
+`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields the body sends
+and answers with the stored task:
+
+- an omitted field is left unchanged;
+- `assignee_id`, `parent_task_id` and `element_id` accept `null` as a real edit
+  (unassign / orphan / untag); `element_id` also accepts the legacy `"none"`
+  string for the same clear;
+- `null` on any other field is a `422` — it cannot be written, so it is not
+  silently ignored;
+- a key the route cannot write (a misspelling, or a read-only column such as
+  `id`, `created_by`, `claimed_by`) is a `422`, never a `200` that echoes back
+  an unchanged task.
+
 ### Grant requirements
 
 Granting `project_tasks` also makes the agent a project member.
@@ -45,7 +60,7 @@ Granting `project_tasks` also makes the agent a project member.
 
 ### project_tasks_update
 
-`PATCH /api/projects/{pid}/tasks/{tid}` — whitelisted fields (title, body, labels, priority). own-or-lead cards only. SEPARATE from `project_tasks`; plain project_tasks token gets 403.
+`PATCH /api/projects/{pid}/tasks/{tid}` — whitelisted fields (title, body, labels, priority). own-or-lead cards only. SEPARATE from `project_tasks`; plain project_tasks token gets 403. The whitelist keys on which fields the body SENDS, so `{"assignee_id": null}` is a 403 like any other assignee edit.
 
 ### canvas_read & canvas_write
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -20,18 +20,11 @@ Access the kanban board for a project. Granting `project_tasks` also makes the a
 
 ### PATCH body semantics
 
-`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields the body sends
-and answers with the stored task:
-
-- an omitted field is left unchanged;
-- `assignee_id`, `parent_task_id` and `element_id` accept `null` as a real edit
-  (unassign / orphan / untag); `element_id` also accepts the legacy `"none"`
-  string for the same clear;
-- `null` on any other field is a `422` — it cannot be written, so it is not
-  silently ignored;
-- a key the route cannot write (a misspelling, or a read-only column such as
-  `id`, `created_by`, `claimed_by`) is a `422`, never a `200` that echoes back
-  an unchanged task.
+`PATCH /api/projects/{pid}/tasks/{id}` writes exactly the fields sent and
+returns the stored task. Omitted = unchanged. `assignee_id`, `parent_task_id`,
+`element_id` accept `null` as a real clear (`element_id` also the legacy
+`"none"`). `null` elsewhere, an unknown key, or a read-only column (`id`,
+`created_by`, `claimed_by`) is a `422` — never a `200` echoing an unchanged task.
 
 ### Grant requirements
 

--- a/tests/projects/test_routes_task_patch_persistence.py
+++ b/tests/projects/test_routes_task_patch_persistence.py
@@ -1,0 +1,168 @@
+"""PATCH /api/projects/{pid}/tasks/{tid} must never assert a write it did not make.
+
+tsk-5xq2mw: the route answered 200 with the task JSON for payloads it silently
+dropped, so every caller check short of a fresh read passed:
+
+  * an explicit null clear -- the board sends ``{"assignee_id": null}`` when a
+    card is dragged to the "Unassigned" lane and ``{"parent_task_id": null}``
+    for the "Orphans" lane (desktop/src/apps/ProjectsApp/board/boardDnd.ts) --
+    was read as "field omitted, leave unchanged";
+  * a field the route does not accept at all (a typo, or a read-only column
+    such as ``id`` / ``created_by`` / ``claimed_by``) was accepted with 200.
+
+Every PATCH here is verified by a re-read, and the fields the route will not
+write are pinned to 422 rather than a silent 200.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _project(client, slug: str) -> str:
+    resp = await client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _task(client, pid: str, **payload) -> dict:
+    body = {"title": "T", "body": "orig body", "priority": 1, "labels": ["a"]}
+    body.update(payload)
+    resp = await client.post(f"/api/projects/{pid}/tasks", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _reread(client, pid: str, tid: str) -> dict:
+    resp = await client.get(f"/api/projects/{pid}/tasks/{tid}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestExplicitNullClears:
+    async def test_clear_assignee_persists(self, client):
+        pid = await _project(client, "clr-assignee")
+        t = await _task(client, pid, assignee_id="worker-1")
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={"assignee_id": None}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["assignee_id"] is None
+        assert (await _reread(client, pid, t["id"]))["assignee_id"] is None
+
+    async def test_clear_parent_persists(self, client):
+        pid = await _project(client, "clr-parent")
+        parent = await _task(client, pid, title="Parent")
+        child = await _task(client, pid, title="Child", parent_task_id=parent["id"])
+        assert child["parent_task_id"] == parent["id"]
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{child['id']}", json={"parent_task_id": None}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["parent_task_id"] is None
+        assert (await _reread(client, pid, child["id"]))["parent_task_id"] is None
+
+    async def test_clear_element_persists(self, client):
+        pid = await _project(client, "clr-element")
+        el = await client.post(
+            f"/api/projects/{pid}/elements", json={"name": "E"}
+        )
+        assert el.status_code == 200, el.text
+        eid = el.json()["id"]
+        t = await _task(client, pid, element_id=eid)
+        assert t["element_id"] == eid
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={"element_id": None}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["element_id"] is None
+        assert (await _reread(client, pid, t["id"]))["element_id"] is None
+
+    async def test_element_none_sentinel_still_clears(self, client):
+        """Regression pin: the documented ``"none"`` string keeps working."""
+        pid = await _project(client, "clr-element-str")
+        el = await client.post(
+            f"/api/projects/{pid}/elements", json={"name": "E"}
+        )
+        eid = el.json()["id"]
+        t = await _task(client, pid, element_id=eid)
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={"element_id": "none"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert (await _reread(client, pid, t["id"]))["element_id"] is None
+
+
+class TestUnwritableFieldsAreRejected:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"despcription": "typo"},
+            {"id": "tsk-spoofed"},
+            {"created_by": "someone-else"},
+            {"claimed_by": "someone-else"},
+            {"project_id": "other-project"},
+        ],
+    )
+    async def test_field_the_route_cannot_write_is_422(self, client, payload):
+        pid = await _project(client, f"rej-{next(iter(payload))}")
+        t = await _task(client, pid)
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json=payload
+        )
+        assert resp.status_code == 422, resp.text
+        after = await _reread(client, pid, t["id"])
+        for field in ("id", "created_by", "claimed_by", "project_id"):
+            assert after[field] == t[field]
+
+    @pytest.mark.parametrize(
+        "field", ["title", "body", "priority", "labels", "status"]
+    )
+    async def test_null_on_a_non_nullable_field_is_422(self, client, field):
+        """A null for a column that cannot hold one is a caller mistake, not a
+        no-op: answering 200 with the unchanged task hides it."""
+        pid = await _project(client, f"null-{field}")
+        t = await _task(client, pid)
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={field: None}
+        )
+        assert resp.status_code == 422, resp.text
+        assert (await _reread(client, pid, t["id"]))[field] == t[field]
+
+
+class TestAcceptedFieldsSurviveAReRead:
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("title", "renamed"),
+            ("body", "revised body"),
+            ("priority", 7),
+            ("labels", ["bug", "urgent"]),
+            ("status", "closed"),
+            ("assignee_id", "worker-2"),
+        ],
+    )
+    async def test_patch_persists(self, client, field, value):
+        pid = await _project(client, f"persist-{field}")
+        t = await _task(client, pid)
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={field: value}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()[field] == value
+        assert (await _reread(client, pid, t["id"]))[field] == value
+
+    async def test_omitted_fields_stay_unchanged(self, client):
+        pid = await _project(client, "persist-omit")
+        t = await _task(client, pid, assignee_id="worker-1")
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={"title": "renamed"}
+        )
+        assert resp.status_code == 200, resp.text
+        after = await _reread(client, pid, t["id"])
+        assert after["title"] == "renamed"
+        assert after["body"] == t["body"]
+        assert after["priority"] == t["priority"]
+        assert after["labels"] == t["labels"]
+        assert after["assignee_id"] == "worker-1"

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -172,6 +172,8 @@ class TestAgentCanDriveOwnBoard:
             )
         assert resp.status_code == 200, resp.text
         assert resp.json()["priority"] == 7
+        after = await ctx.client.get(f"/api/projects/{pid}/tasks/{tid}")
+        assert after.json()["priority"] == 7
 
     async def test_lead_agent_patch_labels_succeeds(self, ctx):
         pid = await _new_project(ctx, "alpha")
@@ -187,6 +189,8 @@ class TestAgentCanDriveOwnBoard:
             )
         assert resp.status_code == 200, resp.text
         assert resp.json()["labels"] == ["bug", "urgent"]
+        after = await ctx.client.get(f"/api/projects/{pid}/tasks/{tid}")
+        assert after.json()["labels"] == ["bug", "urgent"]
 
     async def test_lead_agent_patch_title_succeeds(self, ctx):
         pid = await _new_project(ctx, "alpha")
@@ -202,6 +206,8 @@ class TestAgentCanDriveOwnBoard:
             )
         assert resp.status_code == 200, resp.text
         assert resp.json()["title"] == "renamed by agent"
+        after = await ctx.client.get(f"/api/projects/{pid}/tasks/{tid}")
+        assert after.json()["title"] == "renamed by agent"
 
     async def test_agent_patch_assignee_id_rejected(self, ctx):
         """assignee_id stays human-only: an agent PATCH of it -> 403."""
@@ -232,6 +238,67 @@ class TestAgentCanDriveOwnBoard:
                 headers=_hdr(token),
             )
         assert resp.status_code == 403
+
+    async def test_agent_patch_null_assignee_rejected(self, ctx):
+        """An explicit null is a WRITE (it clears the column, tsk-5xq2mw), so the
+        agent whitelist must refuse it exactly like a non-null value -> 403.
+        Keyed on which fields the caller SENT, not on their value."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tid}", json={"assignee_id": "worker-1"}
+        )
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"assignee_id": None},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 403, resp.text
+        # Re-read as the admin session: this token carries project_tasks_update
+        # only, which does not authorize a read.
+        after = await ctx.client.get(f"/api/projects/{pid}/tasks/{tid}")
+        assert after.json()["assignee_id"] == "worker-1"
+
+    async def test_agent_patch_null_parent_rejected(self, ctx):
+        """Same for parent_task_id: clearing a hierarchy stays human-only."""
+        pid = await _new_project(ctx, "alpha")
+        parent = await _new_task(ctx, pid, title="Parent")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tid}", json={"parent_task_id": parent}
+        )
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"parent_task_id": None},
+                headers=_hdr(token),
+            )
+            assert resp.status_code == 403, resp.text
+        after = await ctx.client.get(f"/api/projects/{pid}/tasks/{tid}")
+        assert after.json()["parent_task_id"] == parent
+
+    async def test_agent_patch_unknown_field_is_422(self, ctx):
+        """A field this route cannot write is refused, not answered 200 with an
+        unchanged task (tsk-5xq2mw)."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"created_by": "someone-else"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 422, resp.text
 
     async def test_non_lead_agent_patch_rejected(self, ctx):
         """An agent that neither created nor leads the project cannot PATCH

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -126,11 +126,11 @@ def _row_to_checklist_item(row, description) -> dict:
     return c
 
 
-# Sentinels for update_task's element_id:
-#   _ELEMENT_UNCHANGED -> leave the task's element tag untouched (PATCH omitted)
-#   _ELEMENT_CLEAR     -> explicitly clear the tag to NULL ("none" sentinel)
-_ELEMENT_UNCHANGED: object = object()
-_ELEMENT_CLEAR: object = object()
+# Sentinel for update_task's nullable columns (assignee_id, parent_task_id,
+# element_id).  For those three, ``None`` is a VALUE -- "clear this to NULL" --
+# so "the caller did not mention this field" needs a marker of its own.  The
+# non-nullable columns keep the simpler ``None means unchanged`` convention.
+_UNCHANGED: object = object()
 
 
 class ProjectTaskStore(BaseStore):
@@ -332,9 +332,9 @@ class ProjectTaskStore(BaseStore):
         priority: int | None = None,
         labels: list[str] | None = None,
         status: str | None = None,
-        assignee_id: str | None = None,
-        parent_task_id: str | None = None,
-        element_id: object = _ELEMENT_UNCHANGED,
+        assignee_id: str | None | object = _UNCHANGED,
+        parent_task_id: str | None | object = _UNCHANGED,
+        element_id: str | None | object = _UNCHANGED,
     ) -> None:
         # Reject generic status transitions from parked: parked is permanent
         # and such a transition would clear claim fields and return the task
@@ -352,8 +352,6 @@ class ProjectTaskStore(BaseStore):
             ("priority", priority, priority),
             ("labels", labels, json.dumps(labels) if labels is not None else None),
             ("status", status, status),
-            ("assignee_id", assignee_id, assignee_id),
-            ("parent_task_id", parent_task_id, parent_task_id),
         ]
         sets: list[str] = []
         params: list = []
@@ -363,16 +361,20 @@ class ProjectTaskStore(BaseStore):
                 sets.append(f"{col} = ?")
                 params.append(serialised)
                 patch[col] = raw
-        # element_id is handled separately so None can mean "unchanged" while an
-        # explicit clear sets the tag to NULL.
-        if element_id is not _ELEMENT_UNCHANGED:
-            sets.append("element_id = ?")
-            if element_id is _ELEMENT_CLEAR:
-                params.append(None)
-                patch["element_id"] = None
-            else:
-                params.append(element_id)
-                patch["element_id"] = element_id
+        # The nullable columns are keyed on the _UNCHANGED sentinel instead, so
+        # an explicit None clears them to NULL rather than being read as "field
+        # omitted" (tsk-5xq2mw: a clear that is silently dropped answers the
+        # caller as if it had been written).
+        for col, value in (
+            ("assignee_id", assignee_id),
+            ("parent_task_id", parent_task_id),
+            ("element_id", element_id),
+        ):
+            if value is _UNCHANGED:
+                continue
+            sets.append(f"{col} = ?")
+            params.append(value)
+            patch[col] = value
         if not sets:
             return
         # A generic edit back to 'open' must also clear the claimer (as the

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -24,7 +24,6 @@ from tinyagentos.projects.folders import (
     write_project_yaml,
 )
 from tinyagentos.projects.project_store import ProjectConflict
-from tinyagentos.projects.task_store import _ELEMENT_CLEAR
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -498,17 +497,53 @@ class CreateTaskIn(_TaskRequestModelMixin, BaseModel):
         return self
 
 
+# Task columns the PATCH route can write as NULL, i.e. the fields for which an
+# explicit ``null`` is a real edit ("unassign me", "orphan this card") rather
+# than a typo.  Every other field must carry a value.
+_NULLABLE_TASK_FIELDS = frozenset({"assignee_id", "parent_task_id", "element_id"})
+
+
 class UpdateTaskIn(_TaskRequestModelMixin, BaseModel):
+    # extra="forbid", as on CreateTaskIn: a key this route cannot write -- a
+    # misspelling, or a read-only column such as id/created_by/claimed_by -- is
+    # refused 422 instead of being answered 200 with the task it did not change
+    # (tsk-5xq2mw).  A dropped write that reports success passes every caller
+    # check short of a re-read.
+    model_config = ConfigDict(extra="forbid")
+
     title: str | None = None
     body: str | None = None
     priority: int | None = None
     labels: list[str] | None = None
     status: str | None = None
+    # Omitted -> unchanged; null -> cleared (the board's "Unassigned" and
+    # "Orphans" lanes send exactly that).
     assignee_id: str | None = None
     parent_task_id: str | None = None
-    # Omit to leave the element tag unchanged; send "none" to clear it to
-    # project-level (NULL); send a real element id to move the task.
+    # Omit to leave the element tag unchanged; send null (or the legacy "none"
+    # string) to clear it to project-level; send a real element id to move the
+    # task.
     element_id: str | None = None
+
+    @model_validator(mode="after")
+    def _reject_null_on_non_nullable_fields(self) -> UpdateTaskIn:
+        """A null for a column that cannot hold one is a caller mistake.
+
+        Treating it as "field omitted" would answer 200 with the unchanged
+        task -- the same silent drop this route is being fixed for -- so it is
+        a 422 naming the offending fields.
+        """
+        nulled = sorted(
+            f
+            for f in self.model_fields_set
+            if f not in _NULLABLE_TASK_FIELDS and getattr(self, f) is None
+        )
+        if nulled:
+            raise ValueError(
+                f"{', '.join(nulled)}: null is not a valid value; "
+                "omit the field to leave it unchanged"
+            )
+        return self
 
 
 class ClaimIn(_TaskRequestModelMixin, BaseModel):
@@ -1001,13 +1036,16 @@ async def update_task(
             )
 
     # Field whitelist for agents: title, body, labels, priority ONLY.
-    # Any other field that is set is rejected 403 (future fields included)
+    # Any other field the caller SENT is rejected 403 (future fields included)
     # so the surface stays minimal and future task fields are protected by
     # default. assignee_id and parent_task_id stay human-only: an agent may
-    # not reassign work to itself or rewire hierarchies.
+    # not reassign work to itself or rewire hierarchies -- including by
+    # clearing them, which is why this keys on which fields were sent rather
+    # than on their value (an explicit null is a write too, tsk-5xq2mw).
+    sent = payload.model_fields_set
     if is_agent:
-        for f in payload.model_fields:
-            if f not in _AGENT_EDITABLE_FIELDS and getattr(payload, f) is not None:
+        for f in sorted(sent):
+            if f not in _AGENT_EDITABLE_FIELDS:
                 return JSONResponse(
                     {"error": f"field {f!r} is not editable by agents"},
                     status_code=403,
@@ -1029,14 +1067,17 @@ async def update_task(
             cur = await store.get_task(cur["parent_task_id"])
 
     estore = request.app.state.project_element_store
+    # Keyed on what the caller SENT: an omitted field is unchanged, a field
+    # sent as null clears its column (the model has already refused a null on
+    # a column that cannot hold one).
     update_fields: dict = {}
     for f in ("title", "body", "priority", "labels", "status", "assignee_id", "parent_task_id"):
-        v = getattr(payload, f)
-        if v is not None:
-            update_fields[f] = v
-    if payload.element_id is not None:
-        if payload.element_id == "none":
-            update_fields["element_id"] = _ELEMENT_CLEAR
+        if f in sent:
+            update_fields[f] = getattr(payload, f)
+    if "element_id" in sent:
+        # "none" is the legacy spelling of the clear; a real null means the same.
+        if payload.element_id is None or payload.element_id == "none":
+            update_fields["element_id"] = None
         else:
             el_check = await _require_active_element(estore, project_id, payload.element_id)
             if isinstance(el_check, JSONResponse):


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Tasks API: PATCH body field is INERT - response echoes the new body but nothing persists
Autonomous build of board card tsk-5xq2mw.

## What changed

`PATCH /api/projects/{pid}/tasks/{tid}` answered `200` with the task JSON for
payloads it silently dropped, so every caller check short of a re-read passed.
The route now writes exactly the fields the request SENT and refuses anything it
cannot write.

**As-written instance: refuted.** The card's literal case - PATCH `{"body": ...}`
echoing the new body while an immediate GET returns the old one - does not
reproduce at the merge ref. Probing every declared field as a session admin
(title / body / priority / labels / status / assignee_id / element_id) shows all
of them persisting through a fresh GET, and
`tests/test_routes_projects_agent_tasks.py::test_lead_agent_patch_body_persists`
has pinned the body case since 2026-08-02 (commit 9d9feae8a) - a week before the
2026-08-10 sighting, which was therefore against a stale deployment.

**Same class, still live: fixed.** Two shapes of "the response asserts a write
that never happened" did reproduce, and the card's own instruction is to fix the
class:

1. **An explicit `null` clear was inert.** `update_fields` was built with
   `if v is not None`, so `{"assignee_id": null}`, `{"parent_task_id": null}` and
   `{"element_id": null}` were read as "field omitted, leave unchanged" and
   answered `200` with the unchanged card. The board sends exactly those payloads
   when a card is dragged to the **Unassigned** or **Orphans** lane
   (`desktop/src/apps/ProjectsApp/board/boardDnd.ts`, `lanePatch`), so unassigning
   a card through the UI did nothing while reporting success.
2. **A key the route cannot write was accepted.** `UpdateTaskIn` was still in the
   `extra="allow"` observation phase, so a misspelling or a read-only column
   (`id`, `created_by`, `claimed_by`, `project_id`) was answered `200` with a task
   nothing had written. `CreateTaskIn` had already flipped to `extra="forbid"`
   (commit 29d0d84c1); this brings PATCH in line.

Also fixed while in there: the agent field whitelist keyed on a field's VALUE
(`getattr(payload, f) is not None`), so an agent's `{"assignee_id": null}` slipped
past the `403` gate. Harmless while the clear was inert; an escalation the moment
the clear works. It now keys on which fields were sent.

Resulting contract (documented in `docs/routes.d/01-project-tasks.md`):

- an omitted field is left unchanged;
- `assignee_id` / `parent_task_id` / `element_id` take `null` as a real edit
  (unassign / orphan / untag); `element_id` still accepts the legacy `"none"`
  string for the same clear;
- `null` on any other field is `422` - it cannot be written, so it is not
  silently ignored;
- an unknown or read-only key is `422`, never a `200` echoing an unchanged task;
- for an agent token, any field outside `title|body|labels|priority` is `403`
  whether it carries a value or a `null`.

`task_store.update_task` takes the same shape: the three nullable columns are
keyed on a single `_UNCHANGED` sentinel (replacing the element-only sentinel
pair), so an explicit `None` writes NULL. The non-nullable columns keep the
existing "None means unchanged" convention, and the only other caller of those
parameters (`routes/delegation.py`) always passes a real id.

## RED FIRST (pasted)

At the merge ref `b8f7726ea`, before the fix - session-admin half:

```
$ /home/jay/Development/tinyagentos/.venv/bin/python -m pytest tests/projects/test_routes_task_patch_persistence.py -q -p no:cacheprovider
        """A null for a column that cannot hold one is a caller mistake, not a
        no-op: answering 200 with the unchanged task hides it."""
        pid = await _project(client, f"null-{field}")
        t = await _task(client, pid)
        resp = await client.patch(
            f"/api/projects/{pid}/tasks/{t['id']}", json={field: None}
        )
>       assert resp.status_code == 422, resp.text
E       AssertionError: {"id":"tsk-zanyi4","project_id":"prj-zn3foi","parent_task_id":null,"title":"T","body":"orig body","status":"open","priority":1,"labels":["a"],"assignee_id":null,"element_id":null,"claimed_by":null,"claimed_at":null,"closed_at":null,"closed_by":null,"close_reason":null,"created_by":"XYBlRTIfJLE","created_at":1788570871.330258,"updated_at":1788570871.330258}
E       assert 200 == 422
E        +  where 200 = <Response [200 OK]>.status_code

tests/projects/test_routes_task_patch_persistence.py:130: AssertionError
=========================== short test summary info ============================
FAILED tests/projects/test_routes_task_patch_persistence.py::TestExplicitNullClears::test_clear_assignee_persists
FAILED tests/projects/test_routes_task_patch_persistence.py::TestExplicitNullClears::test_clear_parent_persists
FAILED tests/projects/test_routes_task_patch_persistence.py::TestExplicitNullClears::test_clear_element_persists
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_field_the_route_cannot_write_is_422[payload0]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_field_the_route_cannot_write_is_422[payload1]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_field_the_route_cannot_write_is_422[payload2]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_field_the_route_cannot_write_is_422[payload3]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_field_the_route_cannot_write_is_422[payload4]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_null_on_a_non_nullable_field_is_422[title]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_null_on_a_non_nullable_field_is_422[body]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_null_on_a_non_nullable_field_is_422[priority]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_null_on_a_non_nullable_field_is_422[labels]
FAILED tests/projects/test_routes_task_patch_persistence.py::TestUnwritableFieldsAreRejected::test_null_on_a_non_nullable_field_is_422[status]
13 failed, 8 passed in 225.96s (0:03:45)
```

The three failures at the top of that list are the card's exact shape: the PATCH
returns `200`, and the GET that follows still shows the OLD value.
`test_clear_assignee_persists` is the payload the board sends for the
"Unassigned" lane.

Agent-token half, same ref:

```
$ /home/jay/Development/tinyagentos/.venv/bin/python -m pytest tests/test_routes_projects_agent_tasks.py -q -p no:cacheprovider -k "null_assignee or null_parent or unknown_field_is_422"
>       assert resp.status_code == 422, resp.text
E       AssertionError: {"id":"tsk-dno7vf","project_id":"prj-pwju5m","parent_task_id":null,"title":"T","body":"","status":"open","priority":0,"labels":[],"assignee_id":null,"element_id":null,"claimed_by":null,"claimed_at":null,"closed_at":null,"closed_by":null,"close_reason":null,"created_by":"jO2FN4s5xDI","created_at":1788571067.982758,"updated_at":1788571067.982758}
E       assert 200 == 422
E        +  where 200 = <Response [200 OK]>.status_code

tests/test_routes_projects_agent_tasks.py:303: AssertionError
=========================== short test summary info ============================
FAILED tests/test_routes_projects_agent_tasks.py::TestAgentCanDriveOwnBoard::test_agent_patch_null_assignee_rejected
FAILED tests/test_routes_projects_agent_tasks.py::TestAgentCanDriveOwnBoard::test_agent_patch_null_parent_rejected
FAILED tests/test_routes_projects_agent_tasks.py::TestAgentCanDriveOwnBoard::test_agent_patch_unknown_field_is_422
3 failed, 3 warnings in 64.64s (0:01:04)
```

## GREEN

```
$ /home/jay/Development/tinyagentos/.venv/bin/python -m pytest \
    tests/projects/test_routes_task_patch_persistence.py \
    tests/test_routes_projects_agent_tasks.py tests/test_routes_projects.py \
    tests/projects/ tests/test_project_task_store.py tests/test_task_store.py \
    tests/test_routes_tasks.py -q -p no:cacheprovider
666 passed in 1555.18s (0:25:55)
```

All 21 new persistence tests and the 3 new agent-token tests pass, and the whole
projects routes + task store surface around them is unchanged: the projects route
tests, the agent-token board tests, both task store suites and the legacy
`/api/tasks` routes are in that run.

Re-run after rebasing onto the current `dev` tip:

```
$ /home/jay/Development/tinyagentos/.venv/bin/python -m pytest \
    tests/projects/test_routes_task_patch_persistence.py \
    tests/test_routes_projects_agent_tasks.py tests/projects/ -q -p no:cacheprovider
480 passed in 358.36s (0:05:58)
```

## Docs

- `docs/routes.d/01-project-tasks.md` - new "PATCH body semantics" section (what is
  unchanged, what a `null` clears, what is `422`).
- `docs/routes.d/02-agent-api.md` and `docs/agent-coordination.md` -
  `project_tasks_update` now states that the whitelist keys on the fields the body
  sends, so a `null` assignee is `403` like any other assignee edit, and records the
  `422` reject path.
- `docs/routes.md` regenerated from `docs/routes.d/` via `scripts/build-routes-doc.py`.
- `changelog.d/tsk-5xq2mw-task-patch-inert-fields.md`.

## Follow-ups (noticed, deliberately not fixed here)

- PATCH `status` is unvalidated: `{"status": "bogus-status"}` PERSISTS junk. The
  aggregate route validates against `_TASK_STATUS_ENUM` (`tinyagentos/routes/projects.py:39`,
  `open|claimed|closed`) but PATCH does not, and the store also knows a `parked`
  status the enum omits. A different defect class (the write lands), so it is left
  for its own card.
- `desktop/src/lib/projects.ts:267` types the patch as `Partial<ProjectTask>`, so
  read-only keys such as `id`/`created_at` are typeable client-side; they now fail
  `422` at runtime rather than being silently dropped. The TS type should be narrowed
  to the writable fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing assignees, parent tasks, and elements now persists correctly through task updates.
  - Invalid, misspelled, read-only, or non-nullable fields now return a clear validation error instead of reporting an unchanged successful update.
  - Agent task update permissions now consistently reject restricted fields, including attempts to clear protected assignments.

- **Documentation**
  - Clarified PATCH behavior, including field-level updates, omitted fields, supported clear values, legacy element handling, and relevant error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->