### PR TITLE
[lib-audit] S2-24 a worker can fabricate unlimited 24 h leases (_worker_for_resource unvalidated)

### DIFF
--- a/changelog.d/tsk-kkytcu-worker-lease-validation-fix.md
+++ b/changelog.d/tsk-kkytcu-worker-lease-validation-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- S2-24: Prevent workers from claiming unlimited leases on fabricated resources. The `_worker_for_resource` method now validates that the resource part of a resource_id matches one of the worker's registered backends before accepting the lease claim. Workers are also limited to a maximum of 10 concurrent leases each (configurable via `_max_leases_per_worker`).

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -480,7 +480,10 @@ class TestWorkerDrain:
     async def test_update_available_can_claim_leases(self):
         """Update-available workers still allow lease claims."""
         mgr = ClusterManager()
-        await mgr.register_worker(_make_worker("update-gpu", url="http://update:9000"))
+        # Create a worker with a backend that matches the resource
+        worker = _make_worker("update-gpu", url="http://update:9000")
+        worker.backends = [{"name": "gpu-cuda-0", "type": "nvidia", "url": "http://gpu:11434"}]
+        await mgr.register_worker(worker)
         worker = mgr.get_worker("update-gpu")
         worker.free_vram_mb = 8000
         mgr.heartbeat("update-gpu", status="update-available")

