### PR TITLE
[lib-audit] R2-24 cluster update-all holds the HTTP request for up to n x 300 s

### DIFF
--- a/changelog.d/tsk-ycm2i6-cluster-update-all-async.md
+++ b/changelog.d/tsk-ycm2i6-cluster-update-all-async.md
@@ -1,0 +1,2 @@
+### Fixed
+- `POST /api/cluster/workers/update-all` now returns 202 with a job id immediately and runs the rolling update as a tracked background task. Poll `GET /api/cluster/workers/update-all/<job_id>` for progress instead of blocking the HTTP request for up to n x 300 s (R2-24).

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -618,6 +618,20 @@ async def _fake_sleep(seconds):
     pass
 
 
+async def _poll_job_status(client, job_id: str, timeout: float = 5.0) -> dict:
+    """Poll GET /api/cluster/workers/update-all/<job_id> until completed or timeout."""
+    import asyncio as _asyncio
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = await client.get(f"/api/cluster/workers/update-all/{job_id}")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        if data.get("status") in ("completed", "failed"):
+            return data
+        await _asyncio.sleep(0.05)
+    raise AssertionError(f"Job {job_id} did not complete within {timeout}s")
+
+
 @pytest.mark.asyncio
 async def test_update_all_workers_happy_path(client, app, monkeypatch):
     """Two online workers: both succeed via restart-disconnect, re-registration wait passes."""
@@ -630,9 +644,6 @@ async def test_update_all_workers_happy_path(client, app, monkeypatch):
 
     async def _mock_do(cluster, worker):
         call_order.append(worker.name)
-        # Simulate the drain→deploy step: set worker to draining, then return success.
-        # The re-registration loop will poll and break once status is "online".
-        # In the real helper, drain_worker sets draining; we simulate that here.
         worker.status = "draining"
         return {
             "success": True,
@@ -642,13 +653,11 @@ async def test_update_all_workers_happy_path(client, app, monkeypatch):
             "drain_cancelled": False,
         }
 
-    # Simulate re-registration: after the first poll, the worker comes back online.
     original_get_worker = app.state.cluster_manager.get_worker
 
     def _get_worker(name):
         w = original_get_worker(name)
         if w is not None and w.status == "draining":
-            # Simulate re-registration: worker comes back online
             w.status = "online"
         return w
 
@@ -660,12 +669,15 @@ async def test_update_all_workers_happy_path(client, app, monkeypatch):
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert sorted(data["updated"]) == ["w1", "w2"]
-    assert data["failed"] == []
-    assert data["total_targets"] == 2
-    # Verify sequential: w1 must be processed before w2
+    assert "job_id" in data
+    job_id = data["job_id"]
+
+    final = await _poll_job_status(client, job_id)
+    assert sorted(final["updated"]) == ["w1", "w2"]
+    assert final["failed"] == []
+    assert final["total_targets"] == 2
     assert call_order == ["w1", "w2"]
 
 
@@ -695,7 +707,6 @@ async def test_update_all_workers_one_fails_others_continue(client, app, monkeyp
             "drain_cancelled": False,
         }
 
-    # Simulate re-registration for w2
     original_get_worker = app.state.cluster_manager.get_worker
 
     def _get_worker(name):
