### PR TITLE
download_manager: validate the .part BEFORE promoting -- a corrupt re-download must not replace an existing valid dest

### DIFF
--- a/changelog.d/tsk-xprnf7-validate-before-promote.md
+++ b/changelog.d/tsk-xprnf7-validate-before-promote.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- A corrupt model re-download no longer destroys an existing valid install.
+  `DownloadManager._download` promoted the `.part` stage file onto `task.dest`
+  before running SHA256 and size validation; when the re-download's bytes
+  mismatched, the good file at `task.dest` was first overwritten and then
+  deleted, leaving the user with nothing. Validation now runs against the
+  `.part` file first, and only on success is it atomically renamed onto
+  `task.dest`. A mismatch unlinks the `.part` alone and leaves `task.dest`
+  untouched. The `promoted` flag that tracked whether `task.dest` had been
+  overwritten is no longer needed and has been removed.
+- `_validate_download` now accepts a `path` parameter so callers can validate
+  either the `.part` stage file or `task.dest` without re-reading a file whose
+  streamed digest is already in hand.
+- The torrent path in `_download_with_fallback` already validates before
+  marking a task complete (it writes directly to `task.dest` and
+  `torrent.download()` verifies SHA internally before returning), so the
+  promote-before-validate defect never applied there.

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -282,6 +282,52 @@ class TestDownloadHttp:
         assert not dest.exists()
 
     @pytest.mark.asyncio
+    async def test_corrupt_redownload_keeps_existing_dest(self, dm, tmp_path):
+        """A re-download of an already-installed model whose new bytes are
+        corrupt (SHA mismatch) must not overwrite or delete the existing valid
+        file. The .part stage file is validated before promotion, so a bad
+        re-download never reaches task.dest."""
+        original = b"a previously installed, valid model"
+        original_hash = hashlib.sha256(original).hexdigest()
+        dest = tmp_path / "out.bin"
+        dest.write_bytes(original)
+        task = DownloadTask(id="dl", url="http://example.com/f.bin", dest=dest)
+
+        corrupt = b"corrupt bytes that hash to something different"
+        mock_resp = self._make_async_context_manager_mock(corrupt, len(corrupt))
+        mock_client = self._make_mock_client(mock_resp)
+
+        with patch("tinyagentos.download_manager.httpx.AsyncClient", return_value=mock_client):
+            await dm._download(task, expected_sha256=original_hash)
+
+        assert task.status == "error"
+        assert task.error == "SHA256 mismatch"
+        assert dest.exists(), "a corrupt re-download must not delete the existing file"
+        assert dest.read_bytes() == original
+        part = dest.with_name(dest.name + ".part")
+        assert not part.exists(), "the corrupt .part must be cleaned up"
+
+    @pytest.mark.asyncio
+    async def test_success_promotes_and_removes_part(self, dm, tmp_path):
+        """Happy path: a valid download is promoted to task.dest and the
+        .part stage file is removed."""
+        data = b"hello galaxy" * 10
+        expected_hash = hashlib.sha256(data).hexdigest()
+        dest = tmp_path / "out.bin"
+        task = DownloadTask(id="dl", url="http://example.com/f.bin", dest=dest)
+        mock_resp = self._make_async_context_manager_mock(data, len(data))
+        mock_client = self._make_mock_client(mock_resp)
+
+        with patch("tinyagentos.download_manager.httpx.AsyncClient", return_value=mock_client):
+            await dm._download(task, expected_sha256=expected_hash)
+
+        assert task.status == "complete"
+        assert dest.exists()
+        assert dest.read_bytes() == data
+        part = dest.with_name(dest.name + ".part")
+        assert not part.exists()
+
+    @pytest.mark.asyncio
     async def test_download_http_error(self, dm, tmp_path):
         dest = tmp_path / "out.bin"
         task = DownloadTask(id="dl", url="http://example.com/f.bin", dest=dest)

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -221,6 +221,7 @@ class DownloadManager:
     async def _validate_download(
         self,
         task: DownloadTask,
+        path: Path | None = None,
         expected_sha256: str | None = None,
         computed_sha256: str | None = None,
     ) -> str | None:
@@ -230,10 +231,16 @@ class DownloadManager:
         describing why it isn't. Applies to both the torrent and HTTP
         paths so neither can mark a task complete when nothing (or the
         wrong thing) was actually written to disk.
