### PR TITLE
[lib-audit] R2-30 restart_orchestrator: non-atomic flag writes; flag never cleared when sha is empty

### DIFF
--- a/changelog.d/tsk-gxma4p-restart-orchestrator-atomic-flag-clear.md
+++ b/changelog.d/tsk-gxma4p-restart-orchestrator-atomic-flag-clear.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `restart_orchestrator.py` now writes the pending-restart flag and controller-side resume notes with `atomic_write_text`, so a power loss mid-write cannot produce a torn file.
+- `apply_pending_restart_check` clears the pending-restart flag when `current_sha` is empty (unknown revision), preventing a stale flag from surviving an indefinite retry loop.

--- a/tests/test_restart_orchestrator.py
+++ b/tests/test_restart_orchestrator.py
@@ -116,6 +116,19 @@ class TestPendingRestartFlag:
         flag.write_text("not json")
         assert ro.read_pending_restart() is None
 
+    def test_write_pending_restart_uses_atomic_rename(self, tmp_path, monkeypatch):
+        """write_pending_restart must use os.replace, never plain write_text."""
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+        replaces = []
+
+        def spy_replace(src, dst):
+            replaces.append((src, dst))
+
+        with patch("os.replace", side_effect=spy_replace):
+            ro.write_pending_restart("abc123")
+
+        assert replaces, "os.replace was never called by write_pending_restart"
+
 
 # ---------------------------------------------------------------------------
 # _load_or_synthesize_note
@@ -416,6 +429,21 @@ class TestWriteControllerNote:
         )
         assert data["context_snapshot"] == {}
 
+    @pytest.mark.asyncio
+    async def test_write_controller_note_uses_atomic_rename(self, tmp_path):
+        """_write_controller_note must use os.replace, never plain write_text."""
+        agent = {"name": "agent1"}
+        orch = ro.RestartOrchestrator(_app_state(tmp_path))
+        replaces = []
+
+        def spy_replace(src, dst):
+            replaces.append((src, dst))
+
+        with patch("os.replace", side_effect=spy_replace):
+            await orch._write_controller_note(agent, "stop", tmp_path)
+
+        assert replaces, "os.replace was never called by _write_controller_note"
+
 
 # ---------------------------------------------------------------------------
 # apply_pending_restart_check
@@ -485,7 +513,27 @@ class TestApplyPendingRestartCheck:
 
         titles = [c.kwargs["title"] for c in state.notifications.add.await_args_list]
         assert any("Restart happened but code didn't update" in t for t in titles)
-        ro.clear_pending_restart.assert_not_called()
+        ro.clear_pending_restart.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_current_sha_clears_flag(self, tmp_path, monkeypatch):
+        """When current_sha is empty the restart flag must be cleared."""
+        monkeypatch.setattr(ro, "read_pending_restart", lambda: {"target_sha": "abc123"})
+        monkeypatch.setattr(ro, "clear_pending_restart", MagicMock())
+
+        mock_stdout = MagicMock()
+        mock_stdout.decode.return_value = "\n"
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(mock_stdout, b""))
+
+        async def fake_create(*args, **kwargs):
+            return mock_proc
+
+        state = _app_state(tmp_path)
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_create):
+            await ro.apply_pending_restart_check(state)
+
+        ro.clear_pending_restart.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -10,6 +10,8 @@ from typing import Literal
 
 import httpx
 
+from tinyagentos.atomic_io import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 Reason = Literal["pause", "stop", "system-shutdown"]
@@ -44,8 +46,8 @@ def _pending_restart_path() -> Path:
 def write_pending_restart(target_sha: str) -> None:
     path = _pending_restart_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps({"target_sha": target_sha, "pulled_at": int(time.time())})
+    atomic_write_text(
+        path, json.dumps({"target_sha": target_sha, "pulled_at": int(time.time())})
     )
 
 
@@ -199,7 +201,7 @@ class RestartOrchestrator:
             "next_step_hint": "controller-side fallback — agent framework did not implement /prepare-for-shutdown",
             "context_snapshot": {},
         }
-        note_path.write_text(json.dumps(note, indent=2))
+        await asyncio.to_thread(atomic_write_text, note_path, json.dumps(note, indent=2))
         return str(note_path)
 
 
@@ -235,6 +237,8 @@ async def apply_pending_restart_check(app_state) -> None:
         )
         clear_pending_restart()
     else:
+        if not current_sha:
+            clear_pending_restart()
         await notif.add(
             title="Restart happened but code didn't update",
             message=f"Still on {short_current}, expected {short_target}. Check git pull output.",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-30 restart_orchestrator: non-atomic flag writes; flag never cleared when sha is empty

Autonomous build of board card tsk-gxma4p.

- write_pending_restart and _write_controller_note now use atomic_write_text
  (os.replace) instead of plain write_text, preventing torn files on power loss
- apply_pending_restart_check clears the pending-restart flag when current_sha
  is empty (unknown revision) so a stale flag cannot survive indefinitely

RED tests added and green after fix:

FAILED tests/test_restart_orchestrator.py::TestPendingRestartFlag::test_write_pending_restart_uses_atomic_rename
FAILED tests/test_restart_orchestrator.py::TestWriteControllerNote::test_write_controller_note_uses_atomic_rename
FAILED tests/test_restart_orchestrator.py::TestApplyPendingRestartCheck::test_empty_current_sha_clears_flag

62 passed in 1.04s

Docs-Reviewed: internal bugfix with no user-facing doc changes

Files:
 ...xma4p-restart-orchestrator-atomic-flag-clear.md |  4 ++
 tests/test_restart_orchestrator.py                 | 50 +++++++++++++++++++++-
 tinyagentos/restart_orchestrator.py                | 10 +++--
 3 files changed, 60 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when recording pending restarts and controller resume information by preventing partially written state.
  - Pending restart state is now cleared when the current revision cannot be determined, preventing stale restart requests after an unsuccessful update check.
  - Improved handling of failed revision lookups so users receive accurate update status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->