@@ -712,14 +723,17 @@ async def test_update_all_workers_one_fails_others_continue(client, app, monkeyp
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert data["updated"] == ["w2"]
-    assert len(data["failed"]) == 1
-    assert data["failed"][0]["name"] == "w1"
-    assert "unreachable" in data["failed"][0]["error"]
-    assert data["total_targets"] == 2
-    # w1 must be processed before w2
+    assert "job_id" in data
+    job_id = data["job_id"]
+
+    final = await _poll_job_status(client, job_id)
+    assert final["updated"] == ["w2"]
+    assert len(final["failed"]) == 1
+    assert final["failed"][0]["name"] == "w1"
+    assert "unreachable" in final["failed"][0]["error"]
+    assert final["total_targets"] == 2
     assert call_order == ["w1", "w2"]
 
 
@@ -738,7 +752,6 @@ async def test_update_all_workers_skips_local(client, app, monkeypatch):
         worker.status = "draining"
         return {"success": True, "worker": worker.name, "drain_cancelled": False}
 
-    # Simulate re-registration
     original_get_worker = app.state.cluster_manager.get_worker
 
     def _get_worker(name):
@@ -755,12 +768,13 @@ async def test_update_all_workers_skips_local(client, app, monkeypatch):
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert sorted(data["updated"]) == ["r1", "r2"]
-    # local must appear in skipped, not updated
-    assert "local" in data["skipped"]
-    assert "local" not in data["updated"]
+    assert "job_id" in data
+    final = await _poll_job_status(client, data["job_id"])
+    assert sorted(final["updated"]) == ["r1", "r2"]
+    assert "local" in final["skipped"]
+    assert "local" not in final["updated"]
 
 
 @pytest.mark.asyncio
@@ -774,7 +788,6 @@ async def test_update_all_workers_skips_offline(client, app, monkeypatch):
         worker.status = "draining"
         return {"success": True, "worker": worker.name, "drain_cancelled": False}
 
-    # Simulate re-registration
     original_get_worker = app.state.cluster_manager.get_worker
 
     def _get_worker(name):
@@ -791,17 +804,19 @@ async def test_update_all_workers_skips_offline(client, app, monkeypatch):
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert data["updated"] == ["online-1"]
-    assert "online-2" in data["skipped"]
+    assert "job_id" in data
+    final = await _poll_job_status(client, data["job_id"])
+    assert final["updated"] == ["online-1"]
+    assert "online-2" in final["skipped"]
 
 
 @pytest.mark.asyncio
 async def test_update_all_workers_no_online_workers(client, app):
     """When no online remote workers exist, return empty with a message."""
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
     assert data["updated"] == []
     assert data["failed"] == []
@@ -815,7 +830,6 @@ async def test_update_all_workers_draining_excluded_from_skipped(client, app, mo
     """Draining workers are not counted as skipped -- they are mid-update."""
     import asyncio as _asyncio
     await _register_workers(app, "w1", "w2")
-    # Set w2 to draining -- it should NOT appear in skipped
     app.state.cluster_manager._workers["w2"].status = "draining"  # noqa: SLF001
 
     async def _mock_do(cluster, worker):
@@ -838,12 +852,13 @@ async def test_update_all_workers_draining_excluded_from_skipped(client, app, mo
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert data["updated"] == ["w1"]
-    # w2 is draining -- NOT skipped
-    assert "w2" not in data["skipped"]
-    assert data["total_targets"] == 1  # only w1 was online
+    assert "job_id" in data
+    final = await _poll_job_status(client, data["job_id"])
+    assert final["updated"] == ["w1"]
+    assert "w2" not in final["skipped"]
+    assert final["total_targets"] == 1
 
 
 @pytest.mark.asyncio
@@ -883,13 +898,15 @@ async def test_update_all_workers_helper_exception_isolated(client, app, monkeyp
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    assert data["updated"] == ["w2"]
-    assert len(data["failed"]) == 1
-    assert data["failed"][0]["name"] == "w1"
-    assert "RuntimeError" in data["failed"][0]["error"]
-    assert data["total_targets"] == 2
+    assert "job_id" in data
+    final = await _poll_job_status(client, data["job_id"])
+    assert final["updated"] == ["w2"]
+    assert len(final["failed"]) == 1
+    assert final["failed"][0]["name"] == "w1"
+    assert "RuntimeError" in final["failed"][0]["error"]
+    assert final["total_targets"] == 2
     assert call_order == ["w1", "w2"]
 
 
@@ -912,7 +929,6 @@ async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
             "drain_cancelled": False,
         }
 
-    # get_worker always returns "draining" -- simulates worker never coming back
     monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
         "tinyagentos.routes.cluster._do_single_worker_update",
@@ -920,12 +936,13 @@ async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 202, resp.text
     data = resp.json()
-    # Both workers should still be listed as updated -- the timeout just logs a warning
-    assert sorted(data["updated"]) == ["w1", "w2"]
-    assert data["failed"] == []
-    assert data["total_targets"] == 2
+    assert "job_id" in data
+    final = await _poll_job_status(client, data["job_id"], timeout=2)
+    assert sorted(final["updated"]) == ["w1", "w2"]
+    assert final["failed"] == []
+    assert final["total_targets"] == 2
     assert call_order == ["w1", "w2"]
 
 
@@ -1081,3 +1098,74 @@ async def test_register_worker_null_ram_mb_does_not_crash_list_workers(client, a
     assert w is not None
     assert w["tier_id"] not in ("", "unknown"), f"tier_id should be derived, got {w['tier_id']!r}"
     await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_returns_202_with_job_id_and_completes_in_background(client, app, monkeypatch):
+    """Two fake workers whose update takes 2s each: POST returns <1s with a job
+    id and the status route reports completion afterwards (R2-24)."""
+    import asyncio as _asyncio
+
+    await _register_workers(app, "w1", "w2")
+
+    async def _mock_do(cluster, worker):
+        await _asyncio.sleep(2)
+        worker.status = "draining"
+        return {
+            "success": True,
+            "worker": worker.name,
+            "status": "updating",
+            "previous_status": "online",
+            "drain_cancelled": False,
+        }
+
+    # Make re-registration instant so the background job can finish quickly.
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
+    )
+
+    start = time.time()
+    resp = await client.post("/api/cluster/workers/update-all")
+    elapsed = time.time() - start
+
+    assert resp.status_code == 202, resp.text
+    data = resp.json()
+    assert "job_id" in data, f"Expected job_id in response, got: {data}"
+    job_id = data["job_id"]
+
+    assert elapsed < 1.0, (
+        f"POST /api/cluster/workers/update-all took {elapsed:.2f}s, expected <1s"
+    )
+
+    deadline = time.time() + 15
+    final_status = None
+    while time.time() < deadline:
+        status_resp = await client.get(f"/api/cluster/workers/update-all/{job_id}")
+        assert status_resp.status_code == 200, status_resp.text
+        final_status = status_resp.json()
+        if final_status.get("status") in ("completed", "failed"):
+            break
+        await _asyncio.sleep(0.2)
+
+    assert final_status is not None
+    assert final_status["status"] == "completed", final_status
+    assert sorted(final_status["updated"]) == ["w1", "w2"]
+    assert final_status["failed"] == []
+    assert final_status["total_targets"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_status_unknown_job_returns_404(client, app):
+    """GET /api/cluster/workers/update-all/<unknown> returns 404."""
+    resp = await client.get("/api/cluster/workers/update-all/does-not-exist")
+    assert resp.status_code == 404, resp.text

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import subprocess
+import time
+import uuid
 from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, Request
@@ -20,8 +22,11 @@ from tinyagentos.cluster.worker_protocol import WorkerInfo
 from tinyagentos.auth_context import require_admin
 from tinyagentos.rate_limit import MovingWindowLimiter, rate_limited_response
 from tinyagentos.routes.auth import _require_admin
+from tinyagentos.task_utils import _create_supervised_task
 
 router = APIRouter()
+
+_update_jobs: dict[str, dict] = {}
 
 # Admin-only fleet mutations / worker execution (tsk-exyzu4). Same gate as
 # revoke/block/unblock but as a dependency so the host local token (taosctl,
@@ -1518,8 +1523,9 @@ async def update_all_workers(request: Request):
     After a successful update, the route waits (with a timeout) for the worker
     to re-register as ``online`` before proceeding to the next target.
 
-    Returns an aggregate ``{updated: [...], failed: [{name, error}], skipped: [...]}``
-    so the admin can see exactly which workers were touched and which failed.
+    Returns 202 with a ``job_id`` immediately; the actual roll runs as a
+    tracked background task. Poll ``GET /api/cluster/workers/update-all/<job_id>``
+    for progress and final results.
     """
     ok, err = _require_admin(request)
     if not ok:
@@ -1533,19 +1539,50 @@ async def update_all_workers(request: Request):
         if w.name == "local" or w.status not in ("online", "draining")
     ]
     if not targets:
-        return {
+        return JSONResponse({
             "updated": [],
             "failed": [],
             "skipped": skipped,
             "total_targets": 0,
             "message": "No online remote workers to update",
-        }
+        }, status_code=202)
 
+    job_id = uuid.uuid4().hex
+    _update_jobs[job_id] = {
+        "job_id": job_id,
+        "status": "running",
+        "updated": [],
+        "failed": [],
+        "skipped": skipped,
+        "total_targets": len(targets),
+        "created_at": time.time(),
+        "completed_at": None,
+    }
+
+    async def _run() -> None:
+        try:
+            await _run_update_all_job(cluster, targets, job_id)
+        except Exception:
+            logger.exception("update-all job %s crashed", job_id)
+            job = _update_jobs.get(job_id)
+            if job is not None:
+                job["status"] = "failed"
+                job["completed_at"] = time.time()
+
+    bg = getattr(request.app.state, "_background_tasks", None)
+    _create_supervised_task(_run(), bg)
+
+    return JSONResponse({"job_id": job_id, "status": "running"}, status_code=202)
+
+
+async def _run_update_all_job(cluster, targets, job_id: str) -> None:
+    """Execute the rolling update and record results in ``_update_jobs``."""
+    job = _update_jobs[job_id]
     updated: list[str] = []
     failed: list[dict] = []
 
-    RE_REGISTER_TIMEOUT = 300  # seconds to wait for worker to come back online
-    RE_REGISTER_POLL = 5       # seconds between status checks
+    RE_REGISTER_TIMEOUT = 300
+    RE_REGISTER_POLL = 5
 
     for worker in targets:
         try:
@@ -1560,9 +1597,6 @@ async def update_all_workers(request: Request):
 
         if result["success"]:
             updated.append(worker.name)
-            # Wait for the worker to re-register as "online" before proceeding
-            # to the next target. This guarantees at most one worker is actively
-            # updating at any moment (never more than one draining concurrently).
             waited = 0
             while waited < RE_REGISTER_TIMEOUT:
                 await asyncio.sleep(RE_REGISTER_POLL)
@@ -1575,8 +1609,6 @@ async def update_all_workers(request: Request):
                     )
                     break
             else:
-                # Timeout: worker didn't come back online in time. Log it but
-                # continue the roll -- the worker's status will resolve on its own.
                 logger.warning(
                     "update-all: worker '%s' did not re-register within %ds timeout; "
                     "continuing roll",
@@ -1589,9 +1621,16 @@ async def update_all_workers(request: Request):
                 worker.name, result.get("error", "unknown"),
             )
 
-    return {
-        "updated": updated,
-        "failed": failed,
-        "skipped": skipped,
-        "total_targets": len(targets),
-    }
+    job["updated"] = updated
+    job["failed"] = failed
+    job["status"] = "completed"
+    job["completed_at"] = time.time()
+
+
+@router.get("/api/cluster/workers/update-all/{job_id}")
+async def get_update_all_job_status(request: Request, job_id: str):
+    """Poll the status of a fleet update started by POST /api/cluster/workers/update-all."""
+    job = _update_jobs.get(job_id)
+    if job is None:
+        return JSONResponse({"error": f"Job '{job_id}' not found"}, status_code=404)
+    return job


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-24 cluster update-all holds the HTTP request for up to n x 300 s

Autonomous build of board card tsk-ycm2i6.

The POST /api/cluster/workers/update-all endpoint used to run the entire
rolling update inline, blocking the HTTP request for up to n x 300 s.
Proxies and browsers timed out first, and the caller could not tell
partial success.

The endpoint now returns 202 with a job id immediately, runs the fan-out
as a tracked background task, and exposes GET
/api/cluster/workers/update-all/{job_id} for progress polling.

Docs-Reviewed: no doc change needed, docs/agent-coordination.md covers
workflow discipline not endpoint behaviour

```
FAILED tests/test_routes_cluster.py::test_update_all_workers_returns_202_with_job_id_and_completes_in_background - AssertionError: assert 200 == 202
```

11 passed in 48.59s

Files:
 changelog.d/tsk-ycm2i6-cluster-update-all-async.md |   2 +
 tests/test_routes_cluster.py                       | 182 +++++++++++++++------
 tinyagentos/routes/cluster.py                      |  73 +++++++--
 3 files changed, 193 insertions(+), 64 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cluster worker updates now run asynchronously, returning a job ID with an HTTP 202 response.
  - Added an endpoint to poll job progress and retrieve final update results.
  - Update jobs report completion, failures, and unexpected errors.

- **Documentation**
  - Added changelog documentation for the asynchronous worker update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->