### PR TITLE
[lib-audit] R2-3 traces hard-wired to port 6969 -- all traces lost on non-default ports

### DIFF
--- a/changelog.d/tsk-j2l2qy-trace-url-port-fix.md
+++ b/changelog.d/tsk-j2l2qy-trace-url-port-fix.md
@@ -1,0 +1,9 @@
+### Fixed
+- `LLMProxy.start()` in `tinyagentos/llm_proxy.py` now exports `TAOS_TRACE_URL`
+  derived from the controller's bound port so the `TaosLiteLLMCallback` inside
+  the LiteLLM subprocess can POST trace, lifecycle and spend events to the
+  correct controller instead of silently dropping them on non-default ports
+  (#tsk-j2l2qy).
+- `TaosLiteLLMCallback` in `tinyagentos/litellm_callback.py` now falls back to
+  `TAOS_PORT` (defaulting to 6969) when `TAOS_TRACE_URL` is unset, so standalone
+  callers and custom-port installs still emit traces (#tsk-j2l2qy).

--- a/tests/test_litellm_callback.py
+++ b/tests/test_litellm_callback.py
@@ -342,3 +342,46 @@ async def test_success_event_without_budget_env_does_not_crash(monkeypatch):
 
     # Must not raise even though TAOS_AGENT_BUDGETS is unset.
     await cb.async_log_success_event(kwargs, resp, t0, t1)
+
+
+def test_callback_uses_taos_port_as_trace_url_fallback(monkeypatch):
+    """When TAOS_TRACE_URL is unset, the callback falls back to TAOS_PORT
+    (defaulting to 6969) so non-default controller ports are not silently
+    dropped."""
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+    monkeypatch.setenv("TAOS_PORT", "7117")
+    monkeypatch.delenv("TAOS_TRACE_URL", raising=False)
+    cb = TaosLiteLLMCallback()
+    assert cb._trace_url == "http://127.0.0.1:7117/api/trace"
+    monkeypatch.delenv("TAOS_PORT", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_success_posts_trace_to_taos_port(monkeypatch):
+    """Trace POST must target the TAOS_PORT-derived URL, not the hard-coded
+    6969 fallback, so agents on non-default ports still emit trace events."""
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+    monkeypatch.setenv("TAOS_PORT", "7117")
+    monkeypatch.delenv("TAOS_TRACE_URL", raising=False)
+    cb = TaosLiteLLMCallback()
+    posted = []
+
+    async def _mock_post(url, payload):
+        posted.append(url)
+
+    cb._post = _mock_post
+
+    from datetime import datetime, timezone
+    t0 = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 10, 0, 1, tzinfo=timezone.utc)
+    await cb.async_log_success_event(_make_kwargs(), _make_response(), t0, t1)
+
+    assert len(posted) >= 1
+    assert "7117" in posted[0]
+    monkeypatch.delenv("TAOS_PORT", raising=False)

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -360,6 +360,79 @@ class TestDatabaseUrlPropagation:
         assert "DATABASE_URL" not in captured["env"]
 
 
+class TestTraceUrlPropagation:
+    @pytest.mark.asyncio
+    async def test_start_exports_trace_url_with_proxy_port(self, tmp_path, monkeypatch):
+        """The proxy must export TAOS_TRACE_URL pointing at its bound port so the
+        LiteLLM callback inside the subprocess can POST traces to the right
+        controller, not silently drop them on non-default ports."""
+        import shutil
+        import tinyagentos.llm_proxy as mod
+
+        class _FakeResp:
+            status_code = 200
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def get(self, url): return _FakeResp()
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, *args, **kwargs):
+                captured["env"] = kwargs.get("env") or {}
+
+        monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
+
+        p = mod.LLMProxy(port=7117)
+        await p.start(backends=[])
+
+        assert captured["env"]["TAOS_TRACE_URL"] == "http://127.0.0.1:7117/api/trace"
+
+    @pytest.mark.asyncio
+    async def test_start_logs_trace_url(self, tmp_path, monkeypatch, caplog):
+        """On successful start, the proxy must log the trace URL it exported so
+        operators can verify traces are targeting the correct port."""
+        import logging
+        import shutil
+        import tinyagentos.llm_proxy as mod
+
+        class _FakeResp:
+            status_code = 200
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def get(self, url): return _FakeResp()
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+
+        class _FakePopen:
+            def __init__(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
+
+        p = mod.LLMProxy(port=7117)
+        with caplog.at_level(logging.INFO, logger="tinyagentos.llm_proxy"):
+            result = await p.start(backends=[])
+
+        assert result is True
+        assert any(
+            "trace URL" in rec.getMessage() and "7117" in rec.getMessage()
+            for rec in caplog.records
+        ), [rec.getMessage() for rec in caplog.records]
+
+
 class TestLLMProxyOwnership:
     def test_is_running_false_by_default(self):
         from tinyagentos.llm_proxy import LLMProxy

--- a/tinyagentos/litellm_callback.py
+++ b/tinyagentos/litellm_callback.py
@@ -78,7 +78,7 @@ try:
 
         def __init__(self) -> None:
             super().__init__()
-            self._trace_url: str = os.environ.get("TAOS_TRACE_URL", "http://127.0.0.1:6969/api/trace")
+            self._trace_url: str = os.environ.get("TAOS_TRACE_URL", f"http://127.0.0.1:{os.environ.get('TAOS_PORT', '6969')}/api/trace")
             self._notify_url: str = self._trace_url.replace("/api/trace", "/api/lifecycle/notify")
 
         async def _post(self, url: str, payload: dict) -> None:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -472,6 +472,7 @@ class LLMProxy:
         # deployer uses when auth'ing /key/generate and agent requests.
         env = os.environ.copy()
         env["LITELLM_MASTER_KEY"] = get_litellm_master_key(self._data_dir)
+        env["TAOS_TRACE_URL"] = f"http://127.0.0.1:{self.port}/api/trace"
         # Forward the local auth token so the TaosLiteLLMCallback inside
         # the subprocess can POST to taOS's /api/trace (otherwise 401).
         if self.local_token:
@@ -559,7 +560,7 @@ class LLMProxy:
                 async with httpx.AsyncClient(timeout=3) as client:
                     resp = await client.get(f"{self.url}/health/readiness")
                     if resp.status_code == 200:
-                        logger.info(f"LiteLLM proxy started on port {self.port}")
+                        logger.info("LiteLLM proxy started on port %d (trace URL: %s)", self.port, env.get("TAOS_TRACE_URL"))
                         return True
             except Exception:
                 pass


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-3 traces hard-wired to port 6969 -- all traces lost on non-default ports

Autonomous build of board card tsk-j2l2qy.

ACCEPTANCE: proxy env now carries TAOS_TRACE_URL on the bound port;
callback falls back to TAOS_PORT (default 6969) when TAOS_TRACE_URL is unset;
proxy logs the trace URL once at start.

```text
FAILED tests/test_litellm_callback.py::test_callback_uses_taos_port_as_trace_url_fallback
FAILED tests/test_litellm_callback.py::test_success_posts_trace_to_taos_port
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_exports_trace_url_with_proxy_port
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_logs_trace_url
4 failed in 6.47s
```

```text
tests/test_litellm_callback.py::test_callback_uses_taos_port_as_trace_url_fallback PASSED
tests/test_litellm_callback.py::test_success_posts_trace_to_taos_port PASSED
tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_exports_trace_url_with_proxy_port PASSED
tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_logs_trace_url PASSED
4 passed in 5.68s
```

Files:
 changelog.d/tsk-j2l2qy-trace-url-port-fix.md |  9 ++++
 tests/test_litellm_callback.py               | 43 ++++++++++++++++
 tests/test_llm_proxy.py                      | 73 ++++++++++++++++++++++++++++
 tinyagentos/litellm_callback.py              |  2 +-
 tinyagentos/llm_proxy.py                     |  3 +-
 5 files changed, 128 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Trace events now reach the correct controller port when using a non-default configuration.
  - Trace URL configuration now respects the configured service port, with a default fallback when unset.
  - Startup logs now include the active trace URL.

- **Tests**
  - Added coverage for trace URL fallback, event delivery, port propagation, and startup logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->