### PR TITLE
fix-forward #2861 (tsk-javfwk): R2-29 test is environment-dependent - it launches the REAL litellm when <venv>/bin/litellm exists

### DIFF
--- a/changelog.d/tsk-javfwk-r2-29-proxy-startup-crash-poll.md
+++ b/changelog.d/tsk-javfwk-r2-29-proxy-startup-crash-poll.md
@@ -1,0 +1,2 @@
+### Fixed
+- `llm_proxy.py` readiness poll now checks `proc.poll()` each iteration and fails fast with the stderr tail when the proxy process exits at startup, instead of blocking for the full 120 s timeout (R2-29).

--- a/changelog.d/tsk-wqm52f-r2-29-proxy-crash-test-fix.md
+++ b/changelog.d/tsk-wqm52f-r2-29-proxy-crash-test-fix.md
@@ -1,0 +1,2 @@
+### Fixed
+- `TestReadinessPollCrashDetection::test_readiness_fails_fast_when_proxy_crashes_at_startup` was environment-dependent: `LLMProxy.start()` resolves the litellm binary via `Path(sys.executable).parent / 'litellm'` before falling back to `shutil.which`, so any checkout whose venv has litellm installed would launch the real proxy and the test would time out. Extracted the resolution into `_resolve_litellm_cmd()` so tests can monkeypatch it directly, making the test deterministic regardless of what is installed in the venv.

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -306,15 +306,13 @@ class TestDatabaseUrlPropagation:
 
         monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         captured: dict = {}
 
         class _FakePopen:
             def __init__(self, *args, **kwargs):
                 captured["env"] = kwargs.get("env") or {}
-                # Raise so start() exits without spawning; the env we
-                # cared about was already captured.
                 raise FileNotFoundError("stubbed")
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
@@ -340,7 +338,7 @@ class TestDatabaseUrlPropagation:
 
         monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
         # Scrub any ambient DATABASE_URL from the test runner so we can
         # assert the proxy didn't invent one.
         monkeypatch.delenv("DATABASE_URL", raising=False)
@@ -802,11 +800,10 @@ class TestStderrLogHandling:
         and a fresh 0600 inode opened. A reader holding a descriptor to the
         old inode cannot observe new output."""
         import os as os_mod
-        import shutil
         import tinyagentos.llm_proxy as mod
 
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         class _FakePopen:
             def __init__(self, *a, **kw):
@@ -863,11 +860,10 @@ class TestStderrLogHandling:
         """When .log and .log.1 both exist, rotation replaces .log.1 with the
         old .log, keeping only one previous generation."""
         import os as os_mod
-        import shutil
         import tinyagentos.llm_proxy as mod
 
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         class _FakePopen:
             def __init__(self, *a, **kw):
@@ -901,7 +897,6 @@ class TestStderrLogHandling:
         it must close its own copy right after Popen() succeeds, or a
         repeated start() leaks one descriptor per attempt."""
         import os as os_mod
-        import shutil
         import tinyagentos.llm_proxy as mod
 
         class _FakeResp:
@@ -915,7 +910,7 @@ class TestStderrLogHandling:
 
         monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         class _FakePopen:
             def __init__(self, *a, **kw):
@@ -947,11 +942,10 @@ class TestStderrLogHandling:
         """Same cleanup is required on the failed-spawn path (litellm binary
         missing) — the handle must not leak just because Popen() failed."""
         import os as os_mod
-        import shutil
         import tinyagentos.llm_proxy as mod
 
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         class _FakePopen:
             def __init__(self, *a, **kw):
