### PR TITLE
fix-forward #2870 (tsk-aiwd2x): add the fenced RED run the card's ACCEPTANCE demands (R2-28)

### DIFF
--- a/changelog.d/tsk-aiwd2x-registry-keypair-atomic-write.md
+++ b/changelog.d/tsk-aiwd2x-registry-keypair-atomic-write.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `load_or_create_signing_keypair`: concurrent reader can see an empty key file when two processes race; fixed by using `filelock` around generate-or-load and `atomic_write_bytes` (tmp + rename, mode 0o600) for the write, so either the old key or the new key is always visible atomically.

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -319,6 +319,65 @@ class TestSigningKeypair:
         assert pem_file.exists()
 
 
+class TestSigningKeypairConcurrentRace:
+    """RED test: concurrent calls must always get the same non-empty key.
+
+    The current load_or_create_signing_keypair has a race condition where two
+    concurrent processes can both see the key file as absent, then one creates
+    it with O_EXCL while the other waits. The second process then reads the
+    empty file (created but not yet written to) and gets an empty key, breaking
+    boot.
+    """
+
+    def test_concurrent_threads_always_get_same_nonempty_key(self, tmp_path):
+        import threading
+        from pathlib import Path
+
+        key_path = tmp_path / "keys"
+        results: list[tuple[bytes, bytes]] = []
+        errors: list[BaseException] = []
+
+        def call_loader():
+            try:
+                priv, pub = load_or_create_signing_keypair(key_path)
+                results.append((priv, pub))
+            except Exception as e:
+                errors.append(e)
+
+        # Run 50 concurrent threads
+        threads = []
+        for _ in range(50):
+            t = threading.Thread(target=call_loader)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # Fail if any errors occurred
+        assert (
+            len(errors) == 0
+        ), f"Unexpected errors during concurrent load: {errors}"
+
+        # All must have gotten a non-empty key
+        assert len(results) == 50, f"Expected 50 results, got {len(results)}"
+
+        first_priv = results[0][0]
+        # Every result must have the same non-empty private key
+        for i, (priv, pub) in enumerate(results):
+            assert priv == first_priv, (
+                f"Result {i} has different private key"
+            )
+            assert len(priv) > 0, f"Result {i} has empty private key"
+            assert b"PRIVATE" in priv, f"Result {i} private key is malformed"
+
+        # Verify file mode is 0o600
+        pem_file = key_path / "agent_registry_signing.pem"
+        assert pem_file.exists(), "Key file was never created"
+        mode = pem_file.stat().st_mode & 0o777
+        assert mode == 0o600, f"Key file mode is {oct(mode)}, expected 0o600"
+
+
 # ---------------------------------------------------------------------------
 # AgentRegistryStore: registration
 # ---------------------------------------------------------------------------

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -265,10 +265,11 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
 
     Generates an Ed25519 keypair on first call and persists the private key
     PEM to ``<data_dir>/agent_registry_signing.pem`` with mode 0600.
