### PR TITLE
[lib-audit] Q2-7 proxy/runtime nits (span registry eviction, undeploy docstring vs code, browser_sessions pragmas)

### DIFF
--- a/changelog.d/tsk-o5xq2m-proxy-runtime-nits.md
+++ b/changelog.d/tsk-o5xq2m-proxy-runtime-nits.md
@@ -1,0 +1,14 @@
+Additional fix: make the undeploy_agent function actually remove the trace dir when delete_state=True, matching the docstring.
+
+While the current code removes agent workspaces and memory, the trace directory is also created by the deployer and should be cleaned up with the agent. The PRAGMA journal_mode=WAL is added directly in _SCHEMA (which is correct), and busy_timeout pragmas are added for consistency with other stores.
+
+Also added an eviction mechanism to the SpanStoreRegistry to keep the registry size bounded with an LRU implementation.
+
+### Fixed
+- Fixed SpanStoreRegistry to use bounded LRU eviction
+- Made undeploy_agent actually remove trace directory when delete_state=True
+- Added busy_timeout pragma to browser_sessions.py
+
+### Added
+- WAL mode journal pragma to browser_sessions.py
+- Trace directory removal in undeploy_agent

--- a/tests/test_browser_sessions_pragmas.py
+++ b/tests/test_browser_sessions_pragmas.py
@@ -1,0 +1,58 @@
+"""RED test for browser_sessions pragmas.
+
+This test demonstrates that browser_sessions.py is missing WAL mode
+and busy_timeout pragmas that all other stores have.
+"""
+from __future__ import annotations
+
+import aiosqlite
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.browser_sessions import BrowserSessionManager
+
+
+@pytest.mark.asyncio
+async def test_browser_sessions_has_wal_and_busy_timeout(tmp_path: Path) -> None:
+    """RED test: browser_sessions must have WAL mode and busy_timeout pragmas.
+    
+    The current implementation is missing these pragmas that all other
+    SQLite stores (otel span store, trace store) have. This test will FAIL
+    before the fix is applied.
+    """
+    db_path = tmp_path / "browser_sessions.db"
+    manager = BrowserSessionManager(db_path=db_path, mock=True)
+    
+    # Initialize the database
+    await manager.init()
+    
+    # Connect to the database directly to check pragmas
+    conn = await aiosqlite.connect(str(db_path))
+    
+    # Check journal_mode is WAL
+    cursor = await conn.execute("PRAGMA journal_mode")
+    journal_mode = await cursor.fetchone()
+    await cursor.close()
+    
+    # RED TEST EXPECTATION: journal_mode should be 'wal' or 'WAL'
+    assert journal_mode[0].upper() == "WAL", f"Expected journal_mode WAL, got {journal_mode[0]}"
+    
+    # Check busy_timeout is set (default is 5000, so we expect at least 30000)
+    cursor = await conn.execute("PRAGMA busy_timeout")
+    busy_timeout = await cursor.fetchone()
+    await cursor.close()
+    
+    # RED TEST EXPECTATION: busy_timeout should be 5000 (5 seconds) to match other stores
+    assert busy_timeout[0] == 5000, f"Expected busy_timeout 5000, got {busy_timeout[0]}"
+    
+    # Verify table can be queried without issues
+    cursor = await conn.execute("SELECT COUNT(*) FROM browser_sessions")
+    count = await cursor.fetchone()
+    await cursor.close()
+    
+    assert count[0] == 0
+    
+    await conn.close()
+    await manager.close()

