### PR TITLE
[lib-audit] Q2-1 security hygiene sweep (compare_digest, 0600 writes, sync httpx, LIKE/column allowlist)

### DIFF
--- a/changelog.d/tsk-wc5fns-security-hygiene-sweep.md
+++ b/changelog.d/tsk-wc5fns-security-hygiene-sweep.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Q2-1 security hygiene sweep: `litellm_auth` and `routes/agents.py` now compare secrets with `secrets.compare_digest` instead of `==`; `OpenCodeServer.write_config` and its serve.log creation use `atomic_write_text(mode=0o600)` / `os.open(..., 0o600)` instead of `write_text` + `chmod`; `TorrentDownloader._params_from_torrent_url` is async and runs `httpx.get` in `asyncio.to_thread` so it no longer blocks the event loop; `KnowledgeStore.update_item` validates column names against a frozenset allowlist and raises on unknown; the `search_fts` LIKE fallback now escapes `%` and `_` with an `ESCAPE` clause.

--- a/tests/taosnet/test_torrent_downloader_taosnet.py
+++ b/tests/taosnet/test_torrent_downloader_taosnet.py
@@ -33,33 +33,38 @@ def test_session_has_dht_disabled(downloader):
     assert settings.get("enable_dht") is False
 
 
-def test_passkey_injected_as_private_tracker(downloader, tmp_path):
-    params = downloader._build_params(MAGNET, tmp_path, passkey="secretpasskey")
+@pytest.mark.asyncio
+async def test_passkey_injected_as_private_tracker(downloader, tmp_path):
+    params = await downloader._build_params(MAGNET, tmp_path, passkey="secretpasskey")
     trackers = [t if isinstance(t, str) else t.url for t in params.trackers]
     assert trackers == ["https://tracker.taos.my/secretpasskey/announce"]
 
 
-def test_web_seeds_added(downloader, tmp_path):
+@pytest.mark.asyncio
+async def test_web_seeds_added(downloader, tmp_path):
     seeds = ["https://huggingface.co/x/resolve/main/model.gguf"]
-    params = downloader._build_params(MAGNET, tmp_path, web_seeds=seeds)
+    params = await downloader._build_params(MAGNET, tmp_path, web_seeds=seeds)
     assert list(params.url_seeds) == seeds
 
 
-def test_no_passkey_leaves_trackers_empty(downloader, tmp_path):
-    params = downloader._build_params(MAGNET, tmp_path)
+@pytest.mark.asyncio
+async def test_no_passkey_leaves_trackers_empty(downloader, tmp_path):
+    params = await downloader._build_params(MAGNET, tmp_path)
     assert list(params.trackers) == []
 
 
-def test_unsupported_source_rejected(downloader, tmp_path):
+@pytest.mark.asyncio
+async def test_unsupported_source_rejected(downloader, tmp_path):
     with pytest.raises(TorrentError):
