### PR TITLE
fix-forward #2876 (tsk-j2l2qy): TAOS_TRACE_URL is built from the LiteLLM port, not the controller port - traces would go to LiteLLM on EVERY config

### DIFF
--- a/changelog.d/tsk-j2l2qy-trace-url-port-fix.md
+++ b/changelog.d/tsk-j2l2qy-trace-url-port-fix.md
@@ -1,0 +1,9 @@
+### Fixed
+- `LLMProxy.start()` in `tinyagentos/llm_proxy.py` now exports `TAOS_TRACE_URL`
+  derived from the controller's bound port so the `TaosLiteLLMCallback` inside
+  the LiteLLM subprocess can POST trace, lifecycle and spend events to the
+  correct controller instead of silently dropping them on non-default ports
+  (#tsk-j2l2qy).
+- `TaosLiteLLMCallback` in `tinyagentos/litellm_callback.py` now falls back to
+  `TAOS_PORT` (defaulting to 6969) when `TAOS_TRACE_URL` is unset, so standalone
+  callers and custom-port installs still emit traces (#tsk-j2l2qy).

--- a/changelog.d/tsk-lqqa2n-trace-url-controller-port.md
+++ b/changelog.d/tsk-lqqa2n-trace-url-controller-port.md
@@ -1,0 +1,2 @@
+### Fixed
+- `TAOS_TRACE_URL` now targets the taOS controller port (resolved via `TAOS_PORT` env var, `config.server['port']`, or default 6969) rather than the LiteLLM proxy port, so trace POSTs from the LiteLLM callback always reach `/api/trace` on the controller regardless of the proxy's bound port.

--- a/tests/test_litellm_callback.py
+++ b/tests/test_litellm_callback.py
@@ -342,3 +342,46 @@ async def test_success_event_without_budget_env_does_not_crash(monkeypatch):
 
     # Must not raise even though TAOS_AGENT_BUDGETS is unset.
     await cb.async_log_success_event(kwargs, resp, t0, t1)
+
+
+def test_callback_uses_taos_port_as_trace_url_fallback(monkeypatch):
+    """When TAOS_TRACE_URL is unset, the callback falls back to TAOS_PORT
+    (defaulting to 6969) so non-default controller ports are not silently
+    dropped."""
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+    monkeypatch.setenv("TAOS_PORT", "7117")
+    monkeypatch.delenv("TAOS_TRACE_URL", raising=False)
+    cb = TaosLiteLLMCallback()
+    assert cb._trace_url == "http://127.0.0.1:7117/api/trace"
+    monkeypatch.delenv("TAOS_PORT", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_success_posts_trace_to_taos_port(monkeypatch):
+    """Trace POST must target the TAOS_PORT-derived URL, not the hard-coded
+    6969 fallback, so agents on non-default ports still emit trace events."""
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+    monkeypatch.setenv("TAOS_PORT", "7117")
+    monkeypatch.delenv("TAOS_TRACE_URL", raising=False)
+    cb = TaosLiteLLMCallback()
+    posted = []
+
+    async def _mock_post(url, payload):
+        posted.append(url)
+
+    cb._post = _mock_post
+
+    from datetime import datetime, timezone
+    t0 = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 10, 0, 1, tzinfo=timezone.utc)
+    await cb.async_log_success_event(_make_kwargs(), _make_response(), t0, t1)
+
+    assert len(posted) >= 1
+    assert "7117" in posted[0]
+    monkeypatch.delenv("TAOS_PORT", raising=False)

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -362,10 +362,9 @@ class TestDatabaseUrlPropagation:
 
 class TestTraceUrlPropagation:
     @pytest.mark.asyncio
-    async def test_start_exports_trace_url_with_proxy_port(self, tmp_path, monkeypatch):
-        """The proxy must export TAOS_TRACE_URL pointing at its bound port so the
-        LiteLLM callback inside the subprocess can POST traces to the right
-        controller, not silently drop them on non-default ports."""
+    async def test_start_exports_trace_url_with_controller_port(self, tmp_path, monkeypatch):
+        """TAOS_TRACE_URL must carry the controller port, not the LiteLLM proxy
+        port, so the callback POSTs to the taOS controller's /api/trace."""
         import shutil
         import tinyagentos.llm_proxy as mod
 
@@ -390,10 +389,12 @@ class TestTraceUrlPropagation:
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 
-        p = mod.LLMProxy(port=7117)
+        proxy_port = 7117
+        controller_port = 6969
+        p = mod.LLMProxy(port=proxy_port, controller_port=controller_port)
         await p.start(backends=[])
 
-        assert captured["env"]["TAOS_TRACE_URL"] == "http://127.0.0.1:7117/api/trace"
+        assert captured["env"]["TAOS_TRACE_URL"] == f"http://127.0.0.1:{controller_port}/api/trace"
 
     @pytest.mark.asyncio
     async def test_start_logs_trace_url(self, tmp_path, monkeypatch, caplog):
@@ -422,13 +423,15 @@ class TestTraceUrlPropagation:
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 
-        p = mod.LLMProxy(port=7117)
+        proxy_port = 7117
+        controller_port = 6969
+        p = mod.LLMProxy(port=proxy_port, controller_port=controller_port)
         with caplog.at_level(logging.INFO, logger="tinyagentos.llm_proxy"):
             result = await p.start(backends=[])
 
         assert result is True
         assert any(
-            "trace URL" in rec.getMessage() and "7117" in rec.getMessage()
+            "trace URL" in rec.getMessage() and str(controller_port) in rec.getMessage()
             for rec in caplog.records
         ), [rec.getMessage() for rec in caplog.records]
 

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -360,6 +360,79 @@ class TestDatabaseUrlPropagation:
         assert "DATABASE_URL" not in captured["env"]
 
 
+class TestTraceUrlPropagation:
+    @pytest.mark.asyncio
+    async def test_start_exports_trace_url_with_proxy_port(self, tmp_path, monkeypatch):
+        """The proxy must export TAOS_TRACE_URL pointing at its bound port so the
+        LiteLLM callback inside the subprocess can POST traces to the right
+        controller, not silently drop them on non-default ports."""
+        import shutil
+        import tinyagentos.llm_proxy as mod
+
+        class _FakeResp:
+            status_code = 200
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def get(self, url): return _FakeResp()
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, *args, **kwargs):
+                captured["env"] = kwargs.get("env") or {}
+
+        monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
+
+        p = mod.LLMProxy(port=7117)
+        await p.start(backends=[])
+
+        assert captured["env"]["TAOS_TRACE_URL"] == "http://127.0.0.1:7117/api/trace"
+
+    @pytest.mark.asyncio
+    async def test_start_logs_trace_url(self, tmp_path, monkeypatch, caplog):
+        """On successful start, the proxy must log the trace URL it exported so
+        operators can verify traces are targeting the correct port."""
+        import logging
+        import shutil
+        import tinyagentos.llm_proxy as mod
+
+        class _FakeResp:
+            status_code = 200
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *exc): return False
+            async def get(self, url): return _FakeResp()
+
+        monkeypatch.setattr(mod.httpx, "AsyncClient", _FakeClient)
+        monkeypatch.setattr(mod, "_pids_listening_on", lambda port: [])
+        monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
+
+        class _FakePopen:
+            def __init__(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
+
+        p = mod.LLMProxy(port=7117)
+        with caplog.at_level(logging.INFO, logger="tinyagentos.llm_proxy"):
+            result = await p.start(backends=[])
+
+        assert result is True
+        assert any(
+            "trace URL" in rec.getMessage() and "7117" in rec.getMessage()
+            for rec in caplog.records
+        ), [rec.getMessage() for rec in caplog.records]
+
+
 class TestLLMProxyOwnership:
     def test_is_running_false_by_default(self):
         from tinyagentos.llm_proxy import LLMProxy

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -178,6 +179,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             import shutil
             shutil.copy2(example, config_path)
     config = load_config(config_path)
+    controller_port = int(os.environ.get("TAOS_PORT", config.server.get("port", 6969)))
 
     # Sweep config.backends for duplicates accumulated over restarts —
     # auto-register and the manual /api/providers POST both write here,
@@ -392,6 +394,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     local_token = local_token_path.read_text().strip() if local_token_path.exists() else None
     llm_proxy = LLMProxy(
         port=config.server.get("litellm_port", 7834),
+        controller_port=controller_port,
         database_url=db_url,
         local_token=local_token,
         # registry lets generate_litellm_config register installed local

--- a/tinyagentos/litellm_callback.py
+++ b/tinyagentos/litellm_callback.py
@@ -78,7 +78,7 @@ try:
 
         def __init__(self) -> None:
             super().__init__()
-            self._trace_url: str = os.environ.get("TAOS_TRACE_URL", "http://127.0.0.1:6969/api/trace")
+            self._trace_url: str = os.environ.get("TAOS_TRACE_URL", f"http://127.0.0.1:{os.environ.get('TAOS_PORT', '6969')}/api/trace")
             self._notify_url: str = self._trace_url.replace("/api/trace", "/api/lifecycle/notify")
 
         async def _post(self, url: str, payload: dict) -> None:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -88,8 +88,10 @@ class LLMProxy:
         registry=None,
         data_dir: Path | None = None,
         inhouse_keys: bool = False,
+        controller_port: int = 6969,
     ):
         self.port = port
+        self.controller_port = controller_port
         # S2-10: config lives under <data_dir>/litellm (0700) so the master key,
         # backend keys and callback shims are not world-readable in a shared
         # /tmp. Fall back to /tmp/taos-litellm only when data_dir is unknown
@@ -472,7 +474,7 @@ class LLMProxy:
         # deployer uses when auth'ing /key/generate and agent requests.
         env = os.environ.copy()
         env["LITELLM_MASTER_KEY"] = get_litellm_master_key(self._data_dir)
-        env["TAOS_TRACE_URL"] = f"http://127.0.0.1:{self.port}/api/trace"
+        env["TAOS_TRACE_URL"] = f"http://127.0.0.1:{self.controller_port}/api/trace"
         # Forward the local auth token so the TaosLiteLLMCallback inside
         # the subprocess can POST to taOS's /api/trace (otherwise 401).
         if self.local_token:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -472,6 +472,7 @@ class LLMProxy:
         # deployer uses when auth'ing /key/generate and agent requests.
         env = os.environ.copy()
         env["LITELLM_MASTER_KEY"] = get_litellm_master_key(self._data_dir)
+        env["TAOS_TRACE_URL"] = f"http://127.0.0.1:{self.port}/api/trace"
         # Forward the local auth token so the TaosLiteLLMCallback inside
         # the subprocess can POST to taOS's /api/trace (otherwise 401).
         if self.local_token:
@@ -559,7 +560,7 @@ class LLMProxy:
                 async with httpx.AsyncClient(timeout=3) as client:
                     resp = await client.get(f"{self.url}/health/readiness")
                     if resp.status_code == 200:
-                        logger.info(f"LiteLLM proxy started on port {self.port}")
+                        logger.info("LiteLLM proxy started on port %d (trace URL: %s)", self.port, env.get("TAOS_TRACE_URL"))
                         return True
             except Exception:
                 pass


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2876 (tsk-j2l2qy): TAOS_TRACE_URL is built from the LiteLLM port, not the controller port - traces would go to LiteLLM on EVERY config

Autonomous build of board card tsk-lqqa2n.

REVISION: built on `exec/tsk-j2l2qy` (cut at `d2dc4c9a907fcc4e4392340728ea3c773586ef23`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

LLMProxy.start() was setting env['TAOS_TRACE_URL'] from self.port (the
LiteLLM proxy port) instead of the taOS controller port.  The controller
resolves its own port via TAOS_PORT env > config.server['port'] > 6969
(the same precedence as __main__.py), and /api/trace is served there.
Posts to the proxy port silently 404 because LiteLLM has no /api/trace
route -- this is a regression on every config, including the default.

Give LLMProxy a new controller_port ctor arg (default 6969), store it as
self.controller_port, and build TAOS_TRACE_URL from that.  Pass it from
create_app() using the same env/config precedence as __main__.py so the
LiteLLM subprocess always knows the right controller endpoint.

Tests renamed/rewritten: TestTraceUrlPropagation now constructs LLMProxy
with proxy_port=7117 and controller_port=6969 and asserts the URL
carries the controller port, proving the fix distinguishes the two.

Docs-Reviewed: no routes files changed, no doc update needed.

Fenced red/green proof:

```
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_exports_trace_url_with_controller_port - AssertionError: assert 'http://127.0.0.1:7117/api/trace' == 'http://127.0.0.1:6969/api/trace'
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_logs_trace_url - AssertionError
2 failed, 68 passed, 13 skipped in 4.34s
```

```
2 passed in 2.30s
```

```
68 passed, 13 skipped in 4.34s
```

Files:
 changelog.d/tsk-j2l2qy-trace-url-port-fix.md       |  9 +++
 .../tsk-lqqa2n-trace-url-controller-port.md        |  2 +
 tests/test_litellm_callback.py                     | 43 ++++++++++++
 tests/test_llm_proxy.py                            | 76 ++++++++++++++++++++++
 tinyagentos/app.py                                 |  3 +
 tinyagentos/litellm_callback.py                    |  2 +-
 tinyagentos/llm_proxy.py                           |  5 +-
 7 files changed, 138 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trace requests now consistently use the taOS controller’s configured port, including when the proxy runs on a different port.
  * Trace URL configuration now respects `TAOS_TRACE_URL` and falls back to the configured controller port or the default port.
  * Startup logs now display the active trace URL.

* **Tests**
  * Added coverage for trace URL resolution and successful trace submission across custom and default ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->