### PR TITLE
[lib-audit] R2-29 proxy readiness poll ignores a crashed process; stderr log never rotated

### DIFF
--- a/changelog.d/tsk-javfwk-r2-29-proxy-startup-crash-poll.md
+++ b/changelog.d/tsk-javfwk-r2-29-proxy-startup-crash-poll.md
@@ -1,0 +1,2 @@
+### Fixed
+- `llm_proxy.py` readiness poll now checks `proc.poll()` each iteration and fails fast with the stderr tail when the proxy process exits at startup, instead of blocking for the full 120 s timeout (R2-29).

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -920,6 +920,8 @@ class TestStderrLogHandling:
         class _FakePopen:
             def __init__(self, *a, **kw):
                 pass
+            def poll(self):
+                return None
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 
@@ -973,6 +975,58 @@ class TestStderrLogHandling:
         assert result is False
         assert len(captured_handles) == 1
         assert captured_handles[0].closed, "parent must close its stderr log handle even on failed spawn"
+
+
+class TestReadinessPollCrashDetection:
+    """R2-29: the readiness poll must detect a crashed proxy process and
+    fail fast, surfacing the stderr tail, not block for the full 120 s."""
+
+    @pytest.mark.asyncio
+    async def test_readiness_fails_fast_when_proxy_crashes_at_startup(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A proxy that exits at startup must cause start() to return False
+        within <2 s with the stderr tail in the error log."""
+        import asyncio
+        import logging
+        import shutil
+        import time
+        import tinyagentos.llm_proxy as mod
+
+        crash_script = tmp_path / "fake_litellm"
+        crash_script.write_text(
+            "#!/bin/sh\necho 'ERROR: proxy startup failure' >&2\nexit 1\n"
+        )
+        crash_script.chmod(0o755)
+
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: str(crash_script))
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url):
+                raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+
+        p = mod.LLMProxy(port=14021, data_dir=tmp_path)
+
+        with caplog.at_level(logging.ERROR, logger="tinyagentos.llm_proxy"):
+            start_time = time.monotonic()
+            result = await asyncio.wait_for(p.start(backends=[]), timeout=5)
+            elapsed = time.monotonic() - start_time
+
+        assert result is False
+        assert elapsed < 2, f"expected failure in <2 s, took {elapsed:.1f}s"
+        assert "ERROR: proxy startup failure" in caplog.text
 
 
 class TestConfigDirPermissions:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -69,6 +69,20 @@ def _pids_listening_on(port: int) -> list[int]:
     return pids
 
 
+def _read_stderr_tail(log_path: Path, max_bytes: int = 2000) -> str:
+    """Read the tail of a stderr log file for crash diagnostics."""
+    try:
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+            return f.read().decode(errors="replace")
+    except FileNotFoundError:
+        return "(no stderr captured)"
+    except OSError:
+        return "(could not read stderr log)"
+
+
 class LLMProxy:
     """Manages LiteLLM proxy as a subprocess.
 
@@ -555,6 +569,17 @@ class LLMProxy:
         # (requires master key → 401 for the polling client).
         for _ in range(120):
             await asyncio.sleep(1)
+            # R2-29: a proxy that crashed at startup would otherwise burn
+            # the full 120 s poll; check proc.poll() and fail fast,
+            # surfacing the stderr tail that explains why it died.
+            if self._process is not None and self._process.poll() is not None:
+                stderr_tail = _read_stderr_tail(stderr_log_path)
+                logger.error(
+                    "LiteLLM proxy process exited early (rc=%s); stderr tail:\n%s",
+                    self._process.returncode,
+                    stderr_tail,
+                )
+                return False
             try:
                 async with httpx.AsyncClient(timeout=3) as client:
                     resp = await client.get(f"{self.url}/health/readiness")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-29 proxy readiness poll ignores a crashed process; stderr log never rotated

Autonomous build of board card tsk-javfwk.

The readiness poll in LLMProxy.start() iterated /health/readiness for
up to 120 s without checking proc.poll(), so a proxy that died at
startup cost the full timeout. The loop now calls proc.poll() each
iteration and, when the process has exited, reads the stderr tail from
the log file, logs it, and returns False immediately.

A _read_stderr_tail helper reads the last 2000 bytes of the stderr log,
handling missing or unreadable files gracefully.

```
FAILED tests/test_llm_proxy.py::TestReadinessPollCrashDetection::test_readiness_fails_fast_when_proxy_crashes_at_startup
1 failed in 5.46s
```

```
tests/test_llm_proxy.py::TestReadinessPollCrashDetection::test_readiness_fails_fast_when_proxy_crashes_at_startup PASSED [100%]
1 passed in 1.22s
```

Full suite: 60 passed in 2.72s

Files:
 .../tsk-javfwk-r2-29-proxy-startup-crash-poll.md   |  2 +
 tests/test_llm_proxy.py                            | 54 ++++++++++++++++++++++
 tinyagentos/llm_proxy.py                           | 25 ++++++++++
 3 files changed, 81 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Proxy startup failures are now detected immediately instead of waiting for the full timeout.
  - Error messages include the subprocess exit code and recent startup log output, making failures easier to diagnose.

- **Tests**
  - Added coverage for successful startup cleanup and immediate proxy crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->