-    Subsequent calls load and return the same keypair.  Idempotent under
-    concurrent processes - the writer uses O_EXCL so only one process
-    creates the file.
+    Subsequent calls load and return the same keypair.  Uses filelock to
+    serialize the generate-or-load and atomic_write (tmp + rename) for the
+    write so concurrent processes never see an empty or partial key.
     """
+    from filelock import FileLock
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import (
         Encoding,
@@ -277,26 +278,21 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
         PublicFormat,
         load_pem_private_key,
     )
+    from tinyagentos.atomic_io import atomic_write_bytes
 
     data_dir.mkdir(parents=True, exist_ok=True)
     pem_path = data_dir / _REGISTRY_KEY_FILENAME
+    lock_path = data_dir / (_REGISTRY_KEY_FILENAME + ".lock")
 
-    if pem_path.exists():
-        private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
-    else:
-        private_key = Ed25519PrivateKey.generate()
-        pem_bytes = private_key.private_bytes(
-            Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
-        )
-        try:
-            fd = os.open(str(pem_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-            try:
-                os.write(fd, pem_bytes)
-            finally:
-                os.close(fd)
-        except FileExistsError:
-            # Lost the race - load the winner's key instead.
+    with FileLock(str(lock_path)):
+        if pem_path.exists():
             private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
+        else:
+            private_key = Ed25519PrivateKey.generate()
+            pem_bytes = private_key.private_bytes(
+                Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()
+            )
+            atomic_write_bytes(pem_path, pem_bytes, mode=0o600)
 
     private_pem = private_key.private_bytes(
         Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2870 (tsk-aiwd2x): add the fenced RED run the card's ACCEPTANCE demands (R2-28)

Autonomous build of board card tsk-5gnjii.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

REVISION: built on `exec/tsk-aiwd2x` (cut at `d8202271ae020d4cea1779e4094eae2c25048e38`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

PR #2870 (exec/tsk-aiwd2x) carries the fix in tinyagentos/agent_registry_store.py,
the test in tests/test_agent_registry_store.py, and the changelog fragment, but its
commit body has no fenced RED run while the card demands RED-FIRST. This commit adds
the proof only; zero source/test-file diff versus BASE.

The fix is already present on exec/tsk-aiwd2x (load_or_create_signing_keypair uses
filelock + atomic_write_bytes). No code changes were needed.

RED run on origin/dev (tinyagentos/agent_registry_store.py fix absent):

```
F                                                                        [100%]
=================================== FAILURES ===================================
_ TestSigningKeypairConcurrentRace.test_concurrent_threads_always_get_same_nonempty_key _

self = <test_agent_registry_store.TestSigningKeypairConcurrentRace object at 0x7ff6704d9310>
tmp_path = PosixPath('/tmp/exec-tsk-5gnjii.tmp/pytest-of-jay/pytest-24/test_concurrent_threads_always0')

    def test_concurrent_threads_always_get_same_nonempty_key(self, tmp_path):
        import threading
        from pathlib import Path

        key_path = tmp_path / "keys"
        results: list[tuple[bytes, bytes]] = []
        errors: list[BaseException] = []

        def call_loader():
            try:
                priv, pub = load_or_create_signing_keypair(key_path)
                results.append((priv, pub))
            except Exception as e:
                errors.append(e)

        # Run 50 concurrent threads
        threads = []
        for _ in range(50):
            t = threading.Thread(target=call_loader)
            threads.append(t)
            t.start()

        for t in threads:
            t.join()

        # Fail if any errors occurred
>       assert (
            len(errors) == 0
        ), f"Unexpected errors during concurrent load: {errors}"
E       AssertionError: Unexpected errors during concurrent load: [ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming')]
E       assert 27 == 0
E        +  where 27 = len([ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for mo...e. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'), ...])

tests/test_agent_registry_store.py:358: AssertionError
=========================== short test summary info ============================
FAILED tests/test_agent_registry_store.py::TestSigningKeypairConcurrentRace::test_concurrent_threads_always_get_same_nonempty_key
1 failed in 0.36s
```

Green run on exec/tsk-aiwd2x (fix present):

```
.                                                                        [100%]
1 passed in 0.34s
```

Full suite on exec/tsk-aiwd2x (fix present):

```
........................................................................ [ 47%]
........................................................................ [ 94%]
........                                                                 [100%]
152 passed in 1.91s
```

Docs-Reviewed: signatory keypair persistence internal; no user-visible API change, no routes/desktop app catalog change

Files:
 .../tsk-aiwd2x-registry-keypair-atomic-write.md    |  3 ++
 tests/test_agent_registry_store.py                 | 59 ++++++++++++++++++++++
 tinyagentos/agent_registry_store.py                | 32 +++++-------
 3 files changed, 76 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved signing-keypair creation when multiple processes access it simultaneously.
  - Prevented incomplete or empty key files from being observed during concurrent writes.
  - Ensured persisted private keys are written securely with restricted file permissions.
  - Ensured concurrent keypair requests consistently use the same valid, non-empty key.
  - Improved reliability when creating or loading signing keys under high concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->