--- a/tests/test_cluster_s2_24_fix.py
+++ b/tests/test_cluster_s2_24_fix.py
@@ -1,0 +1,203 @@
+"""RED test for S2-24 - worker can fabricate unlimited 24 h leases"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tinyagentos.cluster.manager import ClusterManager
+from tinyagentos.cluster.worker_protocol import WorkerInfo
+
+
+def _make_worker(name: str, backends: list[dict], capabilities: list[str] | None = None,
+                 load: float = 0.0, status: str = "online",
+                 url: str = "http://localhost:9000") -> WorkerInfo:
+    return WorkerInfo(
+        name=name,
+        url=url,
+        capabilities=capabilities or ["chat", "embed"],
+        backends=backends,
+        load=load,
+        status=status,
+        platform="linux",
+    )
+
+
+@pytest.mark.asyncio
+class TestS224_FabricatedLeases:
+    """Test that workers cannot fabricate unlimited leases on unregistered resources (S2-24)."""
+    
+    async def test_worker_cannot_claim_leases_on_unregistered_resources(self):
+        """
+        RED test: register a worker with two backends, submit heartbeats claiming
+        leases on 1000 fabricated resources -> assert they are rejected
+        and the heartbeat still succeeds for valid ones.
+        """
+        mgr = ClusterManager()
+        
+        # Register a worker with two registered backends
+        worker_backends = [
+            {
+                "name": "backend-a",
+                "type": "nvidia",
+                "url": "http://backend-a:11434",
+                "capabilities": ["chat"],
+                "models": [{"name": "model-a"}]
+            },
+            {
+                "name": "backend-b",
+                "type": "nvidia",
+                "url": "http://backend-b:11434",
+                "capabilities": ["embed"],
+                "models": [{"name": "model-b"}]
+            }
+        ]
+        
+        worker = _make_worker("test-worker", backends=worker_backends)
+        await mgr.register_worker(worker)
+        
+        # Submit 1000 fabricated resource claims
+        fabricated_rejected = 0
+        valid_claimed = 0
+        
+        for i in range(1000):
+            # Fabricated resources that don't match worker backends
+            fabricated_resource = f"test-worker:fabricated-resource-{i}"
+            
+            lease = await mgr.claim_lease(fabricated_resource, caller="test")
+            
+            # All fabricated resources should be rejected
+            if lease is None:
+                fabricated_rejected += 1
+            else:
+                # This would be a bug - fabrications should be rejected
+                valid_claimed += 1
+        
+        # Verify all fabricated resources were rejected
+        assert fabricated_rejected == 1000, \
+            f"Expected all 1000 fabricated resources to be rejected, got {fabricated_rejected}"
+        assert valid_claimed == 0, \
+            f"Expected no valid claims from fabricated resources, got {valid_claimed}"
+        
+        # Worker should be able to claim valid resources
+        valid_resources = ["test-worker:backend-a", "test-worker:backend-b"]
+        
+        for resource_id in valid_resources:
+            lease = await mgr.claim_lease(resource_id, caller="test")
+            assert lease is not None, f"Expected valid resource {resource_id} to be claimable"
+            assert lease.resource_id == resource_id, \
+                f"Lease resource_id mismatch: expected {resource_id}, got {lease.resource_id}"
+        
+        # Verify worker lease count is now 2 (the valid claims)
+        worker_leases = sum(1 for lease in mgr.get_leases() 
+                          if lease.resource_id.startswith("test-worker:"))
+        assert worker_leases == 2, \
+            f"Expected worker to have 2 leases, got {worker_leases}"
+        
+        print("✓ RED test passed: All fabricated resources rejected, valid resources claimed")
+
+    async def test_worker_lease_cap_enforced(self):
+        """
+        Test that workers cannot exceed lease cap (prevents DoS).
+        
+        This test verifies that the lease cap prevents a worker from claiming
+        unlimited leases, even if they try on valid resources.
+        """
+        mgr = ClusterManager()
+        
+        # Create worker with 15 registered backends
+        # This is more than the lease cap (10), so we can test the cap
+        worker_backends = []
+        for i in range(15):
+            worker_backends.append({
+                "name": f"gpu-{i}",
+                "type": "nvidia",
+                "url": f"http://gpu{i}:11434",
+                "capabilities": ["chat"],
+                "models": [{"name": f"model-{i}"}]
+            })
+        
+        worker = _make_worker("cap-worker", backends=worker_backends)
+        await mgr.register_worker(worker)
+        
+        # Worker should be able to claim up to the cap (10)
+        # Each claim should be on a DIFFERENT registered backend
+        claims_made = 0
+        claimed_resources = set()
+        
+        # Try to claim 15 distinct resources (one per backend)
+        # We have 15 backends but only 10 leases allowed
+        for i in range(15):
+            resource_id = f"cap-worker:gpu-{i}"
+            
+            lease = await mgr.claim_lease(resource_id, caller=f"cap-test{i}")
+            
+            if lease is not None:
+                claims_made += 1
+                claimed_resources.add(resource_id)
+            # else: claim rejected (either resource already leased or cap reached)
+        
+        # Exactly 10 claims should succeed (the cap)
+        assert claims_made == 10, \
+            f"Expected exactly 10 claims (lease cap), got {claims_made}"
+        
+        # Verify we have 10 distinct resources claimed (one per backend)
+        assert len(claimed_resources) == 10, \
+            f"Expected 10 distinct resources, got {len(claimed_resources)}"
+        
+        # Verify worker lease count is exactly 10
+        worker_leases = sum(1 for lease in mgr.get_leases() 
+                          if lease.resource_id.startswith("cap-worker:"))
+        assert worker_leases == 10, \
+            f"Expected 10 total leases for worker, got {worker_leases}"
+        
+        print("✓ Lease cap test passed: Worker limited to 10 leases")
+
+    async def test_resource_validation_against_backends(self):
+        """
+        Test that _worker_for_resource validates resource against worker's backends.
+        """
+        mgr = ClusterManager()
+        
+        # Worker registered with specific backend names
+        worker_backends = [
+            {"name": "gpu-0", "type": "nvidia", "url": "http://gpu0"},
+            {"name": "gpu-1", "type": "nvidia", "url": "http://gpu1"},
+        ]
+        
+        worker = _make_worker("gpu-worker", backends=worker_backends)
+        await mgr.register_worker(worker)
+        
+        # Valid resources should return worker info
+        assert mgr._worker_for_resource("gpu-worker:gpu-0") is not None
+        assert mgr._worker_for_resource("gpu-worker:gpu-1") is not None
+        
+        # Invalid resources should return None
+        assert mgr._worker_for_resource("gpu-worker:fake-gpu-0") is None
+        assert mgr._worker_for_resource("gpu-worker:gpu-2") is None
+        assert mgr._worker_for_resource("gpu-worker:gpu-0:extra") is None
+        assert mgr._worker_for_resource("gpu-worker:") is None
+        assert mgr._worker_for_resource("non-existent:gpu-0") is None
+        
+        print("✓ Resource validation test passed: Only registered backends accepted")
+
+
+if __name__ == "__main__":
+    # Run the tests
+    async def run_all_tests():
+        test_obj = TestS224_FabricatedLeases()
+        
+        print("Running RED test for S2-24...")
+        await test_obj.test_worker_cannot_claim_leases_on_unregistered_resources()
+        
+        print("\nRunning lease cap test...")
+        await test_obj.test_worker_lease_cap_enforced()
+        
+        print("\nRunning resource validation test...")
+        await test_obj.test_resource_validation_against_backends()
+        
+        print("\n✅ All tests passed!")
+    
+    asyncio.run(run_all_tests())

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -68,6 +68,8 @@ class ClusterManager:
         self._failure_tracker: FailureTracker | None = failure_tracker
         self._generation: int = 1  # incremented in start() when store is wired
         self._fenced: bool = False  # True when another controller has advanced generation
+        # Maximum number of leases a single worker can hold (prevents DoS)
+        self._max_leases_per_worker = 10
 
     async def start(self):
         # taOS #640: increment generation on each controller start (split-brain
@@ -528,14 +530,26 @@ class ClusterManager:
     def _worker_for_resource(self, resource_id: str) -> WorkerInfo | None:
         """Return the WorkerInfo for a resource_id, or None.
 
