### PR TITLE
fix-forward #2883 (tsk-y5tp24): a non-mapping manifest STILL aborts the whole catalog; from_file's named-error path crashes inside pydantic; doc-gate job lacks pydantic

### DIFF
--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -54,5 +54,5 @@ jobs:
 
       - name: Managed backend manifest lint
         run: |
-          python -m pip install --quiet pyyaml
+          python -m pip install --quiet pyyaml pydantic
           python scripts/check_manifests.py managed-lint

--- a/app-catalog/services/hailo-ollama/manifest.yaml
+++ b/app-catalog/services/hailo-ollama/manifest.yaml
@@ -4,6 +4,7 @@ id: hailo-ollama
 license: Proprietary (Hailo EULA, accepted at install)
 name: hailo-ollama (Hailo-10H NPU LLM)
 type: service
+version: 0.1.0
 category: llm-runtime
 description: "Ollama-compatible LLM server on the Hailo-10H NPU (Raspberry Pi 5 + AI HAT+2)"
 requires:

--- a/changelog.d/tsk-y5tp24-manifest-schema.md
+++ b/changelog.d/tsk-y5tp24-manifest-schema.md
@@ -10,10 +10,20 @@
   The catalog load loop also skips a single bad manifest with a named
   log message instead of aborting the entire store listing, so one
   malformed entry no longer takes the store offline.
+- `tinyagentos/registry`: a non-mapping YAML manifest (list, scalar, or
+  empty file) is now skipped before `from_dict` is called, and
+  `from_dict` itself raises `pydantic.ValidationError` (via
+  `PydanticCustomError`) for non-mapping input instead of crashing with
+  `TypeError`. The `from_file` path also uses `PydanticCustomError`
+  instances for `yaml_parse_error` and `manifest_not_mapping` instead
+  of invented error types that crashed inside pydantic-core.
 - `scripts/check_manifests.py`: the CI lint now validates every service
   manifest against the same `AppManifest` pydantic model the runtime uses,
   closing the mirror-image bug where a typo'd manifest slipped through
   the gate as a silent skip.
+- `.github/workflows/doc-gate.yml`: the managed-backend manifest lint
+  step now installs `pydantic` alongside `pyyaml` so the script can
+  import the model.
 - `scripts/manifest.schema.json`: published JSON Schema for `AppManifest`
   so third-party app authors can validate their catalogs against the same
   contract the runtime enforces.

