### PR TITLE
Supersede #2792 (tsk-iqk2bn): registry-JWT unknown-route + off-allowlist hardening must extend dev's shipped check_agent_identity/_any_route_matches mechanism, not ship a second one

### DIFF
--- a/changelog.d/tsk-etzofb-registry-jwt-unknown-route.md
+++ b/changelog.d/tsk-etzofb-registry-jwt-unknown-route.md
@@ -1,0 +1,2 @@
+### Fixed
+- Auth middleware now distinguishes unknown paths from known paths with the wrong HTTP method when a registry JWT is presented: a live credential on a truly unknown URL returns 404, while a wrong verb on an existing URL falls through to the session gate's 401. This closes the gap where `check_agent_identity` + `_any_route_matches` could be bypassed by a wrong-method request, and ports the `TestRegistryJwtUnknownRouteDispatch` regression suite from #2792 onto dev's mechanism.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -401,15 +401,24 @@ A registered external agent authenticates with its registry JWT
 (`Authorization: Bearer`) and reaches exactly the routes its granted SCOPES
 allow, nothing else: the middleware allowlist is a closed set, no skeleton key.
 
-**A refused request says WHICH thing was wrong, and a dead credential is never
-flattered.** Off the allowlist the handler never runs, and the status code
-splits three ways: no route matches the path -> 404 (a live credential at a
-wrong URL); the route exists but this token is not authorised for it -> 401
-from the session gate (a right URL, an unauthorised credential); the credential
-itself is dead -- revoked, or superseded by `rotate-tokens` because its `iat`
-predates the identity's `token_min_iat` -> 401 on every path, existing or not.
-An anonymous caller gets 401 everywhere, so status codes cannot be used to
-enumerate routes.
+**What a refused request looks like.** Off the allowlist, the request never
+reaches a route handler, and the status code says WHICH thing was wrong:
+
+- **The URL does not exist** (no route in the app matches the path, whatever
+  the method) and the token is a live registry JWT -> **404 `{"error": "Not
+  Found"}`**, straight from the middleware. Routing is never invoked, so this
+  is not a way to reach an unlisted route -- it only tells a correctly
+  credentialled agent that it typed the wrong path.
+- **The URL exists but the token is not authorised for it** -- e.g.
+  `GET /api/agents/registry`, or `POST .../scope-requests/{id}/(approve|deny)`,
+  which are deliberately owner/admin session-only -- -> **401 `{"error":
+  "Authentication required"}`** from the session gate. A correct URL is never
+  reported as missing.
+- **The credential is dead** (revoked, or rotated so its `iat` predates the
+  identity's `token_min_iat`) -> **401**, on any path. A dead credential is
+  never dressed up as a wrong URL.
+- **No credential at all** -> **401** on every path, existing or not, so an
+  anonymous caller cannot enumerate routes by status code.
 
 A SEPARATE credential class exists for the Agent-as-a-Model surface:
 `GET /v1/models` and `POST /v1/chat/completions` are reachable without a

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -509,7 +509,8 @@ class TestTaskChecklistAgentTokenDispatch:
     @pytest.mark.asyncio
     async def test_checklist_delete_requires_session(self):
         """DELETE on the checklist-items path has no matching route, so a
-        valid registry JWT returns 404 (unknown route) rather than 401."""
+        valid registry JWT returns 401 from the session gate: the URL exists,
+        just not for that verb."""
         middleware = AuthMiddleware(app=MagicMock())
         auth_mgr = _default_auth_mgr()
         req = _request(
@@ -524,7 +525,7 @@ class TestTaskChecklistAgentTokenDispatch:
         with patch("tinyagentos.auth_middleware.check_agent_identity", AsyncMock(return_value="agent-1")):
             resp = await middleware.dispatch(req, call_next)
 
-        assert resp.status_code == 404
+        assert resp.status_code == 401
         call_next.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1001,6 +1002,245 @@ class TestAnyRouteMatchesPathConverter:
 
         with patch("tinyagentos.auth_middleware.check_agent_identity", AsyncMock(return_value="agent-1")):
             resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+
+class TestRegistryJwtUnknownRouteDispatch:
+    """Valid cred on a wrong URL, absent cred, garbage cred, dead creds, and
+    the off-allowlist controls: a route that exists keeps its 401 (tsk-vylg2y,
+    tsk-iqk2bn, tsk-sonaie)."""
+
+    UNKNOWN_PATH = "/api/nonexistent/unknown-route"
+
+    def _app_state(self, *, public_pem: bytes | None = None) -> MagicMock:
+        state = MagicMock()
+        if public_pem is not None:
+            state.agent_registry_keypair = (b"private", public_pem)
+        else:
+            state.agent_registry_keypair = None
+        return state
+
+    @pytest.mark.asyncio
+    async def test_valid_registry_jwt_unknown_path_returns_404(self):
+        """RED: a real credential on a path no route serves must return 404
+        from the middleware directly -- routing must NOT be reached."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(return_value={"status": "active"})
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 404
+        assert resp.body == b'{"error":"Not Found"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_credential_unknown_path_returns_401(self):
+        """Control B: no credential on the same unknown path still returns
+        401.  A blanket 404 from the middleware would fail this test."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(path=self.UNKNOWN_PATH, auth_mgr=_default_auth_mgr())
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        req.app.state = self._app_state()
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_garbage_bearer_unknown_path_returns_401(self):
+        """Control C: a forged/garbage bearer on the same unknown path still
+        returns 401.  Verifies the fix keys off a real credential, not merely
+        the presence of an Authorization header."""
+        _priv, _pub = _registry_keypair()
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": "Bearer garbage-not-a-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        _state = self._app_state(public_pem=_pub)
+        _state.agent_registry = MagicMock()
+        _state.agent_registry.get = AsyncMock(return_value={"status": "active"})
+        req.app.state = _state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_revoked_registry_jwt_unknown_path_returns_401(self):
+        """A revoked registry JWT on an unlisted route must return 401, not
+        404.  The auth middleware must distinguish dead credentials from wrong
+        URLs."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(
+            return_value={"status": "revoked"}
+        )
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rotated_registry_jwt_unknown_path_returns_401(self):
+        """A rotated registry JWT (iat < token_min_iat) on an unlisted route
+        must return 401, not 404.  The auth middleware must distinguish dead
+        credentials from wrong URLs."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path=self.UNKNOWN_PATH,
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(
+            return_value={
+                "status": "active",
+                "token_min_iat": int(time.time()) + 3600,
+            }
+        )
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skeleton_key_registry_jwt_existing_non_allowlisted_route(self):
+        """Skeleton-key control: a valid registry JWT on a route that exists
+        but is NOT in the agent-token allowlist must NOT be routed -- the
+        handler must never run.  The URL is correct and the credential is
+        simply not authorised for it, so the answer is the session gate's 401,
+        never the wrong-URL 404."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            path="/api/system",  # exists but is NOT an _AGENT_TOKEN_PATHS entry
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(return_value={"status": "active"})
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"system": "ok"}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_registry_jwt_off_allowlist_param_route_returns_401(self):
+        """The scope-request approve route exists with path parameters and is
+        deliberately owner/admin session-only.  A live registry JWT there must
+        get the gate's 401, not a 404 claiming the URL is wrong."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="POST",
+            path="/api/agents/registry/agent-1/scope-requests/req-1/approve",
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [
+            _fake_route("/api/agents/registry/{cid}/scope-requests/{rid}/approve", {"POST"})
+        ]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(return_value={"status": "active"})
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        assert resp.body == b'{"error":"Authentication required"}'
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_registry_jwt_wrong_method_on_existing_path_returns_401(self):
+        """A verb the route does not accept is still a real URL: the path
+        resolves, so the caller gets the gate's 401 rather than being told the
+        path does not exist."""
+        private_pem, public_pem = _registry_keypair()
+        token = _signed_registry_token(private_pem)
+
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="DELETE",  # /api/system is GET-only
+            path="/api/system",
+            headers={"authorization": f"Bearer {token}"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        req.app.routes = [_fake_route("/api/system", {"GET"})]
+        state = self._app_state(public_pem=public_pem)
+        state.agent_registry = MagicMock()
+        state.agent_registry.get = AsyncMock(return_value={"status": "active"})
+        req.app.state = state
+        req.app.state.auth = _default_auth_mgr()
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
 
         assert resp.status_code == 401
         assert resp.body == b'{"error":"Authentication required"}'

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -248,7 +248,7 @@ def _is_device_bearer_path(method: str, path: str) -> bool:
     return any(m == method and rx.match(path) for m, rx in _DEVICE_BEARER_PATHS)
 
 
-def _any_route_matches(method: str, path: str, routes) -> bool:
+def _any_route_matches(method: str, path: str, routes, *, match_method: bool = True) -> bool:
     """Return True if any registered route matches the given method + path.
 
     FastAPI path parameters (``{pid}``) are treated as ``[^/]+`` for the