--- a/tests/test_span_store_registry_eviction.py
+++ b/tests/test_span_store_registry_eviction.py
@@ -1,0 +1,50 @@
+"""RED test for SpanStoreRegistry eviction - must fail on current code.
+
+This test demonstrates that the SpanStoreRegistry never evicts entries
+and grows indefinitely, which violates the bounded LRU requirement.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.otel.span_store import SpanStoreRegistry
+
+
+@pytest.mark.asyncio
+async def test_span_store_registry_evicts_lru(tmp_path: Path) -> None:
+    """RED test: registry must evict LRU entries when over max_size.
+    
+    The current implementation never evicts, so creating more stores
+    than max_size will cause unbounded growth. This test will FAIL
+    before the fix is applied.
+    """
+    data_dir = tmp_path
+    registry = SpanStoreRegistry(data_dir, max_size=3)
+    
+    # Create 5 different stores - registry should evict oldest when over max_size
+    stores = []
+    for i in range(5):
+        slug = f"agent-{i}"
+        store = await registry.get(slug)
+        stores.append(store)
+    
+    # Check that registry doesn't have more than max_size entries
+    # This will FAIL with the current implementation
+    active_stores = len(registry._stores)
+    assert active_stores <= 3, f"Registry has {active_stores} stores, expected ≤ 3"
+    
+    # Verify that the first (oldest) entries were evicted
+    assert "agent-0" not in registry._stores, "Oldest entry (agent-0) should have been evicted"
+    assert "agent-1" not in registry._stores, "Oldest entry (agent-1) should have been evicted"
+    # agent-2 should remain since we only evict when exceeding max_size of 3
+    # When agent-3 is created, agent-0 is evicted
+    # When agent-4 is created, agent-1 is evicted
+    # So agent-2, agent-3, and agent-4 should remain
+    assert "agent-2" in registry._stores
+    assert "agent-3" in registry._stores
+    assert "agent-4" in registry._stores
+    
+    await registry.close_all()

--- a/tests/test_undeploy_agent_trace_dir.py
+++ b/tests/test_undeploy_agent_trace_dir.py
@@ -1,0 +1,69 @@
+"""RED test for undeploy_agent trace directory removal.
+
+This test demonstrates that undeploy_agent's docstring says it removes
+the agent's trace directory when delete_state=True, but the code never did.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.deployer import undeploy_agent
+
+
+@pytest.mark.asyncio
+async def test_undeploy_agent_removes_trace_dir(tmp_path: Path) -> None:
+    """RED test: undeploy_agent must remove trace directory when delete_state=True.
+    
+    The current implementation's docstring claims trace directory is removed,
+    but the code only removes workspaces and memory, not the trace directory.
+    This test will FAIL on the current implementation.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    
+    agent_name = "test-agent"
+    trace_dir = data_dir / "trace" / agent_name
+    workspaces_dir = data_dir / "agent-workspaces" / agent_name
+    memory_dir = data_dir / "agent-memory" / agent_name
+    
+    # Create the directories that simulate post-deploy state
+    trace_dir.mkdir(parents=True)
+    (trace_dir / "otel-spans.db").write_text("test data")
+    workspaces_dir.mkdir(parents=True)
+    (workspaces_dir / "workspace").write_text("test")
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "memory").write_text("test")
+    
+    # Verify directories exist before undeploy
+    assert trace_dir.exists()
+    assert workspaces_dir.exists()
+    assert memory_dir.exists()
+    
+    # Mock destroy_container to simulate successful undeploy
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+    
+    with patch("tinyagentos.deployer.destroy_container") as mock_destroy:
+        mock_destroy.return_value = {"success": True}
+        
+        # Call undeploy with delete_state=True
+        result = await undeploy_agent(
+            agent_name,
+            data_dir=data_dir,
+            delete_state=True
+        )
+        
+        # Verify undeploy succeeded
+        assert result["success"] is True
+        assert result["name"] == agent_name
+        
+        # RED TEST EXPECTATION: Trace directory should be removed
+        # But current implementation will FAIL because it doesn't remove trace_dir
+        assert not trace_dir.exists(), f"Trace directory {trace_dir} should have been removed"
+        assert not workspaces_dir.exists(), "Workspaces directory should have been removed"
+        assert not memory_dir.exists(), "Memory directory should have been removed"
+        
+        # Verify destroy_container was called
+        mock_destroy.assert_called_once_with(f"taos-agent-{agent_name}")

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -24,6 +24,8 @@ class BrowserWorkerError(Exception):
 IDLE_TIMEOUT_S = 600
 
 BROWSER_SESSIONS_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA busy_timeout=5000;
 CREATE TABLE IF NOT EXISTS browser_sessions (
     id           TEXT PRIMARY KEY,
     owner_type   TEXT NOT NULL,

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -886,6 +886,11 @@ async def undeploy_agent(name: str, *, data_dir: Path | None = None, delete_stat
     result = await destroy_container(container_name)
     if delete_state and data_dir is not None:
         import shutil
+        # Delete the trace directory that was created for this agent
+        trace_dir = data_dir / "trace" / name
+        if trace_dir.exists():
+            shutil.rmtree(trace_dir, ignore_errors=True)
+        # Also delete workspaces and memory as before
         for sub in ("agent-workspaces", "agent-memory"):
             target = data_dir / sub / name
             if target.exists():

--- a/tinyagentos/otel/span_store.py
+++ b/tinyagentos/otel/span_store.py
@@ -202,21 +202,32 @@ class SpanStore:
 
 
 class SpanStoreRegistry:
-    """Opens and caches one SpanStore per agent slug."""
+    """Opens and caches one SpanStore per agent slug with bounded LRU eviction."""
 
-    def __init__(self, data_dir: Path):
+    def __init__(self, data_dir: Path, max_size: int = 100):
         self._data_dir = data_dir
         self._stores: dict[str, SpanStore] = {}
         self._lock = asyncio.Lock()
+        self._max_size = max_size
+        self._access_order: list[str] = []
 
     async def get(self, slug: str) -> SpanStore:
         safe = _safe_slug(slug)
         async with self._lock:
-            store = self._stores.get(safe)
-            if store is None:
-                store = SpanStore(self._data_dir, safe)
-                self._stores[safe] = store
-            return store
+            if safe not in self._stores:
+                # Evict LRU entries if we exceed max_size
+                while len(self._stores) >= self._max_size and self._stores:
+                    lru_key = self._access_order.pop(0)
+                    store_to_evict = self._stores.pop(lru_key, None)
+                    if store_to_evict:
+                        await store_to_evict.close()
+                self._stores[safe] = SpanStore(self._data_dir, safe)
+                self._access_order.append(safe)
+            else:
+                # Move to LRU to mark as recently used
+                self._access_order.remove(safe)
+                self._access_order.append(safe)
+            return self._stores[safe]
 
     async def close_all(self) -> None:
         async with self._lock:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Q2-7 proxy/runtime nits (span registry eviction, undeploy docstring vs code, browser_sessions pragmas)

Autonomous build of board card tsk-o5xq2m.



Files:
 changelog.d/tsk-o5xq2m-proxy-runtime-nits.md | 14 ++++++
 tests/test_browser_sessions_pragmas.py       | 58 +++++++++++++++++++++++
 tests/test_span_store_registry_eviction.py   | 50 ++++++++++++++++++++
 tests/test_undeploy_agent_trace_dir.py       | 69 ++++++++++++++++++++++++++++
 tinyagentos/browser_sessions.py              |  2 +
 tinyagentos/deployer.py                      |  5 ++
 tinyagentos/otel/span_store.py               | 25 +++++++---
 7 files changed, 216 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Undeploying an agent with state deletion enabled now also removes its trace data.
  - Browser session storage now uses improved SQLite locking and concurrency settings.
  - Span store caching is bounded and automatically evicts the least recently used entries.

- **Tests**
  - Added coverage for trace cleanup, browser session database settings, and cache eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


LEAD-MEASURED RED (lane omitted a commit body; @taOS-dev ran the three new tests on origin/dev with the fix absent, then on this head):
```
FAILED tests/test_browser_sessions_pragmas.py::test_browser_sessions_has_wal_and_busy_timeout
FAILED tests/test_span_store_registry_eviction.py::test_span_store_registry_evicts_lru
FAILED tests/test_undeploy_agent_trace_dir.py::test_undeploy_agent_removes_trace_dir
3 failed in 1.18s
```
```
3 passed in 0.82s
```
