### PR TITLE
[lib-audit] Every macOS release ships blank Sparkle release notes

### DIFF
--- a/changelog.d/tsk-jrco6v-sparkle-appcast.md
+++ b/changelog.d/tsk-jrco6v-sparkle-appcast.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Sparkle appcast snippets now include the matching changelog section for the current version, escape CDATA terminators, and include sparkle:shortVersionString.

--- a/mac/build/sparkle_sign.sh
+++ b/mac/build/sparkle_sign.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # Sparkle-sign the DMG and produce an appcast snippet.
 #
-# Args: --dmg <PATH> --version <X.Y.Z> --output <DIR>
+# Args: --dmg <PATH> --version <X.Y.Z> --output <DIR> [--notes-file <PATH>]
 set -euo pipefail
 
 DMG=""
 VERSION=""
 OUTPUT=""
+NOTES_FILE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dmg) DMG="$2"; shift 2 ;;
     --version) VERSION="$2"; shift 2 ;;
     --output) OUTPUT="$2"; shift 2 ;;
+    --notes-file) NOTES_FILE="$2"; shift 2 ;;
     *) echo "sparkle_sign.sh: unknown arg $1" >&2; exit 2 ;;
   esac
 done
@@ -44,13 +46,15 @@ echo -n "$SIG_FIELD" > "${DMG}.sig"
 # Build the appcast snippet
 mkdir -p "$OUTPUT"
 SNIPPET="$OUTPUT/appcast-snippet.xml"
-NOTES_FILE="$REPO_ROOT/CHANGELOG.md"
-NOTES="$(awk -v v="$VERSION" 'BEGIN{p=0} /^## /{p=($2==v)} p' "$NOTES_FILE" 2>/dev/null || echo "")"
+: "${NOTES_FILE:=$REPO_ROOT/CHANGELOG.md}"
+NOTES="$(awk -v v="$VERSION" 'BEGIN{p=0} /^## /{p=($2=="["v"]")} p' "$NOTES_FILE" 2>/dev/null || echo "")"
+NOTES="${NOTES//]]>/]]]]><![CDATA[>}"
 
 cat > "$SNIPPET" <<XML
     <item>
       <title>v${VERSION}</title>
       <sparkle:version>${VERSION}</sparkle:version>
+      <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <description><![CDATA[${NOTES}]]></description>
       <enclosure

--- a/tests/mac/test_sparkle_appcast.sh
+++ b/tests/mac/test_sparkle_appcast.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for Sparkle appcast snippet generation.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/mac/build/sparkle_sign.sh"
+
+# Resolve current version from CHANGELOG.md so the test stays correct across releases.
+CURRENT_VERSION="$(grep -m1 '^## \[.*\] - ' "$REPO_ROOT/CHANGELOG.md" | sed 's/.*\[\(.*\)\].*/\1/')"
+
+setup_fakes() {
+  TMPDIR="$(mktemp -d)"
+  DMG="$TMPDIR/test.dmg"
+  touch "$DMG"
+  KEY="$TMPDIR/key.pem"
+  printf '%s\n' "fake-key" > "$KEY"
+  OUTPUT="$TMPDIR/output"
+  mkdir -p "$OUTPUT"
+  export SPARKLE_ED_PRIVATE_KEY="$KEY"
+  # Provide a stub sign_update so sparkle_sign.sh can produce a snippet.
+  SIGN_STUB="$TMPDIR/sign_update"
+  cat > "$SIGN_STUB" <<'SIGN'
+#!/usr/bin/env bash
+echo 'sparkle:edSignature="fake-ed-signature" length="1234"'
+SIGN
+  chmod +x "$SIGN_STUB"
+  export PATH="$TMPDIR:$PATH"
+}
+
+cleanup() {
+  rm -rf "${TMPDIR:-}"
+}
+trap cleanup EXIT
+
+echo "test: the appcast description is non-empty for the current version"
+setup_fakes
+"$SCRIPT" --dmg "$DMG" --version "$CURRENT_VERSION" --output "$OUTPUT"
+SNIPPET="$OUTPUT/appcast-snippet.xml"
+
+DESCRIPTION="$(python3 -c "
+import re
+with open('$SNIPPET') as f:
+    content = f.read()
+m = re.search(r'<description><!\[CDATA\[(.*?)\]\]></description>', content, re.DOTALL)
+print(m.group(1) if m else '')
+")"
+
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "FAIL: <description><![CDATA[]]></description>"
+  echo "  expected the \"## [$CURRENT_VERSION]\" section body"
+  exit 1
+fi
+
+echo "test: a CDATA terminator in the changelog does not break the XML"
+NOTES="$TMPDIR/NOTES.md"
+cat > "$NOTES" <<EOF
+## [$CURRENT_VERSION] - 2026-08-21
+
+Release notes with a ]]> CDATA terminator inside.
+EOF
+
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT"
+"$SCRIPT" --dmg "$DMG" --version "$CURRENT_VERSION" --output "$OUTPUT" --notes-file "$NOTES"
+
+python3 -c "
+import xml.etree.ElementTree as ET
+with open('$SNIPPET') as f:
+    xml = f.read()
+xml = xml.replace('<item>', '<item xmlns:sparkle=\"http://www.andymatuschak.org/xml-namespaces/sparkle\">')
+ET.fromstring(xml)
+"
+
+echo "all tests passed"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Every macOS release ships blank Sparkle release notes

Autonomous build of board card tsk-jrco6v.

RED:
FAIL: <description><![CDATA[]]></description>
  expected the "## [1.0.0-beta.50]" section body

GREEN:
all tests passed

Files:
 changelog.d/tsk-jrco6v-sparkle-appcast.md |  3 ++
 mac/build/sparkle_sign.sh                 | 10 +++--
 tests/mac/test_sparkle_appcast.sh         | 74 +++++++++++++++++++++++++++++++
 3 files changed, 84 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sparkle update listings now display the changelog section matching the current app version.
  - Update metadata now includes the short version number for more accurate version identification.
  - Changelog content containing special XML characters is safely handled, preventing malformed update information.
  - Release notes can now be sourced from the appropriate changelog file when generating update listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->