@@ -260,7 +260,7 @@ def _any_route_matches(method: str, path: str, routes) -> bool:
         route_path = getattr(route, "path", None)
         if route_path is None:
             continue
-        if route_methods is not None and method.upper() not in {m.upper() for m in route_methods}:
+        if match_method and route_methods is not None and method.upper() not in {m.upper() for m in route_methods}:
             continue
         parts = route_path.split("/")
         pattern = "^" + "/".join(
@@ -675,7 +675,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 # credential authenticates the request. Unknown-route handling
                 # (the 404/401 split for valid registry JWT) is handled
                 # immediately below so it does not interact with session.
-                if not _any_route_matches(request.method, path, request.app.routes):
+                if not _any_route_matches(request.method, path, request.app.routes, match_method=False):
                     try:
                         await check_agent_identity(request)
                         return JSONResponse({"error": "Not Found"}, status_code=404)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Supersede #2792 (tsk-iqk2bn): registry-JWT unknown-route + off-allowlist hardening must extend dev's shipped check_agent_identity/_any_route_matches mechanism, not ship a second one

Autonomous build of board card tsk-etzofb.

Port TestRegistryJwtUnknownRouteDispatch (8 tests) onto dev's check_agent_identity + _any_route_matches mechanism, extending _any_route_matches with a match_method parameter so the 404/401 split keys off path existence (whatever the method) rather than method+path match. A wrong verb on an existing URL now falls through to the session gate's 401 instead of being misreported as a wrong URL. One pre-existing dev test (test_checklist_delete_requires_session) updated to match the corrected behavior.

Step-1 red line: 1 failed, 9 passed (before fix)
Step-2 green line: 139 passed (after fix, across test_auth_middleware.py + test_agent_scope_requests.py + test_token_rotation.py)

Files:
 .../tsk-etzofb-registry-jwt-unknown-route.md       |   2 +
 docs/agent-coordination.md                         |  27 ++-
 tests/test_auth_middleware.py                      | 244 ++++++++++++++++++++-
 tinyagentos/auth_middleware.py                     |   6 +-
 4 files changed, 265 insertions(+), 14 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected authentication responses for registry JWT requests.
  - Requests to genuinely unknown URLs now return 404, while requests using an unsupported method on an existing URL correctly return 401.
  - Invalid, revoked, or absent credentials continue to receive 401 responses.

- **Documentation**
  - Clarified agent API refusal responses, including status codes and representative scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->