### PR TITLE
[lib-audit] R2-16 reddit fetcher: unbounded recursion and edited=True -> 1.0 timestamp

### DIFF
--- a/changelog.d/tsk-pn6ypz-reddit-recursion-edited.md
+++ b/changelog.d/tsk-pn6ypz-reddit-recursion-edited.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Reddit comment fetcher (`knowledge_fetchers/reddit.py`) now walks comment
+  trees iteratively with depth (2 000) and count (10 000) caps, eliminating
+  `RecursionError` on pathologically deep trees. The `edited` field is also
+  corrected: `edited=True` (Reddit's legacy boolean) is mapped to `None`
+  instead of being coerced to `1.0` (the 1970 epoch), while genuine numeric
+  timestamps and `False` are preserved.

--- a/desktop/src/apps/RedditApp.tsx
+++ b/desktop/src/apps/RedditApp.tsx
@@ -119,7 +119,7 @@ function CommentNode({ comment, maxDepth = 4 }: CommentNodeProps) {
             <span className="rd-cmt-meta">{formatScore(comment.score)} pts</span>
             <span className="rd-cmt-meta">·</span>
             <span className="rd-cmt-meta">{timeAgo(comment.created_utc)}</span>
-            {comment.edited && (
+            {comment.edited !== false && (
               <span className="rd-cmt-meta" style={{ fontStyle: "italic" }}>
                 (edited)
               </span>

--- a/desktop/src/lib/reddit.ts
+++ b/desktop/src/lib/reddit.ts
@@ -27,7 +27,7 @@ export interface RedditComment {
   depth: number;
   parent_id: string;
   replies: RedditComment[];
-  edited: boolean;
+  edited: boolean | number | null;
   distinguished: string | null;
 }
 

--- a/tests/test_knowledge_fetcher_reddit.py
+++ b/tests/test_knowledge_fetcher_reddit.py
@@ -15,6 +15,7 @@ from tinyagentos.knowledge_fetchers.reddit import (
     flatten_to_text,
     extract_metadata,
     _normalise_url,
+    _parse_comment,
 )
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -365,3 +366,161 @@ async def test_fetch_subreddit_empty_listing():
 
     assert posts == []
     assert next_after is None
+
+
+# ---------------------------------------------------------------------------
+# R2-16: unbounded recursion in _parse_comment / _flatten_comment
+#          and edited=True -> 1.0 (1970 epoch) timestamp coercion
+# ---------------------------------------------------------------------------
+
+def _build_deep_comment_json(depth: int) -> dict:
+    """Build a Reddit comment *data* dict forming a single chain of
+    ``depth`` nesting levels (each parent has exactly one t1 child reply)."""
+    node_data: dict = {
+        "id": "leaf",
+        "author": "deep_user",
+        "body": "deepest reply",
+        "score": 1,
+        "created_utc": 1712000000.0,
+        "depth": depth,
+        "parent_id": "t1_parent",
+        "edited": False,
+        "distinguished": None,
+        "replies": "",
+    }
+    for d in range(depth - 1, -1, -1):
+        node_data = {
+            "id": f"deep_{d}",
+            "author": "deep_user",
+            "body": f"level {d}",
+            "score": 1,
+            "created_utc": 1712000000.0 + d,
+            "depth": d,
+            "parent_id": "t3_root" if d == 0 else f"t1_deep_{d + 1}",
+            "edited": False,
+            "distinguished": None,
+            "replies": {
+                "kind": "Listing",
+                "data": {
+                    "children": [{"kind": "t1", "data": node_data}],
+                    "after": None,
+                    "before": None,
+                },
+            },
+        }
+    return node_data
+
+
+def _build_deep_comment_chain(depth: int) -> RedditComment:
+    """Build a deeply nested RedditComment chain of ``depth`` levels.
+
+    Construction is iterative (no recursion) so it works regardless of the
+    parser/flatten implementation.
+    """
+    node = _make_comment(
+        id="leaf", author="deep_user", body="deepest reply.", depth=depth,
+    )
+    for d in range(depth - 1, -1, -1):
+        node = _make_comment(
+            id=f"deep_{d}", author="deep_user", body=f"level {d}",
+            depth=d, replies=[node],
+        )
+    return node
+
+
+def test_parse_comment_2000_deep_tree_no_recursion_error():
+    """R2-16: a synthetic 2 000-deep comment tree must not raise RecursionError."""
+    deep_data = _build_deep_comment_json(2000)
+    comment = _parse_comment(deep_data)
+    # Walk to the deepest node to confirm the full tree was built.
+    node = comment
+    count = 0
+    while node.replies:
+        node = node.replies[0]
+        count += 1
+    assert count == 2000  # 2 001 nodes total: depth 0 .. 2 000
+
+
+def test_flatten_to_text_2000_deep_tree_no_recursion_error():
+    """R2-16: flattening a 2 000-deep tree must not raise RecursionError."""
+    comment = _build_deep_comment_chain(2000)
+    post = _make_post()
+    text = flatten_to_text(post, [comment])
+    assert "deep_user" in text
+    assert "deepest reply" in text
+
+
+def test_parse_comment_edited_true_not_epoch_timestamp():
+    """R2-16: edited=True (Reddit legacy boolean) must not become 1.0."""
+    data = {
+        "id": "cmt_edited",
+        "author": "editor",
+        "body": "I edited this comment.",
+        "score": 5,
+        "created_utc": 1712000000.0,
+        "depth": 0,
+        "parent_id": "t3_root",
+        "edited": True,
+        "distinguished": None,
+        "replies": "",
+    }
+    comment = _parse_comment(data)
+    assert comment.edited != 1.0
+    assert comment.edited != 1
+    assert comment.edited is None  # edited, but no timestamp
+
+
+def test_parse_comment_edited_float_preserved():
+    """A numeric edited value is preserved as a float timestamp."""
+    data = {
+        "id": "cmt_ts",
+        "author": "editor",
+        "body": "Edited at a known time.",
+        "score": 5,
+        "created_utc": 1712000000.0,
+        "depth": 0,
+        "parent_id": "t3_root",
+        "edited": 1712002500.0,
+        "distinguished": None,
+        "replies": "",
+    }
+    comment = _parse_comment(data)
+    assert comment.edited == 1712002500.0
+    assert isinstance(comment.edited, float)
+
+
+def test_parse_comment_edited_false_preserved():
+    """edited=False means the comment was not edited."""
+    data = {
+        "id": "cmt_notedited",
+        "author": "original",
+        "body": "Never edited.",
+        "score": 5,
+        "created_utc": 1712000000.0,
+        "depth": 0,
+        "parent_id": "t3_root",
+        "edited": False,
+        "distinguished": None,
+        "replies": "",
+    }
+    comment = _parse_comment(data)
+    assert comment.edited is False
+
+
+def test_parse_comment_edited_int_preserved():
+    """An integer edited value (epoch seconds) is preserved as a float."""
+    data = {
+        "id": "cmt_int_edit",
+        "author": "editor",
+        "body": "Edited at an integer epoch.",
+        "score": 5,
+        "created_utc": 1712000000.0,
+        "depth": 0,
+        "parent_id": "t3_root",
+        "edited": 1712002500,
+        "distinguished": None,
+        "replies": "",
+    }
+    comment = _parse_comment(data)
+    assert comment.edited == 1712002500.0
+    assert isinstance(comment.edited, float)

--- a/tinyagentos/knowledge_fetchers/reddit.py
+++ b/tinyagentos/knowledge_fetchers/reddit.py
@@ -50,7 +50,7 @@ class RedditComment:
     depth: int
     parent_id: str
     replies: list["RedditComment"]
-    edited: bool | float
+    edited: bool | float | None
     distinguished: str | None
 
 
@@ -80,30 +80,37 @@ def _normalise_url(url: str, token: str | None = None) -> str:
 # Comment tree builder
 # ---------------------------------------------------------------------------
 
-def _parse_comment(data: dict, depth: int = 0) -> RedditComment:
-    """Recursively parse a comment data dict into a RedditComment."""
-    replies_raw = data.get("replies")
-    replies: list[RedditComment] = []
-    if isinstance(replies_raw, dict):
-        for child in replies_raw.get("data", {}).get("children", []):
-            if child.get("kind") == "t1":
-                replies.append(_parse_comment(child["data"], depth + 1))
-            # "more" nodes inside replies are skipped (stub)
+_MAX_COMMENT_DEPTH = 2000
+_MAX_COMMENT_COUNT = 10_000
 
+
+def _normalise_edited(edited_raw) -> bool | float | None:
+    """Normalise the Reddit ``edited`` field.
+
+    Reddit returns:
+      - ``False``  — comment was not edited.
+      - ``True``   — legacy boolean meaning "edited, no timestamp".
+      - a number   — epoch timestamp of the edit.
+
+    ``bool`` is a subclass of ``int``, so ``isinstance(True, (int, float))``
+    is true.  We must check ``bool`` *first* to avoid coercing ``True`` to
+    ``float(True)`` == ``1.0`` (the 1970 epoch).
+    """
+    if isinstance(edited_raw, bool):
+        return None if edited_raw else False
+    if isinstance(edited_raw, (int, float)):
+        return float(edited_raw)
+    return False
+
+
+def _build_comment_from_data(data: dict, depth: int) -> RedditComment:
+    """Build a RedditComment from raw data (without recursing into replies)."""
     author = data.get("author", "[deleted]") or "[deleted]"
     body = data.get("body", "[deleted]") or "[deleted]"
-    # Normalise deleted authors/bodies
     if author in ("", None):
         author = "[deleted]"
     if body in ("", None):
         body = "[deleted]"
-
-    edited_raw = data.get("edited", False)
-    edited: bool | float
-    if isinstance(edited_raw, (int, float)) and edited_raw is not False:
-        edited = float(edited_raw)
-    else:
-        edited = bool(edited_raw)
 
     return RedditComment(
         id=data.get("id", ""),
@@ -113,10 +120,38 @@ def _parse_comment(data: dict, depth: int = 0) -> RedditComment:
         created_utc=float(data.get("created_utc", 0.0)),
         depth=depth,
         parent_id=data.get("parent_id", ""),
-        replies=replies,
-        edited=edited,
+        replies=[],
+        edited=_normalise_edited(data.get("edited", False)),
         distinguished=data.get("distinguished"),
     )
+
+
+def _parse_comment(data: dict, depth: int = 0) -> RedditComment:
+    """Parse a comment data dict into a RedditComment.
+
+    Uses an explicit stack instead of recursion so that arbitrarily deep
+    comment trees (e.g. 2 000-level chains) do not exhaust the Python stack.
+    """
+    root = _build_comment_from_data(data, depth)
+    stack: list[tuple[RedditComment, dict]] = [(root, data)]
+    count = 0
+    while stack:
+        node, node_data = stack.pop()
+        count += 1
+        if count >= _MAX_COMMENT_COUNT:
+            break
+        if node.depth >= _MAX_COMMENT_DEPTH:
+            continue
+        replies_raw = node_data.get("replies")
+        if isinstance(replies_raw, dict):
+            for child in replies_raw.get("data", {}).get("children", []):
+                if child.get("kind") == "t1":
+                    child_data = child["data"]
+                    child_comment = _build_comment_from_data(child_data, node.depth + 1)
+                    node.replies.append(child_comment)
+                    stack.append((child_comment, child_data))
+                # "more" nodes inside replies are skipped (stub)
+    return root
 
 
 def _parse_comments_listing(listing: dict) -> list[RedditComment]:
@@ -324,13 +359,21 @@ async def fetch_saved(
 # ---------------------------------------------------------------------------
 
 def _flatten_comment(comment: RedditComment, lines: list[str]) -> None:
-    indent = "  " * comment.depth
-    lines.append(f"{indent}**{comment.author}** (score: {comment.score})")
-    for body_line in comment.body.splitlines():
-        lines.append(f"{indent}{body_line}")
-    lines.append("")
-    for reply in comment.replies:
-        _flatten_comment(reply, lines)
+    """Flatten a comment tree into text lines (iterative to avoid RecursionError)."""
+    stack: list[RedditComment] = [comment]
+    count = 0
+    while stack:
+        node = stack.pop()
+        count += 1
+        if count >= _MAX_COMMENT_COUNT:
+            break
+        indent = "  " * node.depth
+        lines.append(f"{indent}**{node.author}** (score: {node.score})")
+        for body_line in node.body.splitlines():
+            lines.append(f"{indent}{body_line}")
+        lines.append("")
+        for reply in reversed(node.replies):
+            stack.append(reply)
 
 
 def flatten_to_text(post: RedditPost, comments: list[RedditComment]) -> str:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-16 reddit fetcher: unbounded recursion and edited=True -> 1.0 timestamp

Autonomous build of board card tsk-pn6ypz.

Reddit comment parser (_parse_comment) and flattener (_flatten_comment) both
recursed over comment trees with no depth bound, causing RecursionError on
pathologically deep trees (proven at depth 1 200). The edited field coerced
True (Reddit's legacy "edited, no timestamp" boolean) to float(True) == 1.0,
i.e. the 1970 epoch.

Fix: replace both recursions with iterative stack-based walks bounded by
_MAX_COMMENT_DEPTH (2 000) and _MAX_COMMENT_COUNT (10 000). Extract the
per-node build logic into _build_comment_from_data and the edited
normalisation into _normalise_edited, which checks bool before int/float to
avoid the True -> 1.0 coercion. edited=True now maps to None; numeric
timestamps and False are preserved.

TypeScript type for RedditComment.edited updated to boolean | number | null,
and the "(edited)" indicator in RedditApp now triggers on any value that is
not strictly false, preserving user-visible behaviour for legacy True.

RED run on origin/dev (source fix absent, tests from this commit present):

```
FAILED tests/test_knowledge_fetcher_reddit.py::test_parse_comment_2000_deep_tree_no_recursion_error
FAILED tests/test_knowledge_fetcher_reddit.py::test_flatten_to_text_2000_deep_tree_no_recursion_error
FAILED tests/test_knowledge_fetcher_reddit.py::test_parse_comment_edited_true_not_epoch_timestamp
3 failed, 24 passed in 8.55s
```

Green run (fix present):

```
44 passed in 0.78s
```

Files:
 changelog.d/tsk-pn6ypz-reddit-recursion-edited.md |   8 ++
 desktop/src/apps/RedditApp.tsx                    |   2 +-
 desktop/src/lib/reddit.ts                         |   2 +-
 tests/test_knowledge_fetcher_reddit.py            | 159 ++++++++++++++++++++++
 tinyagentos/knowledge_fetchers/reddit.py          |  97 +++++++++----
 5 files changed, 239 insertions(+), 29 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reddit comment trees now load reliably, including deeply nested discussions, without causing errors.
  * Very large comment trees are safely limited to maintain stable performance.
  * Edited comment indicators and timestamps are now represented accurately, including unedited comments and missing edit information.
  * The “edited” label now displays consistently when edit information is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->