### PR TITLE
[lib-audit] Q2-6 app.py and middleware nits (GZip order, /setup prefix, gui fallback, security headers, /manifest 400)

### DIFF
--- a/changelog.d/tsk-gbd2ga-app-middleware-nits.md
+++ b/changelog.d/tsk-gbd2ga-app-middleware-nits.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- Security headers now include `Referrer-Policy: no-referrer` and a restrictive
+  `Permissions-Policy` on every response, closing the unauthenticated header gap
+  found in the September 2026 security audit (S2-31).
+- `X-Taos-Version` is coarsened to `taOS` for unauthenticated callers; the full
+  build version is only sent to requests that presented a credential (S2-32).
+- GZip middleware is now added inside the CSRF cookie-setting layer so response
+  bodies carrying `Set-Cookie` headers are never compressed (BREACH precondition).
+- The `/setup` startup-exempt prefix is anchored as `/setup/` so `/setupfoo` is
+  no longer matched as a setup path.
+- `gui()` now checks for the SPA bundle and exits 503 with a build hint when
+  `static/desktop/index.html` is missing, instead of opening a browser to a
+  500/404.
+- `GET /manifest` without `?app=` now returns a plain 400 instead of leaking
+  the FastAPI 422 validation schema (S2-33).
+- The uvicorn `Server` banner is suppressed via `server_header=False` (S2-32).

--- a/tests/test_manifest_route.py
+++ b/tests/test_manifest_route.py
@@ -35,6 +35,6 @@ async def test_manifest_non_pwa_app_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_manifest_missing_param_returns_404(client):
+async def test_manifest_missing_param_returns_400(client):
     resp = await client.get("/manifest?app=")
-    assert resp.status_code == 404
+    assert resp.status_code == 400

