### PR TITLE
[lib-audit] R2-19 sha256 over read_bytes() loads multi-GB model files into RAM

### DIFF
--- a/changelog.d/tsk-vactp3-r2-19-chunked-sha256-hashing.md
+++ b/changelog.d/tsk-vactp3-r2-19-chunked-sha256-hashing.md
@@ -1,0 +1,2 @@
+### Fixed
+- SHA-256 verification in `DownloadManager._validate_download` and `TorrentDownloader.download` now streams files through `hashlib.file_digest` instead of loading the entire model file into RAM with `read_bytes()`. This prevents multi-GB model downloads from exhausting host memory on 4 GB devices.

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import time
+import tracemalloc
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -688,6 +689,34 @@ class TestStartInstallerTask:
         assert task.status == "complete"
         assert task.downloaded_bytes == 0
         assert task.total_bytes == 0
+
+
+class TestSha256MemoryBudget:
+    """R2-19: SHA-256 verification must not load the whole file into RAM."""
+
+    @pytest.mark.asyncio
+    async def test_validate_download_sha256_under_memory_budget(self, tmp_path):
+        path = tmp_path / "sparse.bin"
+        with open(path, "wb") as f:
+            f.seek(64 * 1024 * 1024 - 1)
+            f.write(b"\x00")
+        reference = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                reference.update(chunk)
+        reference = reference.hexdigest()
+
+        dm = DownloadManager()
+        task = DownloadTask(id="dl", url="http://example.com/f.bin", dest=path)
+
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        error = await dm._validate_download(task, path, expected_sha256=reference)
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert error is None
+        assert peak < 5 * 1024 * 1024, f"peak allocation {peak} bytes exceeds 5 MB budget"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_torrent_downloader.py
+++ b/tests/test_torrent_downloader.py
@@ -11,6 +11,10 @@ production use once the mirror seedbox is live (Phase 2).
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import sys
+import time
+import tracemalloc
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -263,3 +267,56 @@ async def test_download_manager_torrent_sha256_mismatch_falls_back_to_http(tmp_p
     # HTTP fallback succeeded, torrent was attempted
     assert fake_torrent.download.called
     assert dest.read_bytes() == http_data
+
+
+@pytest.mark.asyncio
+async def test_torrent_download_sha256_under_memory_budget(tmp_path: Path):
+    """R2-19: TorrentDownloader.download must not load the whole file into RAM."""
+    path = tmp_path / "sparse.bin"
+    with open(path, "wb") as f:
+        f.seek(64 * 1024 * 1024 - 1)
+        f.write(b"\x00")
+    reference = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            reference.update(chunk)
+    reference = reference.hexdigest()
+
+    mock_lt = MagicMock()
+    mock_status = MagicMock()
+    mock_status.state = "seeding"
+    mock_status.progress = 1.0
+    mock_status.num_peers = 1
+    mock_handle = MagicMock()
+    mock_handle.status.return_value = mock_status
+    mock_session = MagicMock()
+    mock_session.add_torrent.return_value = mock_handle
+    mock_lt.session.return_value = mock_session
+    mock_lt.torrent_status.seeding = "seeding"
+    mock_lt.parse_magnet_uri.return_value = MagicMock()
+
+    with patch.dict(sys.modules, {"libtorrent": mock_lt}), \
+         patch("tinyagentos.torrent_downloader.TORRENT_AVAILABLE", True), \
+         patch("tinyagentos.torrent_downloader.lt", mock_lt):
+        from tinyagentos.torrent_downloader import TorrentDownloader
+        downloader = TorrentDownloader.__new__(TorrentDownloader)
+        downloader.settings = MagicMock()
+        downloader.settings.seed_enabled = False
+        downloader._session = mock_session
+        downloader._peer_timeout = 30.0
+        downloader._handles = {}
+        downloader._tasks = {}
+
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        task = await downloader.download(
+            task_id="dl",
+            magnet_or_torrent="magnet:?xt=urn:btih:abc",
+            dest=path,
+            expected_sha256=reference,
+        )
+        current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert task.status == "complete"
+        assert peak < 5 * 1024 * 1024, f"peak allocation {peak} bytes exceeds 5 MB budget"

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -248,9 +248,9 @@ class DownloadManager:
                 # Fallback for a caller that did not stream the hash. Reading a
                 # potentially multi-GB model is offloaded to a thread so it
                 # never blocks the event loop.
-                digest = await asyncio.to_thread(
-                    lambda: hashlib.sha256(path.read_bytes()).hexdigest()
-                )
+                with open(path, "rb") as f:
+                    digest = await asyncio.to_thread(hashlib.file_digest, f, "sha256")
+                digest = digest.hexdigest()
             # Hex digests are case-insensitive; a caller passing an uppercase
             # expected value must not be treated as a mismatch.
             if digest.lower() != expected_sha256.lower():

--- a/tinyagentos/torrent_downloader.py
+++ b/tinyagentos/torrent_downloader.py
@@ -303,7 +303,8 @@ class TorrentDownloader:
             task.status = "error"
             task.error = "download produced no data"
             raise TorrentError("torrent download produced no data")
-        actual = hashlib.sha256(dest.read_bytes()).hexdigest()
+        with open(dest, "rb") as f:
+            actual = hashlib.file_digest(f, "sha256").hexdigest()
         if actual.lower() != expected_sha256.lower():
             task.status = "error"
             task.error = "sha256 mismatch"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-19 sha256 over read_bytes() loads multi-GB model files into RAM

Autonomous build of board card tsk-vactp3.

Peak allocation on a 64 MB sparse fixture dropped from ~67 MB to under 5 MB
in both the DownloadManager fallback path and the TorrentDownloader
verification path.

```text
FAILED tests/test_download_manager.py::TestSha256MemoryBudget::test_validate_download_sha256_under_memory_budget - AssertionError
E       AssertionError: peak allocation 67123236 bytes exceeds 5 MB budget

FAILED tests/test_torrent_downloader.py::test_torrent_download_sha256_under_memory_budget - AssertionError
E       AssertionError: peak allocation 67165073 bytes exceeds 5 MB budget
```

Green after fix:

```text
2 passed in 2.19s
```

Files:
 .../tsk-vactp3-r2-19-chunked-sha256-hashing.md     |  2 +
 tests/test_download_manager.py                     | 29 +++++++++++
 tests/test_torrent_downloader.py                   | 57 ++++++++++++++++++++++
 tinyagentos/download_manager.py                    |  6 +--
 tinyagentos/torrent_downloader.py                  |  3 +-
 5 files changed, 93 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced memory usage during SHA-256 verification by processing downloaded files incrementally instead of loading them fully into memory.
  - Prevented large downloads from exhausting available memory on devices with limited RAM.
- **Tests**
  - Added coverage confirming memory-efficient verification for large files in both standard and torrent downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->