### PR TITLE
[lib-audit] R2-14 source-type and GitHub URL resolution match hostnames anywhere in the URL; Bearer None

### DIFF
--- a/changelog.d/tsk-h5ceua-source-type-hostname.md
+++ b/changelog.d/tsk-h5ceua-source-type-hostname.md
@@ -1,0 +1,2 @@
+### Fixed
+- Knowledge source resolution (R2-14): `resolve_source_type` now keys platform detection off the URL hostname (exact or a subdomain) via `urlsplit()`, so a platform name in a query string or foreign path (`evil.com/?x=youtu.be/abc`) can no longer spoof a classification; `parse_github_url` rejects non-`github.com` hosts; the GitHub fetcher omits the `Authorization` header when no token is configured (no more `Bearer None`); and 403/429 responses with `Retry-After` or `X-RateLimit-Reset` are honoured with a single retry.

--- a/tests/test_knowledge_fetcher_github.py
+++ b/tests/test_knowledge_fetcher_github.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from tinyagentos.knowledge_fetchers.github import (
+    _auth_headers,
     extract_metadata,
     fetch_issue,
     fetch_releases,
@@ -87,6 +90,28 @@ class TestParseGithubUrlReleases:
         )
         assert ctype == "release"
         assert number is None
+
+
+class TestParseGithubUrlHostCheck:
+    """R2-14: parse_github_url must only accept github.com hosts."""
+
+    def test_rejects_non_github_host(self):
+        with pytest.raises(ValueError):
+            parse_github_url("https://gitlab.com/owner/repo")
+
+    def test_rejects_non_github_host_with_path(self):
+        with pytest.raises(ValueError):
+            parse_github_url("https://gitlab.com/owner/repo/issues/123")
+
+    def test_still_accepts_www_github(self):
+        assert parse_github_url("https://www.github.com/owner/repo") == (
+            "owner", "repo", "repo", None,
+        )
+
+    def test_still_accepts_no_scheme(self):
+        assert parse_github_url("github.com/owner/repo") == (
+            "owner", "repo", "repo", None,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -429,3 +454,95 @@ class TestExtractMetadata:
         data = [{"tag": "v1.0"}, {"tag": "v0.9"}]
         result = extract_metadata(data, "releases")
         assert result["release_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# R2-14: _auth_headers must not emit "Authorization: Bearer None"
+# ---------------------------------------------------------------------------
+
+def test_auth_headers_omits_authorization_when_no_token():
+    """A missing or empty token must drop the Authorization header entirely,
+    otherwise every GitHub fetch without a token fails server-side."""
+    headers = _auth_headers(None)
+    assert "Authorization" not in headers
+    headers = _auth_headers("")
+    assert "Authorization" not in headers
+
+
+def test_auth_headers_includes_authorization_with_token():
+    headers = _auth_headers("tok123")
+    assert headers["Authorization"] == "Bearer tok123"
+
+
+# ---------------------------------------------------------------------------
+# R2-14: honour Retry-After / X-RateLimit-Reset once
+# ---------------------------------------------------------------------------
+
+_RELEASE_BODY = [
+    {
+        "tag_name": "v1.0.0",
+        "name": "v1.0.0",
+        "body": "release notes",
+        "author": {"login": "alice"},
+        "published_at": "2026-01-01T00:00:00Z",
+        "assets": [],
+        "prerelease": False,
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_honours_retry_after():
+    """A 403 carrying Retry-After is retried once; the delay is honoured and the
+    second response is returned."""
+    attempts = {"n": 0}
+
+    def handler(request):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return httpx.Response(403, headers={"Retry-After": "2"}, text="rate limited")
+        return httpx.Response(200, json=_RELEASE_BODY)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        with patch(
+            "tinyagentos.knowledge_fetchers.github.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep:
+            result = await fetch_releases("owner", "repo", "token", client, limit=10)
+            mock_sleep.assert_awaited_once_with(2)
+        assert attempts["n"] == 2
+        assert len(result) == 1
+        assert result[0]["tag"] == "v1.0.0"
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fetch_releases_honours_rate_limit_reset():
+    """A 403 carrying X-RateLimit-Reset is also retried once."""
+    attempts = {"n": 0}
+    reset_ts = str(int(time.time()) + 3)
+
+    def handler(request):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return httpx.Response(
+                403, headers={"X-RateLimit-Reset": reset_ts}, text="rate limited"
+            )
+        return httpx.Response(200, json=_RELEASE_BODY)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        with patch(
+            "tinyagentos.knowledge_fetchers.github.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep:
+            result = await fetch_releases("owner", "repo", "token", client, limit=10)
+            mock_sleep.assert_awaited_once()
+        assert attempts["n"] == 2
+        assert len(result) == 1
+    finally:
+        await client.aclose()

--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -29,6 +29,14 @@ def test_resolve_github():
     assert resolve_source_type("https://github.com/org/repo/issues/1") == "github"
 
 
+def test_resolve_spoofed_query_param_not_platform():
+    """R2-14: a platform name inside a query string or a foreign path must not
+    be matched. Resolution keys off the URL hostname, not a substring scan, so a
+    hostile URL cannot be misclassified as a known platform."""
+    assert resolve_source_type("https://evil.com/?x=youtu.be/abc") == "article"
+    assert resolve_source_type("https://evil.com/x/github.com/owner/repo") == "article"
+
+
 def test_resolve_article_fallback():
     assert resolve_source_type("https://news.ycombinator.com/item?id=123") == "article"
     assert resolve_source_type("https://blog.example.com/some-post") == "article"

--- a/tinyagentos/knowledge_fetchers/github.py
+++ b/tinyagentos/knowledge_fetchers/github.py
@@ -5,9 +5,13 @@ and notifications from the GitHub API.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
-import re
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     import httpx
@@ -22,8 +26,74 @@ _HEADERS_BASE = {
 }
 
 
-def _auth_headers(token: str) -> dict:
-    return {**_HEADERS_BASE, "Authorization": f"Bearer {token}"}
+def _auth_headers(token: str | None) -> dict:
+    """Build request headers, omitting Authorization when no token is set.
+
+    Emitting ``Authorization: Bearer None`` (the pre-fix behaviour) makes every
+    unauthenticated GitHub call fail server-side, so the header is only added
+    when a real token is present.
+    """
+    headers = dict(_HEADERS_BASE)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _retry_delay(resp: "httpx.Response") -> float | None:
+    """Return a retry delay (seconds) from Retry-After / X-RateLimit-Reset.
+
+    ``Retry-After`` may be delta-seconds or an HTTP-date; ``X-RateLimit-Reset``
+    is an epoch-second timestamp. Returns ``None`` when neither header is
+    present or parseable, so the caller only retries when GitHub asks it to.
+    """
+    ra = resp.headers.get("Retry-After")
+    if ra:
+        try:
+            return max(0.0, float(ra))
+        except ValueError:
+            pass
+        try:
+            dt = parsedate_to_datetime(ra)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+        except (ValueError, TypeError, OverflowError):
+            return None
+    reset = resp.headers.get("X-RateLimit-Reset")
+    if reset:
+        try:
+            return max(0.0, float(reset) - time.time())
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+async def _get_with_rate_limit_retry(
+    http_client: "httpx.AsyncClient",
+    url: str,
+    *,
+    headers: dict,
+    **kwargs,
+) -> "httpx.Response":
+    """GET ``url``, honouring Retry-After / X-RateLimit-Reset once on 403/429.
+
+    The caller still owns ``raise_for_status``, so non-rate-limit error handling
+    is unchanged. Only a single retry is performed (GitHub may send a reset far
+    in the future, which we do not want to block on indefinitely).
+    """
+    resp = await http_client.get(url, headers=headers, timeout=30, **kwargs)
+    if resp.status_code in (403, 429):
+        delay = _retry_delay(resp)
+        if delay is not None:
+            logger.warning(
+                "GitHub rate-limited on %s (status %s), retrying after %.1fs",
+                url,
+                resp.status_code,
+                delay,
+            )
+            await asyncio.sleep(delay)
+            resp = await http_client.get(url, headers=headers, timeout=30, **kwargs)
+    return resp
 
 
 # ---------------------------------------------------------------------------
@@ -49,14 +119,21 @@ def parse_github_url(url: str) -> tuple[str, str, str, int | None]:
     >>> parse_github_url("https://github.com/owner/repo/releases")
     ('owner', 'repo', 'releases', None)
     """
-    # Strip scheme and optional www
-    url = re.sub(r"^https?://", "", url)
-    url = re.sub(r"^www\.", "", url)
-    url = re.sub(r"^github\.com/", "", url, count=1)
-    # Remove trailing slashes / query / fragment
-    url = url.split("?")[0].split("#")[0].rstrip("/")
+    # Normalise scheme so urlsplit() can recover the hostname, then require the
+    # host to be github.com. A foreign host (e.g. gitlab.com) must not be
+    # mis-parsed as a GitHub owner/repo -- the old regex stripped a literal
+    # "github.com/" prefix and silently treated any host as GitHub.
+    if "://" not in url:
+        url = "https://" + url
+    parsed = urlsplit(url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname not in ("github.com", "www.github.com"):
+        raise ValueError(f"Not a GitHub URL: {url!r}")
 
-    parts = url.split("/")
+    # Work from the path only; urlsplit() already separates query/fragment.
+    path = parsed.path.lstrip("/")
+    path = path.rstrip("/")
+    parts = path.split("/")
     if len(parts) < 2:
         raise ValueError(f"Cannot parse GitHub URL: {url!r}")
 
@@ -102,7 +179,7 @@ def parse_github_url(url: str) -> tuple[str, str, str, int | None]:
 async def fetch_repo(
     owner: str,
     repo: str,
-    token: str,
+    token: str | None,
     http_client: "httpx.AsyncClient",
 ) -> dict:
     """Fetch repo metadata and README from the GitHub API.
@@ -112,10 +189,10 @@ async def fetch_repo(
     """
     headers = _auth_headers(token)
 
-    meta_resp = await http_client.get(
+    meta_resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/repos/{owner}/{repo}",
         headers=headers,
-        timeout=30,
     )
     meta_resp.raise_for_status()
     meta = meta_resp.json()
@@ -123,10 +200,10 @@ async def fetch_repo(
     readme_content = ""
     try:
         readme_headers = {**headers, "Accept": "application/vnd.github.raw"}
-        readme_resp = await http_client.get(
+        readme_resp = await _get_with_rate_limit_retry(
+            http_client,
             f"{_GH_API}/repos/{owner}/{repo}/readme",
             headers=readme_headers,
-            timeout=30,
         )
         if readme_resp.status_code == 200:
             readme_content = readme_resp.text
@@ -159,7 +236,7 @@ async def fetch_issue(
     owner: str,
     repo: str,
     number: int,
-    token: str,
+    token: str | None,
     http_client: "httpx.AsyncClient",
 ) -> dict:
     """Fetch an issue (or PR) and its comments from the GitHub API.
@@ -169,18 +246,18 @@ async def fetch_issue(
     """
     headers = _auth_headers(token)
 
-    issue_resp = await http_client.get(
+    issue_resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/repos/{owner}/{repo}/issues/{number}",
         headers=headers,
-        timeout=30,
     )
     issue_resp.raise_for_status()
     issue = issue_resp.json()
 
-    comments_resp = await http_client.get(
+    comments_resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/repos/{owner}/{repo}/issues/{number}/comments",
         headers=headers,
-        timeout=30,
     )
     comments_resp.raise_for_status()
     raw_comments = comments_resp.json()
@@ -216,7 +293,7 @@ async def fetch_issue(
 async def fetch_releases(
     owner: str,
     repo: str,
-    token: str,
+    token: str | None,
     http_client: "httpx.AsyncClient",
     limit: int = 10,
 ) -> list[dict]:
@@ -227,11 +304,11 @@ async def fetch_releases(
     """
     headers = _auth_headers(token)
 
-    resp = await http_client.get(
+    resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/repos/{owner}/{repo}/releases",
         headers=headers,
         params={"per_page": limit},
-        timeout=30,
     )
     resp.raise_for_status()
     raw = resp.json()
@@ -265,7 +342,7 @@ async def fetch_releases(
 # ---------------------------------------------------------------------------
 
 async def fetch_starred(
-    token: str,
+    token: str | None,
     http_client: "httpx.AsyncClient",
     page: int = 1,
 ) -> tuple[list[dict], bool]:
@@ -275,11 +352,11 @@ async def fetch_starred(
     """
     headers = _auth_headers(token)
 
-    resp = await http_client.get(
+    resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/user/starred",
         headers=headers,
         params={"per_page": 30, "page": page},
-        timeout=30,
     )
     resp.raise_for_status()
     raw = resp.json()
@@ -310,7 +387,7 @@ async def fetch_starred(
 # ---------------------------------------------------------------------------
 
 async def fetch_notifications(
-    token: str,
+    token: str | None,
     http_client: "httpx.AsyncClient",
 ) -> list[dict]:
     """Fetch unread notifications for the authenticated user.
@@ -319,10 +396,10 @@ async def fetch_notifications(
     """
     headers = _auth_headers(token)
 
-    resp = await http_client.get(
+    resp = await _get_with_rate_limit_retry(
+        http_client,
         f"{_GH_API}/notifications",
         headers=headers,
-        timeout=30,
     )
     resp.raise_for_status()
     raw = resp.json()

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     import httpx
@@ -40,15 +41,24 @@ def resolve_source_type(url: str) -> str:
     """Identify the content platform from a URL.
 
     Returns one of: reddit, youtube, x, github, article.
+
+    Matching keys off the URL *hostname* (exact or a subdomain of the
+    platform) so a platform name appearing in a query string or a foreign
+    path cannot spoof a different source type.
     """
-    url_lower = url.lower()
-    if re.search(r"(^|[./])reddit\.com/", url_lower):
+    hostname = (urlsplit(url).hostname or "").lower()
+    if hostname == "reddit.com" or hostname.endswith(".reddit.com"):
         return "reddit"
-    if re.search(r"(^|[./])youtube\.com/watch|youtu\.be/", url_lower):
+    if hostname == "youtube.com" or hostname.endswith(".youtube.com") or hostname == "youtu.be":
         return "youtube"
-    if re.search(r"(^|[./])(x\.com|twitter\.com)/", url_lower):
+    if (
+        hostname == "x.com"
+        or hostname.endswith(".x.com")
+        or hostname == "twitter.com"
+        or hostname.endswith(".twitter.com")
+    ):
         return "x"
-    if re.search(r"(^|[./])github\.com/", url_lower):
+    if hostname == "github.com" or hostname == "www.github.com":
         return "github"
     return "article"
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-14 source-type and GitHub URL resolution match hostnames anywhere in the URL; Bearer None

Autonomous build of board card tsk-h5ceua.

resolve_source_type and parse_github_url matched platform names as
substrings anywhere in the URL, so a hostile URL could be misclassified:
evil.com/?x=youtu.be/abc resolved as youtube, and gitlab.com/owner/repo
resolved as a GitHub owner/repo. _auth_headers(None) also emitted
"Authorization: Bearer None", which failed every token-less GitHub fetch,
and 403/429 responses carrying Retry-After or X-RateLimit-Reset were never
honoured.

Fix: resolve_source_type and parse_github_url key off urlsplit().hostname
(exact or a subdomain of the platform); _auth_headers omits the
Authorization header entirely when no token is set; fetch functions now
retry once on 403/429 when Retry-After (delta-seconds or HTTP-date) or
X-RateLimit-Reset (epoch) is present.

RED run (tests written, source fix not yet applied; origin/dev code with
only the new tests checked in):
```
FAILED tests/test_knowledge_ingest.py::test_resolve_spoofed_query_param_not_platform
FAILED tests/test_knowledge_fetcher_github.py::TestParseGithubUrlHostCheck::test_rejects_non_github_host
FAILED tests/test_knowledge_fetcher_github.py::TestParseGithubUrlHostCheck::test_rejects_non_github_host_with_path
FAILED tests/test_knowledge_fetcher_github.py::test_auth_headers_omits_authorization_when_no_token
FAILED tests/test_knowledge_fetcher_github.py::test_fetch_releases_honours_retry_after
FAILED tests/test_knowledge_fetcher_github.py::test_fetch_releases_honours_rate_limit_reset
6 failed, 27 passed in 1.75s
```

Green run (after fix):
```
33 passed in 0.64s
```

R2-14 source: tinyagentos/knowledge_ingest.py:46 resolve_source_type;
tinyagentos/knowledge_fetchers/github.py:31 _auth_headers;
github.py:91 parse_github_url; github.py:254 _get_with_rate_limit_retry.

Files:
 changelog.d/tsk-h5ceua-source-type-hostname.md |   2 +
 tests/test_knowledge_fetcher_github.py         | 117 +++++++++++++++++++++
 tests/test_knowledge_ingest.py                 |   8 ++
 tinyagentos/knowledge_fetchers/github.py       | 137 +++++++++++++++++++------
 tinyagentos/knowledge_ingest.py                |  20 +++-
 5 files changed, 249 insertions(+), 35 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform detection so URLs are classified by their actual hostname, preventing misleading query strings or paths from causing incorrect classifications.
  - GitHub URLs are now validated against supported GitHub domains.
  - GitHub requests work without authentication tokens and no longer send invalid authorization headers.
  - GitHub data retrieval now retries rate-limited requests using the server-provided delay, improving reliability when responses are temporarily limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->