### PR TITLE
fix-forward #2834 (tsk-kuslln): add the fenced red run (tests/test_notifications_user_scope.py broadcast per-user state) to the PR body; no code change

### DIFF
--- a/changelog.d/tsk-3vldwp-notification-broadcast-state.md
+++ b/changelog.d/tsk-3vldwp-notification-broadcast-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Broadcast notifications now have per-user read/archived state to prevent cross-user state leaks. Previously, when one user marked a broadcast notification as read or archived it, it affected all users' inboxes. Now each user's read/archived status is tracked independently in the `notification_user_state` table, preserving individual inbox states while maintaining the shared broadcast nature of the notification.

--- a/changelog.d/tsk-3vldwp-notification-broadcast-state.md
+++ b/changelog.d/tsk-3vldwp-notification-broadcast-state.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - Broadcast notifications now have per-user read/archived state to prevent cross-user state leaks. Previously, when one user marked a broadcast notification as read or archived it, it affected all users' inboxes. Now each user's read/archived status is tracked independently in the `notification_user_state` table, preserving individual inbox states while maintaining the shared broadcast nature of the notification.
+- Fixed `unread_count` query missing table alias and `list()` query missing per-user archive filter so broadcast state is correctly scoped per user.

--- a/changelog.d/tsk-kuslln-notification-broadcast-state.md
+++ b/changelog.d/tsk-kuslln-notification-broadcast-state.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed per-user broadcast read/archived state so `list()` and `unread_count()` correctly exclude broadcasts archived by a specific user, and the `unread_count` query no longer references an undefined table alias.

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -209,7 +209,10 @@ async def test_notification_api_mark_read(client):
     notif_id = items[0]["id"]
     resp = await client.post(f"/api/notifications/{notif_id}/read")
     assert resp.status_code == 200
-    assert await store.unread_count() == 0
+    user_id = client._transport.app.state.auth.find_user("admin")["id"]
+    assert await store.unread_count(user_id=user_id) == 0
+    items = await store.list(user_id=user_id)
+    assert items[0]["read"] is True
 
 
 @pytest.mark.asyncio
@@ -230,8 +233,9 @@ async def test_notification_api_archive(client):
     resp = await client.post(f"/api/notifications/{notif_id}/archive")
     assert resp.status_code == 200
     # Gone from the active feed, present in history.
-    assert (await store.list()) == []
-    history = await store.list_archived()
+    user_id = client._transport.app.state.auth.find_user("admin")["id"]
+    assert await store.list(user_id=user_id) == []
+    history = await store.list_archived(user_id=user_id)
     assert len(history) == 1
     assert history[0]["id"] == notif_id
 

--- a/tests/test_notifications_user_scope.py
+++ b/tests/test_notifications_user_scope.py
@@ -111,6 +111,67 @@ class TestNotificationStoreUserScope:
         assert affected == 1
         assert len(await notif_store.list_archived(user_id="u1")) == 1
 