--- a/tests/test_q2_6_library_audit.py
+++ b/tests/test_q2_6_library_audit.py
@@ -1,0 +1,187 @@
+"""RED tests for Q2-6 -- app.py and middleware audit findings.
+
+Covers the fixes from docs/audit/library-replacement-audit-2026-09-pass2.md (Q2-6):
+
+- Security header presence (Referrer-Policy, Permissions-Policy) on key routes
+- Server header absent
+- /setupfoo not matching the /setup startup-exempt prefix
+- GET /manifest without ?app returns 400 with a plain body
+- gui() exits 503 when the SPA bundle is missing
+- X-Taos-Version coarsened for unauthenticated callers
+- GZip placed inside the CSRF cookie layer
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.middleware.gzip import GZipMiddleware
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.middleware.csrf import CSRFMiddleware
+
+
+def _make_startonly_app(tmp_path):
+    """Build an app with startup guard armed (startup incomplete)."""
+    import yaml
+    from tinyagentos.app import create_app
+
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    app = create_app(data_dir=tmp_path)
+    app.state._startup_complete = False
+    return app
+
+
+class TestSecurityHeaderPresence:
+    """Q2-6: Referrer-Policy and Permissions-Policy must be present on
+    /auth/login, /desktop, and /api/health, alongside the existing CSP,
+    X-Frame-Options, X-Content-Type-Options and X-Taos-Version headers."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/auth/login", "/desktop", "/api/health"])
+    async def test_security_headers_present(self, client, path):
+        resp = await client.get(path)
+        assert resp.headers.get("content-security-policy", "")
+        assert resp.headers.get("x-frame-options", "")
+        assert resp.headers.get("x-content-type-options", "")
+        assert resp.headers.get("x-taos-version", "")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/auth/login", "/desktop", "/api/health"])
+    async def test_referrer_policy_present(self, client, path):
+        resp = await client.get(path)
+        val = resp.headers.get("referrer-policy", "")
+        assert val, f"Referrer-Policy missing on {path}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/auth/login", "/desktop", "/api/health"])
+    async def test_permissions_policy_present(self, client, path):
+        resp = await client.get(path)
+        val = resp.headers.get("permissions-policy", "")
+        assert val, f"Permissions-Policy missing on {path}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/auth/login", "/desktop", "/api/health"])
+    async def test_server_header_absent(self, client, path):
+        resp = await client.get(path)
+        assert "server" not in {k.lower() for k in resp.headers}, (
+            f"Server header present on {path}"
+        )
+
+
+class TestSetupPrefixNoCollision:
+    """Q2-6: '/setup' prefix must not match '/setupfoo'.  During startup
+    the guard should block /setupfoo (503), just as it would any non-exempt
+    path."""
+
+    @pytest.mark.asyncio
+    async def test_setupfoo_blocked_during_startup(self, tmp_path):
+        app = _make_startonly_app(tmp_path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/setupfoo")
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_setup_prefix_still_exempt_during_startup(self, tmp_path):
+        """/setup/ (with trailing slash) and /setup/complete must still pass
+        the startup guard -- only the prefix-collision on /setupfoo is fixed."""
+        app = _make_startonly_app(tmp_path)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/setup/complete")
+        assert resp.status_code != 503
+
+
+class TestManifestMissingAppParam:
+    """Q2-6: GET /manifest without ?app= must return 400 with a plain body,
+    not the FastAPI 422 validation schema."""
+
+    @pytest.mark.asyncio
+    async def test_manifest_no_param_returns_400(self, client):
+        resp = await client.get("/manifest")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_manifest_empty_param_returns_400(self, client):
+        resp = await client.get("/manifest?app=")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_manifest_400_body_is_plain(self, client):
+        """The body must not be the FastAPI 422 schema (detail as a list)."""
+        resp = await client.get("/manifest")
+        body = resp.json()
+        detail = body.get("detail")
+        assert not isinstance(detail, list), (
+            "expected plain detail, got 422 schema"
+        )
+
+
+class TestGuiMissingSpaBundle:
+    """Q2-6: gui() must detect a missing SPA bundle and exit 503 with a
+    build hint instead of falling through."""
+
+    def test_gui_exits_503_when_spa_missing(self, tmp_path, monkeypatch, capsys):
+        import tinyagentos.app as app_mod
+
+        monkeypatch.setattr(app_mod, "PROJECT_DIR", tmp_path)
+        with pytest.raises(SystemExit) as exc_info:
+            app_mod.gui()
+        assert exc_info.value.code == 503
+        captured = capsys.readouterr()
+        assert "build" in captured.err.lower()
+
+
+class TestVersionHeaderCoarsening:
+    """Q2-6: X-Taos-Version must be coarsened for unauthenticated callers."""
+
+    @pytest.mark.asyncio
+    async def test_version_coarsened_on_exempt_path(self, client):
+        """/api/health is exempt from auth -- version should be coarsened."""
+        import tinyagentos
+
+        resp = await client.get("/api/health")
+        assert resp.headers.get("x-taos-version", "")
+        # The coarsened value must not leak the exact build version.
+        assert resp.headers["x-taos-version"] != tinyagentos.__version__
+
+    @pytest.mark.asyncio
+    async def test_version_full_for_authenticated(self, client):
+        """An authenticated, non-exempt API call must see the full version."""
+        import tinyagentos
+
+        resp = await client.get("/api/secrets")
+        assert resp.status_code == 200
+        if resp.headers.get("x-taos-version"):
+            assert resp.headers["x-taos-version"] == tinyagentos.__version__
+
+
+class TestGZipInsideCsrfLayer:
+    """Q2-6: GZip must be added before CSRF so it is innermost to the
+    cookie-setting layer (BREACH precondition)."""
+
+    def test_gzip_added_before_csrf(self, app):
+        # Starlette stores user_middleware in reverse add order (last added =
+        # index 0).  GZip was added before CSRF → GZip appears at a higher
+        # index, i.e. GZip is INNER (more inner than) CSRF in the stack.
+        mw_classes = [m.cls for m in app.user_middleware]
+        gzip_idx = mw_classes.index(GZipMiddleware)
+        csrf_idx = mw_classes.index(CSRFMiddleware)
+        assert gzip_idx > csrf_idx, (
+            "GZip must be inside (more inner than) the CSRF cookie layer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_csrf_cookie_set_on_response(self, client):
+        """Regression: moving GZip inside CSRF must not break cookie issuance."""
+        resp = await client.get("/api/health")
+        set_cookies = resp.headers.get_list("set-cookie")
+        assert any("csrf_token" in sc for sc in set_cookies), "csrf_token cookie not set"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -120,8 +120,8 @@ PROJECT_DIR = Path(__file__).parent.parent
 # Paths that must remain accessible before startup completes (health checks,
 # static assets, auth endpoints).  Everything else gets 503 until the lifespan
 # finishes its init sequence.
-_STARTUP_EXEMPT_PATHS = frozenset({"/api/health", "/api/version"})
-_STARTUP_EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/auth/", "/setup", "/shortcut/")
+_STARTUP_EXEMPT_PATHS = frozenset({"/api/health", "/api/version", "/setup"})
+_STARTUP_EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/auth/", "/setup/", "/shortcut/")
 
 from tinyagentos.task_utils import _create_supervised_task, cancel_and_wait  # noqa: E402
 
@@ -1636,7 +1636,11 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             status_code=503,
         )
 
-    # Auth middleware — must be added before GZip so it runs first
+    # Auth middleware -- added first so it is innermost. Starlette builds the
+    # middleware stack in reverse add order (last added is outermost), so the
+    # first-added middleware wraps the route last in the request chain, keeping
+    # Auth sitting between the route and every downstream header/compression/
+    # cookie layer.
     from tinyagentos.auth_middleware import AuthMiddleware
     app.add_middleware(AuthMiddleware)
 
@@ -1646,11 +1650,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.middleware.security_headers import SecurityHeadersMiddleware
     app.add_middleware(SecurityHeadersMiddleware)
 
+    # GZip compression for faster transfers on slow SD card / network.
+    # Added BEFORE CSRF so it is innermost to the cookie-setting layer: the
+    # body is compressed but Set-Cookie headers are not (BREACH precondition).
+    app.add_middleware(GZipMiddleware, minimum_size=500)
+
     from tinyagentos.middleware.csrf import CSRFMiddleware
     app.add_middleware(CSRFMiddleware)
-
-    # GZip compression for faster transfers on slow SD card / network
-    app.add_middleware(GZipMiddleware, minimum_size=500)
 
     # Startup guard — return 503 for non-exempt requests that arrive before
     # the lifespan has finished initialising app state.  Added last so it is
@@ -1944,13 +1950,25 @@ def main():
         host=config.server.get("host", "0.0.0.0"),
         port=config.server.get("port", 6969),
         backlog=128,
+        server_header=False,
     )
 
 
 def gui():
     """Launch the TinyAgentOS web UI in a browser window."""
     import subprocess