@@ -989,7 +983,6 @@ class TestReadinessPollCrashDetection:
         within <2 s with the stderr tail in the error log."""
         import asyncio
         import logging
-        import shutil
         import time
         import tinyagentos.llm_proxy as mod
 
@@ -1000,7 +993,7 @@ class TestReadinessPollCrashDetection:
         crash_script.chmod(0o755)
 
         monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
-        monkeypatch.setattr(shutil, "which", lambda _: str(crash_script))
+        monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: str(crash_script))
 
         class _FakeClient:
             def __init__(self, *a, **kw):

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -920,6 +920,8 @@ class TestStderrLogHandling:
         class _FakePopen:
             def __init__(self, *a, **kw):
                 pass
+            def poll(self):
+                return None
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 
@@ -973,6 +975,58 @@ class TestStderrLogHandling:
         assert result is False
         assert len(captured_handles) == 1
         assert captured_handles[0].closed, "parent must close its stderr log handle even on failed spawn"
+
+
+class TestReadinessPollCrashDetection:
+    """R2-29: the readiness poll must detect a crashed proxy process and
+    fail fast, surfacing the stderr tail, not block for the full 120 s."""
+
+    @pytest.mark.asyncio
+    async def test_readiness_fails_fast_when_proxy_crashes_at_startup(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A proxy that exits at startup must cause start() to return False
+        within <2 s with the stderr tail in the error log."""
+        import asyncio
+        import logging
+        import shutil
+        import time
+        import tinyagentos.llm_proxy as mod
+
+        crash_script = tmp_path / "fake_litellm"
+        crash_script.write_text(
+            "#!/bin/sh\necho 'ERROR: proxy startup failure' >&2\nexit 1\n"
+        )
+        crash_script.chmod(0o755)
+
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: str(crash_script))
+
+        class _FakeClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+            async def get(self, url):
+                raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+
+        p = mod.LLMProxy(port=14021, data_dir=tmp_path)
+
+        with caplog.at_level(logging.ERROR, logger="tinyagentos.llm_proxy"):
+            start_time = time.monotonic()
+            result = await asyncio.wait_for(p.start(backends=[]), timeout=5)
+            elapsed = time.monotonic() - start_time
+
+        assert result is False
+        assert elapsed < 2, f"expected failure in <2 s, took {elapsed:.1f}s"
+        assert "ERROR: proxy startup failure" in caplog.text
 
 
 class TestConfigDirPermissions:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -69,6 +69,20 @@ def _pids_listening_on(port: int) -> list[int]:
     return pids
 
 
