### PR TITLE
[lib-audit] R2-28 registry keypair write is not atomic -- concurrent reader sees an empty key

### DIFF
--- a/changelog.d/tsk-aiwd2x-registry-keypair-atomic-write.md
+++ b/changelog.d/tsk-aiwd2x-registry-keypair-atomic-write.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `load_or_create_signing_keypair`: concurrent reader can see an empty key file when two processes race; fixed by using `filelock` around generate-or-load and `atomic_write_bytes` (tmp + rename, mode 0o600) for the write, so either the old key or the new key is always visible atomically.

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -319,6 +319,65 @@ class TestSigningKeypair:
         assert pem_file.exists()
 
 
+class TestSigningKeypairConcurrentRace:
+    """RED test: concurrent calls must always get the same non-empty key.
+
+    The current load_or_create_signing_keypair has a race condition where two
+    concurrent processes can both see the key file as absent, then one creates
+    it with O_EXCL while the other waits. The second process then reads the
+    empty file (created but not yet written to) and gets an empty key, breaking
+    boot.
+    """
+
+    def test_concurrent_threads_always_get_same_nonempty_key(self, tmp_path):
+        import threading
+        from pathlib import Path
+
+        key_path = tmp_path / "keys"
+        results: list[tuple[bytes, bytes]] = []
+        errors: list[BaseException] = []
+
+        def call_loader():
+            try:
+                priv, pub = load_or_create_signing_keypair(key_path)
+                results.append((priv, pub))
+            except Exception as e:
+                errors.append(e)
+
+        # Run 50 concurrent threads
+        threads = []
+        for _ in range(50):
+            t = threading.Thread(target=call_loader)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # Fail if any errors occurred
+        assert (
+            len(errors) == 0
+        ), f"Unexpected errors during concurrent load: {errors}"
+
+        # All must have gotten a non-empty key
+        assert len(results) == 50, f"Expected 50 results, got {len(results)}"
+
+        first_priv = results[0][0]
+        # Every result must have the same non-empty private key
+        for i, (priv, pub) in enumerate(results):
+            assert priv == first_priv, (
+                f"Result {i} has different private key"
+            )
+            assert len(priv) > 0, f"Result {i} has empty private key"
+            assert b"PRIVATE" in priv, f"Result {i} private key is malformed"
+
+        # Verify file mode is 0o600
+        pem_file = key_path / "agent_registry_signing.pem"
+        assert pem_file.exists(), "Key file was never created"
+        mode = pem_file.stat().st_mode & 0o777
+        assert mode == 0o600, f"Key file mode is {oct(mode)}, expected 0o600"
+
+
 # ---------------------------------------------------------------------------
 # AgentRegistryStore: registration
 # ---------------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -265,10 +265,11 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
 
     Generates an Ed25519 keypair on first call and persists the private key
     PEM to ``<data_dir>/agent_registry_signing.pem`` with mode 0600.
-    Subsequent calls load and return the same keypair.  Idempotent under
-    concurrent processes - the writer uses O_EXCL so only one process
-    creates the file.
+    Subsequent calls load and return the same keypair.  Uses filelock to
+    serialize the generate-or-load and atomic_write (tmp + rename) for the
+    write so concurrent processes never see an empty or partial key.
     """
+    from filelock import FileLock
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import (
         Encoding,
@@ -277,26 +278,21 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
         PublicFormat,
         load_pem_private_key,
     )
+    from tinyagentos.atomic_io import atomic_write_bytes
 
     data_dir.mkdir(parents=True, exist_ok=True)
     pem_path = data_dir / _REGISTRY_KEY_FILENAME
+    lock_path = data_dir / (_REGISTRY_KEY_FILENAME + ".lock")
 
-    if pem_path.exists():
-        private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
-    else:
-        private_key = Ed25519PrivateKey.generate()
-        pem_bytes = private_key.private_bytes(
-            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
-        )
-        try:
-            fd = os.open(str(pem_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-            try:
-                os.write(fd, pem_bytes)
-            finally:
-                os.close(fd)
-        except FileExistsError:
-            # Lost the race - load the winner's key instead.
+    with FileLock(str(lock_path)):
+        if pem_path.exists():
             private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
+        else:
+            private_key = Ed25519PrivateKey.generate()
+            pem_bytes = private_key.private_bytes(
+                Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+            )
+            atomic_write_bytes(pem_path, pem_bytes, mode=0o600)
 
     private_pem = private_key.private_bytes(
         Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-28 registry keypair write is not atomic -- concurrent reader sees an empty key

Autonomous build of board card tsk-aiwd2x.

- use filelock around generate-or-load in load_or_create_signing_keypair
- write via atomic_write_bytes (tmp + rename, mode 0o600) instead of hand-rolled O_EXCL write

RED test: 50 concurrent threads always get same non-empty key, file mode 0o600
152 tests pass including new TestSigningKeypairConcurrentRace
Docs-Reviewed: signatory keypair persistence internal; no user-visible API change, no routes/desktop app catalog change

Files:
 .../tsk-aiwd2x-registry-keypair-atomic-write.md    |  3 ++
 tests/test_agent_registry_store.py                 | 59 ++++++++++++++++++++++
 tinyagentos/agent_registry_store.py                | 32 +++++-------
 3 files changed, 76 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved signing-key initialization under concurrent access.
  - Prevented readers from observing incomplete or empty key files.
  - Ensured generated signing keys are written atomically and retain secure file permissions.

- **Tests**
  - Added coverage for concurrent key initialization across multiple threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->