### PR TITLE
security(import): refuse traversal filenames on /api/import upload and embed (GHSA-rwrp-hfc4-qg2w)

### DIFF
--- a/changelog.d/ghsa-rwrp-import-upload-traversal.md
+++ b/changelog.d/ghsa-rwrp-import-upload-traversal.md
@@ -1,0 +1,3 @@
+### Security
+
+- Fixed a path traversal in `POST /api/import/upload` and `POST /api/import/embed`: a client-supplied filename such as an absolute path or `../` escaped the upload directory, letting any authenticated user write or read files the server process can reach, including the auth store. Names must now be a plain basename that resolves inside the upload directory, and `agent_name` is validated. Reported by EQSTLab (GHSA-rwrp-hfc4-qg2w).

--- a/tests/test_import_upload_traversal.py
+++ b/tests/test_import_upload_traversal.py
@@ -1,0 +1,92 @@
+"""GHSA-rwrp-hfc4-qg2w: /api/import/upload and /api/import/embed built paths
+from client-supplied names with ``UPLOAD_DIR / name``. ``pathlib`` drops the
+left operand for an absolute right operand, so any authenticated user could
+write (upload) or read (embed) any file the server process can reach. Every
+name must resolve INSIDE UPLOAD_DIR or be refused with a 400 before the
+filesystem is touched."""
+
+import io
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.routes import import_data as mod
+
+
+def _mock_http(monkeypatch, client):
+    http = MagicMock()
+    http.post = AsyncMock()
+    http.aclose = AsyncMock(return_value=None)
+    monkeypatch.setattr(client._transport.app.state, "http_client", http)
+    return http
+
+
+class TestUploadTraversal:
+    @pytest.mark.asyncio
+    async def test_absolute_filename_is_refused_and_not_written(self, client, tmp_path):
+        target = tmp_path / "auth_user.json"
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": (str(target), io.BytesIO(b'{"users": []}'), "application/json")},
+        )
+        assert resp.status_code == 400, resp.text
+        assert not target.exists(), "upload escaped UPLOAD_DIR via an absolute filename"
+
+    @pytest.mark.asyncio
+    async def test_dotdot_filename_is_refused_and_not_written(self, client):
+        escaped = mod.UPLOAD_DIR.parent / "traversal_probe.txt"
+        escaped.unlink(missing_ok=True)
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": ("../traversal_probe.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+        try:
+            assert resp.status_code == 400, resp.text
+            assert not escaped.exists(), "upload escaped UPLOAD_DIR via ../"
+        finally:
+            escaped.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_hidden_filename_is_refused(self, client):
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": (".auth_user.json", io.BytesIO(b"{}"), "application/json")},
+        )
+        assert resp.status_code == 400, resp.text
+
+    @pytest.mark.asyncio
+    async def test_plain_basename_still_uploads_inside_upload_dir(self, client):
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": ("plain_ok.txt", io.BytesIO(b"hello"), "text/plain")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["path"] == str(mod.UPLOAD_DIR / "plain_ok.txt")
+
+
+class TestEmbedTraversal:
+    @pytest.mark.asyncio
+    async def test_absolute_path_in_files_is_refused_before_read(self, client, tmp_path, monkeypatch):
+        secret = tmp_path / "secret.txt"
+        secret.write_text("do not read me")
+        http = _mock_http(monkeypatch, client)
+        resp = await client.post(
+            "/api/import/embed",
+            json={"agent_name": "test-agent", "files": [str(secret)]},
+        )
+        assert resp.status_code == 400, resp.text
+        http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_traversal_agent_name_is_refused(self, client, monkeypatch):
+        http = _mock_http(monkeypatch, client)
+        await client.post(
+            "/api/import/upload",
+            files={"file": ("agent_name_probe.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+        resp = await client.post(
+            "/api/import/embed",
+            json={"agent_name": "../../escaped", "files": ["agent_name_probe.txt"]},
+        )
+        assert resp.status_code == 400, resp.text
+        http.post.assert_not_called()

--- a/tinyagentos/routes/import_data.py
+++ b/tinyagentos/routes/import_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -13,7 +14,29 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 SUPPORTED_EXTENSIONS = {".txt", ".md", ".pdf", ".html", ".json", ".csv"}
+
 UPLOAD_DIR = Path(tempfile.gettempdir()) / "tinyagentos_imports"
+
+_SAFE_AGENT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _upload_path(filename: str) -> Path | None:
+    """Map a client-supplied filename to a path INSIDE ``UPLOAD_DIR``.
+
+    ``Path("a") / "/etc/x"`` silently discards the left operand, so an
+    absolute or ``..`` filename would let any authenticated user write
+    (upload) or read (embed) any file the server process can reach
+    (GHSA-rwrp-hfc4-qg2w). Browsers only ever send a bare basename, so
+    anything with a separator, a NUL, or a leading dot is rejected outright.
+    """
+    if not filename or "/" in filename or "\\" in filename or "\x00" in filename:
+        return None
+    if filename in {".", ".."} or filename.startswith("."):
+        return None
+    dest = UPLOAD_DIR / filename
+    if dest.resolve().parent != UPLOAD_DIR.resolve():
+        return None
+    return dest
 
 
 @router.post("/api/import/upload")
@@ -28,15 +51,17 @@ async def upload_file(request: Request, file: UploadFile):
             status_code=400,
         )
 
+    dest = _upload_path(file.filename)
+    if dest is None:
+        return JSONResponse({"error": "Invalid filename"}, status_code=400)
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-    dest = UPLOAD_DIR / file.filename
     with open(dest, "wb") as f:
         shutil.copyfileobj(file.file, f)
 
     size = dest.stat().st_size
     return {
         "status": "uploaded",
-        "filename": file.filename,
+        "filename": dest.name,
         "size": size,
         "path": str(dest),
     }
@@ -52,9 +77,20 @@ async def embed_files(request: Request):
         return JSONResponse({"error": "agent_name is required"}, status_code=400)
     if not filenames:
         return JSONResponse({"error": "No files specified"}, status_code=400)
+    if not isinstance(agent_name, str) or not _SAFE_AGENT_NAME.match(agent_name):
+        return JSONResponse({"error": "Invalid agent_name"}, status_code=400)
+
+    # Resolve every name INSIDE UPLOAD_DIR before touching the filesystem;
+    # a traversal name is a 400, not a read of whatever it points at.
+    resolved: dict[str, Path] = {}
+    for f in filenames:
+        p = _upload_path(f) if isinstance(f, str) else None
+        if p is None:
+            return JSONResponse({"error": f"Invalid filename: {f!r}"}, status_code=400)
+        resolved[f] = p
 
     # Verify files exist
-    missing = [f for f in filenames if not (UPLOAD_DIR / f).exists()]
+    missing = [f for f, p in resolved.items() if not p.exists()]
     if missing:
         return JSONResponse({"error": f"Files not found: {', '.join(missing)}"}, status_code=404)
 
@@ -74,7 +110,7 @@ async def embed_files(request: Request):
     all_embedded = True
 
     for fname in filenames:
-        fpath = UPLOAD_DIR / fname
+        fpath = resolved[fname]
         text = fpath.read_text(errors="replace")
         file_embedded = False
 


### PR DESCRIPTION
security(import): refuse traversal filenames on /api/import upload and embed (GHSA-rwrp-hfc4-qg2w)

routes/import_data.py built every path as `UPLOAD_DIR / <client name>`.
pathlib drops the left operand for an absolute right operand and never
normalises `..`, so any authenticated user could write an arbitrary file
via upload (the reported chain overwrites the auth store and injects an
admin) and read an arbitrary file via embed. `agent_name` was joined into
agent_memory_dir the same way.

Fix: `_upload_path()` accepts only a bare, non-hidden basename with no
separator or NUL and checks the resolved parent is UPLOAD_DIR; upload and
embed both go through it before touching the filesystem (400 otherwise).
`agent_name` must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`.

Reported by EQSTLab (GHSA-rwrp-hfc4-qg2w). Thank you.

RED (tests on origin/dev 9440fc9e, route unfixed):
```
FAILED tests/test_import_upload_traversal.py::TestUploadTraversal::test_absolute_filename_is_refused_and_not_written
FAILED tests/test_import_upload_traversal.py::TestUploadTraversal::test_dotdot_filename_is_refused_and_not_written
FAILED tests/test_import_upload_traversal.py::TestUploadTraversal::test_hidden_filename_is_refused
FAILED tests/test_import_upload_traversal.py::TestEmbedTraversal::test_absolute_path_in_files_is_refused_before_read
FAILED tests/test_import_upload_traversal.py::TestEmbedTraversal::test_traversal_agent_name_is_refused
5 failed, 1 passed, 2 warnings in 11.83s
```
GREEN (this branch, new + existing import_data tests):
```
10 passed in 20.25s
```

Docs-Reviewed: no endpoint added, removed or renamed; only input validation (400 on traversal names and bad agent_name). User-facing note is the changelog fragment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened import uploads and embeds against path traversal.
  - Invalid filenames and agent names—including absolute paths, traversal patterns, hidden names, and unsafe characters—are rejected with a 400 response.
  - Prevented uploaded or embedded files from being accessed outside the designated upload directory.
- **Tests**
  - Added coverage for rejected unsafe paths and successful uploads using safe filenames.
  - Verified invalid embed requests are blocked before external requests are made.
- **Documentation**
  - Added a security changelog entry documenting the fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->