+    async def test_broadcast_mark_read_per_user(self, notif_store):
+        await notif_store.add("broadcast", "for everyone")
+        await notif_store.add("a", "a msg", user_id="u1")
+        # Before marking read: u1 sees both, u2 sees only broadcast
+        assert await notif_store.unread_count(user_id="u1") == 2
+        assert await notif_store.unread_count(user_id="u2") == 1
+
+        broadcast_id = _id_by_title(await notif_store.list(), "broadcast")
+        await notif_store.mark_read(broadcast_id, user_id="u1")
+
+        # u1's unread count drops, u2's does not
+        assert await notif_store.unread_count(user_id="u1") == 1
+        assert await notif_store.unread_count(user_id="u2") == 1
+
+        # u2 still lists it unread
+        u2_items = await notif_store.list(user_id="u2")
+        assert _row_by_title(u2_items, "broadcast")["read"] is False
+
+    async def test_broadcast_archive_per_user(self, notif_store):
+        await notif_store.add("broadcast", "for everyone")
+        await notif_store.add("a", "a msg", user_id="u1")
+
+        broadcast_id = _id_by_title(await notif_store.list(), "broadcast")
+        await notif_store.archive(broadcast_id, user_id="u1")
+
+        # Hidden from u1's list
+        u1_items = await notif_store.list(user_id="u1")
+        assert not any(i["title"] == "broadcast" for i in u1_items)
+
+        # Still in u2's list
+        u2_items = await notif_store.list(user_id="u2")
+        assert _row_by_title(u2_items, "broadcast")["read"] is False
+
+        # u1 sees it in archived
+        u1_archived = await notif_store.list_archived(user_id="u1")
+        assert any(h["title"] == "broadcast" for h in u1_archived)
+
+        # u2 doesn't see it in archived
+        u2_archived = await notif_store.list_archived(user_id="u2")
+        assert not any(h["title"] == "broadcast" for h in u2_archived)
+
+    async def test_owned_row_mark_read_behavior(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+
+        u1_id = _id_by_title(await notif_store.list(user_id="u1"), "a")
+        await notif_store.mark_read(u1_id, user_id="u1")
+
+        assert await notif_store.unread_count(user_id="u1") == 0
+        assert (await notif_store.list(user_id="u1"))[0]["read"] is True
+
+    async def test_owned_row_archive_behavior(self, notif_store):
+        await notif_store.add("a", "a msg", user_id="u1")
+        await notif_store.add("b", "b msg", user_id="u2")
+
+        u1_id = _id_by_title(await notif_store.list(user_id="u1"), "a")
+        await notif_store.archive(u1_id, user_id="u1")
+
+        assert len(await notif_store.list(user_id="u1")) == 0
+        assert len(await notif_store.list_archived(user_id="u1")) == 1
+
 
 @pytest_asyncio.fixture
 async def two_user_app(tmp_path):

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -249,7 +249,7 @@ class NotificationStore(BaseStore):
                 "COALESCE(nus.read_at, n.read) as read, n.source, n.data, n.user_id "
                 "FROM notifications n "
                 "LEFT JOIN notification_user_state nus ON n.id = nus.notification_id AND nus.user_id = ? "
-                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND n.archived = 0"
+                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND n.archived = 0 AND (n.user_id IS NOT NULL OR nus.archived_at IS NULL)"
                 + (" AND COALESCE(nus.read_at, n.read) = 0" if unread_only else "") +
                 " ORDER BY n.timestamp DESC LIMIT ?"
             )
@@ -307,9 +307,9 @@ class NotificationStore(BaseStore):
             # For per-user notifications, include both own notifications and broadcasts
             # Read state for broadcasts is stored in notification_user_state
             sql = (
-                "SELECT COUNT(*) FROM notifications "
+                "SELECT COUNT(*) FROM notifications n "
                 "LEFT JOIN notification_user_state nus ON n.id = nus.notification_id AND nus.user_id = ? "
-                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND archived = 0 AND COALESCE(nus.read_at, n.read) = 0"
+                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND (n.user_id IS NOT NULL OR nus.archived_at IS NULL) AND COALESCE(nus.read_at, n.read) = 0"
             )
             params = (user_id, user_id)
         else:

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -33,6 +33,13 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
     event_type TEXT PRIMARY KEY,
     muted INTEGER NOT NULL DEFAULT 0
 );
+CREATE TABLE IF NOT EXISTS notification_user_state (
+    notification_id INTEGER NOT NULL,
+    user_id TEXT NOT NULL,
+    read_at INTEGER,
+    archived_at INTEGER,
+    PRIMARY KEY (notification_id, user_id)
+);
 """
 
 
@@ -147,6 +154,24 @@ class NotificationStore(BaseStore):
             "CREATE INDEX IF NOT EXISTS idx_notif_user ON notifications(user_id)"
         )
         await self._db.commit()
+        # Ensure the notification_user_state table exists for per-user broadcast state.
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS notification_user_state (
+                notification_id INTEGER NOT NULL,
+                user_id TEXT NOT NULL,
+                read_at INTEGER,
+                archived_at INTEGER,
+                PRIMARY KEY (notification_id, user_id)
+            );
+            """
+        )
+        await self._db.commit()
+        # Create an index on notification_id for efficient lookups.
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_notif_state_notif ON notification_user_state(notification_id)"
+        )
+        await self._db.commit()
 
     async def add(
         self,
@@ -217,80 +242,155 @@ class NotificationStore(BaseStore):
         unread_only: bool = False,
         user_id: str | None = None,
     ) -> list[dict]:
-        # Active feed: archived (dismissed) notifications are excluded.
-        conds = ["archived = 0"]
         if user_id is not None:
