### PR TITLE
[lib-audit] R2-26 knowledge chunking: no overlap, orphaned chunks, swallowed failures

### DIFF
--- a/changelog.d/tsk-3ul6fb-r2-26-embed-fix.md
+++ b/changelog.d/tsk-3ul6fb-r2-26-embed-fix.md
@@ -1,0 +1,5 @@
+### Fixed
+- Knowledge ingest (R2-26) now chunks at sentence boundaries with ~200-char
+  overlap instead of fixed 2 000-char slices, deletes an item's old QMD chunks
+  before re-embedding so stale chunks cannot accumulate, and reports a `partial`
+  status (instead of silently `ready`) when some chunks fail to embed.

--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -261,9 +261,9 @@ async def test_embed_called_when_qmd_url_set(store):
     """When qmd_base_url is set, the /ingest endpoint should be called with collection=knowledge."""
     from tinyagentos.knowledge_ingest import IngestPipeline
 
-    qmd_response = AsyncMock()
+    qmd_response = MagicMock()
     qmd_response.status_code = 200
-    qmd_response.raise_for_status = AsyncMock()
+    qmd_response.raise_for_status = MagicMock()
 
     mock_http = AsyncMock()
     mock_http.get = AsyncMock(side_effect=Exception("no HTTP in this test"))
@@ -574,3 +574,144 @@ async def test_download_article_rejects_non_text_content_type(store):
         await pipeline._download_article("https://example.com/bin", "", {})
 
     assert resp.bytes_read == 0, "Non-text response should not be buffered at all"
