### PR TITLE
R2-28 follow-up: make the signing-keypair race test deterministic (it catches the bug 1 run in 10)

### DIFF
--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -377,6 +377,106 @@ class TestSigningKeypairConcurrentRace:
         mode = pem_file.stat().st_mode & 0o777
         assert mode == 0o600, f"Key file mode is {oct(mode)}, expected 0o600"
 
+    def test_deterministic_race_reader_sees_empty_file_before_write(
+        self, tmp_path, monkeypatch
+    ):
+        """Deterministic variant of the R2-28 keypair race (the 50-thread test
+        above only catches it ~1 in 10 runs).
+
+        Forces the exact interleaving the bug requires: the writer has created
+        the key file (so it exists on disk) but has NOT yet written its bytes,
+        and a concurrent reader observes that empty file.
+
+        A controllable seam patches the file-CREATION step -- os.open on the
+        signing-key path -- to create an empty file, release the reader, and
+        only return so the writer can then populate the file. Against the pre-fix
+        load_or_create_signing_keypair (no FileLock; os.open creates the file
+        before os.write populates it) the reader observes b"" and
+        load_pem_private_key raises, so the test fails EVERY run. Against the
+        fixed code the FileLock serializes the reader behind the writer, so the
+        reader never sees the empty file and the test passes EVERY run.
+
+        The seam is deliberately narrow: it only intercepts an os.open whose
+        target path ends in the signing-key filename. The FileLock's *.lock fd,
+        atomic_write_bytes' temp file, and the sqlite store db all use different
+        paths and flow through untouched, so on the fixed code the seam is a pure
+        no-op and only the FileLock enforces safety.
+        """
+        import os
+        import threading
+
+        key_path = tmp_path / "keys"
+        results: list[tuple[str, bytes, bytes]] = []
+        errors: list[BaseException] = []
+
+        pem_name = "agent_registry_signing.pem"
+        # reader_may_go is set by the seam right after the writer creates the
+        # empty file (pre-fix path), releasing the reader to observe it. On the
+        # fixed code the seam never fires, so the writer sets reader_may_go in
+        # its own finally -- by then atomic_write_bytes has persisted real bytes.
+        reader_may_go = threading.Event()
+        # reader_done is set by the reader once it has attempted its load; the
+        # seam waits on it so the writer does not write over the reader's
+        # observation.
+        reader_done = threading.Event()
+        real_os_open = os.open
+
+        def seam_os_open(path, *args, **kwargs):
+            if isinstance(path, str) and path.endswith(pem_name):
+                fd = real_os_open(path, *args, **kwargs)
+                reader_may_go.set()
+                reader_done.wait(timeout=30)
+                return fd
+            return real_os_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", seam_os_open)
+
+        def writer():
+            try:
+                priv, pub = load_or_create_signing_keypair(key_path)
+                results.append(("writer", priv, pub))
+            except Exception as e:
+                errors.append(("writer", e))
+            finally:
+                reader_may_go.set()
+
+        def reader():
+            reader_may_go.wait(timeout=30)
+            try:
+                priv, pub = load_or_create_signing_keypair(key_path)
+                results.append(("reader", priv, pub))
+            except Exception as e:
+                errors.append(("reader", e))
+            finally:
+                reader_done.set()
+
+        w = threading.Thread(target=writer)
+        r = threading.Thread(target=reader)
+        w.start()
+        r.start()
+        w.join(timeout=60)
+        r.join(timeout=60)
+
+        assert not w.is_alive(), "writer thread did not finish"
+        assert not r.is_alive(), "reader thread did not finish"
+
+        # The race: a concurrent reader must never observe an empty/partial key.
+        assert not errors, f"expected no errors, got: {errors!r}"
+
+        by_role = {role: (priv, pub) for role, priv, pub in results}
+        assert set(by_role) == {"writer", "reader"}, f"incomplete results: {results!r}"
+
+        writer_priv = by_role["writer"][0]
+        reader_priv = by_role["reader"][0]
+        assert writer_priv == reader_priv, "reader observed a different key than writer"
+        assert b"PRIVATE" in writer_priv, "writer private key is malformed"
+        assert b"PRIVATE" in reader_priv, "reader private key is malformed"
+
+        pem_file = key_path / pem_name
+        assert pem_file.exists(), "key file was never created"
+        mode = pem_file.stat().st_mode & 0o777
+        assert mode == 0o600, f"key file mode is {oct(mode)}, expected 0o600"
+
 
 # ---------------------------------------------------------------------------
 # AgentRegistryStore: registration


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): R2-28 follow-up: make the signing-keypair race test deterministic (it catches the bug 1 run in 10)

Autonomous build of board card tsk-cbotzt.

The 50-thread TestSigningKeypairConcurrentRace only catches the
load_or_create_signing_keypair race about 1 in 10 runs (the original RED
evidence was 1 FAILED of 10), so it is a weak regression gate. Add a
deterministic variant that forces the exact interleaving the bug needs: the
writer has created the key file (it exists on disk) but has NOT yet written
its bytes, and a concurrent reader observes that empty file.

The seam is deliberately narrow: it patches only os.open whose target path
ends in the signing-key filename. FileLock's *.lock fd, atomic_write_bytes'
temp file, and the sqlite store db all use other paths and pass through
untouched. On the fixed code the seam is a pure no-op and the FileLock alone
enforces safety; on the pre-fix code (os.open creates the file before
os.write populates it) the reader observes b"" and load_pem_private_key
raises ValueError every run.

The 50-thread test is retained, since it passes 5/5 on origin/dev and still
serves as a useful stress test for scheduling jitter.

RED (pre-fix load_or_create_signing_keypair, parent of the #2870 fix commit,
5 of 5 runs fail):
```
tests/test_agent_registry_store.py::TestSigningKeypairConcurrentRace::test_deterministic_race_reader_sees_empty_file_before_write
1 failed in 1.00s
1 failed in 0.88s
1 failed in 0.77s
1 failed in 0.97s
1 failed in 1.20s
AssertionError: expected no errors, got: [('reader', ValueError('Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming'))]
```

GREEN (origin/dev, fixed load_or_create_signing_keypair, 5 of 5 runs pass):
```
tests/test_agent_registry_store.py::TestSigningKeypairConcurrentRace::test_deterministic_race_reader_sees_empty_file_before_write
1 passed in 0.36s
1 passed in 0.57s
1 passed in 0.48s
1 passed in 0.44s
1 passed in 0.50s
```

Test-only change: no changelog fragment (test-only), no routes/desktop-app/catalog
change (doc-gate diff-gate clean on the staged file).

Files:
 tests/test_agent_registry_store.py | 100 +++++++++++++++++++++++++++++++++++++
 1 file changed, 100 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic coverage for a concurrent signing-key access race.
  * Verifies readers and writers obtain matching, non-empty keys without errors.
  * Confirms generated key files retain secure `0o600` permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->