+def _read_stderr_tail(log_path: Path, max_bytes: int = 2000) -> str:
+    """Read the tail of a stderr log file for crash diagnostics."""
+    try:
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as f:
+            if size > max_bytes:
+                f.seek(size - max_bytes)
+            return f.read().decode(errors="replace")
+    except FileNotFoundError:
+        return "(no stderr captured)"
+    except OSError:
+        return "(could not read stderr log)"
+
+
 class LLMProxy:
     """Manages LiteLLM proxy as a subprocess.
 
@@ -555,6 +569,17 @@ class LLMProxy:
         # (requires master key → 401 for the polling client).
         for _ in range(120):
             await asyncio.sleep(1)
+            # R2-29: a proxy that crashed at startup would otherwise burn
+            # the full 120 s poll; check proc.poll() and fail fast,
+            # surfacing the stderr tail that explains why it died.
+            if self._process is not None and self._process.poll() is not None:
+                stderr_tail = _read_stderr_tail(stderr_log_path)
+                logger.error(
+                    "LiteLLM proxy process exited early (rc=%s); stderr tail:\n%s",
+                    self._process.returncode,
+                    stderr_tail,
+                )
+                return False
             try:
                 async with httpx.AsyncClient(timeout=3) as client:
                     resp = await client.get(f"{self.url}/health/readiness")

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -390,6 +390,20 @@ class LLMProxy:
         )
         return False
 
+    def _resolve_litellm_cmd(self) -> str | None:
+        """Return the path to the litellm binary, or None if not found.
+
+        Checks the venv bin first (``<sys.executable parent>/litellm``) so
+        systemd-launched instances find the proxy even when PATH does not
+        include the venv. Falls back to ``shutil.which`` for hand-run
+        dev instances.
+        """
+        import shutil
+        import sys
+        from pathlib import Path
+        venv_bin = Path(sys.executable).parent / "litellm"
+        return str(venv_bin) if venv_bin.exists() else shutil.which("litellm")
+
     async def start(
         self,
         backends: list[dict],
@@ -462,10 +476,7 @@ class LLMProxy:
         # a bare "litellm" lookup fails even when the package is installed
         # in the venv. Falling back to PATH lets hand-run dev instances
         # still work.
-        import shutil
-        import sys
-        venv_bin = Path(sys.executable).parent / "litellm"
-        litellm_cmd = str(venv_bin) if venv_bin.exists() else shutil.which("litellm")
+        litellm_cmd = self._resolve_litellm_cmd()
         if not litellm_cmd and not self._selfheal_attempted:
             # The proxy is a core dependency. A pre-fix update ran a bare
             # `uv sync --frozen` and stripped the proxy extra, so a fresh boot
@@ -474,8 +485,7 @@ class LLMProxy:
             # install does not block controller startup.
             self._selfheal_attempted = True
             if await self._selfheal_proxy_extra():
-                venv_bin = Path(sys.executable).parent / "litellm"
-                litellm_cmd = str(venv_bin) if venv_bin.exists() else shutil.which("litellm")
+                litellm_cmd = self._resolve_litellm_cmd()
         if not litellm_cmd:
             logger.warning("LiteLLM not installed — proxy disabled. Install with: pip install litellm[proxy]")
             return False


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2861 (tsk-javfwk): R2-29 test is environment-dependent - it launches the REAL litellm when <venv>/bin/litellm exists

Autonomous build of board card tsk-wqm52f.

REVISION: built on `exec/tsk-javfwk` (cut at `8b2d66962529aba7096684e6da227e06bf92fca4`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

The R2-29 readiness-poll test monkeypatched only shutil.which, but
LLMProxy.start() resolves the binary as Path(sys.executable).parent /
'litellm' FIRST and falls back to shutil.which only when that path is
absent. On any checkout whose venv has litellm installed, the test
launches the real proxy, polls it for the full 120 s window, and fails
on asyncio.wait_for(..., timeout=5).

Extract the resolution into LLMProxy._resolve_litellm_cmd() and
monkeypatch that method in tests instead of shutil.which. The method
preserves the original precedence (venv bin first, PATH fallback second)
so production behaviour is unchanged.

Carried fragment from BASE (tsk-javfwk-r2-29-proxy-startup-crash-poll).

Proof:

```
(a) PRE-FIX source, stub at Path(sys.executable).parent/'litellm', ORIGINAL test
FAILED tests/test_llm_proxy.py::TestReadinessPollCrashDetection::test_readiness_fails_fast_when_proxy_crashes_at_startup
1 failed, 59 deselected, 2 warnings in 5.71s
```

```
(b) FIXED source, stub at Path(sys.executable).parent/'litellm', FIXED test
1 passed, 59 deselected, 2 warnings in 1.44s
```

```
(c) Full test suite on FIXED source
60 passed, 2 warnings in 2.87s
```

Files:
 .../tsk-javfwk-r2-29-proxy-startup-crash-poll.md   |  2 +
 .../tsk-wqm52f-r2-29-proxy-crash-test-fix.md       |  2 +
 tests/test_llm_proxy.py                            | 71 ++++++++++++++++++----
 tinyagentos/llm_proxy.py                           | 47 ++++++++++++--
 4 files changed, 104 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Proxy startup now detects early process crashes promptly instead of waiting for the full startup timeout.
  - Startup failures include the recent proxy error output to make crash diagnostics clearer.
  - Proxy executable detection is more reliable across virtual environments and recovery attempts.

- **Tests**
  - Added coverage for fast failure and diagnostic logging when the proxy crashes during startup.
  - Improved test consistency across different environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->