-            conds.append("(user_id IS NULL OR user_id = ?)")
-        if unread_only:
-            conds.append("read = 0")
-        params: tuple = (user_id, limit) if user_id is not None else (limit,)
-        sql = (
-            "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
-            f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?"
-        )
-        async with self._db.execute(sql, params) as cursor:
-            rows = await cursor.fetchall()
-        return [_serialize_row(r) for r in rows]
+            # Per-user notifications: include both own notifications and broadcasts
+            sql = (
+                "SELECT n.id, n.timestamp, n.level, n.title, n.message, "
+                "COALESCE(nus.read_at, n.read) as read, n.source, n.data, n.user_id "
+                "FROM notifications n "
+                "LEFT JOIN notification_user_state nus ON n.id = nus.notification_id AND nus.user_id = ? "
+                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND n.archived = 0"
+                + (" AND COALESCE(nus.read_at, n.read) = 0" if unread_only else "") +
+                " ORDER BY n.timestamp DESC LIMIT ?"
+            )
+            params: tuple = (user_id, user_id, limit)
+            async with self._db.execute(sql, params) as cursor:
+                rows = await cursor.fetchall()
+            return [_serialize_row(r) for r in rows]
+        else:
+            # Internal/system caller: unfiltered by user
+            conds = ["archived = 0"]
+            if unread_only:
+                conds.append("read = 0")
+            sql = (
+                "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
+                f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?"
+            )
+            params: tuple = (limit,)
+            async with self._db.execute(sql, params) as cursor:
+                rows = await cursor.fetchall()
+            return [_serialize_row(r) for r in rows]
 
     async def list_archived(
         self,
         limit: int = 50,
         user_id: str | None = None,
     ) -> list[dict]:
-        # History view: the dismissed notifications, newest first. Nothing is
-        # deleted, so this is the durable record (#62 / append-only #103).
-        conds = ["archived = 1"]
         if user_id is not None:
-            conds.append("(user_id IS NULL OR user_id = ?)")
-        params: tuple = (user_id, limit) if user_id is not None else (limit,)
-        async with self._db.execute(
-            "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
-            f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?",
-            params,
-        ) as cursor:
-            rows = await cursor.fetchall()
-        return [_serialize_row(r) for r in rows]
+            # Per-user notifications: include both own notifications and broadcasts
+            # Archive state for broadcasts is stored in notification_user_state
+            sql = (
+                "SELECT n.id, n.timestamp, n.level, n.title, n.message, "
+                "COALESCE(nus.read_at, n.read) as read, n.source, n.data, n.user_id "
+                "FROM notifications n "
+                "LEFT JOIN notification_user_state nus ON n.id = nus.notification_id AND nus.user_id = ? "
+                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND (n.archived = 1 OR nus.archived_at IS NOT NULL)"
+                " ORDER BY n.timestamp DESC LIMIT ?"
+            )
+            params = (user_id, user_id, limit)
+            async with self._db.execute(sql, params) as cursor:
+                rows = await cursor.fetchall()
+            return [_serialize_row(r) for r in rows]
+        else:
+            # Internal/system caller: unfiltered by user
+            sql = (
+                "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
+                " WHERE archived = 1 ORDER BY timestamp DESC LIMIT ?"
+            )
+            params = (limit,)
+            async with self._db.execute(sql, params) as cursor:
+                rows = await cursor.fetchall()
+            return [_serialize_row(r) for r in rows]
 
     async def unread_count(self, user_id: str | None = None) -> int:
-        conds = ["read = 0", "archived = 0"]
         if user_id is not None:
-            conds.append("(user_id IS NULL OR user_id = ?)")
-        params: tuple = (user_id,) if user_id is not None else ()
-        async with self._db.execute(
-            f"SELECT COUNT(*) FROM notifications WHERE {' AND '.join(conds)}",
-            params,
-        ) as cursor:
+            # For per-user notifications, include both own notifications and broadcasts
+            # Read state for broadcasts is stored in notification_user_state
+            sql = (
+                "SELECT COUNT(*) FROM notifications "
+                "LEFT JOIN notification_user_state nus ON n.id = nus.notification_id AND nus.user_id = ? "
+                f"WHERE (n.user_id IS NULL OR n.user_id = ?) AND archived = 0 AND COALESCE(nus.read_at, n.read) = 0"
+            )
+            params = (user_id, user_id)
+        else:
+            # Internal/system caller: unfiltered by user
+            sql = (
+                "SELECT COUNT(*) FROM notifications "
+                "WHERE read = 0 AND archived = 0"
+            )
+            params = ()
+        async with self._db.execute(sql, params) as cursor:
             row = await cursor.fetchone()
         return row[0] if row else 0
 
     async def mark_read(self, notif_id: int, user_id: str | None = None) -> int:
         if user_id is not None:
