### PR TITLE
fix-forward #2913 (tsk-onbvcg/tsk-wdjqxv): S2-15 session-on-exempt-path breaks Q2-6 test_version_coarsened_on_exempt_path - split the test by credential

### DIFF
--- a/changelog.d/tsk-m2lutu-session-exempt-path-version-fix.md
+++ b/changelog.d/tsk-m2lutu-session-exempt-path-version-fix.md
@@ -1,2 +1,0 @@
-### Fixed
-- session-authenticated callers on exempt paths now receive the full X-Taos-Version (credential presented)

--- a/changelog.d/tsk-m2lutu-session-exempt-path-version-fix.md
+++ b/changelog.d/tsk-m2lutu-session-exempt-path-version-fix.md
@@ -1,0 +1,2 @@
+### Fixed
+- session-authenticated callers on exempt paths now receive the full X-Taos-Version (credential presented)

--- a/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
+++ b/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
@@ -1,3 +1,4 @@
 ### Fixed
 
 - `GET /api/cluster/workers` now returns a minimal projection (`name`, `status`, `tier_id`) for unauthenticated callers instead of the full worker inventory. Authenticated admins still receive the complete record including hardware, models, backends, LAN addresses, and auth state.
+- session-authenticated callers on exempt paths now receive the full X-Taos-Version (credential presented)

--- a/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
+++ b/changelog.d/tsk-wdjqxv-cluster-workers-redaction.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `GET /api/cluster/workers` now returns a minimal projection (`name`, `status`, `tier_id`) for unauthenticated callers instead of the full worker inventory. Authenticated admins still receive the complete record including hardware, models, backends, LAN addresses, and auth state.

--- a/tests/test_q2_6_library_audit.py
+++ b/tests/test_q2_6_library_audit.py
@@ -144,14 +144,20 @@ class TestVersionHeaderCoarsening:
     """Q2-6: X-Taos-Version must be coarsened for unauthenticated callers."""
 
     @pytest.mark.asyncio
-    async def test_version_coarsened_on_exempt_path(self, client):
+    async def test_version_coarsened_on_exempt_path(self, app):
         """/api/health is exempt from auth -- version should be coarsened."""
+        from httpx import ASGITransport, AsyncClient
         import tinyagentos
 
-        resp = await client.get("/api/health")
-        assert resp.headers.get("x-taos-version", "")
-        # The coarsened value must not leak the exact build version.
-        assert resp.headers["x-taos-version"] != tinyagentos.__version__
+        # Use an anonymous client with no cookies - same app but fresh client
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as anon_client:
+            resp = await anon_client.get("/api/health")
+            assert resp.headers.get("x-taos-version", "")
+            # The coarsened value must not leak the exact build version.
+            assert resp.headers["x-taos-version"] != tinyagentos.__version__
 
     @pytest.mark.asyncio
     async def test_version_full_for_authenticated(self, client):
@@ -162,6 +168,15 @@ class TestVersionHeaderCoarsening:
         assert resp.status_code == 200
         if resp.headers.get("x-taos-version"):
             assert resp.headers["x-taos-version"] == tinyagentos.__version__
+
+    @pytest.mark.asyncio
+    async def test_version_full_for_session_on_exempt_path(self, app, client):
+        """A session-authenticated caller on an exempt path presents a credential => full version."""
+        import tinyagentos
+
+        resp = await client.get("/api/health")
+        # Session is a credential, so even on exempt paths we should see the full version.
+        assert resp.headers["x-taos-version"] == tinyagentos.__version__
 
 
 class TestGZipInsideCsrfLayer:

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -7,7 +7,7 @@ import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 
 # ---------------------------------------------------------------------------
