### PR TITLE
comments API: reject empty/whitespace-only comment bodies (422)

### DIFF
--- a/changelog.d/tsk-vrh4w2-reject-empty-comments.md
+++ b/changelog.d/tsk-vrh4w2-reject-empty-comments.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- POST `/api/projects/{project_id}/tasks/{task_id}/comments` now rejects an
+  empty or whitespace-only `body` with 422 before storing, preventing
+  board-noise comments from CLI misuse.

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -369,6 +369,40 @@ async def test_add_comment_rejects_cross_task_reply(client):
 
 
 @pytest.mark.asyncio
+async def test_add_comment_rejects_empty_and_whitespace_body(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "T"})).json()
+
+    # Empty body -> 422, nothing stored.
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/comments",
+        json={"body": "", "author_id": "u"},
+    )
+    assert resp.status_code == 422
+
+    # Whitespace-only body -> 422, nothing stored.
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/comments",
+        json={"body": "   \n", "author_id": "u"},
+    )
+    assert resp.status_code == 422
+
+    # Follow-up GET: neither empty nor whitespace comment was stored.
+    thread = (await client.get(f"/api/projects/{pid}/tasks/{t['id']}/comments")).json()["items"]
+    assert len(thread) == 0
+
+    # Positive control: a real non-empty body is accepted and stored.
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks/{t['id']}/comments",
+        json={"body": "hello world", "author_id": "u"},
+    )
+    assert resp.status_code == 200
+    thread = (await client.get(f"/api/projects/{pid}/tasks/{t['id']}/comments")).json()["items"]
+    assert len(thread) == 1
+    assert thread[0]["body"] == "hello world"
+
+
+@pytest.mark.asyncio
 async def test_claim_release_close_reject_cross_project(client):
     p1 = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
     p2 = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1530,6 +1530,8 @@ async def add_comment(
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
         return guard
+    if not payload.body or not payload.body.strip():
+        return JSONResponse({"error": "comment body must not be empty"}, status_code=422)
     try:
         return await store.add_comment(
             task_id=task_id,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): comments API: reject empty/whitespace-only comment bodies (422)

Autonomous build of board card tsk-vrh4w2.

POST /api/projects/{project_id}/tasks/{task_id}/comments stored empty and
whitespace-only bodies as permanent board noise (no DELETE route exists), as
seen on cmt-47e5nk, cmt-jp3rnj and cmt-salp7n from `taos_team.py comment <id> ""`.
Guard the body before storage: an empty or whitespace-only `body` now returns
422 with {"error": "comment body must not be empty"}. No client change, no
DELETE route, no alteration of existing comments.

Acceptance:
- POST body "" and body "   \n" -> both 422 with empty detail.
- Follow-up GET of the thread shows no new comment stored (length 0).
- Positive control: POST body "hello world" -> 200 and present in the thread.

RED proof (test written, fix not yet applied; run against dev before the fix):

```
FAILED tests/test_routes_projects.py::test_add_comment_rejects_empty_and_whitespace_body
1 failed in 4.53s
```

GREEN proof (same test after the fix):

```
1 passed in 3.96s
```

Docs-Reviewed: no docs/agent-coordination.md change -- the comment route is already documented by its scope surface (project_tasks / project_tasks_create at docs/agent-coordination.md:432-445); this is input-validation hardening on an existing documented route, not a new capability or scope, so no doc edit is needed.

Files:
 changelog.d/tsk-vrh4w2-reject-empty-comments.md |  5 ++++
 tests/test_routes_projects.py                   | 34 +++++++++++++++++++++++++
 tinyagentos/routes/projects.py                  |  2 ++
 3 files changed, 41 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task comments containing only whitespace are now rejected with an HTTP 422 response.
  - Empty comments are no longer saved.
  - Valid, non-empty comments continue to be accepted and stored.

- **Documentation**
  - Added a changelog entry describing the comment validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->