--- a/changelog.d/tsk-y5tp24-manifest-schema.md
+++ b/changelog.d/tsk-y5tp24-manifest-schema.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- `tinyagentos/registry`: `AppManifest` is now a `pydantic.BaseModel`, so
+  manifests from the external catalog repo are type-checked at the load
+  boundary. A wrong-typed field (e.g. `requires: "ollama"` where a mapping
+  is required, `context_window: "8192"` where an int is required) now
+  raises `pydantic.ValidationError` *naming the offending field and the
+  manifest path* instead of silently propagating the bad value into
+  install code as `AttributeError: 'str' object has no attribute 'get'`.
+  The catalog load loop also skips a single bad manifest with a named
+  log message instead of aborting the entire store listing, so one
+  malformed entry no longer takes the store offline.
+- `scripts/check_manifests.py`: the CI lint now validates every service
+  manifest against the same `AppManifest` pydantic model the runtime uses,
+  closing the mirror-image bug where a typo'd manifest slipped through
+  the gate as a silent skip.
+- `scripts/manifest.schema.json`: published JSON Schema for `AppManifest`
+  so third-party app authors can validate their catalogs against the same
+  contract the runtime enforces.

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -40,6 +40,15 @@ def lint_managed(root: Path) -> list[str]:
     ``lifecycle.health.expect`` is a literal substring matched against the
     backend's health-endpoint response body (a 200 body must contain it).
     """
+    # Validate every manifest against the same pydantic model the runtime
+    # uses, so a typo'd manifest (e.g. ``requires: ollama`` as a string)
+    # fails the gate instead of silently shipping. The CI mirror-image
+    # bug was: `if not isinstance(lifecycle, dict): continue` skipped
+    # malformed manifests, so a bad one passed the gate.
+    from pydantic import ValidationError
+
+    from tinyagentos.registry import AppManifest
+
     errors: list[str] = []
     services_dir = root / "services"
     for manifest in sorted(services_dir.glob("*/manifest.yaml")):
@@ -54,6 +63,13 @@ def lint_managed(root: Path) -> list[str]:
             continue
         if not isinstance(data, dict):
             errors.append(f"{sid_dir}: manifest.yaml top-level is not a mapping")
+            continue
+
+        # Boundary validation: same model the runtime loads with.
+        try:
+            AppManifest.model_validate({**data, "manifest_dir": manifest.parent})
+        except ValidationError as exc:
+            errors.append(f"{sid_dir}: manifest failed schema validation: {exc}")
             continue
 
         sid = str(data.get("id") or sid_dir)

--- a/scripts/manifest.schema.json
+++ b/scripts/manifest.schema.json
@@ -1,0 +1,117 @@
+{
+  "description": "A loaded catalog manifest.\n\nApp manifests are externally-authored input, pulled from a remote git repo\nby ``tinyagentos/catalog_sync.py``. Validating at this boundary keeps a\nsingle malformed entry from breaking install-time code paths deep in\nthe stack (the prior ``data.get(key, default)`` loader happily let a\nstring ``requires`` through to install code, which then raised\n``AttributeError: 'str' object has no attribute 'get'`` with no\nindication which manifest was malformed).\n\n``extra=\"ignore\"`` keeps the model forward-compatible with newer\ncatalog fields the runtime has not learned about yet.",
+  "properties": {
+    "id": {
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "type": {
+      "title": "Type",
+      "type": "string"
+    },
+    "version": {
+      "title": "Version",
+      "type": "string"
+    },
+    "description": {
+      "default": "",
+      "title": "Description",
+      "type": "string"
+    },
+    "category": {
+      "default": "",
+      "title": "Category",
+      "type": "string"
+    },
+    "icon": {
+      "default": "",
+      "title": "Icon",
+      "type": "string"
+    },
+    "homepage": {
+      "default": "",
+      "title": "Homepage",
+      "type": "string"
+    },
+    "license": {
+      "default": "",
+      "title": "License",
+      "type": "string"
+    },
+    "weights_license": {
+      "default": "",
+      "title": "Weights License",
+      "type": "string"
+    },
+    "license_class": {
+      "default": "",
+      "title": "License Class",
+      "type": "string"
+    },
+    "requires": {
+      "additionalProperties": true,
+      "title": "Requires",
+      "type": "object"
+    },
+    "install": {
+      "additionalProperties": true,
+      "title": "Install",
+      "type": "object"
+    },
+    "hardware_tiers": {
+      "additionalProperties": true,
+      "title": "Hardware Tiers",
+      "type": "object"
+    },
+    "config_schema": {
+      "items": {},
+      "title": "Config Schema",
+      "type": "array"
+    },
+    "variants": {
+      "items": {},
+      "title": "Variants",
+      "type": "array"
+    },
+    "context_window": {
+      "default": 0,
+      "title": "Context Window",
+      "type": "integer"
+    },
+    "capabilities": {
+      "items": {},
+      "title": "Capabilities",
+      "type": "array"
+    },
+    "lifecycle": {
+      "additionalProperties": true,
+      "title": "Lifecycle",
+      "type": "object"
+    },
+    "manifest_dir": {
+      "anyOf": [
+        {
+          "format": "path",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Manifest Dir"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "type",
+    "version"
+  ],
+  "title": "AppManifest",
+  "type": "object"
+}

--- a/tests/test_check_manifests.py
+++ b/tests/test_check_manifests.py
@@ -24,7 +24,9 @@ def _write(root: Path, sid: str, manifest: dict) -> None:
 def _managed_ok(sid: str = "rkllama") -> dict:
     return {
         "id": sid,
+        "name": sid,
         "type": "service",
+        "version": "1.0.0",
         "category": "llm-runtime",
         "lifecycle": {
             "backend_type": "rkllama",
@@ -70,7 +72,9 @@ def test_non_managed_service_is_ignored(tmp_path: Path) -> None:
     # auto_manage false -> not claiming managed, no unit/health required
     m = {
         "id": "rk-llama-cpp",
+        "name": "rk-llama-cpp",
         "type": "service",
+        "version": "1.0.0",
         "category": "llm-runtime",
         "lifecycle": {"backend_type": "openai-compatible", "auto_manage": False},
     }
@@ -79,7 +83,9 @@ def test_non_managed_service_is_ignored(tmp_path: Path) -> None:
 
 
 def test_service_without_lifecycle_is_ignored(tmp_path: Path) -> None:
-    _write(tmp_path, "ollama", {"id": "ollama", "type": "service"})
+    _write(tmp_path, "ollama", {
+        "id": "ollama", "name": "ollama", "type": "service", "version": "1.0.0",
+    })
     assert check_manifests.lint_managed(tmp_path) == []
 
 

--- a/tests/test_check_manifests.py
+++ b/tests/test_check_manifests.py
@@ -132,6 +132,22 @@ def test_non_string_expect_is_flagged(tmp_path: Path) -> None:
     assert any("expect must be a string" in e for e in errors)
 
 
+def test_requires_string_reports_schema_validation_failure(tmp_path: Path) -> None:
+    """A string ``requires`` field fails the same AppManifest schema the
+    runtime loads with and is reported as a schema validation failure."""
+    _write(tmp_path, "bad-requires", {
+        "id": "bad-requires",
+        "name": "bad",
+        "type": "service",
+        "version": "1.0.0",
+        "requires": "ollama",
+    })
+    errors = check_manifests.lint_managed(tmp_path)
+    assert len(errors) == 1
+    assert "bad-requires" in errors[0]
+    assert "failed schema validation" in errors[0]
+
+
 def test_real_catalog_is_clean() -> None:
     """The shipped app-catalog must pass the managed-service lint."""
     root = Path(__file__).resolve().parent.parent / "app-catalog"

--- a/tests/test_registry_manifest.py
+++ b/tests/test_registry_manifest.py
@@ -10,6 +10,8 @@ bad manifest does not abort the rest of the catalog.
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 import yaml
 from pydantic import ValidationError
@@ -110,3 +112,39 @@ class TestWellFormedManifestStillLoads:
         m = AppManifest.from_file(d / "manifest.yaml")
         assert m.id == "happy"
         assert m.type == "agent-framework"
+
+
+class TestNonMappingYAML:
+    def test_list_yaml_skipped_with_warning(self, tmp_path, caplog):
+        """A manifest whose YAML top level is a list is skipped with a
+        warning naming its directory, and the rest of the catalog still
+        loads."""
+        catalog = tmp_path
+        services = catalog / "services"
+        _write_manifest(services / "good", _good_manifest("good"))
+        listy = services / "listy"
+        listy.mkdir(parents=True, exist_ok=True)
+        (listy / "manifest.yaml").write_text("- a\n- b\n")
+        empty = services / "empty"
+        empty.mkdir(parents=True, exist_ok=True)
+        (empty / "manifest.yaml").write_text("")
+        with caplog.at_level(logging.WARNING):
+            reg = AppRegistry(
+                catalog_dir=catalog,
+                installed_path=tmp_path / "installed.json",
+            )
+            apps = reg.list_available()
+        ids = {a.id for a in apps}
+        assert "good" in ids
+        assert any("listy" in r.getMessage() for r in caplog.records)
+        assert any("empty" in r.getMessage() for r in caplog.records)
+
+    def test_from_file_list_yaml_raises_validation_error(self, tmp_path, caplog):
+        """from_file on a list-YAML manifest must raise ValidationError
+        whose string contains the manifest path."""
+        d = tmp_path / "services" / "listy"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "manifest.yaml").write_text("- a\n- b\n")
+        with pytest.raises(ValidationError) as exc:
+            AppManifest.from_file(d / "manifest.yaml")
+        assert str(d / "manifest.yaml") in str(exc.value)

--- a/tests/test_registry_manifest.py
+++ b/tests/test_registry_manifest.py
@@ -1,0 +1,112 @@
+# tests/test_registry_manifest.py
+"""Schema validation at the catalog boundary.
+
+App manifests come from an externally-authored git repo (see
+tinyagentos/catalog_sync.py) and were previously parsed with ``data.get(...)
+`` defaults and no type checks, so a single malformed entry broke the whole
+store listing at install time. These tests pin the boundary contract: wrong
+types are rejected with a named ``ValidationError`` *at load time*, and one
+bad manifest does not abort the rest of the catalog.
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from tinyagentos.registry import AppManifest, AppRegistry
+
+
+# -- helpers ----------------------------------------------------------------
+
+def _write_manifest(app_dir, manifest: dict) -> None:
+    app_dir.mkdir(parents=True, exist_ok=True)
+    (app_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+
+def _good_manifest(mid: str = "good-app") -> dict:
+    return {
+        "id": mid,
+        "name": "Good App",
+        "type": "agent-framework",
+        "version": "1.0.0",
+    }
+
+
+# -- RED tests --------------------------------------------------------------
+
+class TestBoundaryRejectsWrongTypes:
+    def test_string_requires_is_rejected(self, tmp_path, caplog):
+        """A string where ``requires`` should be a mapping would otherwise
+        travel into the install path and raise AttributeError deep in
+        install code, with no indication which manifest was malformed."""
+        import logging
+
+        bad = _good_manifest("bad-requires")
+        bad["requires"] = "ollama"  # YAML string, not a mapping
+        d = tmp_path / "agents" / "bad-requires"
+        _write_manifest(d, bad)
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(ValidationError) as exc:
+                AppManifest.from_file(d / "manifest.yaml")
+        # ValidationError names the offending field...
+        assert "requires" in str(exc.value)
+        # ...and the load-time log names the offending manifest by id and path.
+        assert any("bad-requires" in r.getMessage() for r in caplog.records)
+
+    def test_string_context_window_is_coerced_or_rejected(self, tmp_path):
+        """A string-valued ``context_window`` flowed into model-selection
+        arithmetic. Either coerce to int or reject; a silent string is
+        not acceptable."""
+        bad = _good_manifest("bad-window")
+        bad["type"] = "model"
+        bad["context_window"] = "8192"  # YAML string
+        d = tmp_path / "models" / "bad-window"
+        _write_manifest(d, bad)
+        try:
+            m = AppManifest.from_file(d / "manifest.yaml")
+        except ValidationError:
+            return  # rejected is fine
+        # If coerced, it must be the int 8192, not the string.
+        assert m.context_window == 8192
+        assert isinstance(m.context_window, int)
+
+
+class TestCatalogResilience:
+    def test_one_bad_manifest_does_not_abort_catalog(self, tmp_path):
+        """A manifest missing the required ``id`` field used to raise bare
+        ``KeyError`` from from_dict, which the loop swallowed -- but every
+        subsequent manifest in the same type_dir was loaded into the same
+        loop, and a later exception propagated. Per the audit, one bad
+        manifest must NOT take down the store listing: the rest load."""
+        catalog = tmp_path
+        agents = catalog / "agents"
+        # Good manifest before the bad one.
+        _write_manifest(agents / "alpha", _good_manifest("alpha"))
+        # Bad manifest: missing required id field.
+        bad = agents / "broken"
+        bad.mkdir(parents=True, exist_ok=True)
+        (bad / "manifest.yaml").write_text(
+            yaml.dump({"name": "Broken", "type": "agent-framework", "version": "1.0.0"})
+        )
+        # Good manifest after the bad one.
+        _write_manifest(agents / "zeta", _good_manifest("zeta"))
+
+        reg = AppRegistry(catalog_dir=catalog, installed_path=tmp_path / "installed.json")
+        apps = reg.list_available()
+        ids = {a.id for a in apps}
+        # Both good manifests are listed, the bad one is skipped.
+        assert "alpha" in ids
+        assert "zeta" in ids
+        assert "broken" not in ids
+
+
+class TestWellFormedManifestStillLoads:
+    def test_well_formed_manifest_loads(self, tmp_path):
+        """Sanity: a well-formed manifest still loads cleanly through the
+        new pydantic model."""
+        d = tmp_path / "agents" / "happy"
+        _write_manifest(d, _good_manifest("happy"))
+        m = AppManifest.from_file(d / "manifest.yaml")
+        assert m.id == "happy"
+        assert m.type == "agent-framework"

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import json
 import logging
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +23,22 @@ class AppState(str, Enum):
     ERROR = "error"
 
 
-@dataclass
-class AppManifest:
+class AppManifest(BaseModel):
+    """A loaded catalog manifest.
+
+    App manifests are externally-authored input, pulled from a remote git repo
+    by ``tinyagentos/catalog_sync.py``. Validating at this boundary keeps a
+    single malformed entry from breaking install-time code paths deep in
+    the stack (the prior ``data.get(key, default)`` loader happily let a
+    string ``requires`` through to install code, which then raised
+    ``AttributeError: 'str' object has no attribute 'get'`` with no
+    indication which manifest was malformed).
+
+    ``extra="ignore"`` keeps the model forward-compatible with newer
+    catalog fields the runtime has not learned about yet.
+    """
+    model_config = ConfigDict(extra="ignore", arbitrary_types_allowed=True)
+
     id: str
     name: str
     type: str                   # runtime classification: agent-framework | model | service | plugin
@@ -42,45 +58,63 @@ class AppManifest:
     # license_class is "permissive" | "non-commercial" ("" = unknown/code-only).
     weights_license: str = ""
     license_class: str = ""
-    requires: dict = field(default_factory=dict)
-    install: dict = field(default_factory=dict)
-    hardware_tiers: dict = field(default_factory=dict)
-    config_schema: list = field(default_factory=list)
-    variants: list = field(default_factory=list)   # models only
-    context_window: int = 0                        # model token context window; 0 = unknown
-    capabilities: list = field(default_factory=list)
-    lifecycle: dict = field(default_factory=dict)
+    requires: dict[str, Any] = Field(default_factory=dict)
+    install: dict[str, Any] = Field(default_factory=dict)
+    hardware_tiers: dict[str, Any] = Field(default_factory=dict)
+    config_schema: list[Any] = Field(default_factory=list)
+    variants: list[Any] = Field(default_factory=list)   # models only
+    context_window: int = 0                              # model token context window; 0 = unknown
+    capabilities: list[Any] = Field(default_factory=list)
+    lifecycle: dict[str, Any] = Field(default_factory=dict)
     manifest_dir: Path | None = None
 
     @classmethod
     def from_file(cls, path: Path) -> AppManifest:
-        data = yaml.safe_load(path.read_text())
-        return cls.from_dict(data, manifest_dir=path.parent)
+        try:
+            data = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            raise ValidationError.from_exception_data(
+                title=cls.__name__,
+                line_errors=[
+                    {
+                        "type": "yaml_parse_error",
+                        "loc": (),
+                        "input": str(exc),
+                        "ctx": {"manifest_path": str(path)},
+                    }
+                ],
+            ) from exc
+        if not isinstance(data, dict):
+            raise ValidationError.from_exception_data(
+                title=cls.__name__,
+                line_errors=[
+                    {
+                        "type": "manifest_not_mapping",
+                        "loc": (),
+                        "input": data,
+                        "ctx": {"manifest_path": str(path)},
+                    }
+                ],
+            )
+        try:
+            return cls.model_validate({**data, "manifest_dir": path.parent})
+        except ValidationError:
+            # Re-raise with the manifest path appended so the offending
+            # manifest is named in logs -- otherwise ValidationError only
+            # names the field, and a load-time error report tells the
+            # operator *what* but not *which*.
+            logger.warning(
+                "manifest %s failed validation -- the manifest at %s is malformed",
+                data.get("id", "<no-id>"),
+                path,
+                exc_info=True,
+            )
+            raise
 
     @classmethod
     def from_dict(cls, data: dict, manifest_dir: Path | None = None) -> AppManifest:
-        return cls(
-            id=data["id"],
-            name=data["name"],
-            type=data["type"],
-            version=data["version"],
-            description=data.get("description", ""),
-            category=data.get("category", ""),
-            icon=data.get("icon", ""),
-            homepage=data.get("homepage", ""),
-            license=data.get("license", ""),
-            weights_license=data.get("weights_license", ""),
-            license_class=data.get("license_class", ""),
-            requires=data.get("requires", {}),
-            install=data.get("install", {}),
-            hardware_tiers=data.get("hardware_tiers", {}),
-            config_schema=data.get("config_schema", []),
-            variants=data.get("variants", []),
-            context_window=data.get("context_window", 0),
-            capabilities=data.get("capabilities", []),
-            lifecycle=data.get("lifecycle", {}),
-            manifest_dir=manifest_dir,
-        )
+        payload = {**data, "manifest_dir": manifest_dir}
+        return cls.model_validate(payload)
 
     def is_compatible(self, profile_id: str) -> bool:
         if not self.hardware_tiers:
@@ -93,6 +127,16 @@ class AppManifest:
         if isinstance(tier, dict):
             return tier.get("recommended") is not None or tier.get("fallback") is not None
         return False
+
+
+def manifest_json_schema() -> dict:
+    """Return the JSON Schema for ``AppManifest``.
+
+    Published as ``manifest.schema.json`` so third-party app authors can
+    validate their catalogs against the same contract CI and the runtime
+    enforce. See ``scripts/check_manifests.py`` for the CI half.
+    """
+    return AppManifest.model_json_schema()
 
 
 @dataclass(frozen=True)
@@ -162,25 +206,40 @@ class AppRegistry:
                 continue
             for app_dir in sorted(base.iterdir()):
                 manifest = app_dir / "manifest.yaml"
-                if manifest.exists():
-                    try:
-                        raw_dict = yaml.safe_load(manifest.read_text())
-                        catalog.append(AppManifest.from_dict(raw_dict, manifest_dir=app_dir))
-                        if self._signing_key is not None:
-                            from tinyagentos.store_signing import sign_manifest
+                if not manifest.exists():
+                    continue
+                try:
+                    raw_dict = yaml.safe_load(manifest.read_text())
+                except yaml.YAMLError as exc:
+                    logger.warning(
+                        "skipping manifest %s: unparseable YAML (%s)",
+                        app_dir, exc,
+                    )
+                    continue
+                # schema-validate at the boundary; one malformed manifest
+                # must NOT abort the rest of the store listing
+                try:
+                    loaded = AppManifest.from_dict(raw_dict, manifest_dir=app_dir)
+                except ValidationError as exc:
+                    logger.warning(
+                        "skipping manifest %s: schema validation failed: %s",
+                        app_dir, exc,
+                    )
+                    continue
+                catalog.append(loaded)
+                if self._signing_key is not None:
+                    from tinyagentos.store_signing import sign_manifest
 
-                            try:
-                                sig = sign_manifest(raw_dict, self._signing_key)
-                                signatures[catalog[-1].id] = sig
-                                manifest_dicts[catalog[-1].id] = raw_dict
-                            except Exception:
-                                logger.exception(
-                                    "failed to sign manifest %s — install gate will block it",
-                                    catalog[-1].id,
-                                )
-                                signing_failures.add(catalog[-1].id)
-                    except (yaml.YAMLError, KeyError):
-                        pass  # skip invalid manifests
+                    try:
+                        sig = sign_manifest(raw_dict, self._signing_key)
+                        signatures[loaded.id] = sig
+                        manifest_dicts[loaded.id] = raw_dict
+                    except Exception:
+                        logger.exception(
+                            "failed to sign manifest %s -- install gate will block it",
+                            loaded.id,
+                        )
+                        signing_failures.add(loaded.id)
         # Single atomic assignment: the entire snapshot is replaced at once,
         # so readers never see a mix of old and new state (e.g. a new manifest
         # from the new catalog paired with an old signatures dict).

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic_core import PydanticCustomError
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +78,14 @@ class AppManifest(BaseModel):
                 title=cls.__name__,
                 line_errors=[
                     {
-                        "type": "yaml_parse_error",
+                        "type": PydanticCustomError(
+                            "yaml_parse_error",
+                            "manifest {path} has invalid YAML",
+                            {"path": str(path)},
+                        ),
                         "loc": (),
                         "input": str(exc),
-                        "ctx": {"manifest_path": str(path)},
+                        "ctx": {},
                     }
                 ],
             ) from exc
