### PR TITLE
test(llm_proxy): give TestTraceUrlPropagation fakes a poll() so dev CI is green again

### DIFF
--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -384,6 +384,9 @@ class TestTraceUrlPropagation:
         class _FakePopen:
             def __init__(self, *args, **kwargs):
                 captured["env"] = kwargs.get("env") or {}
+            # R2-29 readiness loop calls proc.poll(); None = still running.
+            def poll(self):
+                return None
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 
@@ -418,6 +421,9 @@ class TestTraceUrlPropagation:
         class _FakePopen:
             def __init__(self, *a, **kw):
                 pass
+            # R2-29 readiness loop calls proc.poll(); None = still running.
+            def poll(self):
+                return None
 
         monkeypatch.setattr(mod.subprocess, "Popen", _FakePopen)
 


### PR DESCRIPTION
test(llm_proxy): give TestTraceUrlPropagation fakes a poll() so dev CI is green again

#2877 (R2-29) made start() call self._process.poll() inside the readiness
loop; #2879 (R2-3) added TestTraceUrlPropagation with two _FakePopen stubs
that have no poll(). Each PR was green on its own; merged one minute apart
they broke dev: shards (3.13, 3) failed on 9440fc9e and every PR opened
since inherits the red. Test-only change, no fragment required.

RED (origin/dev 9440fc9e):
```
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_exports_trace_url_with_controller_port
FAILED tests/test_llm_proxy.py::TestTraceUrlPropagation::test_start_logs_trace_url
2 failed, 60 deselected in 2.45s
```
GREEN (this branch):
```
62 passed in 4.66s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated trace URL propagation test mocks to accurately represent running subprocesses during readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->