+    import sys
     import webbrowser
+
+    spa_index = PROJECT_DIR / "static" / "desktop" / "index.html"
+    if not spa_index.exists():
+        print(
+            "Desktop shell not built -- the SPA bundle is missing. "
+            "Run: cd desktop && npm run build",
+            file=sys.stderr,
+        )
+        raise SystemExit(503)
+
     port = 6969
     url = f"http://localhost:{port}"
     # Try Chromium in app mode first (cleanest look), fall back to default browser

--- a/tinyagentos/middleware/security_headers.py
+++ b/tinyagentos/middleware/security_headers.py
@@ -84,6 +84,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("Content-Security-Policy", csp)
         response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        response.headers.setdefault(
+            "Permissions-Policy",
+            "geolocation=(), camera=(), microphone=(), payment=(), usb=(), "
+            "accelerometer=(), gyroscope=(), magnetometer=(), sync-xhr=()",
+        )
         if request.url.path.startswith(_NO_STORE_PREFIXES):
             # setdefault, never a hard set: handlers that chose their own
             # policy keep it -- SSE streams ship "no-cache" so proxies do not

--- a/tinyagentos/middleware/version_header.py
+++ b/tinyagentos/middleware/version_header.py
@@ -9,9 +9,20 @@ from starlette.responses import Response
 
 import tinyagentos
 
+# Unauthenticated callers (exempt paths, loopback shutdown) receive a
+# coarsened value -- enough for the SPA to know a backend is alive, but not
+# the exact build fingerprint an attacker could use for targeted CVE scanning.
+# The full version is only revealed to callers that presented a credential
+# (session, local token, registry JWT, or device bearer).
+_COARSENED_VERSION = "taOS"
+
 
 class VersionHeaderMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         response = await call_next(request)