@@ -1169,3 +1169,144 @@ async def test_update_all_workers_status_unknown_job_returns_404(client, app):
     """GET /api/cluster/workers/update-all/<unknown> returns 404."""
     resp = await client.get("/api/cluster/workers/update-all/does-not-exist")
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_get_workers_returns_minimal_projection(client, app):
+    """Unauthenticated GET /api/cluster/workers must not expose sensitive fields.
+
+    Red-test for S2-15: an unauthenticated caller must not receive url,
+    worker_url, host_lan_ip, hardware, models, backends, kernel, version,
+    live_token, or any other identifying/hardware detail.
+    """
+    import json as _json
+
+    # Register a worker with full sensitive data via the admin client.
+    key = await pair_worker(client, app, "secret-worker", "http://10.0.0.1:9000")
+    reg_body = _json.dumps({
+        "name": "secret-worker",
+        "url": "http://10.0.0.1:9000",
+        "platform": "linux",
+        "capabilities": ["chat", "embed"],
+        "hardware": {
+            "cpu": {"model": "Ryzen 9", "arch": "x86_64"},
+            "ram_gb": 64,
+            "os": {"kernel": "6.1.0", "distro": "ubuntu", "version": "24.04"},
+        },
+        "models": ["llama3"],
+        "host_lan_ip": "192.168.1.50",
+        "worker_url": "http://secret-worker:9000",
+        "backends": [{"name": "llama-cpp", "models": [{"name": "llama3"}]}],
+        "live_token": True,
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "secret-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Hit the endpoint with a completely unauthenticated client (no cookies).
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as anon_client:
+        resp = await anon_client.get("/api/cluster/workers")
+        assert resp.status_code == 200, resp.text
+        workers = resp.json()
+        assert len(workers) == 1
+        w = workers[0]
+
+        # Minimal projection must be present.
+        assert w["name"] == "secret-worker"
+        assert w["status"] == "online"
+        assert "tier_id" in w
+
+        # Sensitive fields must NOT be present.
+        sensitive_fields = [
+            "url",
+            "worker_url",
+            "host_lan_ip",
+            "hardware",
+            "models",
+            "backends",
+            "capabilities",
+            "kernel",
+            "version",
+            "live_token",
+            "revoked",
+            "blocked",
+            "last_heartbeat",
+            "load",
+            "platform",
+            "potential_capabilities",
+            "kv_cache_quant_support",
+            "kv_cache_quant_k_support",
+            "kv_cache_quant_v_support",
+            "kv_cache_quant_boundary_layer_protect",
+            "storage_cap_bytes",
+            "storage_used_bytes",
+            "bytes_deduped_total",
+            "worker_lxc_image_version",
+            "degraded",
+            "degraded_reason",
+            "free_vram_mb",
+            "used_vram_mb",
+            "available_models",
+            "resources",
+            "registered_at",
+            "generation",
+            "tls_cert_provider",
+            "signing_key",
+        ]
+        for field in sensitive_fields:
+            assert field not in w, f"sensitive field {field} leaked in unauthenticated response"
+
+    await app.state.cluster_pairing.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_get_workers_returns_full_record(client, app):
+    """Authenticated admin GET /api/cluster/workers returns the full record."""
+    import json as _json
+
+    key = await pair_worker(client, app, "admin-worker", "http://10.0.0.2:9000")
+    reg_body = _json.dumps({
+        "name": "admin-worker",
+        "url": "http://10.0.0.2:9000",
+        "platform": "linux",
+        "capabilities": ["chat"],
+        "hardware": {
+            "cpu": {"model": "Ryzen 9", "arch": "x86_64"},
+            "ram_gb": 64,
+            "os": {"kernel": "6.1.0", "distro": "ubuntu", "version": "24.04"},
+        },
+        "models": ["llama3"],
+        "host_lan_ip": "192.168.1.51",
+        "worker_url": "http://admin-worker:9000",
+        "backends": [{"name": "llama-cpp", "models": [{"name": "llama3"}]}],
+        "live_token": True,
+    }).encode()
+    resp = await client.post(
+        "/api/cluster/workers",
+        content=reg_body,
+        headers={**sign_worker_request(key, "admin-worker", "POST", "/api/cluster/workers", reg_body), "content-type": "application/json"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The admin client has a session cookie, so it must receive the full record.
+    resp = await client.get("/api/cluster/workers")
+    assert resp.status_code == 200, resp.text
+    workers = resp.json()
+    assert len(workers) == 1
+    w = workers[0]
+    assert w["name"] == "admin-worker"
+    assert w["url"] == "http://10.0.0.2:9000"
+    assert w["host_lan_ip"] == "192.168.1.51"
+    assert w["hardware"] is not None
+    assert w["models"] == ["llama3"]
+    assert w["backends"] is not None
+    assert w["live_token"] is True
+    assert w["status"] == "online"
+
+    await app.state.cluster_pairing.close()

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -586,7 +586,24 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # endpoints, cluster heartbeat). Without this, a cached old client
         # could bypass onboarding by hitting an /api endpoint that the
         # not-configured branch used to allow through unconditionally.
+        #
+        # Exempt paths do not require auth, but if a valid session cookie is
+        # present we preserve the caller's identity so route handlers can serve
+        # a reduced view to unauthenticated callers and the full view to
+        # authenticated admins (e.g. GET /api/cluster/workers).
         if _is_exempt(request.method, path):
+            token = request.cookies.get("taos_session")
+            if token:
+                user_agent = request.headers.get("user-agent", "")
+                user_id = auth_mgr.validate_session(token, user_agent=user_agent)
+                if user_id is not None:
+                    user_record = auth_mgr.get_user_by_id(user_id)
+                    request.state.user_id = user_id
+                    request.state.is_admin = bool(
+                        user_record.get("is_admin") if user_record else False
+                    )
+                    request.state.via = "session"
+                    return await call_next(request)
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "exempt"

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -309,6 +309,7 @@ class MoveRequest(BaseModel):
 
 @router.get("/api/cluster/workers")
 async def list_workers(request: Request):
+    is_admin = getattr(request.state, "is_admin", False)
     cluster = request.app.state.cluster_manager
     pairing = getattr(request.app.state, "cluster_pairing", None)
     registry = getattr(request.app.state, "registry", None)
@@ -323,6 +324,13 @@ async def list_workers(request: Request):
         # non-utf8 signing key, and (2) even when serialization didn't
         # crash, the secret has no business being on the wire.
         d.pop("signing_key", None)
+        if not is_admin:
+            result.append({
+                "name": d["name"],
+                "status": d["status"],
+                "tier_id": d.get("tier_id", ""),
+            })
+            continue
         # Surface the persistent auth state from the pairing store so the
         # Cluster UI can show whether a node's signing key is live (not
         # revoked/blocked) and offer revoke/block/unblock actions. A worker


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2913 (tsk-onbvcg/tsk-wdjqxv): S2-15 session-on-exempt-path breaks Q2-6 test_version_coarsened_on_exempt_path - split the test by credential

Autonomous build of board card tsk-m2lutu.

REVISION: built on `exec/tsk-onbvcg` (cut at `9d98d1e3284b4141a14dd42af805564df1740d17`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.



Files:
 .../tsk-m2lutu-session-exempt-path-version-fix.md  |   2 +
 .../tsk-wdjqxv-cluster-workers-redaction.md        |   3 +
 tests/test_q2_6_library_audit.py                   |  25 +++-
 tests/test_routes_cluster.py                       | 143 ++++++++++++++++++++-
 tinyagentos/auth_middleware.py                     |  17 +++
 tinyagentos/routes/cluster.py                      |   8 ++
 6 files changed, 192 insertions(+), 6 deletions(-)


## Red-first evidence

(a) The current test on BASE (`exec/tsk-onbvcg`, CI run 34229968677 / job 102073350998, shards 3.12 and 3.13):

```
FAILED tests/test_q2_6_library_audit.py::TestVersionHeaderCoarsening::test_version_coarsened_on_exempt_path - assert '1.0.0-beta.52' != '1.0.0-beta.52'
```

(b) The new test file copied into a scratch checkout of `origin/dev` (f08274213) - the session test MUST fail there, the anonymous one passes:

```
E       AssertionError: assert 'taOS' == '1.0.0-beta.52'
tests/test_q2_6_library_audit.py:179: AssertionError
FAILED tests/test_q2_6_library_audit.py::TestVersionHeaderCoarsening::test_version_full_for_session_on_exempt_path
1 failed, 2 passed, 20 deselected in 20.77s
```

Green on this branch (`exec/tsk-m2lutu`):

```
3 passed, 20 deselected in 16.71s
```

Fragment: the line is appended to BASE's `changelog.d/tsk-wdjqxv-cluster-workers-redaction.md` (no duplicate fragment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Unauthenticated requests to the cluster workers endpoint now receive only limited worker details.
  * Admins continue to receive complete worker information, including pairing and capability data.
  * Valid sessions are preserved on exempt paths, allowing authenticated callers to receive the full version header.
  * Requests without valid sessions remain anonymous and receive the coarsened version header.

* **Documentation**
  * Updated changelog entries to describe worker data visibility and version header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
