### PR TITLE
installer: hardware verification silently skipped - /api/system/hardware/refresh returned nothing (community: taOS#2)

### DIFF
--- a/changelog.d/tsk-zgjc24-hw-verify-loud.md
+++ b/changelog.d/tsk-zgjc24-hw-verify-loud.md
@@ -1,0 +1,11 @@
+### Fixed
+- install-server.sh now POSTs `/api/system/hardware/refresh` (the route is
+  POST-only; a GET returned 405 and `curl -sf` swallowed it, producing the
+  silent "hardware verification skipped" line from taOS #2 on the Orange Pi
+  5B run). The verification step also retries for up to 30 s so a controller
+  still finishing first-boot init is no longer treated as a failure, and on
+  a persistent empty response it now dies loud with the journal tail and a
+  checklist of what to inspect (`/dev/rknpu`, data dir writability, journal)
+  instead of silently exiting 0. The detected profile (NPU type, device,
+  profile_id) is now surfaced in the success banner so a tester can confirm
+  at a glance that the NPU was recognised.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -2548,18 +2548,74 @@ fi
 # warn the user; verified ones log a quiet success. Failures are non-blocking
 # — the controller runs regardless — but are prominently displayed so the
 # user knows what's broken before they walk away from the install (#370).
+#
+# The /api/system/hardware/refresh route is registered as POST, so a GET
+# against it returns 405 and `curl -sf` exits non-zero -- which is exactly
+# what produced taOS #2's silent skip on the Orange Pi 5B run. We POST, and
+# we retry briefly: a fresh install can hit this endpoint while the controller
+# is still finishing first-boot init, in which case the right behaviour is to
+# wait, not to silently walk away (taOS #2).
+
+# Globals consumed by the success banner below. Set to "unknown" if verification
+# never ran so the banner still renders something sensible.
+HW_PROFILE_ID="${HW_PROFILE_ID:-unknown}"
+HW_NPU_TYPE="${HW_NPU_TYPE:-none}"
+HW_NPU_DEVICE="${HW_NPU_DEVICE:-}"
 
 verify_hardware_capabilities() {
     local claimed_vulkan=0 claimed_cuda=0 claimed_rocm=0 claimed_rknpu=0 claimed_mlx=0
     local verified_ok=0 verified_warn=0
 
-    # Fetch the hardware profile from the now-running controller.
-    local hw_json
-    hw_json=$(curl -sf "http://localhost:$TAOS_PORT/api/system/hardware/refresh" 2>/dev/null || true)
+    # Fetch the hardware profile from the now-running controller. POST is the
+    # only method the route accepts; a GET gets 405 and looks like "empty".
+    # Retry for up to 30 s so the controller can finish first-boot init
+    # (litellm prisma migration, store creation) without us declaring failure.
+    local hw_json=""
+    local _hw_tries=0
+    local _hw_deadline=$(( SECONDS + 30 ))
+    while [[ $_hw_tries -lt 30 ]]; do
+        _remaining=$(( _hw_deadline - SECONDS ))
+        [[ $_remaining -le 0 ]] && break
+        _curl_timeout=$(( _remaining > 1 ? _remaining : 1 ))
+        hw_json=$(curl -sf --max-time "$_curl_timeout" -X POST \
+            "http://localhost:$TAOS_PORT/api/system/hardware/refresh" 2>/dev/null || true)
+        [[ -n "$hw_json" ]] && break
+        _remaining=$(( _hw_deadline - SECONDS ))
+        [[ $_remaining -le 1 ]] && break
+        sleep 1
+        _hw_tries=$((_hw_tries + 1))
+    done
+
     if [[ -z "$hw_json" ]]; then
-        warn "hardware verification skipped — controller did not return a profile"
-        return 0
+        # Loud failure: the controller never answered hardware/refresh. The old
+        # code swallowed this with a quiet warn and the user never learned
+        # whether their NPU was recognised (taOS #2 -- Orange Pi 5B / RK3588).
+        warn "controller did not return a hardware profile within 30 s"
+        warn "  checked: POST http://localhost:$TAOS_PORT/api/system/hardware/refresh"
+        warn "  the controller is up (port-open + /api/cluster/workers already passed),"
+        warn "  so this is a hardware-detection failure inside the controller."
+        warn "  what to check:"
+        warn "    1. journalctl -u tinyagentos --no-pager -n 80 | grep -i 'hardware'"
+        warn "    2. ls -l /dev/rknpu   (for Rockchip boards)"
+        warn "    3. the controller data dir is writable:"
+        warn "         data_dir=\$(systemctl show -p Environment tinyagentos | tr ',' '\\n' | grep TAOS_DATA_DIR | cut -d= -f2)"
+        warn "         test -w \"\$data_dir\""
+        if command -v journalctl >/dev/null 2>&1; then
+            warn "latest journal output:"
+            journalctl -u tinyagentos --no-pager -n 30 2>/dev/null || true
+        fi
+        die "hardware verification failed -- fix the controller-side hardware detection above and re-run the install"
     fi
+
+    # Pull a few fields out of the profile for the success banner. The
+    # controller returns the dataclass serialised with asdict() plus the
+    # profile_id field appended (see tinyagentos/routes/system.py:hardware_refresh).
+    HW_PROFILE_ID=$(echo "$hw_json" | grep -o '"profile_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    [[ -z "$HW_PROFILE_ID" ]] && HW_PROFILE_ID="unknown"
+    HW_NPU_TYPE=$(echo "$hw_json" | grep -o '"npu"[[:space:]]*:[[:space:]]*{[^}]*"type"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    [[ -z "$HW_NPU_TYPE" ]] && HW_NPU_TYPE="none"
+    HW_NPU_DEVICE=$(echo "$hw_json" | grep -o '"npu"[[:space:]]*:[[:space:]]*{[^}]*"device"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*"device"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    [[ -z "$HW_NPU_DEVICE" ]] && HW_NPU_DEVICE=""
 
     # Parse claimed capabilities from the JSON response. Uses grep+sed
     # instead of jq to avoid a dependency. The API response is a flat
@@ -2739,6 +2795,20 @@ if [[ "$TAOS_BROWSER_PROXY_PORT" != "0" ]]; then
 fi
 log "  Install dir : $INSTALL_DIR"
 log "  Storage pool: ${COW_EFFECTIVE_MODE:-n/a} (detected fs: ${COW_FS_TYPE:-unknown})"
+# Surface what the controller actually detected so a tester can confirm at
+# a glance (taOS #2 -- installer used to silently skip, so testers had no
+# way to tell whether the NPU was recognised). HW_PROFILE_ID/HW_NPU_TYPE
+# are set by verify_hardware_capabilities; if that never ran, the defaults
+# above render as "unknown" / "none".
+if [[ "$HW_NPU_TYPE" == "none" || -z "$HW_NPU_TYPE" ]]; then
+    log "  Hardware    : $HW_PROFILE_ID (no NPU detected)"
+else
+    if [[ -n "$HW_NPU_DEVICE" ]]; then
+        log "  Hardware    : $HW_PROFILE_ID (NPU: $HW_NPU_TYPE, device: $HW_NPU_DEVICE)"
+    else
+        log "  Hardware    : $HW_PROFILE_ID (NPU: $HW_NPU_TYPE detected)"
+    fi
+fi
 if [[ "${COW_EFFECTIVE_MODE:-}" == "btrfs" || "${COW_EFFECTIVE_MODE:-}" == "zfs" ]]; then
     log "    * CoW clones enabled - container deploys <=5 seconds"
 elif [[ "${COW_EFFECTIVE_MODE:-}" == "dir" ]]; then

--- a/tests/test_install_server.sh
+++ b/tests/test_install_server.sh
@@ -110,8 +110,12 @@ grep -q "rknpu.*claimed_rknpu" "$SCRIPT"
 echo "test: verification detects Apple Silicon for MLX"
 grep -q "Darwin.*claimed_mlx" "$SCRIPT"
 
-echo "test: verification is non-blocking (return 0 on skip, not die)"
-grep -q "verification skipped" "$SCRIPT" && grep -q "return 0" "$SCRIPT"
+echo "test: verification dies loud on persistent empty profile (taOS#2)"
+# The old "skipped -- controller did not return a profile" + return 0 path was
+# the silent failure mode the OP hit on Orange Pi 5B; the new behaviour must
+# be a die() with what to check.
+grep -q "die \"hardware verification failed" "$SCRIPT"
+! grep -q "warn \"hardware verification skipped — controller did not return a profile\"" "$SCRIPT"
 
 echo "test: verification counts verified_ok and verified_warn"
 grep -q "verified_ok=" "$SCRIPT" && grep -q "verified_warn=" "$SCRIPT"

--- a/tests/test_install_server_hardware_verify.py
+++ b/tests/test_install_server_hardware_verify.py
@@ -1,0 +1,147 @@
+"""Gate: install-server.sh hardware verification must FAIL LOUD when the
+controller endpoint returns no profile, and must POST (not GET) the endpoint.
+
+Background (taOS #2): the installer used to call GET /api/system/hardware/refresh
+and silently skip on any non-2xx response. On a fresh install where the
+controller hasn't finished first-boot init yet, that means the user never learns
+whether their NPU was recognised -- exactly the May regression where wizard NPU
+detection did not fire the rkllama install.
+
+The gate extracts verify_hardware_capabilities() verbatim from the real
+install-server.sh so it exercises the production function (not a copy), points
+curl at a stub that returns empty, and asserts the function dies non-zero
+instead of returning 0 with a quiet warn.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "install-server.sh"
+
+
+def _extract_verify_function() -> str:
+    """Return the body of verify_hardware_capabilities() from install-server.sh,
+    from the opening line through the matching closing brace. We deliberately
+    work on the real script so a regression in the production function fails
+    this gate."""
+    text = SCRIPT.read_text()
+    # Find the function header line and then walk braces to find the close.
+    m = re.search(r"^verify_hardware_capabilities\(\)\s*\{", text, re.MULTILINE)
+    assert m, "verify_hardware_capabilities() not found in install-server.sh"
+    start = m.start()
+    depth = 0
+    i = m.end() - 1  # at the '{'
+    while i < len(text):
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+        i += 1
+    raise AssertionError("could not find matching closing brace of verify_hardware_capabilities()")
+
+
+def _write_wrapper(tmp_path: Path, curl_body: str, function_body: str) -> Path:
+    wrapper = tmp_path / "wrapper.sh"
+    wrapper.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -u\n"
+        "log()  { printf '[server-install] %s\\n' \"$*\"; }\n"
+        "warn() { printf '[server-install] %s\\n' \"$*\" >&2; }\n"
+        "die()  { printf '[server-install] %s\\n' \"$*\" >&2; exit 1; }\n"
+        f"curl() {{\n{curl_body}\n}}\n"
+        "TAOS_PORT=\"$TAOS_PORT\"\n"
+        "os_name=\"$os_name\"\n"
+        "HW_PROFILE_ID=\"${HW_PROFILE_ID:-unknown}\"\n"
+        "HW_NPU_TYPE=\"${HW_NPU_TYPE:-none}\"\n"
+        "HW_NPU_DEVICE=\"${HW_NPU_DEVICE:-}\"\n"
+        + function_body
+        + "\nverify_hardware_capabilities\n"
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_verify_dies_loud_when_endpoint_returns_empty(tmp_path: Path) -> None:
+    """The bug from #2: a controller that returns nothing must not be a quiet
+    skip. The installer must die non-zero so the operator knows hardware
+    detection did not actually run."""
+    function_body = _extract_verify_function()
+    wrapper = _write_wrapper(tmp_path, "    :", function_body)
+
+    # The function retries for ~30 s when curl returns empty. Cap the wrapper's
+    # own wall-clock so a regression that breaks the deadline doesn't hang the
+    # test; in the fixed script the function exits quickly via die().
+    result = subprocess.run(
+        ["/usr/bin/env", "bash", str(wrapper)],
+        env={**os.environ, "TAOS_PORT": "0", "os_name": "Linux"},
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+    assert result.returncode != 0, (
+        "verify_hardware_capabilities returned 0 against an empty endpoint; "
+        "this is the regression from taOS #2 -- the installer must fail loud "
+        "instead of printing 'hardware verification skipped' and walking away.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = (result.stdout + result.stderr).lower()
+    assert "hardware" in combined, (
+        f"failure output does not even mention hardware; "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_verify_returns_clean_when_endpoint_serves_a_profile(tmp_path: Path) -> None:
+    """Sanity: when the endpoint returns a non-empty profile, the function
+    should NOT die on the empty-profile path (it may still warn about claimed
+    accelerators, but the empty-curl branch must not fire)."""
+    function_body = _extract_verify_function()
+    profile = (
+        '{"profile_id":"arm-npu-16gb",'
+        '"npu":{"type":"rknpu","device":"RK3588","tops":6,"cores":3},'
+        '"gpu":{"type":"none","model":"","vram_mb":0,"vulkan":false,"cuda":false,"rocm":false}}'
+    )
+    curl_body = f"    printf '%s' '{profile}'\n    return 0\n"
+    wrapper = _write_wrapper(tmp_path, curl_body, function_body)
+
+    result = subprocess.run(
+        ["/usr/bin/env", "bash", str(wrapper)],
+        env={**os.environ, "TAOS_PORT": "0", "os_name": "Linux"},
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+    combined = (result.stdout + result.stderr).lower()
+    assert "did not return a hardware profile" not in combined, (
+        "verify_hardware_capabilities treated a real profile as empty -- "
+        "the empty-profile guard is firing too eagerly.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_install_script_uses_post_for_hardware_refresh() -> None:
+    """The installer must POST /api/system/hardware/refresh. The route is
+    registered as POST (see tinyagentos/routes/system.py:225); a GET will get
+    a 405 and the old curl -sf would swallow it, returning nothing. That is
+    the exact mechanism that produced taOS #2's silent skip."""
+    text = SCRIPT.read_text()
+    assert "curl -sf --max-time \"$_curl_timeout\" -X POST" in text and "hardware/refresh" in text, (
+        "install-server.sh must POST /api/system/hardware/refresh with a "
+        "bounded --max-time; a GET against a POST-only route silently returns "
+        "405 and triggers the empty-profile skip from taOS #2."
+    )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): installer: hardware verification silently skipped - /api/system/hardware/refresh returned nothing (community: taOS#2)

Autonomous build of board card tsk-zgjc24.

The post-install hardware verification step GET'd /api/system/hardware/refresh,
but the route is registered as POST. curl -sf swallowed the resulting 405,
the empty-profile branch printed a warn, and the installer exited 0. That is
exactly the failure @redkjuegos hit on Orange Pi 5B / RK3588 (taOS#2): the
controller was up, the NPU was on the bus, and the user never learned whether
it was recognised.

Three changes:

1. POST instead of GET. The route only accepts POST; GET gets 405.
2. Retry for up to 30 s so a controller still finishing first-boot init
   (litellm prisma migration, store creation) is not treated as a failure.
3. On a persistent empty response, die() loud with a journal tail and a
   checklist of what to inspect (/dev/rknpu, data dir writability, the
   controller journal). The detected profile (NPU type, device, profile_id)
   is also surfaced in the success banner so a tester can confirm at a
   glance.

Docs-Reviewed: this change is internal to scripts/install-server.sh and the
hardware verification step already documented in the success banner itself;
README.md's "install" section does not enumerate individual verification
behaviour and the change is a bugfix rather than a new installer entry point,
so no README edit is required.

GATE PROOF (RED-FIRST, RED run before fix):

```
$ uv run pytest tests/test_install_server_hardware_verify.py
FAILED tests/test_install_server_hardware_verify.py::test_verify_dies_loud_when_endpoint_returns_empty - AssertionError: verify_hardware_capabilities returned 0 against an empty endpoint; this is the regression from taOS #2 -- the installer must fail loud instead of printing 'hardware verification skipped' and walking away.
  assert 0 != 0
   +  where 0 = CompletedProcess(args=['/usr/bin/env', 'bash', '/tmp/.../wrapper.sh'], returncode=0, stdout='', stderr='[server-install] hardware verification skipped -- controller did not return a profile\n').returncode
FAILED tests/test_install_server_hardware_verify.py::test_install_script_uses_post_for_hardware_refresh - AssertionError: install-server.sh must POST /api/system/hardware/refresh with a bounded --max-time; a GET against a POST-only route silently returns 405 and triggers the empty-profile skip from taOS #2.
========================= 2 failed, 1 passed in 0.32s ==========================
```

GREEN run with the fix applied:

```
$ uv run pytest tests/test_install_server_hardware_verify.py tests/test_routes_system.py tests/test_hardware.py
55 passed in 85.29s (0:01:25)
```

Bash regression test `tests/test_install_server.sh` (all tests passed),
script syntax `bash -n scripts/install-server.sh` (OK).

Files:
 changelog.d/tsk-zgjc24-hw-verify-loud.md     |  11 ++
 scripts/install-server.sh                    |  80 ++++++++++++++-
 tests/test_install_server.sh                 |   8 +-
 tests/test_install_server_hardware_verify.py | 147 +++++++++++++++++++++++++++
 4 files changed, 239 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hardware verification during installation now reliably communicates with the controller and retries while first-time setup completes.
  - Installations now fail with actionable diagnostic information when hardware details cannot be retrieved, instead of silently continuing.
- **New Features**
  - Successful installation summaries now display the detected hardware profile, NPU type, and device, or clearly indicate when no NPU is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->