### PR TITLE
security(import): upload dir must be service-owned, non-symlink, under data_dir (not a predictable /tmp path) - CodeRabbit CWE-59 on #2894

### DIFF
--- a/changelog.d/tsk-msce3t-import-upload-dir.md
+++ b/changelog.d/tsk-msce3t-import-upload-dir.md
@@ -1,0 +1,2 @@
+### Fixed
+- `/api/import/upload` and `/api/import/embed` now place files under `<data_dir>/imports/uploads` instead of a predictable `/tmp` path, and refuse requests when the upload directory is a symlink, not a directory, or not owned by the service user.

--- a/tests/test_import_upload_traversal.py
+++ b/tests/test_import_upload_traversal.py
@@ -6,6 +6,7 @@ name must resolve INSIDE UPLOAD_DIR or be refused with a 400 before the
 filesystem is touched."""
 
 import io
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -33,8 +34,8 @@ class TestUploadTraversal:
         assert not target.exists(), "upload escaped UPLOAD_DIR via an absolute filename"
 
     @pytest.mark.asyncio
-    async def test_dotdot_filename_is_refused_and_not_written(self, client):
-        escaped = mod.UPLOAD_DIR.parent / "traversal_probe.txt"
+    async def test_dotdot_filename_is_refused_and_not_written(self, client, app):
+        escaped = Path(app.state.data_dir) / "imports" / "traversal_probe.txt"
         escaped.unlink(missing_ok=True)
         resp = await client.post(
             "/api/import/upload",
@@ -55,13 +56,14 @@ class TestUploadTraversal:
         assert resp.status_code == 400, resp.text
 
     @pytest.mark.asyncio
-    async def test_plain_basename_still_uploads_inside_upload_dir(self, client):
+    async def test_plain_basename_still_uploads_inside_upload_dir(self, client, app):
         resp = await client.post(
             "/api/import/upload",
             files={"file": ("plain_ok.txt", io.BytesIO(b"hello"), "text/plain")},
         )
         assert resp.status_code == 200, resp.text
-        assert resp.json()["path"] == str(mod.UPLOAD_DIR / "plain_ok.txt")
+        expected = Path(app.state.data_dir) / "imports" / "uploads" / "plain_ok.txt"
+        assert resp.json()["path"] == str(expected)
 
 
 class TestEmbedTraversal:
@@ -90,3 +92,44 @@ class TestEmbedTraversal:
         )
         assert resp.status_code == 400, resp.text
         http.post.assert_not_called()
+
+
+class TestUploadDirSecurity:
+    @pytest.mark.asyncio
+    async def test_symlink_upload_dir_is_refused(self, client, tmp_path, app):
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        upload_dir = Path(app.state.data_dir) / "imports" / "uploads"
+        upload_dir.parent.mkdir(parents=True, exist_ok=True)
+        if upload_dir.exists():
+            if upload_dir.is_dir() and not upload_dir.is_symlink():
+                import shutil
+                shutil.rmtree(upload_dir)
+            else:
+                upload_dir.unlink()
+        upload_dir.symlink_to(victim)
+
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": ("x.json", io.BytesIO(b'{}'), "application/json")},
+        )
+        assert resp.status_code == 500, resp.text
+        assert not any(victim.iterdir()), f"files leaked into victim: {list(victim.iterdir())}"
+
+    @pytest.mark.asyncio
+    async def test_regular_file_upload_dir_is_refused(self, client, app):
+        upload_dir = Path(app.state.data_dir) / "imports" / "uploads"
+        upload_dir.parent.mkdir(parents=True, exist_ok=True)
+        if upload_dir.exists():
+            if upload_dir.is_dir() and not upload_dir.is_symlink():
+                import shutil
+                shutil.rmtree(upload_dir)
+            else:
+                upload_dir.unlink()
+        upload_dir.write_text("not a directory")
+
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": ("x.json", io.BytesIO(b'{}'), "application/json")},
+        )
+        assert resp.status_code == 500, resp.text

--- a/tinyagentos/routes/import_data.py
+++ b/tinyagentos/routes/import_data.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import shutil
-import tempfile
+import stat
 from pathlib import Path
 
-from fastapi import APIRouter, Request, UploadFile
+from fastapi import APIRouter, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
@@ -15,26 +16,44 @@ router = APIRouter()
 
 SUPPORTED_EXTENSIONS = {".txt", ".md", ".pdf", ".html", ".json", ".csv"}
 
-UPLOAD_DIR = Path(tempfile.gettempdir()) / "tinyagentos_imports"
-
 _SAFE_AGENT_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
-def _upload_path(filename: str) -> Path | None:
-    """Map a client-supplied filename to a path INSIDE ``UPLOAD_DIR``.
+def _get_upload_dir(data_dir: Path) -> Path:
+    return data_dir / "imports" / "uploads"
 
