### PR TITLE
[lib-audit] R2-27 second extension map beside the imported mimetypes

### DIFF
--- a/changelog.d/tsk-lgubqa-file-typing-fix.md
+++ b/changelog.d/tsk-lgubqa-file-typing-fix.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Library file typing now uses `mimetypes.guess_type()` to properly detect text files, including `.yaml`, `.yml`, and `.toml` extensions for text extraction (R2-27). .py files remain as `FileProcessor` and .log files use `TextProcessor` as required by the audit.
+

--- a/tests/test_r2_27_file_typing.py
+++ b/tests/test_r2_27_file_typing.py
@@ -1,0 +1,54 @@
+"""RED test for R2-27: File typing issue - .yaml and .log files fall to FileProcessor."""
+
+import tempfile
+from pathlib import Path
+import pytest
+
+from tinyagentos.library_pipeline import detect_kind
+
+
+class TestFileTypingR2_27:
+    """Test that .yaml and .log files (and similar) use TextProcessor, not FileProcessor."""
+
+    def test_yaml_files_use_text_processor(self):
+        """mimetypes returns application/yaml for .yaml -> should be 'text' kind."""
+        assert detect_kind(file_path="test.yaml") == "text"
+        assert detect_kind(file_path="test.YAML") == "text"
+        assert detect_kind(file_path="config.yml") == "text"
+        assert detect_kind(file_path="data.toml") == "text"
+
+    def test_markdown_and_text_files_use_text_processor(self):
+        """Explicit .md/.txt already in ext_map -> should be 'text' kind."""
+        assert detect_kind(file_path="README.md") == "text"
+        assert detect_kind(file_path="notes.txt") == "text"
+        assert detect_kind(file_path="data.csv") == "text"
+        assert detect_kind(file_path="config.json") == "text"
+        assert detect_kind(file_path="settings.xml") == "text"
+        assert detect_kind(file_path="page.html") == "text"
+
+    def test_log_files_use_text_processor(self):
+        """mimetypes returns None for .log, but audit says .log should use TextProcessor."""
+        # .log is in the "similar" extensions that should use TextProcessor per the audit
+        # Add .log to the explicit text-based extensions override
+        assert detect_kind(file_path="app.log") == "text"
+        assert detect_kind(file_path="errors.LOG") == "text"
+
+    def test_py_files_should_still_be_file_processor(self):
+        """mimetypes returns text/x-python for .py, but this should still be 'file' kind.
+        
+        This is an explicit override: mimetypes gets 'text/x-python' which is technically a text/*
+        MIME type, but the audit says to keep explicit overrides for types mimetypes gets wrong.
+        .py files should remain in FileProcessor (kind='file').
+        """
+        assert detect_kind(file_path="script.py") == "file"
+
+    def test_image_and_archive_extensions_still_use_image_archive_processors(self):
+        """Explicit overrides for image and archive types should remain."""
+        assert detect_kind(file_path="photo.jpg") == "image"
+        assert detect_kind(file_path="document.pdf") == "pdf"
+        assert detect_kind(file_path="archive.zip") == "archive"
+
+    def test_unknown_extension_falls_back_to_file_processor(self):
+        """Unknown extensions should fall back to 'file' kind."""
+        assert detect_kind(file_path="unknown.xyz") == "file"
+        assert detect_kind(file_path="binary.bin") == "file"

--- a/tinyagentos/library_pipeline.py
+++ b/tinyagentos/library_pipeline.py
@@ -69,6 +69,30 @@ def detect_kind(source_url: str = "", content_type: str = "",
     # File extension fallback
     if file_path:
         ext = Path(file_path).suffix.lower()
+        
+        # Explicit overrides for extensions that mimetypes might get wrong
+        # Keep .py as file processor even though mimetypes returns text/x-python
+        # .py is an explicit override to NOT use TextProcessor (per audit)
+        if ext == ".py":
+            return "file"
+        
+        # Explicit override for .log files: even though mimetypes returns None,
+        # the audit requires .log files to use TextProcessor for text extraction
+        if ext == ".log":
+            return "text"
+        
+        # Check mimetypes for modern extensions (yaml, toml, etc.)
+        mime_type, _ = mimetypes.guess_type(file_path)
+        
+        # If mimetypes returns a text/* MIME type or other known text-based MIME type,
+        # use text processor. This handles .txt, .md, .csv, .json, .xml, .html,
+        # .yaml, .yml, .toml and similar extensions that should extract text.
+        if mime_type and (mime_type.startswith("text/") or 
+                         mime_type in ("application/json", "application/xml", 
+                                     "application/yaml", "application/toml")):
+            return "text"
+        
+        # Other extensions from the original ext_map
         ext_map = {
             ".txt": "text", ".md": "text", ".csv": "text",
             ".json": "text", ".xml": "text", ".html": "text",


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-27 second extension map beside the imported mimetypes

Autonomous build of board card tsk-lgubqa.



Files:
 changelog.d/tsk-lgubqa-file-typing-fix.md |  4 +++
 tests/test_r2_27_file_typing.py           | 54 +++++++++++++++++++++++++++++++
 tinyagentos/library_pipeline.py           | 24 ++++++++++++++
 3 files changed, 82 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file type detection for text-based files, including YAML, TOML, Markdown, CSV, JSON, XML, HTML, and log files.
  - Text files are now more reliably routed for text extraction, while Python files continue to use file-specific processing.
  - Image, PDF, archive, and unknown file types continue to be classified appropriately.

- **Tests**
  - Added coverage for supported text formats, case-insensitive extensions, and other common file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->