+
+
+# ------------------------------------------------------------------
+# R2-26: Sentence-boundary chunking with overlap, delete-before-embed,
+# and failure-aware status.
+# ------------------------------------------------------------------
+
+def test_chunk_text_short_text_single_chunk():
+    """Text shorter than max_chars returns as a single chunk."""
+    from tinyagentos.knowledge_ingest import _chunk_text
+
+    short = "This is a short sentence."
+    assert _chunk_text(short, max_chars=2000, overlap_chars=200) == [short]
+
+
+def test_chunk_text_long_text_multiple_chunks():
+    """Long text produces multiple chunks at sentence boundaries."""
+    from tinyagentos.knowledge_ingest import _chunk_text
+
+    text = "Sentence one here. " * 100
+    chunks = _chunk_text(text, max_chars=100, overlap_chars=30)
+    assert len(chunks) > 1
+
+
+def test_chunk_text_chunks_overlap():
+    """Consecutive chunks must share text (tail of chunk N == prefix of N+1)."""
+    from tinyagentos.knowledge_ingest import _chunk_text
+
+    text = "Sentence one here. " * 100
+    chunks = _chunk_text(text, max_chars=100, overlap_chars=30)
+    assert len(chunks) > 1
+    for i in range(len(chunks) - 1):
+        found = False
+        for L in range(min(len(chunks[i]), len(chunks[i + 1])) - 1, 5, -1):
+            if chunks[i][-L:] == chunks[i + 1][:L]:
+                found = True
+                break
+        assert found, f"Chunks {i} and {i + 1} should overlap"
+
+
+def test_chunk_text_ends_at_sentence_boundary():
+    """Each chunk (except possibly the last) ends at a sentence terminator."""
+    from tinyagentos.knowledge_ingest import _chunk_text
+
+    text = "First sentence. Second sentence. Third sentence. Fourth sentence. " * 20
+    chunks = _chunk_text(text, max_chars=100, overlap_chars=30)
+    assert len(chunks) > 1
+    for chunk in chunks[:-1]:
+        assert chunk.rstrip()[-1] in ".!?", "Chunk should end at sentence boundary"
+
+
+@pytest.mark.asyncio
+async def test_embed_deletes_old_chunks_before_inserting(store):
+    """R2-26a: re-embedding an item must delete old chunks before inserting
+    new ones so no chunks from a previous run remain."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+
+    qmd_response = MagicMock()
+    qmd_response.status_code = 200
+    qmd_response.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.get = AsyncMock(side_effect=Exception("no HTTP in this test"))
+    mock_http.post = AsyncMock(return_value=qmd_response)
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+
+    pipeline = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        fetch_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        qmd_base_url="http://localhost:7832",
+        llm_base_url="",
+    )
+
+    item_id = "test-item-id"
+    content = "This is test content. " * 200  # Long enough to produce multiple chunks
+
+    await pipeline._embed(item_id, "Test Title", content)
+
+    calls = [str(call) for call in mock_http.post.call_args_list]
+    assert any("/delete-chunk" in c for c in calls), (
+        "Expected /delete-chunk call before inserting new chunks"
+    )
+
+    delete_idx = next((i for i, c in enumerate(calls) if "/delete-chunk" in c), -1)
+    ingest_idx = next((i for i, c in enumerate(calls) if "/ingest" in c), -1)
+    assert delete_idx != -1 and ingest_idx != -1, (
+        "Expected both /delete-chunk and /ingest calls"
+    )
+    assert delete_idx < ingest_idx, "delete-chunk must precede ingest calls"
+
+
+@pytest.mark.asyncio
+async def test_embed_failure_sets_partial_status(store):
+    """R2-26b: when QMD embedding calls fail, the item status should be
+    'partial', not 'ready'."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+
+    qmd_response = MagicMock()
+    qmd_response.status_code = 500
+    qmd_response.raise_for_status = MagicMock(side_effect=Exception("QMD error"))
+
+    mock_http = AsyncMock()
+    mock_http.get = AsyncMock(side_effect=Exception("no HTTP in this test"))
+    mock_http.post = AsyncMock(return_value=qmd_response)
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+
+    pipeline = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        fetch_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        qmd_base_url="http://localhost:7832",
+        llm_base_url="",
+    )
+
+    item_id = await pipeline.submit(
+        url="https://example.com/embed-fail",
+        title="Fail Test",
+        text="Content long enough to trigger embedding. " * 50,
+        categories=[],
+        source="test",
+    )
+    await pipeline.run(item_id)
+
+    item = await store.get_item(item_id)
+    assert item["status"] != "ready", "Status should not be 'ready' when embed fails"
+    assert item["status"] == "partial", (
+        f"Expected 'partial' status on embed failure, got '{item['status']}'"
+    )

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -40,6 +40,53 @@ _DEFAULT_MONITOR: dict[str, dict] = {
     "manual":  {"frequency": 0,     "decay_rate": 1.0, "stop_after_days": 0,   "pinned": False, "last_poll": 0, "current_interval": 0},
 }
 
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _chunk_text(text: str, max_chars: int = 2000, overlap_chars: int = 200) -> list[str]:
+    """Split *text* into chunks at sentence boundaries with overlap.
+
+    Sentences are split on ``.`` / ``!`` / ``?`` followed by whitespace.
+    Chunks accumulate complete sentences until *max_chars* is reached, then
+    the last sentence(s) that fit within *overlap_chars* are prepended to the
+    next chunk so context is preserved across boundaries.
+
+    Falls back to a sliding character window (with overlap) when no sentence
+    boundaries are present.  Text shorter than *max_chars* is returned as a
+    single chunk.
+    """
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+
+    sentences = [s.strip() for s in _SENTENCE_END_RE.split(text) if s.strip()]
+
+    if not sentences:
+        step = max(1, max_chars - overlap_chars)
+        return [text[i : i + max_chars] for i in range(0, len(text), step)]
+
+    chunks: list[str] = []
+    current: list[str] = []
+
+    for sent in sentences:
+        if current and len(" ".join(current)) + 1 + len(sent) > max_chars:
+            chunks.append(" ".join(current))
+            overlap: list[str] = []
+            for s in reversed(current):
+                trial = " ".join([*overlap, s]) if overlap else s
+                if len(trial) <= overlap_chars:
+                    overlap.insert(0, s)
+                else:
+                    break
+            current = overlap
+        current.append(sent)
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks
+
 
 def resolve_source_type(url: str) -> str:
     """Identify the content platform from a URL.
@@ -226,9 +273,9 @@ class IngestPipeline:
             summary = await self._summarise(title, content)
 
             # Step 4: embed via QMD (best-effort, non-fatal)
-            await self._embed(item_id, title, content)
+            embed_failures = await self._embed(item_id, title, content)
 
-            # Step 5: write final data and mark ready
+            # Step 5: write final data
             await self._store.update_item(
                 item_id,
                 title=title or item["source_url"],
@@ -238,7 +285,10 @@ class IngestPipeline:
                 categories=categories,
                 metadata=metadata,
             )
-            await self._store.update_status(item_id, "ready")
+            if embed_failures:
+                await self._store.update_status(item_id, "partial")
+            else:
+                await self._store.update_status(item_id, "ready")
 
             # Step 6: notify subscribed agents
             await self._notify(item_id, title, categories)
@@ -415,17 +465,33 @@ class IngestPipeline:
     # Embed step
     # ------------------------------------------------------------------
 
-    async def _embed(self, item_id: str, title: str, content: str) -> None:
-        """Send content to QMD for vector embedding into the 'knowledge' collection."""
+    async def _embed(self, item_id: str, title: str, content: str) -> int:
+        """Send content to QMD for vector embedding into the 'knowledge' collection.
+
+        Returns the number of chunks that failed to embed.
+        """
         if not self._qmd_base_url or not content:
-            return
+            return 0
         text_to_embed = f"{title}\n\n{content}"
-        # Chunk if content is very long (simple fixed-size chunking)
-        chunk_size = 2000
-        chunks = [text_to_embed[i:i + chunk_size] for i in range(0, len(text_to_embed), chunk_size)]
+        chunks = _chunk_text(text_to_embed, max_chars=2000, overlap_chars=200)
+        # Delete old chunks for this item before inserting new ones so that
+        # re-embedding (e.g. after an update or algorithm change) does not leave
+        # orphaned chunks from a previous run.
+        try:
+            await self._http_client.post(
+                f"{self._qmd_base_url}/delete-chunk",
+                json={
+                    "collection": "knowledge",
+                    "path": f"knowledge/{item_id}",
+                },
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.warning("QMD delete-chunk failed for item %s: %s", item_id, exc)
+        failures = 0
         for seq, chunk in enumerate(chunks):
             try:
-                await self._http_client.post(
+                resp = await self._http_client.post(
                     f"{self._qmd_base_url}/ingest",
                     json={
                         "collection": "knowledge",
@@ -435,8 +501,11 @@ class IngestPipeline:
                     },
                     timeout=60,
                 )
+                resp.raise_for_status()
             except Exception as exc:
+                failures += 1
                 logger.warning("QMD embed failed for item %s chunk %d: %s", item_id, seq, exc)
+        return failures
 
     # ------------------------------------------------------------------
     # Notify step


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-26 knowledge chunking: no overlap, orphaned chunks, swallowed failures

Autonomous build of board card tsk-3ul6fb.

Replace fixed 2 000-char no-overlap chunking with sentence-boundary splitting
that carries ~200 chars of overlap between chunks. Delete an item's old QMD
chunks via POST /delete-chunk before inserting new ones, preventing orphaned
chunks on re-embed. Count per-chunk embed failures and set item status to
'partial' instead of silently marking 'ready' when some chunks fail.

Files:
 changelog.d/tsk-3ul6fb-r2-26-embed-fix.md |   5 ++
 tests/test_knowledge_ingest.py            | 145 +++++++++++++++++++++++++++++-
 tinyagentos/knowledge_ingest.py           |  89 +++++++++++++++---
 3 files changed, 227 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge ingestion by splitting content at sentence boundaries with overlapping context.
  * Prevented stale content from accumulating during re-embedding.
  * Items now show a `partial` status when some content fails to embed, instead of being marked `ready`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->