-        Excludes draining and offline workers (taOS #890)."""
+        Excludes draining and offline workers (taOS #890). Validates that the
+        resource part of the resource_id matches one of the worker's registered
+        backends to prevent a compromised worker from fabricating arbitrary
+        resources (S2-24)."""
         parsed = self._parse_resource_id(resource_id)
         if parsed is None:
             return None
-        worker_name, _ = parsed
+        worker_name, resource_part = parsed
         worker = self._workers.get(worker_name)
         if worker is None or worker.status not in ("online", "update-available"):
             return None
+        
+        # Validate that the resource part matches one of the worker's registered backends
+        # The resource_id format is "worker-name:backend-name"
+        # Check if the worker has any backends with this name
+        valid_backends = worker.backends or []
+        if not any(backend.get("name") == resource_part for backend in valid_backends):
+            # Resource not registered for this worker
+            return None
+            
         return worker
 
     def find_existing_lease(self, resource_id: str) -> GpuLease | None:
@@ -595,6 +609,20 @@ class ClusterManager:
                 logger.debug(
                     "claim_lease: %s needs %d MiB VRAM but %s has %d MiB free",
                     caller, required_vram_mb, worker.name, worker.free_vram_mb,
+                )
+                return None
+
+            # Enforce lease cap per worker to prevent DoS (S2-24)
+            # Count existing leases for this worker
+            worker_lease_count = 0
+            for lid, lease in self._leases.items():
+                if (parsed := self._parse_resource_id(lease.resource_id)) and parsed[0] == worker.name:
+                    worker_lease_count += 1
+            
+            if worker_lease_count >= self._max_leases_per_worker:
+                logger.debug(
+                    "claim_lease: worker %s has reached max leases (%d), rejecting new claim",
+                    worker.name, self._max_leases_per_worker,
                 )
                 return None
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] S2-24 a worker can fabricate unlimited 24 h leases (_worker_for_resource unvalidated)

Autonomous build of board card tsk-kkytcu.



Files:
 .../tsk-kkytcu-worker-lease-validation-fix.md      |   3 +
 tests/test_cluster.py                              |   5 +-
 tests/test_cluster_s2_24_fix.py                    | 203 +++++++++++++++++++++
 tinyagentos/cluster/manager.py                     |  32 +++-
 4 files changed, 240 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workers can claim leases only for resources associated with their registered backends.
  - Limited each worker to a maximum of 10 concurrent leases.
  - Invalid or fabricated resource identifiers are rejected.
  - Valid registered resources remain available for lease claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->