### PR TITLE
fix-forward #2846 (tsk-p7elu6): add the RED test the card's ACCEPTANCE demands (trace_store.list() leak); fenced red run in the body

### DIFF
--- a/changelog.d/tsk-p7elu6-trace-store-leak-fix.md
+++ b/changelog.d/tsk-p7elu6-trace-store-leak-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+Fixed trace_store.list() connection leak by opening read-only connections for listing and closing them after use instead of caching them. This prevents opening a connection and thread per bucket for every bucket touched during list operations.

--- a/tests/test_trace_store.py
+++ b/tests/test_trace_store.py
@@ -22,6 +22,7 @@ from tinyagentos.trace_store import (
     VALID_KINDS,
     SCHEMA_VERSION,
     SEAL_AGE_SECONDS,
+    TRACE_SCHEMA,
 )
 
 
@@ -549,6 +550,48 @@ async def test_list_dedup_by_id_primary_wins(tmp_path):
     if isinstance(payload, str):
         payload = json.loads(payload)
     assert payload.get("source") == "db", "DB version should win over late version"
+
+
+@pytest.mark.asyncio
+async def test_list_does_not_leak_connections_or_threads(tmp_path):
+    """list() must not leave open connections or threads behind."""
+    import sqlite3
+    import threading
+    store = AgentTraceStore(tmp_path, "agent-leak")
+
+    for i in range(20):
+        ts = _ts(hour=i)
+        bucket = _bucket_key(ts)
+        db_path = _bucket_db_path(tmp_path, "agent-leak", bucket)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(TRACE_SCHEMA)
+        conn.execute(
+            "INSERT INTO trace_events (id, v, created_at, agent_name, kind, payload) VALUES (?, ?, ?, ?, ?, ?)",
+            (f"id-{i}", 1, ts, "agent-leak", "lifecycle", '{"event":"test"}'),
+        )
+        conn.commit()
+        conn.close()
+
+    before_threads = threading.active_count()
+    before_conns = len(store._connections)
+
+    await store.list()
+    after_first_threads = threading.active_count()
+    after_first_conns = len(store._connections)
+
+    await store.list()
+    after_second_threads = threading.active_count()
+    after_second_conns = len(store._connections)
+
+    assert after_second_conns == before_conns, (
+        f"open connections leaked: {after_second_conns} (before {before_conns})"
+    )
+    assert after_second_threads <= before_threads + 1, (
+        f"threads leaked: {after_second_threads} (before {before_threads})"
+    )
+
+    await store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/trace_store.py
+++ b/tinyagentos/trace_store.py
@@ -219,10 +219,13 @@ class AgentTraceStore:
         """Inject the reasoning judge.  None disables judging."""
         self._judge = judge
 
-    async def _open_bucket(self, bucket: str) -> aiosqlite.Connection:
-        conn = self._connections.get(bucket)
-        if conn is not None:
-            return conn
+    async def _open_bucket(self, bucket: str, *, read_only: bool = False) -> aiosqlite.Connection:
+        # Only cache non-read-only connections (write connections)
+        if not read_only:
+            conn = self._connections.get(bucket)
+            if conn is not None:
+                return conn
+        
         trace_dir = _agent_trace_dir(self._data_dir, self._slug)
         trace_dir.mkdir(parents=True, exist_ok=True)
         try:
@@ -230,11 +233,16 @@ class AgentTraceStore:
         except OSError:
             pass
         db_path = _bucket_db_path(self._data_dir, self._slug, bucket)
-        conn = await aiosqlite.connect(str(db_path))
+        # Open read-only connection if requested
+        if read_only:
+            conn = await aiosqlite.connect(str(db_path), mode='ro')
+        else:
+            conn = await aiosqlite.connect(str(db_path))
         await apply_wal_pragmas_async(conn)
         await conn.executescript(TRACE_SCHEMA)
         await conn.commit()
-        self._connections[bucket] = conn
+        if not read_only:
+            self._connections[bucket] = conn
         return conn
 
     async def _evict_old_buckets(self, current_bucket: str) -> None:
@@ -437,38 +445,42 @@ class AgentTraceStore:
                 if not _bucket_overlaps(bucket, since, until):
                     continue
                 try:
