### PR TITLE
[lib-audit] Q2-2 cluster manager hardening nits (_format_hw, _ever_seen order, notif_store typo, task drain)

### DIFF
--- a/changelog.d/tsk-bz2mqo-cluster-hardening-nits.md
+++ b/changelog.d/tsk-bz2mqo-cluster-hardening-nits.md
@@ -1,0 +1,12 @@
+### Fixed
+- Cluster manager hardening: `_format_hw` coerces non-integer `ram_mb`/`vram_mb`
+  from worker heartbeats instead of raising `TypeError` (500); the register and
+  heartbeat routes now reject non-integer hardware fields with `400`.
+- Rejected stale-generation (or fenced) worker registrations no longer poison
+  `_ever_seen`, so a subsequent valid registration correctly emits the
+  `worker.join` notification.
+- The worker storage-backup notification path in `routes/cluster.py` now reads
+  `app.state.notifications` (the attribute that is actually assigned) instead of
+  the never-set `app.state.notif_store`, so the notification fires.
+- `ClusterManager.stop()` now drains `_background_tasks` with a 10-second
+  timeout so fire-and-forget work completes before shutdown.

--- a/tests/test_cluster_q2_2_hardening.py
+++ b/tests/test_cluster_q2_2_hardening.py
@@ -1,0 +1,189 @@
+"""Q2-2 cluster manager hardening nit tests.
+
+Covers four fixes from docs/audit/library-replacement-audit-2026-09-pass2.md (Q2-2):
+
+1. _format_hw raises TypeError on non-int ram/vram        -> coerce + route guard
+2. _ever_seen.add runs before the generation guards         -> move after guards
+3. routes/cluster.py uses app.state.notif_store            -> notifications
+4. stop() never drains _background_tasks                  -> gather with timeout
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.cluster.manager import ClusterManager, _format_hw
+from tinyagentos.cluster.worker_protocol import WorkerInfo
+
+# ── 1. _format_hw coercion ────────────────────────────────────────────
+
+def test_format_hw_non_int_ram_does_not_raise():
+    """Worker-supplied ram_mb='lots' must not raise TypeError in _format_hw."""
+    result = _format_hw({"ram_mb": "lots"})
+    assert isinstance(result, str)
+
+
+def test_format_hw_non_int_vram_does_not_raise():
+    """Worker-supplied gpu.vram_mb='lots' must not raise TypeError."""
+    result = _format_hw({
+        "ram_mb": 16384,
+        "gpu": {"type": "nvidia", "vram_mb": "lots"},
+    })
+    assert isinstance(result, str)
+
+
+def test_format_hw_none_ram_is_safe():
+    result = _format_hw({"ram_mb": None})
+    assert isinstance(result, str)
+
+
+def test_format_hw_non_dict_gpu_is_safe():
+    result = _format_hw({"ram_mb": 16384, "gpu": "not-a-dict"})
+    assert isinstance(result, str)
+
+
+# ── 2. _ever_seen.add after guards ────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestEverSeenOrdering:
+    async def test_stale_generation_does_not_suppress_join_notification(self):
+        """A rejected stale-generation registration must not mark the worker
+        as 'ever seen', so a subsequent valid registration fires worker.join
+        (PROVEN in audit pass-2 Q2-2)."""
+        notif = AsyncMock()
+        mgr = ClusterManager(notifications=notif)
+        mgr._generation = 1
+
+        w = WorkerInfo(name="w1", url="http://w1:9000", capabilities=["chat"])
+
+        # Stale generation -- rejected before _ever_seen.add
+        ok, reason = await mgr.register_worker(w, generation=999)
+        assert ok is False
+        assert reason == "stale_generation"
+
+        # Valid registration -- should fire worker.join since the stale
+        # registration did not poison _ever_seen.
+        ok, reason = await mgr.register_worker(w, generation=1)
+        assert ok is True
+        assert reason == ""
+
+        join_calls = [
+            c for c in notif.emit_event.await_args_list
+            if c.args and c.args[0] == "worker.join"
+        ]
+        assert len(join_calls) == 1, (
+            f"Expected exactly 1 worker.join notification, got {len(join_calls)}"
+        )
+
+        # Clean up background tasks (model promotion is fire-and-forget).
+        if mgr._background_tasks:
+            await asyncio.gather(
+                *mgr._background_tasks, return_exceptions=True
+            )
+
+
+# ── 3. notif_store typo (routes/cluster.py) ───────────────────────────
+
+def test_surface_storage_backup_emits_notification():
+    """_surface_storage_backup must read app.state.notifications (not
+    notif_store) so the storage-backup notification actually fires."""
+    from tinyagentos.routes.cluster import _surface_storage_backup
+
+    mock_notif = MagicMock()
+    mock_notif.add = AsyncMock()
+
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            notifications=mock_notif,
+            data_dir=None,  # skip the file-writing path
+        )
+    )
+
+    asyncio.run(
+        _surface_storage_backup(
+            app,
+            "test-worker",
+            {
+                "backed_up_pool": "old-pool",
+                "original_name": "taos-worker-pool",
+                "timestamp_utc": "2026-01-01",
+                "reason": "migration",
+            },
+        )
+    )
+
+    mock_notif.add.assert_awaited_once()
+    call = mock_notif.add.await_args
+    assert "storage pool backed up" in call.args[0]
+    assert call.kwargs.get("level") == "warning"
+
+
+# ── 4. stop() drains _background_tasks ─────────────────────────────────
+
+@pytest.mark.asyncio
+class TestStopDrainsTasks:
+    async def test_stop_awaits_pending_background_tasks(self):
+        """stop() must drain _background_tasks so fire-and-forget tasks
+        complete before shutdown (R2-25)."""
+        mgr = ClusterManager()
+        mgr._monitor_task = None
+
+        flag = {"done": False}
+
+        async def _task():
+            await asyncio.sleep(0.05)
+            flag["done"] = True
+
+        task = asyncio.create_task(_task())
+        mgr._background_tasks.add(task)
+        task.add_done_callback(mgr._background_tasks.discard)
+
+        await mgr.stop()
+
+        assert flag["done"] is True
+        assert len(mgr._background_tasks) == 0
+
+
+# ── Route-level: heartbeat with non-int hardware → 400 ────────────────
+
+@pytest.mark.asyncio
+class TestHeartbeatHardwareValidation:
+    async def test_heartbeat_non_int_ram_returns_400(self, client, app):
+        """Heartbeat carrying ram_mb='lots' must return 400, not 500."""
+        from test_routes_cluster import pair_worker, sign_worker_request
+
+        key = await pair_worker(
+            client, app, "bad-hw-worker", "http://10.0.0.1:9000"
+        )
+        # Register with valid (no) hardware
+        reg_body = json.dumps({
+            "name": "bad-hw-worker",
+            "url": "http://10.0.0.1:9000",
+        }).encode()
+        headers = sign_worker_request(
+            key, "bad-hw-worker", "POST", "/api/cluster/workers", reg_body
+        )
+        resp = await client.post(
+            "/api/cluster/workers", content=reg_body,
+            headers={**headers, "content-type": "application/json"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Heartbeat with non-int ram_mb
+        hb_body = json.dumps({
+            "name": "bad-hw-worker",
+            "hardware": {"ram_mb": "lots"},
+        }).encode()
+        hb_headers = sign_worker_request(
+            key, "bad-hw-worker", "POST", "/api/cluster/heartbeat", hb_body
+        )
+        resp = await client.post(
+            "/api/cluster/heartbeat", content=hb_body,
+            headers={**hb_headers, "content-type": "application/json"},
+        )
+        assert resp.status_code == 400, resp.text
+        await app.state.cluster_pairing.close()

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -32,15 +32,22 @@ def _format_hw(hw) -> str:
     if not isinstance(hw, dict):
         return "Unknown hardware"
     parts = []
-    ram = hw.get("ram_mb", 0)
+
+    def _safe_int(val) -> int:
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return 0
+
+    ram = _safe_int(hw.get("ram_mb", 0))
     if ram:
         parts.append(f"{ram // 1024}GB RAM")
     gpu = hw.get("gpu", {})
-    if gpu.get("type") not in (None, "none", ""):
-        vram = gpu.get("vram_mb", 0)
+    if isinstance(gpu, dict) and gpu.get("type") not in (None, "none", ""):
+        vram = _safe_int(gpu.get("vram_mb", 0))
         parts.append(f"{gpu.get('model', gpu['type'])}" + (f" {vram // 1024}GB" if vram else ""))
     npu = hw.get("npu", {})
-    if npu.get("type", "none") != "none":
+    if isinstance(npu, dict) and npu.get("type", "none") != "none":
         parts.append(f"{npu['type']} {npu.get('tops', 0)} TOPS")
     return ", ".join(parts) if parts else "CPU only"
 
@@ -96,6 +103,19 @@ class ClusterManager:
                 await self._monitor_task
             except asyncio.CancelledError:
                 pass
+        if self._background_tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(
+                        *self._background_tasks, return_exceptions=True
+                    ),
+                    timeout=10,
+                )
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                logger.warning(
+                    "Timed out waiting for %d background tasks to complete",
+                    len(self._background_tasks),
+                )
 
     async def register_worker(
         self, info: WorkerInfo, generation: int | None = None
@@ -114,13 +134,12 @@ class ClusterManager:
             caps_before = {k for k, v in self._capabilities.get_all_capabilities().items() if v["available"]}
 
         is_first_time = info.name not in self._ever_seen
-        self._ever_seen.add(info.name)
 
-        # taOS #640: controller fence — if this instance has been superseded
+        # taOS #640: controller fence -- if this instance has been superseded
         # by another controller, reject all registrations (CodeRabbit PR #1928).
         if self._fenced:
             return (False, "fenced")
-        # taOS #640: split-brain protection — reject registration from a
+        # taOS #640: split-brain protection -- reject registration from a
         # worker that echoes a different generation (another active controller).
         # Legacy workers that don't send generation get a pass (None).
         if generation is not None and generation != self._generation:
@@ -129,6 +148,7 @@ class ClusterManager:
                 info.name, generation, self._generation,
             )
             return (False, "stale_generation")
+        self._ever_seen.add(info.name)
 
         prev_status = self._workers[info.name].status if info.name in self._workers else None
 

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -390,6 +390,9 @@ async def register_worker(request: Request, body: WorkerRegister):
     if hw.get("ram_mb") is None:
         hw = dict(hw)
         hw.pop("ram_mb", None)
+    bad = _bad_hardware(hw)
+    if bad:
+        return JSONResponse({"error": bad}, status_code=400)
     info = WorkerInfo(
         name=body.name,
         url=body.url,
@@ -479,7 +482,7 @@ async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
         f"renamed it to '{backed_up}' before creating a fresh pool. "
         f"No data was deleted — see your workspace inbox for the full note."
     )
-    notif = getattr(app.state, "notif_store", None)
+    notif = getattr(app.state, "notifications", None)
     if notif is not None:
         try:
             await notif.add(title, short_msg, level="warning", source=f"worker:{worker_name}")
@@ -535,6 +538,21 @@ async def _surface_storage_backup(app, worker_name: str, marker: dict) -> None:
         logger.warning("storage-backup notify: failed to write workspace inbox file")
 
 
+def _bad_hardware(hw: dict | None) -> str | None:
+    """Return an error string if hardware carries non-int ram_mb/vram_mb, else None."""
+    if not hw:
+        return None
+    ram = hw.get("ram_mb")
+    if ram is not None and not isinstance(ram, int):
+        return "hardware.ram_mb must be an integer"
+    gpu = hw.get("gpu")
+    if isinstance(gpu, dict):
+        vram = gpu.get("vram_mb")
+        if vram is not None and not isinstance(vram, int):
+            return "hardware.gpu.vram_mb must be an integer"
+    return None
+
+
 @router.post("/api/cluster/heartbeat")
 async def worker_heartbeat(request: Request, body: HeartbeatBody):
     # HMAC gate — only paired, registered workers may heartbeat.
@@ -548,6 +566,9 @@ async def worker_heartbeat(request: Request, body: HeartbeatBody):
             {"error": "Worker name in header does not match body"},
             status_code=403,
         )
+    bad_hw = _bad_hardware(body.hardware)
+    if bad_hw:
+        return JSONResponse({"error": bad_hw}, status_code=400)
     cluster = request.app.state.cluster_manager
     ok = cluster.heartbeat(
         body.name,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Q2-2 cluster manager hardening nits (_format_hw, _ever_seen order, notif_store typo, task drain)

Autonomous build of board card tsk-bz2mqo.

Fix four issues from pass-2 audit (docs/audit/library-replacement-audit-2026-09-pass2.md, Q2-2):

1. _format_hw: coerce non-int ram_mb/vram_mb instead of raising TypeError.
   The register and heartbeat routes now reject non-integer hardware fields
   with 400 (RED test: heartbeat with ram='lots' -> 400 not 500).

2. register_worker: move _ever_seen.add after the fenced/stale_generation
   guards so a rejected stale-generation registration does not suppress
   the worker.join notification on a subsequent valid registration.

3. _surface_storage_backup: use app.state.notifications (the assigned
   attribute) instead of app.state.notif_store, which was never set.

4. stop(): drain _background_tasks with a 10s timeout so fire-and-forget
   tasks complete before shutdown (pairs with R2-25).

S2-24 (fabricated leases) is out of scope -- separate card.

Proof: 8/8 tests in tests/test_cluster_q2_2_hardening.py pass;
122 existing cluster/route tests still pass.

Docs-Reviewed: hardening only -- no user-facing API contract change, no agent-coordination.md update needed

Files:
 changelog.d/tsk-bz2mqo-cluster-hardening-nits.md |  12 ++
 tests/test_cluster_q2_2_hardening.py             | 189 +++++++++++++++++++++++
 tinyagentos/cluster/manager.py                   |  34 +++-
 tinyagentos/routes/cluster.py                    |  23 ++-
 4 files changed, 250 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worker registration and heartbeat requests now return clear HTTP 400 responses when hardware memory values are invalid.
  - Invalid or incomplete hardware details no longer cause server errors during worker status processing.
  - Stale worker registrations no longer prevent valid subsequent registrations from generating join notifications.
  - Storage-backup notifications are now delivered reliably.
  - Pending cluster tasks are given time to finish during shutdown, improving graceful termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->