### PR TITLE
[lib-audit] R2-22 agent self-service routes unreachable with a LiteLLM key (middleware 401s first)

### DIFF
--- a/changelog.d/tsk-ax7b6h-readability-fix.md
+++ b/changelog.d/tsk-ax7b6h-readability-fix.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Use `readability-lxml` for HTML extraction in both `knowledge_ingest.py` and `library_pipeline.py`
+- Extract text properly handles HTML entities with `html.unescape()`
+- Remove the 100-character threshold for readability extraction
+- Fix regex pattern that broke when `>` appeared inside HTML attributes
+- Maintain fallback to simple tag-stripping when `readability-lxml` is not installed

--- a/changelog.d/tsk-khfib3-agent-token-paths.md
+++ b/changelog.d/tsk-khfib3-agent-token-paths.md
@@ -1,0 +1,6 @@
+### Fixed: Add agent self-service routes to _AGENT_TOKEN_PATHS
+
+Added `/api/agents/me/models` and `/api/agents/me/model` to `_AGENT_TOKEN_PATHS` in
+`tinyagentos/auth_middleware.py` so that agent LiteLLM keys (Bearer tokens) are accepted
+for agent self-service routes. Previously, AuthMiddleware rejected these requests with 401
+before the handler could authenticate the agent key.

--- a/test_agent_token_paths.py
+++ b/test_agent_token_paths.py
@@ -1,0 +1,45 @@
+"""Unit test verifying the fix for agent self-service routes."""
+import pytest
+from tinyagentos.auth_middleware import _AGENT_TOKEN_PATHS, _is_exempt
+
+
+class TestAgentTokenPaths:
+    """Test that agent self-service routes are in _AGENT_TOKEN_PATHS."""
+
+    def test_agent_models_path_is_allowlisted(self):
+        "/api/agents/me/models should be in _AGENT_TOKEN_PATHS."
+        assert "/api/agents/me/models" in _AGENT_TOKEN_PATHS
+
+    def test_agent_model_path_is_allowlisted(self):
+        "/api/agents/me/model should be in _AGENT_TOKEN_PATHS."
+        assert "/api/agents/me/model" in _AGENT_TOKEN_PATHS
+
+    def test_bogus_path_is_not_allowlisted(self):
+        "A random path should NOT be in _AGENT_TOKEN_PATHS."
+        assert "/api/random/path" not in _AGENT_TOKEN_PATHS
+
+    def test_is_exempt_returns_false_for_agent_paths(self):
+        "Agent paths should NOT be exempt (they use _AGENT_TOKEN_PATHS instead)."
+        assert _is_exempt("GET", "/api/agents/me/models") is False
+        assert _is_exempt("POST", "/api/agents/me/model") is False
+
+
+class TestAgentTokenPathsMiddlewareLogic:
+    """Test the middleware logic for agent token paths."""
+
+    def test_get_agent_models_allowlisted(self):
+        "GET /api/agents/me/models is in _AGENT_TOKEN_PATHS -> Bearer token accepted."
+        assert "/api/agents/me/models" in _AGENT_TOKEN_PATHS
+
+    def test_post_agent_model_allowlisted(self):
+        "POST /api/agents/me/model is in _AGENT_TOKEN_PATHS -> Bearer token accepted."
+        assert "/api/agents/me/model" in _AGENT_TOKEN_PATHS
+
+    def test_bogus_not_allowlisted(self):
+        "Bogus path should not be allowlisted, ensuring skeleton key protection."
+        assert "/api/agents/nonexistent" not in _AGENT_TOKEN_PATHS
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -75,12 +75,15 @@ _AGENT_CONTAINER_QUOTA_ROUTE = ("GET", re.compile(r"^/api/agents/containers/quot
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate any other route (no skeleton key).
+# Agent self-serve routes: /api/agents/me/models (GET) and /api/agents/me/model (POST)
+# accept a LiteLLM/Bearer key for agent self-service.
 _AGENT_TOKEN_PATHS = (
     _REGISTRY_FEED_PATHS
     | _A2A_BUS_READ_PATHS
     | _A2A_BUS_WRITE_PATHS
     | _OBSERVATORY_PATHS
     | _CONTAINER_REQUEST_PATHS
+    | frozenset({"/api/agents/me/models", "/api/agents/me/model"})
 )
 
 # Project kanban routes an agent may reach with its own registry JWT (scope


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-22 agent self-service routes unreachable with a LiteLLM key (middleware 401s first)

Autonomous build of board card tsk-khfib3.



Files:
 changelog.d/tsk-ax7b6h-readability-fix.md   |  7 +++++
 changelog.d/tsk-khfib3-agent-token-paths.md |  6 ++++
 test_agent_token_paths.py                   | 45 +++++++++++++++++++++++++++++
 tinyagentos/auth_middleware.py              |  3 ++
 4 files changed, 61 insertions(+)