-    ``Path("a") / "/etc/x"`` silently discards the left operand, so an
-    absolute or ``..`` filename would let any authenticated user write
-    (upload) or read (embed) any file the server process can reach
-    (GHSA-rwrp-hfc4-qg2w). Browsers only ever send a bare basename, so
-    anything with a separator, a NUL, or a leading dot is rejected outright.
-    """
+
+def _ensure_upload_dir(upload_dir: Path) -> None:
+    if not upload_dir.exists():
+        upload_dir.mkdir(parents=True, mode=0o700)
+        return
+    st = os.lstat(upload_dir)
+    if stat.S_ISLNK(st.st_mode):
+        raise HTTPException(
+            status_code=500,
+            detail="Upload directory is a symlink",
+        )
+    if not stat.S_ISDIR(st.st_mode):
+        raise HTTPException(
+            status_code=500,
+            detail="Upload directory is not a directory",
+        )
+    if st.st_uid != os.getuid():
+        raise HTTPException(
+            status_code=500,
+            detail="Upload directory is not owned by the service",
+        )
+    if st.st_mode & 0o077:
+        os.chmod(upload_dir, 0o700)
+
+
+def _upload_path(filename: str, upload_dir: Path) -> Path | None:
     if not filename or "/" in filename or "\\" in filename or "\x00" in filename:
         return None
     if filename in {".", ".."} or filename.startswith("."):
         return None
-    dest = UPLOAD_DIR / filename
-    if dest.resolve().parent != UPLOAD_DIR.resolve():
+    dest = upload_dir / filename
+    if dest.resolve().parent != upload_dir.resolve():
         return None
     return dest
 
@@ -51,10 +70,15 @@ async def upload_file(request: Request, file: UploadFile):
             status_code=400,
         )
 
-    dest = _upload_path(file.filename)
+    data_dir = getattr(request.app.state, "data_dir", None)
+    if data_dir is None:
+        return JSONResponse({"error": "data_dir not configured"}, status_code=500)
+    upload_dir = _get_upload_dir(data_dir)
+    _ensure_upload_dir(upload_dir)
+
+    dest = _upload_path(file.filename, upload_dir)
     if dest is None:
         return JSONResponse({"error": "Invalid filename"}, status_code=400)
-    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     with open(dest, "wb") as f:
         shutil.copyfileobj(file.file, f)
 
@@ -80,11 +104,15 @@ async def embed_files(request: Request):
     if not isinstance(agent_name, str) or not _SAFE_AGENT_NAME.match(agent_name):
         return JSONResponse({"error": "Invalid agent_name"}, status_code=400)
 
-    # Resolve every name INSIDE UPLOAD_DIR before touching the filesystem;
-    # a traversal name is a 400, not a read of whatever it points at.
+    data_dir = getattr(request.app.state, "data_dir", None)
+    if data_dir is None:
+        return JSONResponse({"error": "data_dir not configured"}, status_code=500)
+    upload_dir = _get_upload_dir(data_dir)
+    _ensure_upload_dir(upload_dir)
+
     resolved: dict[str, Path] = {}
     for f in filenames:
-        p = _upload_path(f) if isinstance(f, str) else None
+        p = _upload_path(f, upload_dir) if isinstance(f, str) else None
         if p is None:
             return JSONResponse({"error": f"Invalid filename: {f!r}"}, status_code=400)
         resolved[f] = p


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): security(import): upload dir must be service-owned, non-symlink, under data_dir (not a predictable /tmp path) - CodeRabbit CWE-59 on #2894

Autonomous build of board card tsk-msce3t.

Move the import upload directory from a predictable /tmp path to
<data_dir>/imports/uploads, matching how the rest of the routes resolve
data_dir from request.app.state.

Add _ensure_upload_dir() which runs before any file handling in both
/api/import/upload and /api/import/embed: creates the directory with
mode 0o700 when absent, refuses the request with HTTP 500 when the
path is a symlink, not a directory, or not owned by the service uid,
and tightens permissions to 0o700 when group/other bits are set.

Keep the existing basename and resolve checks from beta.51 on top.

Red-first proof (lead re-measured on origin/dev in a scratch worktree, 3 failed / 5 passed):

```
$ python -m pytest tests/test_import_upload_traversal.py -q
FAILED tests/test_import_upload_traversal.py::TestUploadTraversal::test_plain_basename_still_uploads_inside_upload_dir
FAILED tests/test_import_upload_traversal.py::TestUploadDirSecurity::test_symlink_upload_dir_is_refused
FAILED tests/test_import_upload_traversal.py::TestUploadDirSecurity::test_regular_file_upload_dir_is_refused
3 failed, 5 passed in 17.15s
```

After fix:

```
8 passed in 14.63s
```

Docs-Reviewed: no docs mention the old upload dir path

Files:
 changelog.d/tsk-msce3t-import-upload-dir.md |  2 +
 tests/test_import_upload_traversal.py       | 51 ++++++++++++++++++++--
 tinyagentos/routes/import_data.py           | 66 ++++++++++++++++++++---------
 3 files changed, 96 insertions(+), 23 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Import uploads and embeds are now stored in the application data directory under `imports/uploads` instead of temporary paths.
  - Unsafe or unavailable upload directories are rejected, preventing uploads from being written outside the intended location.
  - Upload and embed operations now return a server error when the configured data directory cannot be safely used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