+            # Per-user or broadcast notification for a specific user:
+            # Update shared columns if it's a per-user notification
+            # For broadcast notifications, update per-user state
+            ts = int(time.time())
             cursor = await self._db.execute(
-                "UPDATE notifications SET read = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
-                (notif_id, user_id),
+                "SELECT user_id FROM notifications WHERE id = ?", (notif_id,)
             )
+            row = await cursor.fetchone()
+            
+            if row and row[0] is None:
+                # This is a broadcast notification - upsert into per-user state
+                await self._db.execute(
+                    "INSERT OR REPLACE INTO notification_user_state (notification_id, user_id, read_at) VALUES (?, ?, ?)",
+                    (notif_id, user_id, ts),
+                )
+                await self._db.commit()
+                return 1
+            else:
+                # This is a per-user notification - update shared columns
+                cursor = await self._db.execute(
+                    "UPDATE notifications SET read = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
+                    (notif_id, user_id),
+                )
+                await self._db.commit()
+                return cursor.rowcount
         else:
-            # Internal/system caller: unfiltered update.
+            # System/internal caller: update shared columns for broadcast notifications
             cursor = await self._db.execute(
                 "UPDATE notifications SET read = 1 WHERE id = ?", (notif_id,)
             )
-        await self._db.commit()
-        return cursor.rowcount
+            await self._db.commit()
+            return cursor.rowcount
 
     async def archive(self, notif_id: int, user_id: str | None = None) -> int:
-        # Dismiss = archive. The row stays; the History view still shows it.
         if user_id is not None:
+            # Check if this is a broadcast notification
             cursor = await self._db.execute(
-                "UPDATE notifications SET archived = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
-                (notif_id, user_id),
+                "SELECT user_id FROM notifications WHERE id = ?", (notif_id,)
             )
+            row = await cursor.fetchone()
+            
+            if row and row[0] is None:
+                # This is a broadcast notification
+                ts = int(time.time())
+                await self._db.execute(
+                    "INSERT OR REPLACE INTO notification_user_state (notification_id, user_id, archived_at) VALUES (?, ?, ?)",
+                    (notif_id, user_id, ts),
+                )
+                await self._db.commit()
+                # Do NOT update the shared archived column for broadcasts
+                return 1
+            else:
+                # This is a per-user notification
+                cursor = await self._db.execute(
+                    "UPDATE notifications SET archived = 1 WHERE id = ? AND (user_id IS NULL OR user_id = ?)",
+                    (notif_id, user_id),
+                )
+                await self._db.commit()
+                return cursor.rowcount
         else:
-            # Internal/system caller: unfiltered update.
+            # Internal/system caller: unfiltered update
             cursor = await self._db.execute(
                 "UPDATE notifications SET archived = 1 WHERE id = ?", (notif_id,)
             )
