### PR TITLE
[lib-audit] R2-25 fire-and-forget tasks can be garbage-collected mid-flight

### DIFF
--- a/changelog.d/tsk-6ernm7-r2-25-bg-task-gc.md
+++ b/changelog.d/tsk-6ernm7-r2-25-bg-task-gc.md
@@ -1,0 +1,7 @@
+### Fixed
+- Fire-and-forget asyncio tasks in `ClusterManager` and the `/api/agents` deploy
+  route are now kept alive via a new `_spawn_background_task` helper that holds
+  a strong reference in `_background_tasks` (asyncio recommended pattern).  Tasks
+  created inline without a reference can be garbage-collected mid-flight, which
+  previously left agents stuck in `"deploying"` forever.  The done-callback now
+  logs exceptions instead of silently discarding them.

--- a/tests/test_cluster_r2_25_background_tasks.py
+++ b/tests/test_cluster_r2_25_background_tasks.py
@@ -1,0 +1,92 @@
+"""RED tests for R2-25: fire-and-forget tasks must survive GC.
+
+The manager must keep strong references to background asyncio tasks so that
+``gc.collect()`` before the event loop gets a chance to run them does not
+collect (cancel) the task mid-flight.  ``stop()`` must also drain outstanding
+tasks and log any exceptions surfaced by the done-callback.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+
+import pytest
+
+from tinyagentos.cluster.manager import ClusterManager
+
+
+@pytest.mark.asyncio
+class TestSpawnBackgroundTaskSurvivesGC:
+    """R2-25: fire-and-forget tasks must not be garbage-collected mid-flight."""
+
+    async def test_task_survives_gc_before_execution(self):
+        """Creating a task via the manager helper and gc.collect()-ing
+        before the loop runs must NOT cancel the task, it should still
+        complete."""
+        mgr = ClusterManager()
+
+        started = asyncio.Event()
+
+        async def _work():
+            started.set()
+
+        task = mgr._spawn_background_task(_work())
+        gc.collect()
+
+        # Wait for the task to actually run.  If GC cancelled it, this
+        # raises TimeoutError.
+        await asyncio.wait_for(started.wait(), timeout=5)
+        await asyncio.wait_for(asyncio.shield(task), timeout=5)
+        assert task.done()
+        await mgr.stop()
+
+    async def test_task_result_preserved(self):
+        """The helper must return the task so callers can inspect results."""
+        mgr = ClusterManager()
+
+        async def _work():
+            await asyncio.sleep(0.01)
+            return "ok"
+
+        task = mgr._spawn_background_task(_work())
+        result = await task
+        assert result == "ok"
+        await mgr.stop()
+
+    async def test_stop_awaits_outstanding_tasks(self):
+        """stop() must drain _background_tasks so fire-and-forget tasks
+        complete before shutdown."""
+        mgr = ClusterManager()
+        mgr._monitor_task = None
+
+        flag = {"done": False}
+
+        async def _work():
+            await asyncio.sleep(0.05)
+            flag["done"] = True
+
+        mgr._spawn_background_task(_work())
+        await mgr.stop()
+
+        assert flag["done"] is True
+        assert len(mgr._background_tasks) == 0
+
+    async def test_exception_logged_in_callback(self, caplog):
+        """Exceptions inside background tasks must be logged by the done
+        callback, not silently swallowed."""
+        mgr = ClusterManager()
+
+        async def _boom():
+            raise ValueError("kaboom")
+
+        with caplog.at_level(logging.ERROR, logger="tinyagentos.cluster.manager"):
+            mgr._spawn_background_task(_boom())
+            # Let the event loop run so the task and its callback fire.
+            await asyncio.sleep(0.1)
+
+        assert any(
+            record.levelno >= logging.ERROR and "Background task" in record.getMessage()
+            for record in caplog.records
+        ), f"Expected logged error for failed background task, got: {[r.getMessage() for r in caplog.records]}"
+        await mgr.stop()

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -5,7 +5,7 @@ import logging
 import re
 import secrets
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Coroutine
 
 from tinyagentos.cluster.worker_protocol import GpuLease, WorkerInfo
 
@@ -83,6 +83,28 @@ class ClusterManager:
         self._fenced: bool = False  # True when another controller has advanced generation
         # Maximum number of leases a single worker can hold (prevents DoS)
         self._max_leases_per_worker = max_leases_per_worker
+
+    def _spawn_background_task(self, coro: Coroutine) -> asyncio.Task:
+        """Create a fire-and-forget task that survives garbage collection.
+
+        Uses the asyncio-recommended pattern: the task is held in
+        ``_background_tasks`` so the garbage collector cannot collect it
+        mid-flight, and removed via ``add_done_callback(discard)`` on
+        completion.  Exceptions are logged so silently-failing tasks do not
+        disappear into the void.
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+
+        def _on_done(t: asyncio.Task) -> None:
+            self._background_tasks.discard(t)
+            if not t.cancelled():
+                exc = t.exception()
+                if exc is not None:
+                    logger.exception("Background task failed: %s", exc, exc_info=exc)
+
+        task.add_done_callback(_on_done)
+        return task
 
     async def start(self):
         # taOS #640: increment generation on each controller start (split-brain
@@ -222,9 +244,7 @@ class ClusterManager:
                     info.name,
                 )
 
-        task = asyncio.create_task(_promote_bg())
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        self._spawn_background_task(_promote_bg())
         return (True, "")
 
     def kv_quant_union(self) -> list[str]:
@@ -444,7 +464,7 @@ class ClusterManager:
                 "updating": f"Worker '{worker.name}' is applying an update (reason: {reason}). It will restart when done.",
             }
             try:
-                asyncio.get_running_loop().create_task(
+                self._spawn_background_task(
                     self._notifications.emit_event(
                         event_type,
                         title_map.get(status, f"Worker '{worker.name}' {status}"),
@@ -469,9 +489,7 @@ class ClusterManager:
                     logger.exception("Failed to persist worker '%s'", worker.name)
 
             try:
-                task = asyncio.get_running_loop().create_task(_safe_persist())
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
+                self._spawn_background_task(_safe_persist())
             except RuntimeError:
                 pass  # no running loop (e.g. sync tests) — skip gracefully
         # Fire worker.online notification when a previously-offline worker recovers.
@@ -481,7 +499,7 @@ class ClusterManager:
         # trigger a false "back online" event (taOS #890 C2).
         if self._notifications and prev_status in ("offline", "stale") and worker.status == "online":
             try:
-                asyncio.get_running_loop().create_task(
+                self._spawn_background_task(
                     self._notifications.emit_event(
                         "worker.online",
                         f"Worker '{worker.name}' came back online",
@@ -780,7 +798,7 @@ class ClusterManager:
                 f"{'Tasks will complete before detach.' if graceful else 'All leases released immediately.'}"
             )
             try:
-                task = asyncio.get_running_loop().create_task(
+                self._spawn_background_task(
                     self._notifications.emit_event(
                         "worker.drain",
                         f"Worker '{name}' draining",
@@ -788,8 +806,6 @@ class ClusterManager:
                         level="info",
                     )
                 )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
             except RuntimeError:
                 pass
 
@@ -816,7 +832,7 @@ class ClusterManager:
 
         if self._notifications:
             try:
-                task = asyncio.get_running_loop().create_task(
+                self._spawn_background_task(
                     self._notifications.emit_event(
                         "worker.online",
                         f"Worker '{name}' drain cancelled",
@@ -824,8 +840,6 @@ class ClusterManager:
                         level="info",
                     )
                 )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
             except RuntimeError:
                 pass
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -864,7 +864,11 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
             finally:
                 await save_config_locked(config, config.config_path)
 
-        asyncio.create_task(_background_deploy())
+        cm = getattr(request.app.state, "cluster_manager", None)
+        if cm is not None:
+            cm._spawn_background_task(_background_deploy())
+        else:
+            asyncio.create_task(_background_deploy())
 
         # Archive smoke-check: verify trace path end-to-end after provisioning.
         # A failure here does NOT abort the deploy — it surfaces a warning flag.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-25 fire-and-forget tasks can be garbage-collected mid-flight

Autonomous build of board card tsk-6ernm7.

Fire-and-forget asyncio tasks created without a strong reference can be
garbage-collected mid-flight. Two unscheduled notification tasks in
ClusterManager.heartbeat (worker-initiated drain and worker.online recovery)
were spawned via get_running_loop().create_task() with no reference kept, so
the GC could cancel them before they emitted -- leaving the event unlogged
and the worker stuck. The _background_deploy task in routes/agents.py had
the same defect: if GC collected it the agent stayed in "deploying" forever.

Fix: add a _spawn_background_task helper on ClusterManager that follows the
asyncio-recommended strong-reference pattern: add to _background_tasks set
plus add_done_callback(discard), with exception logging in the callback.
All inline create_task call-sites in manager.py (register_worker,
heartbeat, drain_worker, cancel_drain) now use the helper, including the
two previously-untracked notification tasks. The deploy route in agents.py
now uses the same helper via app.state.cluster_manager when available.

stop() already drains _background_tasks with gather + 10s timeout (Q2-2).

RED proof (test written, fix not yet applied, run against origin/dev):

    $ uv run pytest tests/test_cluster_r2_25_background_tasks.py -q
    FAILED tests/test_cluster_r2_25_background_tasks.py::TestSpawnBackgroundTaskSurvivesGC::test_task_survives_gc_before_execution - AttributeError: 'ClusterManager' object has no attribute '_spawn_background_task'
    FAILED tests/test_cluster_r2_25_background_tasks.py::TestSpawnBackgroundTaskSurvivesGC::test_task_result_preserved - AttributeError: 'ClusterManager' object has no attribute '_spawn_background_task'
    FAILED tests/test_cluster_r2_25_background_tasks.py::TestSpawnBackgroundTaskSurvivesGC::test_stop_awaits_outstanding_tasks - AttributeError: 'ClusterManager' object has no attribute '_spawn_background_task'
    FAILED tests/test_cluster_r2_25_background_tasks.py::TestSpawnBackgroundTaskSurvivesGC::test_exception_logged_in_callback - AttributeError: 'ClusterManager' object has no attribute '_spawn_background_task'
    4 failed in 0.27s

GREEN after fix:

    $ uv run pytest tests/test_cluster_r2_25_background_tasks.py -q
    4 passed in 0.37s

Proof: 4/4 new tests pass on dev HEAD 37ae7d958; 158 cluster tests and 21
agents tests still pass (no regressions).

Docs-Reviewed: agents.py change is an internal task-tracking detail with no
user-facing API contract change; agent-coordination.md covers development
discipline, not fire-and-forget task lifecycle, so no doc update needed.

Files:
 changelog.d/tsk-6ernm7-r2-25-bg-task-gc.md   |  7 +++
 tests/test_cluster_r2_25_background_tasks.py | 92 ++++++++++++++++++++++++++++
 tinyagentos/cluster/manager.py               | 44 ++++++++-----
 tinyagentos/routes/agents.py                 |  6 +-
 4 files changed, 133 insertions(+), 16 deletions(-)