### PR TITLE
fix-forward #2835 (tsk-qnyed7): add the fenced red run (tests/test_installers.py linkwarden postgres companion) to the PR body; no code change

### DIFF
--- a/app-catalog/services/linkwarden/manifest.yaml
+++ b/app-catalog/services/linkwarden/manifest.yaml
@@ -21,7 +21,16 @@ install:
   env:
     NEXTAUTH_SECRET: "changeme"
     NEXTAUTH_URL: "http://localhost:3000"
-    DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/linkwarden"
+    DATABASE_URL: "postgresql://linkwarden:{secret_key}@postgres:5432/linkwarden"
+  companions:
+    - name: postgres
+      image: postgres:16-alpine
+      volumes:
+        - pgdata:/var/lib/postgresql/data
+      env:
+        POSTGRES_PASSWORD: "{secret_key}"
+        POSTGRES_USER: "linkwarden"
+        POSTGRES_DB: "linkwarden"
 
 lifecycle:
   health_check: "curl -sf http://localhost:3000"

--- a/changelog.d/tsk-qnyed7-linkwarden-postgres-companion.md
+++ b/changelog.d/tsk-qnyed7-linkwarden-postgres-companion.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- linkwarden manifest now declares a postgres:16-alpine companion service with a persisted volume and {secret_key}-style generated password; DATABASE_URL points at the companion's service name "postgres" instead of unresolvable localhost

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -218,6 +218,176 @@ class TestDockerInstaller:
             assert any("up" in c and "-d" in c for c in calls)
 
 