@@ -89,10 +94,14 @@ class AppManifest(BaseModel):
                 title=cls.__name__,
                 line_errors=[
                     {
-                        "type": "manifest_not_mapping",
+                        "type": PydanticCustomError(
+                            "manifest_not_mapping",
+                            "manifest {path} top level is not a mapping",
+                            {"path": str(path)},
+                        ),
                         "loc": (),
                         "input": data,
-                        "ctx": {"manifest_path": str(path)},
+                        "ctx": {},
                     }
                 ],
             )
@@ -113,6 +122,22 @@ class AppManifest(BaseModel):
 
     @classmethod
     def from_dict(cls, data: dict, manifest_dir: Path | None = None) -> AppManifest:
+        if not isinstance(data, dict):
+            raise ValidationError.from_exception_data(
+                title=cls.__name__,
+                line_errors=[
+                    {
+                        "type": PydanticCustomError(
+                            "manifest_not_mapping",
+                            "manifest {path} top level is not a mapping",
+                            {"path": str(manifest_dir) if manifest_dir else "<unknown>"},
+                        ),
+                        "loc": (),
+                        "input": data,
+                        "ctx": {},
+                    }
+                ],
+            )
         payload = {**data, "manifest_dir": manifest_dir}
         return cls.model_validate(payload)
 