-        downloader._build_params("ftp://nope/file.torrent", tmp_path)
+        await downloader._build_params("ftp://nope/file.torrent", tmp_path)
 
 
-def test_torrent_url_fetch_parses_metadata(downloader, tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_torrent_url_fetch_parses_metadata(downloader, tmp_path, monkeypatch):
     import libtorrent as lt
 
     # Build a real .torrent for a small file, then serve its bytes via a
-    # monkeypatched httpx.get so _params_from_torrent_url can parse it.
+    # monkeypatched asyncio.to_thread so _params_from_torrent_url can parse it.
     data_file = tmp_path / "weights.bin"
     data_file.write_bytes(b"taosnet-test-weights" * 1024)
 
@@ -76,8 +81,9 @@ def test_torrent_url_fetch_parses_metadata(downloader, tmp_path, monkeypatch):
         def raise_for_status(self):
             return None
 
+    import asyncio
     monkeypatch.setattr(
-        "httpx.get", lambda *a, **k: _Resp(), raising=True
+        "asyncio.to_thread", lambda fn, *a, **k: _Resp(), raising=True
     )
-    params = downloader._params_from_torrent_url("https://taos.my/taosnet/x.torrent")
+    params = await downloader._params_from_torrent_url("https://taos.my/taosnet/x.torrent")
     assert str(params.ti.info_hash()) == expected_ih

--- a/tests/test_q2_1_security_sweep.py
+++ b/tests/test_q2_1_security_sweep.py
@@ -1,0 +1,310 @@
+"""RED tests for Q2-1 security hygiene sweep (tsk-wc5fns).
+
+Covers:
+  - litellm_auth: secrets.compare_digest for master-key comparison
+  - routes/agents.py: secrets.compare_digest for llm_key bearer match
+  - opencode_runtime: atomic_write_text(mode=0o600) for config; log file created
+    with mode 0o600 at open-time (no separate chmod)
+  - torrent_downloader: _params_from_torrent_url is async (no sync httpx on loop)
+  - knowledge_store: update_item rejects unknown columns; search_fts LIKE
+    fallback escapes % and _
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import pytest_asyncio
+from tinyagentos.knowledge_store import KnowledgeStore
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def knowledge_store(tmp_path):
+    s = KnowledgeStore(tmp_path / "knowledge.db", media_dir=tmp_path / "knowledge-media")
+    await s.init()
+    yield s
+    await s.close()
+
+
+async def _add_item(store, title="T", content="C", summary="S", author="A"):
+    return await store.add_item(
+        source_type="article",
+        source_url="https://example.com/1",
+        title=title,
+        author=author,
+        content=content,
+        summary=summary,
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. litellm_auth -- secrets.compare_digest for master key
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal request stand-in for _requested_model."""
+    def __init__(self, body: dict | None = None):
+        self._body = body or {}
+
+    async def json(self):
+        return self._body
+
+
+def _stub_litellm(monkeypatch):
+    """Inject a minimal litellm.proxy._types.UserAPIKeyAuth into sys.modules."""
+    class _UserAPIKeyAuth:
+        def __init__(self, **kw):
+            self.api_key = kw.get("api_key")
+            self.key_alias = kw.get("key_alias")
+            self.models = kw.get("models", [])
+            self.metadata = kw.get("metadata", {})
+
+    litellm = types.ModuleType("litellm")
+    proxy = types.ModuleType("litellm.proxy")
+    _types = types.ModuleType("litellm.proxy._types")
+    _types.UserAPIKeyAuth = _UserAPIKeyAuth
+    proxy._types = _types
+    litellm.proxy = proxy
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.proxy", proxy)
+    monkeypatch.setitem(sys.modules, "litellm.proxy._types", _types)
+
+
+@pytest.mark.asyncio
+async def test_litellm_auth_master_key_uses_compare_digest(monkeypatch):
+    """Master-key comparison must go through secrets.compare_digest."""
+    import secrets as secrets_mod
+
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "sk-master-123")
+    monkeypatch.delenv("TAOS_LITELLM_KEYSTORE", raising=False)
+    monkeypatch.delenv("TAOS_AGENT_BUDGETS", raising=False)
+
+    _stub_litellm(monkeypatch)
+
+    called = []
+    real = secrets_mod.compare_digest
+    def spy(a, b):
+        called.append((a, b))
+        return real(a, b)
+    monkeypatch.setattr(secrets_mod, "compare_digest", spy)
+
+    import tinyagentos.litellm_auth as auth
+    importlib.reload(auth)
+
+    result = await auth.user_api_key_auth(_FakeRequest(), "sk-master-123")
+    assert result is not None
+    assert called, "secrets.compare_digest was not called for master-key check"
+    assert called[0][0] == "sk-master-123"
+    assert called[0][1] == "sk-master-123"
+
+
+# ---------------------------------------------------------------------------
+# 2. routes/agents.py -- secrets.compare_digest for bearer token match
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self, agents):
+        self.agents = agents
+        self.config_path = "/dev/null"
+        self.backends = []
+
+
+class _FakeState:
+    def __init__(self, config):
+        self.config = config
+
+
+class _FakeApp:
+    def __init__(self, state):
+        self.state = state
+
+
+class _FakeBearerRequest:
+    """Request stub whose .headers behaves like a dict for .get()."""
+    def __init__(self, agents, token):
+        state = _FakeState(_FakeConfig(agents))
+        self.app = _FakeApp(state)
+        self.headers = {"authorization": f"Bearer {token}"}
+
+
+def test_resolve_agent_by_bearer_uses_compare_digest(monkeypatch):
+    """Bearer-token match must use secrets.compare_digest, not ==."""
+    import secrets as secrets_mod
+
+    called = []
+    real = secrets_mod.compare_digest
+    def spy(a, b):
+        called.append((a, b))
+        return real(a, b)
+    monkeypatch.setattr(secrets_mod, "compare_digest", spy)
+
+    from tinyagentos.routes.agents import _resolve_agent_by_bearer
+
+    agents = [
+        {"name": "alpha", "llm_key": "sk-agent-secret", "model": "gpt-4o"},
+        {"name": "beta", "llm_key": "sk-other-key", "model": "gpt-4o"},
+    ]
+    request = _FakeBearerRequest(agents, "sk-agent-secret")
+    agent = _resolve_agent_by_bearer(request)
+    assert agent is not None
+    assert agent["name"] == "alpha"
+    assert called, "secrets.compare_digest was not called for bearer match"
+    assert called[0][0] == "sk-agent-secret"
+    assert called[0][1] == "sk-agent-secret"
+
+
+# ---------------------------------------------------------------------------
+# 3. opencode_runtime -- write_config uses atomic_write_text(mode=0o600)
+# ---------------------------------------------------------------------------
+
+
+def _make_server_cfg(tmp_path, port=5900):
+    from tinyagentos.opencode_runtime import OpenCodeServerConfig
+    return OpenCodeServerConfig(
+        home=str(tmp_path),
+        port=port,
+        server_password=None,
+        litellm_base_url="http://127.0.0.1:4000/v1",
+        litellm_key="sk-test",
+        model_ids=["gpt-4o", "gpt-3.5-turbo"],
+    )
+
+
+def test_write_config_uses_atomic_write_text(tmp_path, monkeypatch):
+    """write_config must go through atomic_write_text with mode=0o600."""
+    import tinyagentos.opencode_runtime as ocr_mod
+    from tinyagentos.atomic_io import atomic_write_text as real_awt
+
+    calls = []
+
+    def spy(path, text, **kwargs):
+        calls.append((str(path), text, kwargs))
+        real_awt(path, text, **kwargs)
+
+    monkeypatch.setattr(ocr_mod, "atomic_write_text", spy, raising=False)
+
+    cfg = _make_server_cfg(tmp_path)
+    ocr_mod.OpenCodeServer(cfg).write_config()
+
+    assert calls, "atomic_write_text was not called by write_config"
+    assert calls[0][2].get("mode") == 0o600, \
+        f"expected mode=0o600, got {calls[0][2]}"
+
+
+# ---------------------------------------------------------------------------
+# 4. opencode_runtime -- serve.log created with mode 0o600 (no separate chmod)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.returncode = None
+        self.pid = 12345
+
+    async def wait(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_log_file_not_chmod_separately(tmp_path, monkeypatch):
+    """serve.log must be created with mode 0600 at open-time, not chmod'd."""
+    from tinyagentos.opencode_runtime import OpenCodeServer
+
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    chmod_targets = []
+    real_chmod = os.chmod
+
+    def spy_chmod(path, mode):
+        chmod_targets.append(str(path))
+        return real_chmod(path, mode)
+
+    monkeypatch.setattr(os, "chmod", spy_chmod)
+
+    async def fake_create_subprocess(*args, **kwargs):
+        return _FakeProcess()
+
+    async def fake_health(self_inner):
+        return True
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess)
+    monkeypatch.setattr(OpenCodeServer, "_health_check", fake_health)
+
+    await server.ensure_running(poll_s=0.0)
+
+    log_path = str(tmp_path / ".config" / "opencode" / "serve.log")
+    assert log_path not in chmod_targets, \
+        "serve.log should be created with mode at open-time, not chmod'd separately"
+    assert os.stat(log_path).st_mode & 0o777 == 0o600, \
+        f"expected 0o600, got {oct(os.stat(log_path).st_mode & 0o777)}"
+
+
+# ---------------------------------------------------------------------------
+# 5. torrent_downloader -- _params_from_torrent_url is async
+# ---------------------------------------------------------------------------
+
+
+def test_params_from_torrent_url_is_async():
+    """_params_from_torrent_url must be async so it never blocks the event loop."""
+    from tinyagentos.torrent_downloader import TorrentDownloader
+    assert asyncio.iscoroutinefunction(
+        TorrentDownloader._params_from_torrent_url
+    ), "_params_from_torrent_url must be async (was sync httpx.get on the loop)"
+
+
+# ---------------------------------------------------------------------------
+# 6. knowledge_store -- update_item rejects unknown columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_item_rejects_unknown_column(knowledge_store):
+    """update_item must reject column names not in the allowlist."""
+    item_id = await _add_item(knowledge_store)
+    with pytest.raises(ValueError, match="unknown column"):
+        await knowledge_store.update_item(item_id, evil_column="data")
+
+
+# ---------------------------------------------------------------------------
+# 7. knowledge_store -- LIKE fallback escapes % and _
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_fts_like_escapes_wildcards(knowledge_store):
+    """LIKE fallback must escape % and _ so they match literally."""
+    await _add_item(knowledge_store, title="100% Complete", content="c1")
+    await _add_item(knowledge_store, title="100 dollars", content="c2")
+
+    # Force the FTS MATCH path to fail so the LIKE fallback is exercised.
+    real_execute = knowledge_store._db.execute
+
+    async def failing_on_fts(sql, *args, **kwargs):
+        if "MATCH" in sql:
+            raise RuntimeError("forced FTS failure")
+        return await real_execute(sql, *args, **kwargs)
+
+    knowledge_store._db.execute = failing_on_fts
+
+    results = await knowledge_store.search_fts("100%")
+    # Before fix: LIKE '%100%%' treats % as wildcard, matching both rows.
+    # After fix:  LIKE '%100\%%' ESCAPE '\' matches only "100% Complete".
+    assert len(results) == 1
+    assert results[0]["title"] == "100% Complete"

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -70,6 +70,12 @@ CREATE TABLE IF NOT EXISTS agent_knowledge_subscriptions (
 );
 """
 
+_ALLOWED_UPDATE_FIELDS = frozenset({
+    "source_type", "source_url", "source_id", "title", "author", "summary",
+    "content", "media_path", "thumbnail", "categories", "tags", "metadata",
+    "status", "monitor", "updated_at", "user_id",
+})
+
 
 def _row_to_item(row: tuple) -> dict:
     return {
@@ -221,6 +227,8 @@ class KnowledgeStore(BaseStore):
         set_clauses = []
         params = []
         for k, v in fields.items():
+            if k not in _ALLOWED_UPDATE_FIELDS:
+                raise ValueError(f"unknown column: {k!r}")
             set_clauses.append(f"{k} = ?")
             params.append(json.dumps(v) if k in json_fields else v)
         set_clauses.append("updated_at = ?")
@@ -333,7 +341,7 @@ class KnowledgeStore(BaseStore):
                        content, media_path, thumbnail, categories, tags, metadata,
                        status, monitor, created_at, updated_at, user_id
                 FROM knowledge_items
-                WHERE (title LIKE ? OR content LIKE ? OR summary LIKE ?) AND user_id = ?
+                WHERE (title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\') AND user_id = ?
                 ORDER BY created_at DESC LIMIT ?
             """
         else:
@@ -355,7 +363,7 @@ class KnowledgeStore(BaseStore):
                        content, media_path, thumbnail, categories, tags, metadata,
                        status, monitor, created_at, updated_at, user_id
                 FROM knowledge_items
-                WHERE title LIKE ? OR content LIKE ? OR summary LIKE ?
+                WHERE title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\' OR summary LIKE ? ESCAPE '\\'
                 ORDER BY created_at DESC LIMIT ?
             """
         try:
@@ -363,7 +371,8 @@ class KnowledgeStore(BaseStore):
             rows = await cursor.fetchall()
         except Exception:
             # Fallback to LIKE when FTS query syntax is invalid
-            pattern = f"%{query}%"
+            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            pattern = f"%{escaped}%"
             cursor = await self._db.execute(fallback_sql, fallback_params_fn(pattern))
             rows = await cursor.fetchall()
         return [_row_to_item(r) for r in rows]

--- a/tinyagentos/litellm_auth.py
+++ b/tinyagentos/litellm_auth.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +88,7 @@ async def user_api_key_auth(request, api_key: str):
     from litellm.proxy._types import UserAPIKeyAuth
 
     master = os.environ.get("LITELLM_MASTER_KEY")
-    if master and api_key == master:
-        # Admin / proxy operations: full access.
+    if master and secrets.compare_digest(api_key, master):
         return UserAPIKeyAuth(api_key=api_key)
 
     store = _keystore()

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -23,6 +23,7 @@ from typing import Callable
 import httpx
 
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.atomic_io import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -190,13 +191,7 @@ class OpenCodeServer:
             },
         }
         config_path = config_dir / "opencode.json"
-        config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        # The config embeds the agent's LiteLLM key in plaintext — keep it
-        # owner-only (mirrors install_hermes.sh's chmod 600 on ~/.hermes/.env).
-        try:
-            os.chmod(config_path, 0o600)
-        except OSError:
-            logger.debug("opencode_runtime: could not chmod %s", config_path)
+        atomic_write_text(config_path, json.dumps(payload, indent=2), mode=0o600)
         logger.debug("opencode_runtime: wrote config to %s", config_path)
 
     # ---------------------------------------------------------------- lifecycle
@@ -244,13 +239,11 @@ class OpenCodeServer:
 
         # Redirect output to a log file rather than PIPE: a long-lived server
         # with an unread PIPE deadlocks once the OS buffer fills, and we still
-        # want the serve logs for diagnosing the host taOS agent.
+        # want the serve logs for diagnosing the host taOS agent. Create it
+        # with mode 0600 at open time (no TOCTOU window).
         log_path = Path(self._cfg.home) / ".config" / "opencode" / "serve.log"
-        self._log_fh = open(log_path, "ab")
-        try:
-            os.chmod(log_path, 0o600)
-        except OSError:
-            pass
+        fd = os.open(log_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        self._log_fh = os.fdopen(fd, "ab")
 
         # Resolve the bare "opencode" default past the PATH gap described in
         # OpenCodeBinaryNotFoundError; an explicit binary override (tests, or

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import math
+import secrets
 import time
 from collections import OrderedDict
 
@@ -208,7 +209,14 @@ def _resolve_agent_by_bearer(request: Request) -> dict | None:
     if not token:
         return None
     config = request.app.state.config
-    return next((a for a in config.agents if a.get("llm_key") == token), None)
+    return next(
+        (
+            a for a in config.agents
+            if a.get("llm_key") is not None
+            and secrets.compare_digest(a["llm_key"], token)
+        ),
+        None,
+    )
 
 
 @router.get("/api/agents/me/models")

--- a/tinyagentos/torrent_downloader.py
+++ b/tinyagentos/torrent_downloader.py
@@ -184,20 +184,22 @@ class TorrentDownloader:
     def get_task(self, task_id: str) -> Optional[TorrentTask]:
         return self._tasks.get(task_id)
 
-    def _params_from_torrent_url(self, url: str):
+    async def _params_from_torrent_url(self, url: str):
         """Fetch a .torrent over HTTP (the public taOSnet metadata path) and
         build add_torrent_params from it. Used when a manifest supplies a
         ``torrent_url`` instead of a magnet."""
         import httpx
 
-        resp = httpx.get(url, timeout=30.0, follow_redirects=True)
+        resp = await asyncio.to_thread(
+            httpx.get, url, timeout=30.0, follow_redirects=True
+        )
         resp.raise_for_status()
         ti = lt.torrent_info(lt.bdecode(resp.content))
         params = lt.add_torrent_params()
         params.ti = ti
         return params
 
-    def _build_params(
+    async def _build_params(
         self,
         magnet_or_torrent: str,
         save_dir: Path,
@@ -214,7 +216,7 @@ class TorrentDownloader:
         if magnet_or_torrent.startswith("magnet:"):
             params = lt.parse_magnet_uri(magnet_or_torrent)
         elif magnet_or_torrent.startswith(("http://", "https://")):
-            params = self._params_from_torrent_url(magnet_or_torrent)
+            params = await self._params_from_torrent_url(magnet_or_torrent)
         else:
             raise TorrentError(
                 f"unsupported torrent source: {magnet_or_torrent[:40]!r}"
@@ -263,7 +265,7 @@ class TorrentDownloader:
         )
         self._tasks[task_id] = task
 
-        params = self._build_params(magnet_or_torrent, dest.parent, passkey, web_seeds)
+        params = await self._build_params(magnet_or_torrent, dest.parent, passkey, web_seeds)
         handle = self._session.add_torrent(params)
         self._handles[task_id] = handle
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Q2-1 security hygiene sweep (compare_digest, 0600 writes, sync httpx, LIKE/column allowlist)

Autonomous build of board card tsk-wc5fns.

secrets.compare_digest for secret comparisons, mode-0o600 at file
creation (atomic_write_text / os.open) instead of write+chmod, async
httpx via asyncio.to_thread to avoid blocking the event loop, column
allowlist in KnowledgeStore.update_item, and LIKE ESCAPE for % and _
wildcards in the search fallback.

RED (before fix):
```
$ uv run --group dev pytest tests/test_q2_1_security_sweep.py -v --timeout=30
... FAILED tests/test_q2_1_security_sweep.py::test_litellm_auth_master_key_uses_compare_digest
... FAILED tests/test_q2_1_security_sweep.py::test_resolve_agent_by_bearer_uses_compare_digest
... FAILED tests/test_q2_1_security_sweep.py::test_write_config_uses_atomic_write_text
... FAILED tests/test_q2_1_security_sweep.py::test_ensure_running_log_file_not_chmod_separately
... FAILED tests/test_q2_1_security_sweep.py::test_params_from_torrent_url_is_async
... FAILED tests/test_q2_1_security_sweep.py::test_update_item_rejects_unknown_column
... FAILED tests/test_q2_1_security_sweep.py::test_search_fts_like_escapes_wildcards
========================= 7 failed in 0.50s =========================
```

GREEN (after fix):
```
$ uv run --group dev pytest tests/test_q2_1_security_sweep.py -v --timeout=30
... PASSED tests/test_q2_1_security_sweep.py::test_litellm_auth_master_key_uses_compare_digest
... PASSED tests/test_q2_1_security_sweep.py::test_resolve_agent_by_bearer_uses_compare_digest
... PASSED tests/test_q2_1_security_sweep.py::test_write_config_uses_atomic_write_text
... PASSED tests/test_q2_1_security_sweep.py::test_ensure_running_log_file_not_chmod_separately
... PASSED tests/test_q2_1_security_sweep.py::test_params_from_torrent_url_is_async
... PASSED tests/test_q2_1_security_sweep.py::test_update_item_rejects_unknown_column
... PASSED tests/test_q2_1_security_sweep.py::test_search_fts_like_escapes_wildcards
========================= 7 passed in 0.48s =========================
```

Docs-Reviewed: routes/agents.py bearer llm_key comparison hardened to
secrets.compare_digest (constant-time); no route added, removed, or
modified, so agent-coordination.md needs no change.

Files:
 tests/taosnet/test_torrent_downloader_taosnet.py |  30 ++-
 tests/test_q2_1_security_sweep.py                | 310 +++++++++++++++++++++++
 tinyagentos/knowledge_store.py                   |  15 +-
 tinyagentos/litellm_auth.py                      |   4 +-
 tinyagentos/opencode_runtime.py                  |  19 +-
 tinyagentos/routes/agents.py                     |  10 +-
 tinyagentos/torrent_downloader.py                |  12 +-
 8 files changed, 367 insertions(+), 36 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved protection for authentication credentials and bearer tokens through safer comparisons.
  - Configurations and server logs are now written with restricted file permissions and safer file handling.
  - Database updates reject unknown fields to prevent unintended changes.

- **Bug Fixes**
  - Search now treats `%`, `_`, and backslashes as literal characters in fallback searches.
  - Torrent downloads perform network fetching without blocking the main application flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->