### PR TITLE
security(headers): Cache-Control: no-store on key-bearing responses (GET /api/providers inline api_key, agent secrets read) - CodeRabbit CWE-525 on #2893

### DIFF
--- a/changelog.d/tsk-u2dj2a-no-store.md
+++ b/changelog.d/tsk-u2dj2a-no-store.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /api/providers`, `GET /api/secrets/{name}`, `GET /api/secrets/agent/{name}`, and `GET /api/secrets/agent/{name}/github` now carry `Cache-Control: no-store` and `Pragma: no-cache` so secret-bearing responses cannot be replayed from a shared cache or the browser back/forward cache.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -380,6 +380,11 @@ grants, project files -- and without the header a shared proxy, or the browser's
 back/forward cache on a shared machine, can hand one user's response to the
 next.
 
+Routes that return secret material inline (`GET /api/providers` with `api_key`,
+`GET /api/secrets/{name}`, `GET /api/secrets/agent/{name}`) call the shared
+`tinyagentos.http_headers.no_store` helper so the header is present even if the
+middleware stack is bypassed in tests.
+
 It is a `setdefault`, never an overwrite, so a handler that picked its own
 policy keeps it:
 

--- a/docs/routes.d/13-admin-gates.md
+++ b/docs/routes.d/13-admin-gates.md
@@ -6,8 +6,8 @@ A session alone doesn't authorize these: non-admin members get `403`; the host l
 
 | Router | Gated | Open / owner-scoped |
 |---|---|---|
-| secrets | list, get, add, update, delete, `categories` | `GET /api/secrets/agent/{agent}`: the agent's owner (registry `user_id`) or admin |
+| secrets | list, get, add, update, delete, `categories` | `GET /api/secrets/agent/{agent}`: the agent's owner (registry `user_id`) or admin; secret-bearing reads return `Cache-Control: no-store` |
 | system | `restart/prepare`, `ai-stack/restart`, non-loopback `prepare-shutdown` | loopback `prepare-shutdown`, `restart/status`, `hardware/refresh` |
-| providers | create, patch, delete, `start`, `stop` | `GET /api/providers` (model pickers) with `api_key` stripped for non-admins |
+| providers | create, patch, delete, `start`, `stop` | `GET /api/providers` (model pickers) with `api_key` stripped for non-admins; admin and local-token callers receive `Cache-Control: no-store` |
 | mcp | `start`/`stop`/`restart`, uninstall, `config` PUT, `env`, permission attach/detach, `/api/mcp/call` | list, logs, capabilities, permissions list, `config` GET |
 | agent-model-keys | `POST /api/agent-model-keys` mints only for agents the caller owns (admin: any) | |

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -349,9 +349,9 @@ A session alone doesn't authorize these: non-admin members get `403`; the host l
 
 | Router | Gated | Open / owner-scoped |
 |---|---|---|
-| secrets | list, get, add, update, delete, `categories` | `GET /api/secrets/agent/{agent}`: the agent's owner (registry `user_id`) or admin |
+| secrets | list, get, add, update, delete, `categories` | `GET /api/secrets/agent/{agent}`: the agent's owner (registry `user_id`) or admin; secret-bearing reads return `Cache-Control: no-store` |
 | system | `restart/prepare`, `ai-stack/restart`, non-loopback `prepare-shutdown` | loopback `prepare-shutdown`, `restart/status`, `hardware/refresh` |
-| providers | create, patch, delete, `start`, `stop` | `GET /api/providers` (model pickers) with `api_key` stripped for non-admins |
+| providers | create, patch, delete, `start`, `stop` | `GET /api/providers` (model pickers) with `api_key` stripped for non-admins; admin and local-token callers receive `Cache-Control: no-store` |
 | mcp | `start`/`stop`/`restart`, uninstall, `config` PUT, `env`, permission attach/detach, `/api/mcp/call` | list, logs, capabilities, permissions list, `config` GET |
 | agent-model-keys | `POST /api/agent-model-keys` mints only for agents the caller owns (admin: any) | |
 

--- a/tests/test_no_store_headers.py
+++ b/tests/test_no_store_headers.py
@@ -1,0 +1,106 @@
+"""Red-first tests: secret-bearing routes must set Cache-Control: no-store.
+
+Each test drives the route through a bare FastAPI app (no SecurityHeadersMiddleware)
+so the assertion fails on origin/dev and only passes once the route itself applies
+the header.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Ensure tinyagentos is importable when running pytest from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+class TestProvidersNoStore:
+    """GET /api/providers returns inline api_key for admin callers."""
+
+    def test_list_providers_sets_no_store(self):
+        from tinyagentos.routes.providers import router
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def _fake_admin_auth(request, call_next):
+            request.state.is_admin = True
+            request.state.via = "session"
+            return await call_next(request)
+
+        app.include_router(router)
+
+        config = MagicMock()
+        config.backends = [
+            {"name": "b1", "type": "openai", "url": "http://b1", "api_key": "sk-secret"}
+        ]
+        config.config_path = Path("/tmp/test-config.yaml")
+
+        catalog = MagicMock()
+        catalog.backends = lambda: []
+        catalog.get_lifecycle_state = lambda name: "running"
+
+        with TestClient(app) as client:
+            client.app.state.config = config
+            client.app.state.backend_catalog = catalog
+            client.app.state.http_client = MagicMock()
+            resp = client.get("/api/providers")
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-store"
+
+
+class TestSecretsNoStore:
+    """Secret-bearing routes must set Cache-Control: no-store."""
+
+    def test_get_secret_sets_no_store(self):
+        from tinyagentos.routes.secrets import router
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def _fake_admin_auth(request, call_next):
+            request.state.is_admin = True
+            return await call_next(request)
+
+        app.include_router(router)
+
+        store = AsyncMock()
+        store.get.return_value = {"name": "TEST_KEY", "value": "secret-value"}
+        app.state.secrets = store
+
+        with TestClient(app) as client:
+            resp = client.get("/api/secrets/TEST_KEY")
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-store"
+
+    def test_get_agent_secrets_sets_no_store(self):
+        from tinyagentos.routes.secrets import router
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def _fake_admin_auth(request, call_next):
+            request.state.user_id = "user-1"
+            request.state.is_admin = True
+            request.state.via = "session"
+            return await call_next(request)
+
+        app.include_router(router)
+
+        store = AsyncMock()
+        store.get_agent_secrets.return_value = [
+            {"name": "AGENT_SEC", "value": "secret-value"}
+        ]
+        app.state.secrets = store
+
+        registry = MagicMock()
+        registry.get_by_handle.return_value = {"user_id": "user-1"}
+        app.state.agent_registry = registry
+
+        with TestClient(app) as client:
+            resp = client.get("/api/secrets/agent/test-agent")
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-store"

--- a/tinyagentos/http_headers.py
+++ b/tinyagentos/http_headers.py
@@ -1,0 +1,6 @@
+"""HTTP header helpers for security-sensitive responses."""
+from __future__ import annotations
+
+def no_store(response) -> None:
+    response.headers.setdefault("Cache-Control", "no-store")
+    response.headers.setdefault("Pragma", "no-cache")

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from tinyagentos.auth_context import require_admin
 from tinyagentos.backend_adapters import get_adapter
 from tinyagentos.config import save_config_locked, VALID_BACKEND_TYPES
+from tinyagentos.http_headers import no_store
 from tinyagentos.lifecycle_manager import LifecycleManager
 from tinyagentos.litellm_config import get_litellm_master_key
 from tinyagentos.providers import CLOUD_TYPES
@@ -518,7 +519,9 @@ async def list_providers(request: Request):
             # whole endpoint, just skip remote backends.
             pass
 
-    return providers
+    resp = JSONResponse(providers)
+    no_store(resp)
+    return resp
 
 @router.post("/api/providers/test")
 async def test_provider(request: Request, body: ProviderTest):

--- a/tinyagentos/routes/secrets.py
+++ b/tinyagentos/routes/secrets.py
@@ -13,6 +13,7 @@ from tinyagentos.auth_context import (
     require_agent_owner_or_admin,
     require_owner_or_admin,
 )
+from tinyagentos.http_headers import no_store
 
 # The keystore is system-global (one store, plaintext values on read), so every
 # handler is admin-or-local-token EXCEPT the two agent-scoped reads, which stay
@@ -60,7 +61,9 @@ async def get_agent_secrets(
     await require_agent_owner_or_admin(request, user, agent_name)
     store = request.app.state.secrets
     secrets = await store.get_agent_secrets(agent_name)
-    return secrets
+    resp = JSONResponse(secrets)
+    no_store(resp)
+    return resp
 
 
 @router.get("/api/secrets/agent/{agent_name}/github")
@@ -87,7 +90,9 @@ async def get_agent_github_grants(
             require_owner_or_admin(user, agent["user_id"])
     store = request.app.state.secrets
     installations = await store.get_agent_github_installations(agent_name)
-    return installations
+    resp = JSONResponse(installations)
+    no_store(resp)
+    return resp
 
 
 @router.get("/api/secrets/{name:path}", dependencies=[Depends(require_admin)])
@@ -96,7 +101,9 @@ async def get_secret(request: Request, name: str):
     secret = await store.get(name)
     if not secret:
         return JSONResponse({"error": "Secret not found"}, status_code=404)
-    return secret
+    resp = JSONResponse(secret)
+    no_store(resp)
+    return resp
 
 
 @router.get("/api/secrets", dependencies=[Depends(require_admin)])


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): security(headers): Cache-Control: no-store on key-bearing responses (GET /api/providers inline api_key, agent secrets read) - CodeRabbit CWE-525 on #2893

Autonomous build of board card tsk-u2dj2a.

CodeRabbit flagged GET /api/providers and GET /api/secrets/agent/{name}
returning secret material with no cache policy (CWE-525). Added
tinyagentos/http_headers.py:no_store helper and applied it to those routes
plus GET /api/secrets/{name} and GET /api/secrets/agent/{name}/github.
Tests drive bare FastAPI apps without SecurityHeadersMiddleware so they
fail on origin/dev and pass once the helper is wired in.

Handlers touched:
- GET /api/providers (providers.py: list_providers)
- GET /api/secrets/{name} (secrets.py: get_secret)
- GET /api/secrets/agent/{name} (secrets.py: get_agent_secrets)
- GET /api/secrets/agent/{name}/github (secrets.py: get_agent_github_grants)

Candidates audited and NOT touched:
- POST /api/devices/register (devices.py): returns scoped_token once at
  registration; token issuance is intentional and the endpoint is a write.
- POST /api/agent-model-keys (agent_model_keys.py): returns minted key once;
  key issuance is intentional and the endpoint is a write.
- POST /api/cluster/migrate (cluster_migrate.py): returns migration token;
  internal operation, not a shared-cache replay risk.
- GET /api/browser/sessions/* (browser_sessions.py): returns stream_token;
  per-session and short-lived.
- GET /api/github/* (github.py): _get_token returns tokens internally but
  never exposes them in HTTP responses.
- GET /api/reddit/* (reddit.py): _get_token returns token internally but
  never exposes it in HTTP responses.

Red run (origin/dev, before fix):
```
FAILED tests/test_no_store_headers.py::TestProvidersNoStore::test_list_providers_sets_no_store - AssertionError
FAILED tests/test_no_store_headers.py::TestSecretsNoStore::test_get_secret_sets_no_store - AssertionError
FAILED tests/test_no_store_headers.py::TestSecretsNoStore::test_get_agent_secrets_sets_no_store - AssertionError
============================= 3 failed, 1 warning in 0.43s =========================
```

Green run (head, after fix):
```
41 passed, 3 warnings in 57.18s
```

Docs: updated docs/agent-coordination.md, docs/routes.md, and
docs/routes.d/13-admin-gates.md.

Files:
 docs/agent-coordination.md         |   5 ++
 docs/routes.d/13-admin-gates.md    |   4 +-
 docs/routes.md                     |   4 +-
 tests/test_no_store_headers.py     | 106 +++++++++++++++++++++++++++++++++++++
 tinyagentos/http_headers.py        |   6 +++
 tinyagentos/routes/providers.py    |   5 +-
 tinyagentos/routes/secrets.py      |  13 +++--
 8 files changed, 138 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secret-bearing API responses are now marked `no-store` and `no-cache`, preventing sensitive data from being cached or replayed.
  * Provider listings and secret reads consistently include the appropriate cache-control headers.

* **Documentation**
  * Updated route and coordination documentation to describe the cache-protection behavior.

* **Tests**
  * Added coverage verifying cache-control headers on provider and secret retrieval endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->