+class TestLinkwardenCompose:
+    @pytest.mark.asyncio
+    async def test_generate_compose_linkwarden_has_postgres_companion(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        compose, host_port = installer._generate_compose(
+            "linkwarden",
+            {
+                "image": "ghcr.io/linkwarden/linkwarden:latest",
+                "volumes": ["data:/data/data"],
+                "ports": [3000],
+                "env": {
+                    "NEXTAUTH_SECRET": "changeme",
+                    "NEXTAUTH_URL": "http://localhost:3000",
+                    "DATABASE_URL": "postgresql://linkwarden:{secret_key}@postgres:5432/linkwarden",
+                },
+                "companions": [
+                    {
+                        "name": "postgres",
+                        "image": "postgres:16-alpine",
+                        "volumes": ["pgdata:/var/lib/postgresql/data"],
+                        "env": {
+                            "POSTGRES_PASSWORD": "{secret_key}",
+                            "POSTGRES_USER": "linkwarden",
+                            "POSTGRES_DB": "linkwarden",
+                        },
+                    }
+                ],
+            },
+        )
+        # Compose must have both linkwarden and postgres services
+        assert "linkwarden" in compose["services"]
+        assert "postgres" in compose["services"]
+        # postgres service must use the alpine image
+        pg_service = compose["services"]["postgres"]
+        assert pg_service["image"] == "postgres:16-alpine"
+        # postgres must have a named volume
+        assert "volumes" in pg_service
+        pg_volumes = pg_service["volumes"]
+        assert any(
+            v.startswith("pgdata:") or (":" in v and v.split(":")[0] == "pgdata")
+            for v in pg_volumes
+        )
+        # linkwarden must have DATABASE_URL pointing at the postgres service
+        lw_env = compose["services"]["linkwarden"]["environment"]
+        docker_url = lw_env["DATABASE_URL"]
+        assert "postgres" in docker_url
+        assert "localhost" not in docker_url
+        # The host in DATABASE_URL must resolve to the postgres service name
+        # Format: postgresql://[user[:password]@][host][:port][/dbname]
+        # e.g. postgresql://linkwarden:{password}@postgres:5432/linkwarden
+        assert docker_url.startswith("postgresql://linkwarden:")
+        # Extract host (between @ and :port or /dbname)
+        after_at = docker_url.split("@")[1]  # e.g. "postgres:5432/linkwarden"
+        host_with_port = after_at.split("/")[0]  # e.g. "postgres:5432"
+        host_part = host_with_port.split(":")[0]  # e.g. "postgres"
+        assert host_part == "postgres", f"Expected host 'postgres', got '{host_part}'"
+        # Host port must be in the managed pool, not 3000
+        assert host_port is not None
+        assert _POOL_START <= host_port < _POOL_END
+        assert host_port not in RESERVED_PORTS
+
+    @pytest.mark.asyncio
+    async def test_generate_compose_linkwarden_secret_key_persisted(self, tmp_path):
+        """Verify {secret_key} is replaced with a persisted 64-hex-char secret."""
+        installer = DockerInstaller(apps_dir=tmp_path)
+        # Verify {secret_key} is replaced with a persisted 64-hex-char secret.
+        installer = DockerInstaller(apps_dir=tmp_path)
+        # First install - should generate a secret
+        compose1, _ = installer._generate_compose(
+            "linkwarden",
+            {
+                "image": "ghcr.io/linkwarden/linkwarden:latest",
+                "volumes": ["data:/data/data"],
+                "ports": [3000],
+                "env": {
+                    "NEXTAUTH_SECRET": "changeme",
+                    "NEXTAUTH_URL": "http://localhost:3000",
+                    "DATABASE_URL": "postgresql://linkwarden:{secret_key}@postgres:5432/linkwarden",
+                },
+                "companions": [
+                    {
+                        "name": "postgres",
+                        "image": "postgres:16-alpine",
+                        "volumes": ["pgdata:/var/lib/postgresql/data"],
+                        "env": {
+                            "POSTGRES_PASSWORD": "{secret_key}",
+                            "POSTGRES_USER": "linkwarden",
+                            "POSTGRES_DB": "linkwarden",
+                        },
+                    }
+                ],
+            },
+        )
+        # Verify {secret_key} was replaced
+        for env_key, env_val in compose1["services"]["linkwarden"]["environment"].items():
+            assert "{secret_key}" not in str(env_val)
+        # Check DATABASE_URL host resolves to postgres
+        db_url = compose1["services"]["linkwarden"]["environment"]["DATABASE_URL"]
+        assert "postgres" in db_url
+        assert "localhost" not in db_url
+        after_at = db_url.split("@")[1]
+        host_with_port = after_at.split("/")[0]
+        host_part = host_with_port.split(":")[0]
+        assert host_part == "postgres", f"Expected host 'postgres', got '{host_part}'"
+
+        # Second install with same app_dir - should reuse the same secret
+        compose2, _ = installer._generate_compose(
+            "linkwarden",
+            {
+                "image": "ghcr.io/linkwarden/linkwarden:latest",
+                "volumes": ["data:/data/data"],
+                "ports": [3000],
+                "env": {
+                    "NEXTAUTH_SECRET": "changeme",
+                    "NEXTAUTH_URL": "http://localhost:3000",
+                    "DATABASE_URL": "postgresql://linkwarden:{secret_key}@postgres:5432/linkwarden",
+                },
+                "companions": [
+                    {
+                        "name": "postgres",
+                        "image": "postgres:16-alpine",
+                        "volumes": ["pgdata:/var/lib/postgresql/data"],
+                        "env": {
+                            "POSTGRES_PASSWORD": "{secret_key}",
+                            "POSTGRES_USER": "linkwarden",
+                            "POSTGRES_DB": "linkwarden",
+                        },
+                    }
+                ],
+            },
+        )
+        # Same secret should be reused
+        for env_key, env_val in compose2["services"]["linkwarden"]["environment"].items():
+            assert "{secret_key}" not in str(env_val)
+        # The secret values should match across installs
+        db_url_1 = compose1["services"]["linkwarden"]["environment"]["DATABASE_URL"]
+        db_url_2 = compose2["services"]["linkwarden"]["environment"]["DATABASE_URL"]
+        assert db_url_1 == db_url_2
+
+    @pytest.mark.asyncio
+    async def test_generate_compose_linkwarden_no_companions(self, tmp_path):
+        """Verify linkwarden without companions still works (single-service compose)."""
+        installer = DockerInstaller(apps_dir=tmp_path)
+        compose, host_port = installer._generate_compose(
+            "linkwarden",
+            {
+                "image": "ghcr.io/linkwarden/linkwarden:latest",
+                "volumes": ["data:/data/data"],
+                "ports": [3000],
+                "env": {
+                    "NEXTAUTH_SECRET": "changeme",
+                    "NEXTAUTH_URL": "http://localhost:3000",
+                    # No companions - DATABASE_URL would point at localhost which is fine
+                    # for a single-service setup, but the app wouldn't have a real DB
+                    "DATABASE_URL": "postgresql://postgres:postgres@localhost:5432/linkwarden",
+                },
+                # No 'companions' key
+            },
+        )
+        # Should still produce a single-service compose
+        assert "linkwarden" in compose["services"]
+        assert "postgres" not in compose["services"]
+        assert host_port is not None
+        assert _POOL_START <= host_port < _POOL_END
+        # DATABASE_URL should still point at localhost since there's no companion
+        lw_env = compose["services"]["linkwarden"]["environment"]
+        docker_url = lw_env["DATABASE_URL"]
+        assert "localhost" in docker_url
+
+
 class TestDownloadInstaller:
     @pytest.mark.asyncio
     async def test_install_downloads_file(self, tmp_path):

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -110,6 +110,21 @@ class DockerInstaller(AppInstaller):
         Returns a ``(compose_dict, host_port)`` tuple.  ``host_port`` is
         ``None`` when the manifest declares no ports.
         """
+        # Handle {secret_key} substitution for env vars and companion passwords
+        app_dir = self.apps_dir / app_id
+        secret_key_path = app_dir / ".secret_key"
+        secret_key = ""
+        if secret_key_path.exists():
+            secret_key = secret_key_path.read_text().strip()
+        if len(secret_key) != 64 or not all(c in "0123456789abcdef" for c in secret_key):
+            secret_key = secrets.token_hex(32)
+            app_dir.mkdir(parents=True, exist_ok=True)
+            secret_key_path.write_text(secret_key)
+            secret_key_path.chmod(0o600)
+
+        def _sub_secret_key(text: str) -> str:
+            return text.replace("{secret_key}", secret_key) if "{secret_key}" in text else text
+
         service = {
             "image": install_config["image"],
             "restart": "unless-stopped",
@@ -125,7 +140,39 @@ class DockerInstaller(AppInstaller):
                 if self._is_named_volume(source):
                     named_volumes[source] = None
         if "env" in install_config:
-            service["environment"] = install_config["env"]
+            service["environment"] = {
+                k: _sub_secret_key(v) for k, v in install_config["env"].items()
+            }
+
+        # Companion services (e.g. postgres for linkwarden)
+        companions: list[dict] = install_config.get("companions", [])
+        companion_services: list[dict] = []
+        companion_names: list[str] = []
+        if companions:
+            for comp in companions:
+                comp_name = comp.get("name", f"companion-{len(companion_services)}")
+                companion_names.append(comp_name)
+                comp_service = {
+                    "image": comp["image"],
+                    "restart": "unless-stopped",
+                }
+                # companion volumes
+                comp_named_volumes: dict[str, None] = {}
+                if "volumes" in comp:
+                    comp_service["volumes"] = comp["volumes"]
+                    for vol in comp["volumes"]:
+                        source = str(vol).split(":", 1)[0]
+                        if self._is_named_volume(source):
+                            comp_named_volumes[source] = None
+                # companion environment (e.g. POSTGRES_PASSWORD using {secret_key})
+                if "env" in comp:
+                    comp_service["environment"] = {
+                        k: _sub_secret_key(v) for k, v in comp["env"].items()
+                    }
+                companion_services.append(comp_service)
+                # Map named companion volumes into the top-level volumes block
+                for vn in comp_named_volumes:
+                    named_volumes[vn] = None
 
         # Collect the container-internal ports from the manifest.
         container_ports: list[int] = []
@@ -155,9 +202,15 @@ class DockerInstaller(AppInstaller):
                 for hp, cport in zip(host_ports, container_ports)
             ]
 
+        # Build the services dict: app service first, then companions
+        all_services: dict[str, dict] = {}
+        all_services[app_id] = service
+        for i, comp_service in enumerate(companion_services):
+            all_services[companion_names[i]] = comp_service
+
         # No top-level `version:` — it's obsolete in Compose v2 and emits a
         # warning on every command.
-        compose: dict = {"services": {app_id: service}}
+        compose: dict = {"services": all_services}
         if named_volumes:
             compose["volumes"] = named_volumes
         return compose, allocated_host_port


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2835 (tsk-qnyed7): add the fenced red run (tests/test_installers.py linkwarden postgres companion) to the PR body; no code change

Autonomous build of board card tsk-enmc4g.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

REVISION: built on `exec/tsk-qnyed7` (cut at `53831d633d19562beb6f2b3f2a2322cd24388bbc`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Supersedes #2835 (card tsk-qnyed7). The merge gate aborted because the PR
body carried prose ("RED test: ...") instead of a fenced code block showing
the tests failing before the fix. This commit carries zero source or test
changes; the fix and tests already live on this branch (exec/tsk-qnyed7).

Red run: origin/dev checked out at /tmp/red with only tests/test_installers.py
cherry-picked from this branch, then run:

GREEN run: same tests on BASE (with fix applied):

```
=== RED (origin/dev, no companion/secret_key support) ===
FAILED tests/test_installers.py::TestLinkwardenCompose::test_generate_compose_linkwarden_has_postgres_companion
FAILED tests/test_installers.py::TestLinkwardenCompose::test_generate_compose_linkwarden_secret_key_persisted
2 failed, 1 passed in 0.44s
=== GREEN (BASE / exec/tsk-qnyed7, fix applied) ===
3 passed in 0.26s
```

Why the tests prove the defect:
- has_postgres_companion fails because DockerInstaller._generate_compose on
  origin/dev does not read the "companions" key, so no postgres service appears
- secret_key_persisted fails because origin/dev has no {secret_key} substitution
  logic, leaving the placeholder in DATABASE_URL and POSTGRES_PASSWORD

Note: PR #2821 (exec/tsk-zcaout) also edits the linkwarden manifest and
tests/test_installers.py. Its content is intentionally NOT merged here; the
lead orders the merges.

Docs-Reviewed: no documentation change needed; this commit introduces no code,
manifest, or route changes, only red/green test evidence for #2835

Files:
 app-catalog/services/linkwarden/manifest.yaml      |  11 +-
 .../tsk-qnyed7-linkwarden-postgres-companion.md    |   3 +
 tests/test_installers.py                           | 170 +++++++++++++++++++++
 tinyagentos/installers/docker_installer.py         |  57 ++++++-
 4 files changed, 238 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Linkwarden installations now connect to a managed PostgreSQL 16 database instead of relying on an unavailable local database.
  - PostgreSQL data is persisted across restarts and reinstalls.
  - Database credentials and application secrets are generated and retained automatically, improving reliability and preserving existing configuration.
- **Chores**
  - Added validation to ensure Linkwarden deployments generate the expected application and database services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->