@@ -214,6 +239,12 @@ class AppRegistry:
                     logger.warning(
                         "skipping manifest %s: unparseable YAML (%s)",
                         app_dir, exc,
+                    )
+                    continue
+                if not isinstance(raw_dict, dict):
+                    logger.warning(
+                        "skipping manifest %s: top level is not a mapping",
+                        app_dir,
                     )
                     continue
                 # schema-validate at the boundary; one malformed manifest


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2883 (tsk-y5tp24): a non-mapping manifest STILL aborts the whole catalog; from_file's named-error path crashes inside pydantic; doc-gate job lacks pydantic

Autonomous build of board card tsk-ggzoq4.

REVISION: built on `exec/tsk-y5tp24` (cut at `e2f60e6d2c129b489aa916c1d5cb1e50b11daeec`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Defect 1: catalog load loop now rejects non-mapping YAML (list, scalar, empty
file -> None) before calling from_dict, logging a warning naming the app_dir
and continuing. from_dict itself also raises ValidationError (via
PydanticCustomError) for non-mapping input instead of TypeError, so the schema
boundary is uniform.

Defect 2: from_file's invented error types 'yaml_parse_error' and
'manifest_not_mapping' are replaced with PydanticCustomError instances so
ValidationError.from_exception_data no longer crashes with KeyError. The
load loop's existing except ValidationError covers from_dict's new error.

Defect 3: doc-gate.yml managed-backend manifest lint step now installs
pydantic alongside pyyaml so scripts/check_manifests.py can import AppManifest.

Docs-Reviewed: no user-facing doc change needed; pydantic added to CI pip install only

RED-FIRST proof (BASE exec/tsk-y5tp24):

```
FAILED tests/test_registry_manifest.py::TestNonMappingYAML::test_list_yaml_skipped_with_warning - TypeError: 'NoneType' object is not a mapping
FAILED tests/test_registry_manifest.py::TestNonMappingYAML::test_from_file_list_yaml_raises_validation_error - KeyError: "Invalid error type: 'manifest_not_mapping'"
2 failed, 1 passed in 0.25s
```

Green after fix:

```
19 passed in 0.64s
```

Fix-forward-of: #2883
Card: tsk-y5tp24

Files:
 app-catalog/services/hailo-ollama/manifest.yaml |   1 +
 changelog.d/tsk-y5tp24-manifest-schema.md       |  29 ++++
 scripts/check_manifests.py                      |  16 ++
 scripts/manifest.schema.json                    | 117 ++++++++++++++
 tests/test_check_manifests.py                   |  24 ++-
 tests/test_registry_manifest.py                 | 150 ++++++++++++++++++
 tinyagentos/registry.py                         | 196 +++++++++++++++++-------
 8 files changed, 480 insertions(+), 55 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest schema validation when loading catalog entries.
  * Added a published JSON Schema for application manifests.
  * Added a version field to the hailo-ollama service manifest.

* **Bug Fixes**
  * Malformed manifests are now reported and skipped without preventing valid catalog entries from loading.
  * Improved validation errors for invalid manifest data.

* **Chores**
  * Updated manifest linting to use the same validation rules as runtime loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->