-        response.headers["X-Taos-Version"] = tinyagentos.__version__
+        via = getattr(request.state, "via", None)
+        if via in (None, "exempt", "loopback"):
+            response.headers["X-Taos-Version"] = _COARSENED_VERSION
+        else:
+            response.headers["X-Taos-Version"] = tinyagentos.__version__
         return response

--- a/tinyagentos/routes/manifest.py
+++ b/tinyagentos/routes/manifest.py
@@ -25,11 +25,19 @@ _PWA_APPS: dict[str, dict] = {
 
 
 @router.get("/manifest")
-async def get_manifest(app: str) -> JSONResponse:
+async def get_manifest(app: str | None = None) -> JSONResponse:
     """Return a Web App Manifest for a PWA-enabled app.
 
     Returns 404 for unknown or non-PWA app ids.
+    Returns 400 when the ``app`` query parameter is absent or empty, avoiding
+    the FastAPI 422 validation schema that would otherwise leak the route's
+    parameter contract to unauthenticated callers.
     """
+    if not app:
+        return JSONResponse(
+            {"detail": "Query parameter 'app' is required"},
+            status_code=400,
+        )
     meta = _PWA_APPS.get(app)
     if not meta:
         raise HTTPException(status_code=404, detail="App not found or not PWA-enabled")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Q2-6 app.py and middleware nits (GZip order, /setup prefix, gui fallback, security headers, /manifest 400)

Autonomous build of board card tsk-gbd2ga.

- Move GZip middleware inside the CSRF cookie-setting layer so response
  bodies carrying Set-Cookie headers are never compressed (BREACH precondition)
- Fix the middleware-order comment (was backwards about execution order)
- Anchor '/setup' startup-exempt prefix as '/setup/' and add '/setup' as
  an exact exempt path so '/setupfoo' is no longer matched as setup
- gui() now checks for the SPA bundle and exits 503 with a build hint when
  static/desktop/index.html is missing
- Add Referrer-Policy: no-referrer and a restrictive Permissions-Policy to
  every response (S2-31)
- Suppress the uvicorn Server banner via server_header=False (S2-32)
- Coarsen X-Taos-Version to 'taOS' for unauthenticated callers; full version
  only sent to requests with a presented credential (S2-32)
- GET /manifest without ?app now returns 400 with a plain body instead of
  leaking the FastAPI 422 schema (S2-33)
- Tests: 22 new assertions covering all six fixes; updated
  test_manifest_missing_param to expect 400

RED tests were run on origin/dev before the fix: 13 failures across
Referrer-Policy, Permissions-Policy, /setupfoo, /manifest 400, gui 503,
version coarsening, and GZip/CSRF ordering.

Docs-Reviewed: routes/manifest.py change (400 instead of 422 on missing
app param) is a security-hardening of error handling, not an API contract
change documented in docs/agent-coordination.md

Files:
 changelog.d/tsk-gbd2ga-app-middleware-nits.md |  17 +++
 tests/test_manifest_route.py                  |   4 +-
 tests/test_q2_6_library_audit.py              | 187 ++++++++++++++++++++++++++
 tinyagentos/app.py                            |  30 ++++-
 tinyagentos/middleware/security_headers.py    |   6 +
 tinyagentos/middleware/version_header.py      |  13 +-
 tinyagentos/routes/manifest.py                |  10 +-
 7 files changed, 257 insertions(+), 10 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added Referrer-Policy and Permissions-Policy headers to responses.
  * Reduced version information exposed to unauthenticated callers.
  * Suppressed the server identification banner.

* **Bug Fixes**
  * Restricted setup-route exemptions to valid setup paths.
  * `/manifest` now returns a clear 400 response when the app parameter is missing.
  * Added an actionable error when the desktop bundle is unavailable.
  * Preserved CSRF cookie delivery while applying compression safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Removes-Intentionally: tests/test_manifest_route.py:test_manifest_missing_param_returns_404
