### PR TITLE
check_all_skip: a file whose tests ERROR at setup is misreported as 'collection yielded 0 of N' and its pytest output is discarded

### DIFF
--- a/.github/scripts/check_all_skip.py
+++ b/.github/scripts/check_all_skip.py
@@ -52,10 +52,10 @@ def find_changed_test_files(base_ref: str) -> list[str]:
 
 
 def get_test_outcomes(test_files: list[str]) -> dict[str, dict]:
-    """Run pytest -rs on each test file and return skip/pass/fail counts.
+    """Run pytest -rs on each test file and return skip/pass/fail/error counts.
 
-    Returns: {filename: {"total": int, "skipped": int, "passed": int, "failed": int,
-                       "import_guards": [str]}}
+    Returns: {filename: {"total": int, "skipped": int, "passed": int, "failed": int, "errors": int,
+                       "returncode": int, "tail": str, "import_guards": [str]}}
     """
     results: dict[str, dict] = {}
 
@@ -88,6 +88,7 @@ def get_test_outcomes(test_files: list[str]) -> dict[str, dict]:
         skipped = 0
         passed = 0
         failed = 0
+        errors = 0
         import_guards: list[str] = []
 
         # Count from summary line: "X passed, Y skipped, Z failed"
@@ -100,12 +101,15 @@ def get_test_outcomes(test_files: list[str]) -> dict[str, dict]:
         m = re.search(r"(\d+)\s+failed", output)
         if m:
             failed = int(m.group(1))
-        total = passed + skipped + failed
+        m = re.search(r"(\d+)\s+errors?", output)
+        if m:
+            errors = int(m.group(1))
+        total = passed + skipped + failed + errors
 
         # Also count from individual test outcome lines: "test_name SKIPPED"
-        # Pattern: word characters, dash, underscore, followed by SKIPPED/FAILED/PASSED
+        # Pattern: word characters, dash, underscore, followed by SKIPPED/FAILED/PASSED/ERROR
         outcome_lines = re.findall(
-            r"^([\w\.-]+)\s+(SKIPPED|FAILED|PASSED)\s*$",
+            r"^([\w\.-]+)\s+(SKIPPED|FAILED|PASSED|ERROR)\s*$",
             output,
             re.MULTILINE,
         )
@@ -121,6 +125,8 @@ def get_test_outcomes(test_files: list[str]) -> dict[str, dict]:
                 failed += 1
             elif outcome == "PASSED":
                 passed += 1
+            elif outcome == "ERROR":
+                errors += 1
 
         # If we couldn't parse total from summary, use outcome lines
         if total == 0:
@@ -128,12 +134,19 @@ def get_test_outcomes(test_files: list[str]) -> dict[str, dict]:
             skipped = sum(1 for _o, o in outcome_lines if o == "SKIPPED")
             passed = sum(1 for _o, o in outcome_lines if o == "PASSED")
             failed = sum(1 for _o, o in outcome_lines if o == "FAILED")
+            errors = sum(1 for _o, o in outcome_lines if o == "ERROR")
+
+        tail_lines = output.splitlines()[-40:]
+        tail = "\n".join(tail_lines)
 
         results[filepath] = {
             "total": total,
             "skipped": skipped,
             "passed": passed,
             "failed": failed,
+            "errors": errors,
+            "returncode": proc.returncode,
+            "tail": tail,
             "import_guards": import_guards,
             "defined_tests": _count_defined_tests(filepath),
         }
@@ -272,16 +285,40 @@ def main() -> int:
         total = info["total"]
         defined_tests = info["defined_tests"]
         guards = info["import_guards"]
+        errors = info.get("errors", 0)
+        tail = info.get("tail", "")
 
         if total == 0:
             if defined_tests > 0:
-                print(
-                    f"FAIL: {filepath} — collection yielded 0 of "
-                    f"{defined_tests} defined tests"
-                )
+                if info.get("returncode") == 5:
+                    msg = (
+                        f"FAIL: {filepath} — collection yielded 0 of "
+                        f"{defined_tests} defined tests"
+                    )
+                elif errors > 0:
+                    msg = (
+                        f"FAIL: {filepath} — {errors} setup/teardown errors"
+                    )
+                else:
+                    msg = (
+                        f"FAIL: {filepath} — no parseable outcomes for "
+                        f"{defined_tests} defined tests"
+                    )
+                print(msg)
+                if tail:
+                    print(tail)
                 any_fail = True
             else:
                 print(f"WARNING: {filepath} has 0 test outcomes, skipping check")
+            continue
+
+        if errors > 0:
+            print(
+                f"FAIL: {filepath} — {errors} setup/teardown errors"
+            )
+            if tail:
+                print(tail)
+            any_fail = True
             continue
 
         if skip_count == total:
@@ -313,6 +350,9 @@ def main() -> int:
     zero_collected_files = sum(
         1 for info in results.values() if info["total"] == 0 and info["defined_tests"] > 0
     )
+    setup_error_files = sum(
+        1 for info in results.values() if info.get("errors", 0) > 0
+    )
     # The error line must mirror exactly the conditions that set any_fail:
     # a WAIVED all-skip file did not fail, so it must not be counted here
     # (all_skip_files keeps including waived files for the OK-branch note).
@@ -329,6 +369,8 @@ def main() -> int:
             parts.append(f"{unwaived_all_skip} file(s) have all tests skipping")
         if zero_collected_files > 0:
             parts.append(f"{zero_collected_files} file(s) yielded no collected tests")
+        if setup_error_files > 0:
+            parts.append(f"{setup_error_files} file(s) had setup/teardown errors")
         print(f"\n::error:: {', '.join(parts)} — see above for details")
         return 1
 

--- a/changelog.d/tsk-544ia3-check-all-skip-errors.md
+++ b/changelog.d/tsk-544ia3-check-all-skip-errors.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `.github/scripts/check_all_skip.py` now counts pytest `errors` as a distinct outcome, prints the last 40 lines of pytest output when setup/teardown errors occur, and reports `N setup/teardown errors` instead of mislabeling the file as a collection failure. A file with only setup errors is no longer reported as `collection yielded 0 of N`.

--- a/tests/scripts/test_check_all_skip.py
+++ b/tests/scripts/test_check_all_skip.py
@@ -98,6 +98,9 @@ class TestMainZeroCollectedWithDefinedTests:
                 "skipped": 0,
                 "passed": 0,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 5,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": check_mod._count_defined_tests(str(test_file)),
             }
@@ -123,6 +126,9 @@ class TestMainZeroCollectedWithDefinedTests:
                 "skipped": 0,
                 "passed": 0,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 5,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": 0,
             }
@@ -157,6 +163,9 @@ class TestMainZeroCollectedWithDefinedTests:
                 "skipped": 0,
                 "passed": 0,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 5,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": check_mod._count_defined_tests(str(test_file)),
             }
@@ -183,11 +192,13 @@ class TestMainZeroCollectedWithDefinedTests:
         results = {
             str(zc_file): {
                 "total": 0, "skipped": 0, "passed": 0, "failed": 0,
+                "errors": 0, "returncode": 5, "tail": "",
                 "import_guards": [],
                 "defined_tests": check_mod._count_defined_tests(str(zc_file)),
             },
             str(waived_file): {
                 "total": 2, "skipped": 2, "passed": 0, "failed": 0,
+                "errors": 0, "returncode": 0, "tail": "",
                 "import_guards": ["pytest.importorskip"],
                 "defined_tests": 2,
             },
@@ -213,6 +224,9 @@ class TestMainAllSkipStillFails:
                 "skipped": 3,
                 "passed": 0,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 0,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": 3,
             }
@@ -236,6 +250,9 @@ class TestMainAllSkipStillFails:
                 "skipped": 3,
                 "passed": 0,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 0,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": 3,
             }
@@ -260,6 +277,9 @@ class TestMainPartialSkipsPass:
                 "skipped": 2,
                 "passed": 3,
                 "failed": 0,
+                "errors": 0,
+                "returncode": 0,
+                "tail": "",
                 "import_guards": [],
                 "defined_tests": 5,
             }
@@ -273,3 +293,94 @@ class TestMainPartialSkipsPass:
         assert rc == 0
         captured = capsys.readouterr()
         assert "2/5 tests skip" in captured.out
+
+
+class TestErrorsCountedAndReported:
+    def test_errors_parsed_from_stdout(
+        self, check_mod, tmp_path: Path
+    ) -> None:
+        test_file = tmp_path / "test_errors.py"
+        test_file.write_text(
+            "def test_a():\n    assert True\n"
+            "def test_b():\n    assert True\n"
+            "def test_c():\n    assert True\n"
+        )
+        fake_proc = type("FakeProc", (), {})()
+        fake_proc.returncode = 1
+        fake_proc.stdout = (
+            "ERROR tests/test_errors.py::test_a - RuntimeError: boom\n"
+            "ERROR tests/test_errors.py::test_b - RuntimeError: boom\n"
+            "ERROR tests/test_errors.py::test_c - RuntimeError: boom\n"
+            "3 errors in 0.10s\n"
+        )
+        fake_proc.stderr = ""
+
+        with patch.object(check_mod.subprocess, "run", return_value=fake_proc):
+            results = check_mod.get_test_outcomes([str(test_file)])
+
+        info = results[str(test_file)]
+        assert info["errors"] == 3
+        assert info["total"] == 3
+
+    def test_error_file_fails_without_collection_yielded_message(
+        self, check_mod, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        test_file = tmp_path / "test_errors.py"
+        test_file.write_text(
+            "def test_a():\n    assert True\n"
+            "def test_b():\n    assert True\n"
+            "def test_c():\n    assert True\n"
+        )
+        results = {
+            str(test_file): {
+                "total": 3,
+                "skipped": 0,
+                "passed": 0,
+                "failed": 0,
+                "errors": 3,
+                "returncode": 1,
+                "tail": "ERROR tests/test_errors.py::test_a - RuntimeError: boom\n",
+                "import_guards": [],
+                "defined_tests": 3,
+            }
+        }
+        with patch.object(check_mod, "resolve_base_ref", return_value="origin/dev"):
+            with patch.object(check_mod, "get_test_outcomes", return_value=results):
+                with patch.object(check_mod, "find_changed_test_files", return_value=[str(test_file)]):
+                    with patch.object(check_mod, "get_pr_body", return_value=""):
+                        with patch.object(check_mod.os, "environ", {"BASE_REF": "origin/dev"}):
+                            rc = check_mod.main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "collection yielded" not in captured.out
+        assert "boom" in captured.out
+
+    def test_rc5_no_tests_ran_still_reports_collection_message(
+        self, check_mod, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        test_file = tmp_path / "test_empty.py"
+        test_file.write_text(
+            "def test_a():\n    assert True\n"
+        )
+        results = {
+            str(test_file): {
+                "total": 0,
+                "skipped": 0,
+                "passed": 0,
+                "failed": 0,
+                "errors": 0,
+                "returncode": 5,
+                "tail": "no tests ran\n",
+                "import_guards": [],
+                "defined_tests": 1,
+            }
+        }
+        with patch.object(check_mod, "resolve_base_ref", return_value="origin/dev"):
+            with patch.object(check_mod, "get_test_outcomes", return_value=results):
+                with patch.object(check_mod, "find_changed_test_files", return_value=[str(test_file)]):
+                    with patch.object(check_mod, "get_pr_body", return_value=""):
+                        with patch.object(check_mod.os, "environ", {"BASE_REF": "origin/dev"}):
+                            rc = check_mod.main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "collection yielded 0 of 1 defined tests" in captured.out


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): check_all_skip: a file whose tests ERROR at setup is misreported as 'collection yielded 0 of N' and its pytest output is discarded

Autonomous build of board card tsk-544ia3.

get_test_outcomes now counts errors from the summary regex and ERROR
outcome lines, stores returncode and tail in per-file results, and
main() prints the last 40 lines of pytest output when total==0 or
errors>0. Reword total==0 message to distinguish rc5 collection
failures from setup/teardown errors and unparseable output.

Files:
 .github/scripts/check_all_skip.py               |  62 ++++++++++---
 changelog.d/tsk-544ia3-check-all-skip-errors.md |   3 +
 tests/scripts/test_check_all_skip.py            | 111 ++++++++++++++++++++++++
 3 files changed, 166 insertions(+), 10 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-result reporting to distinguish setup and teardown errors from collection failures.
  - Test checks now fail when setup or teardown errors occur, even if some tests pass.
  - Error reports include the final portion of test output to aid troubleshooting.
  - Zero-test results continue to be reported separately from setup and teardown errors.

- **Documentation**
  - Added changelog coverage for the updated test-checking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Reviewer-measured red (taOS-dev, worktree on origin/dev = 277daf405 + this PR's test file only, `python -m pytest tests/scripts/test_check_all_skip.py -q`):

```text
FAILED tests/scripts/test_check_all_skip.py::TestErrorsCountedAndReported::test_errors_parsed_from_stdout
FAILED tests/scripts/test_check_all_skip.py::TestErrorsCountedAndReported::test_error_file_fails_without_collection_yielded_message
2 failed, 15 passed in 0.29s
```

Same worktree with the full PR applied:

```text
17 passed in 0.22s
```

The lane omitted this block from the body; the card required it. Noted on the card.
