### PR TITLE
fix(tests): stop test_merge_attribution flaking on a sha substring (tsk-oqpbvn)

### DIFF
--- a/changelog.d/tsk-oqpbvn-merge-attribution-flake.md
+++ b/changelog.d/tsk-oqpbvn-merge-attribution-flake.md
@@ -1,0 +1,3 @@
+### Tests
+
+- Fixed a CI flake in `tests/test_merge_attribution.py`: two assertions checked that an excluded PR number ("41") was a bare substring of `result.stdout`, but the fixture commit shas are generated at runtime, so a sha for the in-scope PR could coincidentally contain "41" and fail the assertion for a reason unrelated to the actual reconciliation logic. Both now assert on the exact `"#41"` PR-reference token the checker prints, which cannot collide with a hex sha substring.

--- a/tests/test_merge_attribution.py
+++ b/tests/test_merge_attribution.py
@@ -454,6 +454,9 @@ class TestMergeAttributionReconciliation:
         # sha, not PR #41's number. The fixed pattern checks the PR-reference
         # token the checker actually prints (f"#{pr_num} {short}"), which
         # cannot collide with a hex sha substring the way a bare number can.
+        # First prove the collision is really present in the fixture, so this
+        # test cannot pass vacuously if the sha above is ever edited.
+        assert "41" in stdout
         assert "#41" not in stdout
 
     # ---- acceptance (c): checker enumerates from gh API, not git log ----

--- a/tests/test_merge_attribution.py
+++ b/tests/test_merge_attribution.py
@@ -422,11 +422,39 @@ class TestMergeAttributionReconciliation:
         result = self._run_checker(tmp_path, env, cutoff="2026-08-28T00:00:00Z")
 
         assert result.returncode == 1
-        # Only PR #42 (after cutoff) should be reported.
-        assert "42" in result.stdout
-        assert "41" not in result.stdout
+        # Only PR #42 (after cutoff) should be reported. Assert on the exact
+        # "#41"/"#42" PR-reference token the checker prints
+        # (f"#{pr_num} {short}"), not the bare digits: a runtime-generated
+        # commit sha is asserted present right alongside it, and a bare "41"
+        # or "42" can coincidentally appear inside THAT hex sha, making the
+        # assertion flake independent of whether PR #41 was actually reported.
+        assert "#42" in result.stdout
+        assert "#41" not in result.stdout
         assert old_sha[:12] not in result.stdout
         assert new_sha[:12] in result.stdout
+
+    def test_bare_pr_number_assertion_is_not_sha_safe(self) -> None:
+        """Pins WHY the two tests above assert "#41"/"#42", not the bare
+        digits. The fixture shas in this file are generated at runtime by
+        real git commits, so the IN-SCOPE PR's own sha can coincidentally
+        contain the excluded PR's number as a hex substring -- CI hit this
+        three times in one hour (#2798 shard 3.12/3, #2800 shard 3.13/3)
+        because "41" happened to land inside PR #42's sha. This test fixes
+        the collision instead of hoping for one, so it is deterministic, not
+        probabilistic.
+        """
+        # Stand-in for the checker's real stdout: PR #41 correctly excluded
+        # (cutoff/pre-adoption), PR #42 in scope and unmatched. The #42 sha
+        # is chosen to contain "41" as a hex-digit coincidence -- exactly the
+        # collision a real run hit by chance.
+        stdout = "UNMATCHED MERGE: #42 a41bcdef0123 -- no audit entry found\n"
+
+        # A bare-digit assertion here (`assert "41" not in stdout`) fails
+        # even though PR #41 was never reported -- "41" matches inside #42's
+        # sha, not PR #41's number. The fixed pattern checks the PR-reference
+        # token the checker actually prints (f"#{pr_num} {short}"), which
+        # cannot collide with a hex sha substring the way a bare number can.
+        assert "#41" not in stdout
 
     # ---- acceptance (c): checker enumerates from gh API, not git log ----
 
@@ -539,10 +567,13 @@ class TestMergeAttributionReconciliation:
         result = self._run_checker(tmp_path, env, cutoff=cutoff_sha)
 
         assert result.returncode == 1, result.stdout + result.stderr
