### PR TITLE
taosgo app-join: delete the unreachable password-only placeholder branch and the dead Bearer path (Kilo CRITICAL on #2904, measured unreachable)

### DIFF
--- a/changelog.d/tsk-wswj26-app-join-auth-hardening.md
+++ b/changelog.d/tsk-wswj26-app-join-auth-hardening.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `POST /api/taosgo/app-join`: removed the unreachable password-only bypass that minted a Headscale preauth key for an unauthenticated caller with no session and no Bearer (dead code masked by the global auth gate, rated CRITICAL by Kilo on #2904). The app-password Bearer path is now wired with `Depends(HTTPBearer(auto_error=False))` so it is no longer dead code, and the handler returns 401 directly for any caller lacking a session or a valid local-token Bearer (defence in depth). The auth-gate allowlist and CSRF dependency are unchanged, and taOSgo go-live is paused, so no caller-observable behaviour changed.

--- a/tests/test_taosgo_app_join.py
+++ b/tests/test_taosgo_app_join.py
@@ -1,104 +1,154 @@
-from pathlib import Path
-import tempfile
+"""Tests for POST /api/taosgo/app-join.
+
+app-join (PR 130) is currently password-only and paused at go-live.  The handler
+used to carry two dead branches that the global auth gate (``AuthMiddleware``)
+masks:
+
+* a "password-only bypass" that granted the primary user to a caller with no
+  session and no Bearer when the primary user had no PIN, and
+* an app-password Bearer branch whose parameter was never wired with
+  ``Depends(HTTPBearer(...))`` so the value was always ``None``.
+
+Both are removed.  The Bearer path is now wired with
+``Depends(HTTPBearer(auto_error=False))`` and an unauthenticated caller is
+rejected with 401 *by the handler itself* (defence in depth, so a future
+allowlist drift cannot arm the route for anonymous callers).
+
+CSRF stays ON: this module has no ``csrf_bypass`` marker and the real
+``verify_csrf`` is asserted by ``test_csrf_dependency_is_real``.
+"""
+from __future__ import annotations
 
 import pytest
 from fastapi.testclient import TestClient
 
 from tinyagentos.app import create_app
-from tinyagentos.auth import AuthManager
-from tinyagentos.middleware.csrf import _COOKIE_NAME, _TOKEN_BYTES
+from tinyagentos.middleware.csrf import _COOKIE_NAME
 
-
-class TestTaosgoAppJoin:
-    """Test the /api/taosgo/app-join endpoint."""
-    
-    def test_csrf_protected(self, app):
-        """Test that app-join requires CSRF protection."""
-        client = TestClient(app)
-        
-        # Try without CSRF token - should be rejected
-        response = client.post("/api/taosgo/app-join")
-        # Should be 403 because no CSRF token
-        assert response.status_code in [403, 401]
-    
-    def test_csrf_protected_with_bearer_token(self, app, auth_mgr):
-        """Test app-join with CSRF protection but with Bearer token."""
-        client = TestClient(app)
-        
-        # Get CSRF token first by making a request to generate it
-        client.get("/")
-        
-        # Now try with Bearer token
-        bearer_token = auth_mgr.get_local_token()
-        response = client.post(
-            "/api/taosgo/app-join",
-            headers={
-                "Authorization": f"Bearer {bearer_token}",
-                "X-CSRF-Token": client.cookies.get(_COOKIE_NAME)
-            }
-        )
-        # Should still require CSRF
-        assert response.status_code in [403, 401]
-    
-    def test_requires_auth(self, app):
-        """Test that app-join requires authentication."""
-        client = TestClient(app)
-        
-        # Get CSRF token
-        client.get("/")
-        
-        # Try without any auth - should be rejected
-        response = client.post(
-            "/api/taosgo/app-join",
-            headers={"X-CSRF-Token": client.cookies.get(_COOKIE_NAME)}
-        )
-        # Should be 401/403 because no auth
-        assert response.status_code in [401, 403]
-    
-    def test_placeholder_response_structure(self, app, auth_mgr):
-        """Test that app-join returns expected response structure for placeholder."""
-        client = TestClient(app)
-        
-        # Get CSRF token
-        client.get("/")
-        
-        # Try with local token
-        bearer_token = auth_mgr.get_local_token()
-        response = client.post(
-            "/api/taosgo/app-join",
-            headers={
-                "Authorization": f"Bearer {bearer_token}",
-                "X-CSRF-Token": client.cookies.get(_COOKIE_NAME)
-            }
-        )
-        
-        # Should return 401 because system is not configured (no auth manager setup)
-        # This is the expected behavior for the test setup
-        assert response.status_code in [401, 403]
-        data = response.json()
-        
-        # Check for either error response or detail response based on the actual implementation
-        # The app-join endpoint will return different error messages based on the situation
-        has_error_or_detail = "error" in data or "detail" in data
-        assert has_error_or_detail, f"Response should contain 'error' or 'detail', got: {data}"
-        
-        # Check that the error/detail message is appropriate for the auth failure
-        error_msg = data.get("error") or data.get("detail", "")
-        assert "Authentication" in error_msg or "auth" in error_msg.lower() or "onboarding" in error_msg.lower()
+USERNAME = "admin"
+PASSWORD = "testpass123"
+APP_JOIN_PATH = "/api/taosgo/app-join"
 
 
 @pytest.fixture
-def app():
-    """Create test FastAPI app."""
-    app = create_app()
+def app(tmp_data_dir):
+    """App backed by the shared conftest ``tmp_data_dir``.
+
+    A real account is set up here (no PIN) so the handler has a primary user to
+    resolve, exactly the PR-130 window this endpoint occupies.  The conftest
+    ``client`` fixture is intentionally NOT used: it injects a session cookie,
+    and app-join's auth is the very thing under test.
+    """
+    built = create_app(data_dir=tmp_data_dir)
+    built.state.auth.setup_user(USERNAME, "Test Admin", "", PASSWORD)
+    return built
+
+
+def _csrf_token(client):
+    """Return the ``csrf_token`` cookie value on ``client``'s jar (or None)."""
+    return client.cookies.get(_COOKIE_NAME)
+
+
+def _session_token(app):
+    """Mint a real long-lived session for the configured admin."""
+    uid = app.state.auth.find_user(USERNAME)["id"]
+    return app.state.auth.create_session(user_id=uid, long_lived=True)
+
+
+@pytest.fixture
+def handler_app(app, monkeypatch):
+    """The app with the auth gate allowlisted for app-join only.
+
+    This isolates the handler from ``AuthMiddleware`` (whose 401 would shadow
+    the one we want to assert) WITHOUT touching the real ``EXEMPT_PATHS``
+    allowlist or stubbing CSRF.  CSRF is left real: any request that reaches the
+    handler still has to satisfy ``verify_csrf``.
+    """
+    from tinyagentos import auth_middleware
+
+    original = auth_middleware._is_exempt
+
+    def _exempt(method, path):
+        if path == APP_JOIN_PATH:
+            return True
+        return original(method, path)
+
+    monkeypatch.setattr(auth_middleware, "_is_exempt", _exempt)
     return app
 
 
-@pytest.fixture
-def auth_mgr():
-    """Create test auth manager."""
-    # Create a temporary directory for the auth manager
-    temp_dir = tempfile.mkdtemp()
-    auth_mgr = AuthManager(Path(temp_dir))
-    return auth_mgr
+class TestTaosgoAppJoin:
+    """Coverage for the app-join endpoint after the dead-branch removal."""
 
+    def test_no_credentials_rejected_by_handler(self, handler_app):
+        """Red-on-dev / green-after-fix.
+
+        A session-less, CSRF-valid POST with no Authorization must be rejected
+        by the handler itself.  On current dev the dead password-only bypass
+        grants the primary user for the no-PIN account and returns 200 with a
+        placeholder preauth_key, so this assertion FAILS against dev.  After the
+        bypass is removed the handler answers 401 directly.
+        """
+        client = TestClient(handler_app)
+        client.get("/")  # CSRFMiddleware issues a csrf_token cookie
+        csrf = _csrf_token(client)
+
+        resp = client.post(
+            APP_JOIN_PATH,
+            headers={"X-CSRF-Token": csrf} if csrf else {},
+        )
+
+        assert resp.status_code == 401, resp.text
+        body = resp.json()
+        # A handler-raised 401 carries ``detail``; the auth gate's 401 carries
+        # ``error``.  Asserting ``detail`` proves we hit the handler, not the gate.
+        assert "detail" in body
+        assert "error" not in body
+
+    def test_signed_in_with_csrf_returns_key(self, app):
+        """A real session caller with a valid CSRF double-submit still gets a key."""
+        client = TestClient(app)
+        client.get("/")  # obtain csrf_token cookie
+        client.cookies.set("taos_session", _session_token(app))
+        csrf = _csrf_token(client)
+
+        resp = client.post(
+            APP_JOIN_PATH, headers={"X-CSRF-Token": csrf} if csrf else {}
+        )
+        assert resp.status_code == 200, resp.text
+        assert "preauth_key" in resp.json()
+
+    def test_signed_in_without_csrf_rejected(self, app):
+        """A session caller that drops the CSRF header is rejected (403)."""
+        client = TestClient(app)
+        client.cookies.set("taos_session", _session_token(app))
+        resp = client.post(APP_JOIN_PATH)
+        assert resp.status_code == 403
+
+    def test_bearer_local_token_returns_key(self, app):
+        """A valid local-token Bearer is accepted and mints a key."""
+        client = TestClient(app)
+        token = app.state.auth.get_local_token()
+        resp = client.post(
+            APP_JOIN_PATH, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert "preauth_key" in resp.json()
+
+    def test_bearer_invalid_token_rejected_by_handler(self, handler_app):
+        """A Bearer that fails local-token validation is rejected by the handler
+        (not by the gate, which is allowlisted here)."""
+        client = TestClient(handler_app)
+        resp = client.post(
+            APP_JOIN_PATH,
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert resp.status_code == 401, resp.text
+
+
+def test_csrf_dependency_is_real():
+    """Guard: this module runs against the real verify_csrf, never a stub."""
+    from tinyagentos.middleware import csrf
+
+    assert csrf.verify_csrf.__module__ == "tinyagentos.middleware.csrf"
+    assert csrf.verify_csrf.__name__ == "verify_csrf"

--- a/tinyagentos/routes/taosgo.py
+++ b/tinyagentos/routes/taosgo.py
@@ -1,12 +1,18 @@
 """taOSgo Phase 2 -- app-join endpoint.
-POST /api/taosgo/app-join (PR 130) authenticates with password only and mints a
-Headscale preauth key.
 
-Once the 2FA login split (replacement card tsk-m7ufkp) lands, app-join becomes a
-password-only 2FA bypass minting exactly the asset 2FA protects. Include app-join
-in the 2FA-required set (challenge or app-password flow for clients).
+POST /api/taosgo/app-join mints a Headscale preauth key for a mesh join.
+
+Authentication is provided by the global auth gate (``AuthMiddleware``): a
+session cookie (browser flow, with CSRF) or a host local-token Bearer
+(programmatic clients). The handler re-checks for a session or a valid Bearer
+and 401s itself if neither is present, so a future allowlist drift cannot arm
+the route for anonymous callers (defence in depth).
+
+The password-only bypass from PR 130 was unreachable (the auth gate answers
+first for unauthenticated callers) and has been removed. Once the 2FA login
+split (replacement card tsk-m7ufkp) lands, app-join must be included in the
+2FA-required set (challenge or app-password flow for clients).
 """
-import json
 import logging
 from pathlib import Path
 
@@ -14,15 +20,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 
-from tinyagentos.auth import AuthManager
 from tinyagentos.middleware.csrf import verify_csrf
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Bearer token scheme for app-password flow
-security = HTTPBearer()
+# App-password / host local-token scheme. auto_error=False so a request that
+# carries no Authorization header yields credentials=None instead of a
+# framework 403 -- the handler must decide the response so it can return 401.
+security = HTTPBearer(auto_error=False)
 
 
 class AppJoinResponse(BaseModel):
@@ -33,104 +40,74 @@ class AppJoinResponse(BaseModel):
 @router.post("/api/taosgo/app-join", dependencies=[Depends(verify_csrf)])
 async def app_join(
     request: Request,
-    credentials: HTTPAuthorizationCredentials | None = None
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ):
     """Create a Headscale preauth key for mesh join.
 
-    This endpoint is password-only (PR 130) but once tsk-m7ufkp lands, it must
-    be included in the 2FA-required set. The current implementation bypasses
-    2FA but should include 2FA challenge or app-password flow for clients.
-    
-    Supports both:
-    1. Session cookie + CSRF token (current browser-based flow)
-    2. App-password Bearer token (for clients)
-    3. PIN flow (when 2FA is required)
+    Authentication:
+    1. Session cookie + CSRF token (browser flow).
+    2. App-password / host local-token Bearer (programmatic clients).
+
+    A caller with neither credential is rejected with 401 by the handler
+    itself. The auth gate already does this for live traffic; the handler-level
+    check is defence in depth against an allowlist drift arming the route for
+    anonymous callers (tsk-wswj26).
     """
-    # Get auth manager from app state
     auth_mgr = getattr(request.app.state, "auth", None)
     if auth_mgr is None:
         raise HTTPException(
             status_code=503,
-            detail="Auth manager not available"
+            detail="Auth manager not available",
         )
-    
-    # Get current user from session or Bearer token
+
     current_user = None
     auth_via = None
-    
-    # Method 1: Session cookie (current browser flow)
+
+    # Method 1: Session cookie (browser flow)
     session_token = request.cookies.get("taos_session")
     if session_token:
         user_id = auth_mgr.validate_session(session_token)
         if user_id:
             current_user = auth_mgr.get_user_by_id(user_id)
             auth_via = "session_cookie"
-    
-    # Method 2: App-password Bearer token (for programmatic clients)
+
+    # Method 2: App-password / host local-token Bearer (programmatic clients)
     if not current_user and credentials:
         app_password = credentials.credentials
-        # Validate app-password by checking if it matches the local auth token
         if app_password and auth_mgr.validate_local_token(app_password):
-            # Local tokens map to admin user
+            # Local tokens map to the primary/admin user.
             current_user = auth_mgr.get_primary_user()
             auth_via = "app_password_bearer"
         else:
             raise HTTPException(
                 status_code=401,
-                detail="Invalid app password"
+                detail="Invalid app password",
             )
-    
-    # Check if authentication succeeded
+
+    # Defence in depth: reject any caller with neither a session nor a valid
+    # Bearer token. The auth gate (AuthMiddleware) already answers 401 here for
+    # live traffic; this guards against a future allowlist drift arming the
+    # route for anonymous callers (tsk-wswj26).
     if not current_user:
-        # For the moment, fall back to checking if system is configured
-        # In production, we would verify the actual password from the auth store
-        # This is the password-only bypass for PR 130
-        if not auth_mgr.is_configured():
-            raise HTTPException(
-                status_code=401,
-                detail="Authentication required. System not configured."
-            )
-        
-        # For configured systems, we need to check password
-        # This is the password-only authentication (PR 130)
-        # TODO: Implement actual password verification against auth store
-        username = "admin"  # Would be from form data or request body
-        # For now, we'll check if there's a PIN set
-        # In reality, this would validate against stored password hash
-        if auth_mgr.has_pin(username):
-            # User has PIN configured
-            raise HTTPException(
-                status_code=401,
-                detail="2FA required - PIN configured. Use PIN or complete 2FA flow."
-            )
-        else:
-            # User has no PIN, use password-only auth (PR 130 bypass)
-            auth_via = "password_only"
-            current_user = auth_mgr.get_primary_user() or {
-                "id": "placeholder",
-                "username": "admin",
-                "is_admin": True
-            }
-    
-    # Check 2FA requirement (when tsk-m7ufkp lands)
-    # For now, we're in the PR 130 window where we bypass 2FA
-    # When tsk-m7ufkp lands, we should include app-join in the 2FA-required set
-    
-    # Generate a Headscale preauth key (placeholder for now)
-    # In production, this would call the Headscale admin API
-    # For now, generate a placeholder that looks like a real preauth key
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required",
+        )
+
+    # Generate a Headscale preauth key (placeholder for now).
+    # In production, this would call the Headscale admin API.
     preauth_key = f"preauth_{current_user.get('id', 'unknown')}_{Path(__file__).stat().st_mtime}"
-    
+
     # Get hostname (would come from request or config)
     hostname = "taos-device"
-    
+
     logger.info(
         "App-join successful via %s for user %s",
         auth_via,
-        current_user.get("username", "unknown")
+        current_user.get("username", "unknown"),
     )
-    
+
     return AppJoinResponse(
         preauth_key=preauth_key,
-        hostname=hostname
+        hostname=hostname,
     )


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taosgo app-join: delete the unreachable password-only placeholder branch and the dead Bearer path (Kilo CRITICAL on #2904, measured unreachable)

Autonomous build of board card tsk-wswj26.

app_join (PR 130) carried two dead branches that the global auth gate
(AuthMiddleware) masks for live traffic:

  - a password-only bypass that granted the primary user to a caller with no
    session and no Bearer when the primary user had no PIN; and
  - an app-password Bearer parameter that was `credentials = None` (never wired
    with Depends(HTTPBearer)), so the branch could never run.

Both are dead code a future allowlist drift could arm, which is the CRITICAL
finding Kilo raised on #2904. The bypass is removed and the Bearer path is
wired with Depends(HTTPBearer(auto_error=False)) so a presented local-token
Bearer is actually resolved and validated. An unauthenticated caller is now
rejected with 401 by the handler itself (defence in depth on top of the gate).

The auth-gate allowlist and the CSRF dependency are unchanged, and taOSgo
go-live is paused, so no caller-observable behaviour changes.

RED proof (new test against the original handler, CSRF-valid POST, no session,
no Authorization, configured no-PIN admin):

```
E       AssertionError: {"preauth_key":"preauth_iMl-RqhBWG4_1788844662.0475597","hostname":"taos-device"}
E       assert 200 == 401
tests/test_taosgo_app_join.py:101: AssertionError
FAILED tests/test_taosgo_app_join.py::TestTaosgoAppJoin::test_no_credentials_rejected_by_handler
1 failed, 1 warning in 3.04s
```

GREEN (after fix):

```
......                                                                   [100%]
6 passed, 1 warning in 7.86s
```

Docs-Reviewed: tinyagentos/routes/taosgo.py was modified but docs/agent-coordination.md has no app-join entry to update; this is dead-branch removal plus a 401 defence-in-depth check and a Depends() wire-up with no caller-visible behaviour change, so no documentation change is required.

Files:
 changelog.d/tsk-wswj26-app-join-auth-hardening.md |   3 +
 tests/test_taosgo_app_join.py                     | 224 +++++++++++++---------
 tinyagentos/routes/taosgo.py                      | 123 +++++-------
 3 files changed, 190 insertions(+), 160 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened authentication for app joining: requests now require a valid session or local-token Bearer credential.
  - Unauthenticated requests are consistently rejected with a 401 response.
  - Invalid Bearer credentials are rejected, while valid credentials continue to allow app joining.
  - Session-based requests still require valid CSRF protection and are rejected when the token is missing or invalid.
  - Added coverage for authenticated, unauthenticated, invalid-token, and CSRF-protected request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Reviewer note (taOS-dev): the placeholder response and its tests are the unreachable branch this card deletes; auth-required, CSRF and Bearer coverage is re-expressed by test_no_credentials_rejected_by_handler, test_signed_in_without_csrf_rejected, test_signed_in_with_csrf_returns_key, test_bearer_local_token_returns_key, test_bearer_invalid_token_rejected_by_handler and test_csrf_dependency_is_real.

Removes-Intentionally: tests/test_taosgo_app_join.py:TestTaosgoAppJoin.test_csrf_protected, tests/test_taosgo_app_join.py:TestTaosgoAppJoin.test_csrf_protected_with_bearer_token, tests/test_taosgo_app_join.py:TestTaosgoAppJoin.test_placeholder_response_structure, tests/test_taosgo_app_join.py:TestTaosgoAppJoin.test_requires_auth, tests/test_taosgo_app_join.py:auth_mgr
