### PR TITLE
check_all_skip.py: Tests-Skipped-Intentionally must accept a path whose basename matches (docstring says basename match is sufficient; code refuses a full path)

### DIFF
--- a/.github/scripts/check_all_skip.py
+++ b/.github/scripts/check_all_skip.py
@@ -206,7 +206,7 @@ def has_escape_hatch(pr_body: str, filepath: str) -> bool:
     """Check if the PR body has a Tests-Skipped-Intentionally trailer for this file.
 
     Expected format: Tests-Skipped-Intentionally: <file>, <why>
-    The file path must match (basename match is sufficient).
+    The file path may be a bare basename or a full repo-relative path (basename match is sufficient).
     """
     # Look for the trailer pattern at the end of the PR body or on its own line
     # Pattern: "Tests-Skipped-Intentionally: <file>, <why>"
@@ -220,10 +220,11 @@ def has_escape_hatch(pr_body: str, filepath: str) -> bool:
         m = re.match(r"Tests-Skipped-Intentionally:\s*(.+)", stripped)
         if m:
             trailer_claim = m.group(1).strip()
-            # "<file>, <why>": exact basename match plus a non-empty reason,
-            # so a waiver for test_x.py.bak cannot waive test_x.py
+            # "<file>, <why>": basename of the claim must match the file's basename
+            # plus a non-empty reason, so a waiver for test_x.py.bak cannot waive test_x.py.
+            # A claim may carry a directory prefix or be a bare basename.
             claimed_file, _, reason = trailer_claim.partition(",")
-            if claimed_file.strip() == basename and reason.strip():
+            if os.path.basename(claimed_file.strip()) == basename and reason.strip():
                 return True
     return False
 

--- a/changelog.d/tsk-g5iqv2-escape-hatch-basename-match.md
+++ b/changelog.d/tsk-g5iqv2-escape-hatch-basename-match.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **`Tests-Skipped-Intentionally` trailer now accepts full repo paths as well as bare basenames**: `has_escape_hatch()` in `.github/scripts/check_all_skip.py` now compares the basename of the claimed file against the file's basename, so trailers written with paths like `tests/taosnet/test_torrent_downloader_taosnet.py, why` are correctly matched. The defence against suffix spoofing (`test_x.py.bak` cannot waive `test_x.py`) is preserved.

--- a/tests/scripts/test_check_all_skip.py
+++ b/tests/scripts/test_check_all_skip.py
@@ -252,6 +252,22 @@ class TestMainAllSkipStillFails:
         assert "WAIVED" in captured.out
 
 
+class TestHasEscapeHatchBasenameMatch:
+    """has_escape_hatch must accept both bare basename and full path in the trailer."""
+
+    def test_full_path_trailer_accepted(self, check_mod) -> None:
+        assert check_mod.has_escape_hatch(
+            "Tests-Skipped-Intentionally: tests/taosnet/test_torrent_downloader_taosnet.py, why",
+            "tests/taosnet/test_torrent_downloader_taosnet.py",
+        ) is True
+
+    def test_bak_suffix_still_rejected(self, check_mod) -> None:
+        assert check_mod.has_escape_hatch(
+            "Tests-Skipped-Intentionally: test_x.py.bak, why",
+            "test_x.py",
+        ) is False
+
+
 class TestMainPartialSkipsPass:
     def test_partial_skips_pass(self, check_mod, capsys: pytest.CaptureFixture) -> None:
         results = {


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_all_skip.py: Tests-Skipped-Intentionally must accept a path whose basename matches (docstring says basename match is sufficient; code refuses a full path)

Autonomous build of board card tsk-g5iqv2.

has_escape_hatch() compared claimed_file.strip() directly against the
file basename, so trailers written with a repo-relative path never
matched even though the docstring said basename match is sufficient.

Now take os.path.basename(claimed_file.strip()) before comparing, so
both bare basenames and full paths are accepted. The defence against
suffix spoofing (test_x.py.bak cannot waive test_x.py) is preserved
because the basename must still match exactly.

RED (before fix):
```
FAILED tests/scripts/test_check_all_skip.py::TestHasEscapeHatchBasenameMatch::test_full_path_trailer_accepted
1 failed, 15 passed in 0.42s
```

GREEN (after fix):
```
16 passed in 0.20s
```

Files:
 .github/scripts/check_all_skip.py                     |  9 +++++----
 changelog.d/tsk-g5iqv2-escape-hatch-basename-match.md |  3 +++
 tests/scripts/test_check_all_skip.py                  | 16 ++++++++++++++++
 3 files changed, 24 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Test-skip declarations now accept full repository paths while matching the intended test file correctly.
  - Suffix-spoofed paths, such as those ending in `.bak`, continue to be rejected.
  - A non-empty reason remains required for intentionally skipped tests.

- **Tests**
  - Added coverage for full-path matching and invalid suffix handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->