-        assert "42" in result.stdout
+        assert "#42" in result.stdout
         assert new_sha[:12] in result.stdout
-        # The control stays out of scope.
-        assert "41" not in result.stdout
+        # The control stays out of scope. Assert on "#41", not the bare
+        # digits: new_sha (asserted present two lines up) is a runtime commit
+        # sha that can coincidentally contain "41" as a substring, which would
+        # fail this assertion even though PR #41 was correctly excluded.
+        assert "#41" not in result.stdout
         assert old_sha[:12] not in result.stdout
 
     def test_unparseable_cutoff_is_an_error_not_an_empty_scope(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes tsk-oqpbvn

## What

`tests/test_merge_attribution.py::TestMergeAttributionReconciliation::test_cutoff_excludes_pre_adoption_merges` has hit CI three times in the last hour on unrelated PRs (#2798 shard 3.12/3, #2800 shard 3.13/3) via `assert "41" not in result.stdout`. Two spots in this file asserted an excluded PR's number was a bare substring absent from `result.stdout`, but the fixture commit shas are generated at runtime by real git commits -- so whenever the IN-SCOPE PR's own sha (asserted present two lines earlier) happened to contain "41" as a hex-digit coincidence, the assertion failed for a reason unrelated to the reconciliation logic under test.

Fixed both to assert on the exact PR-reference token the checker prints (`f"#{pr_num} {short}"` -> `UNMATCHED MERGE: #42 <sha> -- no audit entry found`), i.e. `"#41"` / `"#42"`, which cannot collide with a hex sha substring the way a bare number can.

Added a deterministic regression test (`test_bare_pr_number_assertion_is_not_sha_safe`) that fixes the collision directly with a hand-built stdout string rather than depending on a real git sha happening to reproduce it at test time -- the fix is not itself probabilistic.

## Sweep

`grep -rnE 'assert "[0-9]+" (not )?in result' tests/` plus a broader pass for any bare-digit `not in stdout/output` assertion against output containing a runtime-generated sha:

- `tests/test_merge_attribution.py:427` and `:545` -- the two hits, fixed here.
- All other `assert "<digits>" in result...` hits in the repo (`test_shibaclaw_adapter.py`, `test_containers.py`, `test_container_docker.py`, `test_backend_adapters.py`) assert *presence* of a fixed, deterministic value (an HTTP status code baked into a static error message), not absence from output containing runtime-random data -- not the same bug class, left alone.
- `tests/test_auth_pin.py:194` (`assert "4913" not in raw`) checks a salted argon2 hash -- also random per run, structurally the same flake shape, but not sha/PR-related and not part of this card's scope. Flagging for a separate look rather than touching it here.
- `tests/test_log_redaction.py:134` (`assert "0000" not in out`) is against a fully static, hardcoded input string -- no runtime randomness, not actually at risk.

## RED

Command: `python -m pytest tests/test_merge_attribution.py::TestMergeAttributionReconciliation::test_bare_pr_number_assertion_is_not_sha_safe -v`

```
        stdout = "UNMATCHED MERGE: #42 a41bcdef0123 -- no audit entry found\n"
>       assert "41" not in stdout
E       AssertionError: assert '41' not in 'UNMATCHED M...ntry found\n'
E
E         '41' is contained here:
E           UNMATCHED MERGE: #42 a41bcdef0123 -- no audit entry found
E         ?                       ++

tests/test_merge_attribution.py:455: AssertionError
FAILED tests/test_merge_attribution.py::TestMergeAttributionReconciliation::test_bare_pr_number_assertion_is_not_sha_safe
1 failed in 0.50s
```

## GREEN

Command: `python -m pytest tests/test_merge_attribution.py -q`

```
................
16 passed in 4.90s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge attribution checks to prevent intermittent failures when commit SHAs contain numbers matching pull request references.

* **Tests**
  * Added coverage for cases where hexadecimal commit identifiers overlap with pull request numbers, ensuring attribution results are validated against the correct reference tokens.

* **Documentation**
  * Added a changelog entry describing the merge attribution reliability fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->