-        await self._db.commit()
-        return cursor.rowcount
+            await self._db.commit()
+            return cursor.rowcount
 
     async def archive_by_source_ref(self, source: str, request_id) -> int:
         """Archive active notifications whose JSON `data.request_id` matches.
@@ -331,15 +431,27 @@ class NotificationStore(BaseStore):
 
     async def mark_all_read(self, user_id: str | None = None) -> int:
         if user_id is not None:
+            # Mark all per-user notifications (both user-specific and broadcasts for that user) as read
             cursor = await self._db.execute(
                 "UPDATE notifications SET read = 1 WHERE read = 0 AND (user_id IS NULL OR user_id = ?)",
                 (user_id,),
             )
+            await self._db.commit()
+            
+            # Also mark any per-user state as read for this user
+            await self._db.execute(
+                "UPDATE notification_user_state SET read_at = ? WHERE user_id = ?",
+                (int(time.time()), user_id),
+            )
+            await self._db.commit()
+            
+            return cursor.rowcount
         else:
-            # Internal/system caller: unfiltered update.
+            # System/internal caller: mark all notifications as read
+            # This updates the shared read column for both per-user and broadcast notifications
             cursor = await self._db.execute("UPDATE notifications SET read = 1 WHERE read = 0")
-        await self._db.commit()
-        return cursor.rowcount
+            await self._db.commit()
+            return cursor.rowcount
 
     async def cleanup(self, max_age_days: int = 30) -> int:
         # Age out only old UNdismissed notifications. Archived rows are the


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2834 (tsk-kuslln): add the fenced red run (tests/test_notifications_user_scope.py broadcast per-user state) to the PR body; no code change

Autonomous build of board card tsk-w546jk.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

REVISION: built on `exec/tsk-kuslln` (cut at `376722de493c54cd06e0c2c949d5a6eff66936b5`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Supersede #2834. The previous PR body used prose instead of a fenced code block and was rejected by the RED-FIRST gate (exit 13). This commit carries zero source diff versus BASE and adds the required verbatim red run and green line.

RED run on origin/dev (fix absent):

```text
Using CPython 3.12.13
Creating virtual environment at: .venv
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If this is intentional, set `export UV_LINK_MODE=copy` to suppress this warning.
Installed 107 packages in 1.81s
...............................FF................                        [100%]
=================================== FAILURES ===================================
_______ TestNotificationStoreUserScope.test_broadcast_mark_read_per_user _______

self = <test_notifications_user_scope.TestNotificationStoreUserScope object at 0x71ecd4c191c0>
notif_store = <tinyagentos.notifications.NotificationStore object at 0x71ecd40c2ed0>

    async def test_broadcast_mark_read_per_user(self, notif_store):
        await notif_store.add("broadcast", "for everyone")
        await notif_store.add("a", "a msg", user_id="u1")
        # Before marking read: u1 sees both, u2 sees only broadcast
        assert await notif_store.unread_count(user_id="u1") == 2
        assert await notif_store.unread_count(user_id="u2") == 1

        broadcast_id = _id_by_title(await notif_store.list(), "broadcast")
        await notif_store.mark_read(broadcast_id, user_id="u1")

        # u1's unread count drops, u2's does not
        assert await notif_store.unread_count(user_id="u1") == 1
>       assert await notif_store.unread_count(user_id="u2") == 1
E       assert 0 == 1

tests/test_notifications_user_scope.py:126: AssertionError
________ TestNotificationStoreUserScope.test_broadcast_archive_per_user _________

self = <test_notifications_user_scope.TestNotificationStoreUserScope object at 0x71ecd4c19820>
notif_store = <tinyagentos.notifications.NotificationStore object at 0x71ecd40c1be0>

    async def test_broadcast_archive_per_user(self, notif_store):
        await notif_store.add("broadcast", "for everyone")
        await notif_store.add("a", "a msg", user_id="u1")

        broadcast_id = _id_by_title(await notif_store.list(), "broadcast")
        await notif_store.archive(broadcast_id, user_id="u1")

        # Hidden from u1's list
        u1_items = await notif_store.list(user_id="u1")
        assert not any(i["title"] == "broadcast" for i in u1_items)

        # Still in u2's list
        u2_items = await notif_store.list(user_id="u2")
>       assert _row_by_title(u2_items, "broadcast")["read"] is False
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_notifications_user_scope.py:145:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

items = [], title = 'broadcast'

    def _row_by_title(items: list[dict], title: str) -> dict:
        """Pick a notification by title, never by list position.

        Every row added in a test shares the same whole-second ``timestamp``, so the
        ORDER BY on ties is whatever the index happens to yield. Selecting by title
        also keeps route-scoping setups off the scoped store API, so the red these
        tests produce on unfixed code is the leak, not a signature TypeError.
        """
        for item in items:
            if item["title"] == title:
                return item
>       raise AssertionError(f"no notification titled {title!r}")
E       AssertionError: no notification titled 'broadcast'

tests/test_notifications_user_scope.py:22: AssertionError
=========================== short test summary info ============================
FAILED tests/test_notifications_user_scope.py::TestNotificationStoreUserScope::test_broadcast_mark_read_per_user
FAILED tests/test_notifications_user_scope.py::TestNotificationStoreUserScope::test_broadcast_archive_per_user
2 failed, 47 passed in 45.29s
```

GREEN run on BASE (fix present):

```text
Using CPython 3.12.13
Creating virtual environment at: .venv
warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If this is intentional, set `export UV_LINK_MODE=copy` to suppress this warning.
Installed 107 packages in 955ms
.................................................                        [100%]
49 passed in 42.97s
```

Files:
 .../tsk-3vldwp-notification-broadcast-state.md     |   4 +
 .../tsk-kuslln-notification-broadcast-state.md     |   3 +
 tests/test_notifications.py                        |  10 +-
 tests/test_notifications_user_scope.py             |  61 ++++++
 tinyagentos/notifications.py                       | 204 ++++++++++++++++-----
 5 files changed, 233 insertions(+), 49 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broadcast notification read and archive status so each user’s actions are tracked independently.
  * Corrected unread counts and notification lists to consistently reflect each user’s archived and read notifications.
  * Ensured marking all notifications as read updates the current user’s view without affecting others.

* **Tests**
  * Added coverage for user-specific broadcast and personal notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->