-                    conn = await self._open_bucket(bucket)
-                    clauses = []
-                    params: list[Any] = []
-                    if kind is not None:
-                        clauses.append("kind = ?"); params.append(kind)
-                    if channel_id is not None:
-                        clauses.append("channel_id = ?"); params.append(channel_id)
-                    if trace_id is not None:
-                        clauses.append("trace_id = ?"); params.append(trace_id)
-                    if since is not None:
-                        clauses.append("created_at >= ?"); params.append(since)
-                    if until is not None:
-                        clauses.append("created_at <= ?"); params.append(until)
-                    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-                    sql = f"SELECT * FROM trace_events{where} ORDER BY created_at DESC LIMIT ?"
-                    params.append(limit)
-                    cur = await conn.execute(sql, params)
-                    rows = await cur.fetchall()
-                    cols = [d[0] for d in cur.description]
-                    await cur.close()
-                    for r in rows:
-                        ev = dict(zip(cols, r))
-                        try:
-                            ev["payload"] = json.loads(ev.get("payload") or "{}")
-                        except Exception:
-                            pass
-                        ev_id = ev.get("id")
-                        if ev_id and ev_id in seen_ids:
-                            continue
-                        if ev_id:
-                            seen_ids.add(ev_id)
-                        merged.append(ev)
+                    # Open read-only connection for listing, close after use
+                    conn = await aiosqlite.connect(f"file:{_bucket_db_path(self._data_dir, self._slug, bucket)}?mode=ro", uri=True)
+                    try:
+                        clauses = []
+                        params: list[Any] = []
+                        if kind is not None:
+                            clauses.append("kind = ?"); params.append(kind)
+                        if channel_id is not None:
+                            clauses.append("channel_id = ?"); params.append(channel_id)
+                        if trace_id is not None:
+                            clauses.append("trace_id = ?"); params.append(trace_id)
+                        if since is not None:
+                            clauses.append("created_at >= ?"); params.append(since)
+                        if until is not None:
+                            clauses.append("created_at <= ?"); params.append(until)
+                        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+                        sql = f"SELECT * FROM trace_events{where} ORDER BY created_at DESC LIMIT ?"
+                        params.append(limit)
+                        cur = await conn.execute(sql, params)
+                        rows = await cur.fetchall()
+                        cols = [d[0] for d in cur.description]
+                        await cur.close()
+                        for r in rows:
+                            ev = dict(zip(cols, r))
+                            try:
+                                ev["payload"] = json.loads(ev.get("payload") or "{}")
+                            except Exception:
+                                pass
+                            ev_id = ev.get("id")
+                            if ev_id and ev_id in seen_ids:
+                                continue
+                            if ev_id:
+                                seen_ids.add(ev_id)
+                            merged.append(ev)
+                    finally:
+                        await conn.close()
                 except Exception as exc:
                     logger.warning("trace_store: list() bucket %s skipped: %s", bucket, exc)
                 if len(merged) >= limit * 4:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2846 (tsk-p7elu6): add the RED test the card's ACCEPTANCE demands (trace_store.list() leak); fenced red run in the body

Autonomous build of board card tsk-p6hemb.

REVISION: built on `exec/tsk-p7elu6` (cut at `3aeb75d4567b0ff51b2962201e6a39a9019170ab`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Keep the fix from exec/tsk-p7elu6, add the proof the card demands.

RED-FIRST on origin/dev (fix absent):

```
tests/test_trace_store.py::test_list_does_not_leak_connections_or_threads FAILED [100%]

=================================== FAILURES ===================================
________________ test_list_does_not_leak_connections_or_threads ________________

tmp_path = PosixPath('/tmp/exec-tsk-p6hemb.tmp/pytest-of-jay/pytest-45/test_list_does_not_leak_connec0')

    @pytest.mark.asyncio
    async def test_list_does_not_leak_connections_or_threads(tmp_path):
        """list() must not leave open connections or threads behind."""
        import sqlite3
        import threading
        store = AgentTraceStore(tmp_path, "agent-leak")

        for i in range(20):
            ts = _ts(hour=i)
            bucket = _bucket_key(ts)
            db_path = _bucket_db_path(tmp_path, "agent-leak", bucket)
            db_path.parent.mkdir(parents=True, exist_ok=True)
            conn = sqlite3.connect(str(db_path))
            conn.executescript(TRACE_SCHEMA)
            conn.execute(
                "INSERT INTO trace_events (id, v, created_at, agent_name, kind, payload) VALUES (?, ?, ?, ?, ?, ?)",
                (f"id-{i}", 1, ts, "agent-leak", "lifecycle", '{"event":"test"}'),
            )
            conn.commit()
            conn.close()

        before_threads = threading.active_count()
        before_conns = len(store._connections)

        await store.list()
        after_first_threads = threading.active_count()
        after_first_conns = len(store._connections)

        await store.list()
        after_second_threads = threading.active_count()
        after_second_conns = len(store._connections)

>       assert after_second_conns == before_conns, (
            f"open connections leaked: {after_second_conns} (before {before_conns})"
        )
E       AssertionError: open connections leaked: 20 (before 0)
E       assert 20 == 0

tests/test_trace_store.py:587: AssertionError
=========================== short test summary info ============================
FAILED tests/test_trace_store.py::test_list_does_not_leak_connections_or_threads
============================== 1 failed, 0 passed in 0.66s =========================
```

GREEN on exec/tsk-p7elu6 (fix present):

```
tests/test_trace_store.py::test_list_does_not_leak_connections_or_threads PASSED [100%]
============================== 1 passed in 0.27s =========================
```

Files:
 changelog.d/tsk-p7elu6-trace-store-leak-fix.md |  3 +
 tests/test_trace_store.py                      | 43 +++++++++++++
 tinyagentos/trace_store.py                     | 88 +++++++++++++++-----------
 3 files changed, 96 insertions(+), 38 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed trace listing to prevent database connections and background threads from accumulating.
  - Trace listings now use temporary read-only connections that close automatically after each operation.
  - Repeated listings across multiple trace buckets no longer leave resources open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->