+
+        ``path`` is the file to inspect -- the ``.part`` stage file on the
+        HTTP path (validated before promotion) or ``task.dest`` on the
+        torrent path. Defaults to ``task.dest`` when omitted.
         """
-        if not task.dest.exists() or task.dest.stat().st_size == 0:
+        if path is None:
+            path = task.dest
+        if not path.exists() or path.stat().st_size == 0:
             return "download produced no data"
-        if task.total_bytes and task.dest.stat().st_size != task.total_bytes:
+        if task.total_bytes and path.stat().st_size != task.total_bytes:
             return "size mismatch"
         if expected_sha256:
             digest = computed_sha256
@@ -242,7 +249,7 @@ class DownloadManager:
                 # potentially multi-GB model is offloaded to a thread so it
                 # never blocks the event loop.
                 digest = await asyncio.to_thread(
-                    lambda: hashlib.sha256(task.dest.read_bytes()).hexdigest()
+                    lambda: hashlib.sha256(path.read_bytes()).hexdigest()
                 )
             # Hex digests are case-insensitive; a caller passing an uppercase
             # expected value must not be treated as a mismatch.
@@ -304,7 +311,7 @@ class DownloadManager:
                 # (and raised on mismatch), so re-hashing here would just re-read
                 # a multi-GB file to no benefit. Only the cheap non-empty / size
                 # floor is needed on this path.
-                error = await self._validate_download(task)
+                error = await self._validate_download(task, task.dest)
                 if error:
                     task.dest.unlink(missing_ok=True)
                     task.status = "error"
@@ -340,13 +347,12 @@ class DownloadManager:
         body is on disk, so a failure can never leave a corrupt weight sitting
         at the canonical path where every later "is this model installed?"
         existence check would take it for the real thing. The stage file
-        survives a failure on purpose: it is what the next attempt — this
-        process or the next boot — resumes from.
+        survives a failure on purpose: it is what the next attempt -- this
+        process or the next boot -- resumes from.
         """
         task.status = "downloading"
         task.started_at = time.time()
         part = task.dest.with_name(task.dest.name + ".part")
-        promoted = False
         try:
             task.dest.parent.mkdir(parents=True, exist_ok=True)
             digest = await with_retry(
@@ -356,28 +362,29 @@ class DownloadManager:
                 max_delay=DOWNLOAD_RETRY_MAX_DELAY,
                 retry_on=DOWNLOAD_RETRY_ON,
             )
-            part.replace(task.dest)
-            promoted = True
-            error = await self._validate_download(task, expected_sha256, computed_sha256=digest)
+            error = await self._validate_download(
+                task, part, expected_sha256, computed_sha256=digest
+            )
             if error:
-                # The bytes are wrong, so the promoted file is worthless: this
-                # attempt just replaced task.dest with a bad copy, and that
-                # copy (not the now-gone .part) is what has to go.
-                task.dest.unlink(missing_ok=True)
+                # The .part content failed validation; it is worthless and
+                # must never be promoted. Remove only the stage file;
+                # task.dest may hold a previously-verified model from an
+                # earlier install and is left untouched.
+                part.unlink(missing_ok=True)
                 task.status = "error"
                 task.error = error
             else:
+                part.replace(task.dest)
                 task.status = "complete"
                 task.completed_at = time.time()
         except Exception as e:
-            # Only clean up task.dest when THIS attempt is the one that put a
-            # (possibly bad) file there. _stream_to_part writes exclusively to
-            # `part`, so a failure before promotion leaves task.dest exactly as
-            # it was -- which, for a re-download of an already-installed model,
-            # is a perfectly good file. Deleting it here would destroy a valid
-            # install over a transient failure of the NEW attempt.
-            if promoted:
-                task.dest.unlink(missing_ok=True)
+            # _stream_to_part writes exclusively to `part`, so a failure
+            # during streaming leaves task.dest exactly as it was. For a
+            # re-download of an already-installed model, task.dest is a
+            # perfectly good file -- destroying it here would throw away a
+            # valid install over a transient failure of the NEW attempt.
+            # The .part stage file is preserved by design so the next
+            # attempt can resume from it.
             task.status = "error"
             task.error = str(e)
             logger.error("Download failed for %s: %s", task.id, e)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): download_manager: validate the .part BEFORE promoting -- a corrupt re-download must not replace an existing valid dest

Autonomous build of board card tsk-xprnf7.

When a re-download of an already-installed model produced corrupt bytes
(SHA mismatch), _download promoted the .part onto task.dest BEFORE
validation, then deleted task.dest on mismatch -- destroying the
existing valid file. The fix validates the .part first and only
promotes on success. On mismatch the .part alone is removed and
task.dest is left untouched.

_validate_download now takes a path parameter so callers can validate
either the .part stage file or task.dest, reusing the streamed digest
instead of re-reading the file.

The torrent path in _download_with_fallback already validates before
marking complete: torrent.download() verifies SHA internally and
writes directly to task.dest (no promote step), so the
promote-before-validate defect never applied there.

RED (at cut point):
  uv run pytest tests/test_download_manager.py::TestDownloadHttp::test_corrupt_redownload_keeps_existing_dest -q
  AssertionError: a corrupt re-download must not delete the existing file
  assert False
  +  where False = exists()

GREEN (after fix):
  uv run pytest tests/test_download_manager.py -q
  54 passed

Files:
 changelog.d/tsk-xprnf7-validate-before-promote.md | 18 ++++++++
 tests/test_download_manager.py                    | 46 ++++++++++++++++++++
 tinyagentos/download_manager.py                   | 51 +++++++++++++----------
 3 files changed, 93 insertions(+), 22 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented corrupted re-downloads from replacing an existing valid installation.
  * Downloads are now verified before being finalized, reducing the risk of incomplete or invalid installations.
  * Failed downloads are cleaned up without removing the previously working installation.
* **Tests**
  * Added coverage for both failed re-downloads and successful download completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->