### PR TITLE
[lib-audit] S2-15 GET /api/cluster/workers returns the full cluster inventory unauthenticated

### DIFF
--- a/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
+++ b/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /api/cluster/workers` now returns a minimal projection (`name`, `status`, `tier_id`) for unauthenticated callers instead of the full worker inventory. Authenticated admins still receive the complete record including hardware, models, backends, LAN addresses, and auth state.

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -7,7 +7,7 @@ import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 
 # ---------------------------------------------------------------------------
@@ -1169,3 +1169,144 @@ async def test_update_all_workers_status_unknown_job_returns_404(client, app):
     """GET /api/cluster/workers/update-all/<unknown> returns 404."""
     resp = await client.get("/api/cluster/workers/update-all/does-not-exist")
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_get_workers_returns_minimal_projection(client, app):
+    """Unauthenticated GET /api/cluster/workers must not expose sensitive fields.
+
+    Red-test for S2-15: an unauthenticated caller must not receive url,
+    worker_url, host_lan_ip, hardware, models, backends, kernel, version,
+    live_token, or any other identifying/hardware detail.
+    """
+    import json as _json
+
+    # Register a worker with full sensitive data via the admin client.
+    key = await pair_worker(client, app, "secret-worker", "http://10.0.0.1:9000")
+    reg_body = _json.dumps({
+        "name": "secret-worker",
+        "url": "http://10.0.0.1:9000",
+        "platform": "linux",
+        "capabilities": ["chat", "embed"],
+        "hardware": {
+            "cpu": {"model": "Ryzen 9", "arch": "x86_64"},
+            "ram_gb": 64,
+            "os": {"kernel": "6.1.0", "distro": "ubuntu", "version": "24.04"},
+        },
+        "models": ["llama3"],
+        "host_lan_ip": "192.168.1.50",
+        "worker_url": "http://secret-worker:9000",
+        "backends": [{"name": "llama-cpp", "models": [{"name": "llama3"}]}],
+        "live_token": True,
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "secret-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Hit the endpoint with a completely unauthenticated client (no cookies).
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as anon_client:
+        resp = await anon_client.get("/api/cluster/workers")
+        assert resp.status_code == 200, resp.text
+        workers = resp.json()
+        assert len(workers) == 1
+        w = workers[0]
+
+        # Minimal projection must be present.
+        assert w["name"] == "secret-worker"
+        assert w["status"] == "online"
+        assert "tier_id" in w
+
+        # Sensitive fields must NOT be present.
+        sensitive_fields = [
+            "url",
+            "worker_url",
+            "host_lan_ip",
+            "hardware",
+            "models",
+            "backends",
+            "capabilities",
+            "kernel",
+            "version",
+            "live_token",
+            "revoked",
+            "blocked",
+            "last_heartbeat",
+            "load",
+            "platform",
+            "potential_capabilities",
+            "kv_cache_quant_support",
+            "kv_cache_quant_k_support",
+            "kv_cache_quant_v_support",
+            "kv_cache_quant_boundary_layer_protect",
+            "storage_cap_bytes",
+            "storage_used_bytes",
+            "bytes_deduped_total",
+            "worker_lxc_image_version",
+            "degraded",
+            "degraded_reason",
+            "free_vram_mb",
+            "used_vram_mb",
+            "available_models",
+            "resources",
+            "registered_at",
+            "generation",
+            "tls_cert_provider",
+            "signing_key",
+        ]
+        for field in sensitive_fields:
+            assert field not in w, f"sensitive field {field} leaked in unauthenticated response"
+
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_get_workers_returns_full_record(client, app):
+    """Authenticated admin GET /api/cluster/workers returns the full record."""
+    import json as _json
+
+    key = await pair_worker(client, app, "admin-worker", "http://10.0.0.2:9000")
+    reg_body = _json.dumps({
+        "name": "admin-worker",
+        "url": "http://10.0.0.2:9000",
+        "platform": "linux",
+        "capabilities": ["chat"],
+        "hardware": {
+            "cpu": {"model": "Ryzen 9", "arch": "x86_64"},
+            "ram_gb": 64,
+            "os": {"kernel": "6.1.0", "distro": "ubuntu", "version": "24.04"},
+        },
+        "models": ["llama3"],
+        "host_lan_ip": "192.168.1.51",
+        "worker_url": "http://admin-worker:9000",
+        "backends": [{"name": "llama-cpp", "models": [{"name": "llama3"}]}],
+        "live_token": True,
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "admin-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The admin client has a session cookie, so it must receive the full record.
+    resp = await client.get("/api/cluster/workers")
+    assert resp.status_code == 200, resp.text
+    workers = resp.json()
+    assert len(workers) == 1
+    w = workers[0]
+    assert w["name"] == "admin-worker"
+    assert w["url"] == "http://10.0.0.2:9000"
+    assert w["host_lan_ip"] == "192.168.1.51"
+    assert w["hardware"] is not None
+    assert w["models"] == ["llama3"]
+    assert w["backends"] is not None
+    assert w["live_token"] is True
+    assert w["status"] == "online"
+
+    await app.state.cluster_pairing.close()

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -586,7 +586,24 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # endpoints, cluster heartbeat). Without this, a cached old client
         # could bypass onboarding by hitting an /api endpoint that the
         # not-configured branch used to allow through unconditionally.
+        #
+        # Exempt paths do not require auth, but if a valid session cookie is
+        # present we preserve the caller's identity so route handlers can serve
+        # a reduced view to unauthenticated callers and the full view to
+        # authenticated admins (e.g. GET /api/cluster/workers).
         if _is_exempt(request.method, path):
+            token = request.cookies.get("taos_session")
+            if token:
+                user_agent = request.headers.get("user-agent", "")
+                user_id = auth_mgr.validate_session(token, user_agent=user_agent)
+                if user_id is not None:
+                    user_record = auth_mgr.get_user_by_id(user_id)
+                    request.state.user_id = user_id
+                    request.state.is_admin = bool(
+                        user_record.get("is_admin") if user_record else False
+                    )
+                    request.state.via = "session"
+                    return await call_next(request)
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "exempt"

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -309,6 +309,7 @@ class MoveRequest(BaseModel):
 
 @router.get("/api/cluster/workers")
 async def list_workers(request: Request):
+    is_admin = getattr(request.state, "is_admin", False)
     cluster = request.app.state.cluster_manager
     pairing = getattr(request.app.state, "cluster_pairing", None)
     registry = getattr(request.app.state, "registry", None)
@@ -323,6 +324,13 @@ async def list_workers(request: Request):
         # non-utf8 signing key, and (2) even when serialization didn't
         # crash, the secret has no business being on the wire.
         d.pop("signing_key", None)
+        if not is_admin:
+            result.append({
+                "name": d["name"],
+                "status": d["status"],
+                "tier_id": d.get("tier_id", ""),
+            })
+            continue
         # Surface the persistent auth state from the pairing store so the
         # Cluster UI can show whether a node's signing key is live (not
         # revoked/blocked) and offer revoke/block/unblock actions. A worker


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] S2-15 GET /api/cluster/workers returns the full cluster inventory unauthenticated

Autonomous build of board card tsk-wdjqxv.

GET /api/cluster/workers now returns only name, status, tier_id when the
caller is not an authenticated admin. Full records (url, host_lan_ip,
hardware, models, backends, live_token, etc.) are reserved for admin
callers. The auth middleware preserves admin session state on exempt
paths so the desktop Cluster app and other authenticated consumers
continue to receive the full inventory.

Fixes S2-15.

Docs-Reviewed: agent-coordination.md only references the route name
and visibility behavior, not response shape, so no doc edit was needed

Files:
 .../tsk-wdjqxv-cluster-workers-redaction.md        |   3 +
 tests/test_routes_cluster.py                       | 143 ++++++++++++++++++++-
 tinyagentos/auth_middleware.py                     |  17 +++
 tinyagentos/routes/cluster.py                      |   8 ++
 4 files changed, 170 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Limited unauthenticated worker listings to basic information: name, status, and tier.
  * Preserved full worker details for authenticated administrators.
  * Session-authenticated requests on exempt routes now retain the caller’s identity and permissions.

* **Tests**
  * Added coverage for restricted unauthenticated responses and full administrator access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->