### PR TITLE
[lib-audit] R2-7 INSERT OR REPLACE into standalone FTS5 table duplicates rows

### DIFF
--- a/changelog.d/tsk-rjksje-r2-7-fts-duplicate-rows.md
+++ b/changelog.d/tsk-rjksje-r2-7-fts-duplicate-rows.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Knowledge search (R2-7): `update_item` now deletes the old FTS5 row before
+  re-inserting, instead of `INSERT OR REPLACE` which appends a duplicate row
+  on a standalone FTS5 table, so re-indexing an item no longer leaves stale
+  text searchable.

--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -341,3 +341,55 @@ async def test_category_filter_exact_match(store):
     results = await store.list_items(category="Rockchip")
     assert len(results) == 1
     assert results[0]["title"] == "Exact Match"
+
+
+# ---------------------------------------------------------------------------
+# R2-7: INSERT OR REPLACE on a standalone FTS5 table duplicates rows
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fts_upsert_does_not_duplicate_rows(store):
+    """Re-indexing the same item must leave exactly one FTS row and must
+    not keep stale text searchable.
+
+    A standalone (non-external-content) FTS5 table does not honour
+    INSERT OR REPLACE on a non-rowid column: each upsert inserts a new
+    row, so re-indexing N times yields N rows and old text stays matchable.
+    """
+    item_id = await store.add_item(
+        source_type="article",
+        source_url="https://example.com/upsert",
+        title="Alpha Article",
+        author="tester",
+        content="apple content here",
+        summary="alpha summary",
+        categories=[],
+        tags=[],
+        metadata={},
+    )
+
+    # Re-index the same item two more times with different searchable text.
+    await store.update_item(
+        item_id, title="Beta Article", content="banana content here",
+        summary="beta summary",
+    )
+    await store.update_item(
+        item_id, title="Gamma Article", content="cherry content here",
+        summary="gamma summary",
+    )
+
+    # Exactly one FTS row must exist for this item after three upserts.
+    cursor = await store._db.execute(
+        "SELECT COUNT(*) FROM knowledge_fts WHERE id = ?", (item_id,)
+    )
+    count = (await cursor.fetchone())[0]
+    assert count == 1, f"expected 1 FTS row, got {count}"
+
+    # Only the latest text should be searchable.
+    latest = await store.search_fts("cherry")
+    assert len(latest) == 1
+    assert latest[0]["title"] == "Gamma Article"
+
+    # Stale text from earlier upserts must no longer be searchable.
+    stale = await store.search_fts("apple")
+    assert len(stale) == 0

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -238,13 +238,19 @@ class KnowledgeStore(BaseStore):
             f"UPDATE knowledge_items SET {', '.join(set_clauses)} WHERE id = ?",
             params,
         )
-        # Sync FTS for content-bearing fields
+        # Sync FTS for content-bearing fields.  knowledge_fts is a standalone
+        # (non-external-content) FTS5 table, so INSERT OR REPLACE does not
+        # de-duplicate: it appends a new row each time and stale text remains
+        # searchable.  Delete first, then insert, within this same transaction.
         fts_fields = {"title", "content", "summary", "author"}
         if fts_fields & set(fields.keys()):
             item = await self.get_item(item_id)
             if item:
                 await self._db.execute(
-                    "INSERT OR REPLACE INTO knowledge_fts (id, title, content, summary, author) VALUES (?,?,?,?,?)",
+                    "DELETE FROM knowledge_fts WHERE id = ?", (item_id,)
+                )
+                await self._db.execute(
+                    "INSERT INTO knowledge_fts (id, title, content, summary, author) VALUES (?,?,?,?,?)",
                     (item_id, item["title"], item["content"], item["summary"], item["author"]),
                 )
         await self._db.commit()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-7 INSERT OR REPLACE into standalone FTS5 table duplicates rows

Autonomous build of board card tsk-rjksje.

A standalone (non-external-content) FTS5 table does not honor INSERT OR
REPLACE on a non-rowid column: the `id` column in knowledge_fts is UNINDEXED,
so each REPLACE upsert inserts a new row and stale text stays searchable.
Re-indexing an item three times yielded three FTS rows with stale content.

Replace INSERT OR REPLACE with DELETE + INSERT inside the same transaction
in update_item(), so exactly one FTS row per item is maintained.

library_store.py was checked for the same pattern: no FTS5 table exists
there, so the bug is not present.

RED run (test written, fix not yet applied):

```text
FAILED tests/test_knowledge_store.py::test_fts_upsert_does_not_duplicate_rows - AssertionError: expected 1 FTS row, got 3
1 failed in 0.37s
```

Green after fix:

```text
tests/test_knowledge_store.py::test_fts_upsert_does_not_duplicate_rows PASSED
17 passed in 0.69s
```

Files:
 changelog.d/tsk-rjksje-r2-7-fts-duplicate-rows.md |  6 +++
 tests/test_knowledge_store.py                     | 52 +++++++++++++++++++++++
 tinyagentos/knowledge_store.py                    | 10 ++++-
 3 files changed, 66 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed knowledge search re-indexing so updated items no longer create duplicate search records.
  - Removed stale text from search results after an item’s content is updated.
  - Ensured search results reflect only the latest version of indexed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->