### PR TITLE
[lib-audit] R2-18 delete the LiteLLM prisma/Postgres migration path

### DIFF
--- a/changelog.d/tsk-tspevi-remove-prisma-migration-path.md
+++ b/changelog.d/tsk-tspevi-remove-prisma-migration-path.md
@@ -1,0 +1,2 @@
+### Fixed
+- **R2-18 remove LiteLLM prisma/Postgres migration path**: `litellm_migrate` no longer shells out to `prisma generate` at runtime. When `DATABASE_URL` is configured the module raises a clear "not supported" error; without it the proxy starts cleanly with no prisma package installed. The `prisma>=0.11.0` dependency is removed from the `proxy` extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ worker = ["pystray>=0.19.0", "Pillow>=10.0"]
 # rule and scripts/check_install_licences.py re-checks the resolved licences.
 proxy = [
     "litellm>=1.94.2,<1.95",
-    "prisma>=0.11.0",
     # --- litellm 1.94.2 [proxy], minus litellm-enterprise ---
     "apscheduler>=3.11.2,<4.0",
     "azure-identity>=1.25.2,<2.0",

--- a/tests/test_litellm_migrate.py
+++ b/tests/test_litellm_migrate.py
@@ -90,3 +90,15 @@ async def test_migrate_raises_when_prisma_cli_missing(tmp_path):
     data_dir = _write_db_url(tmp_path)
     with pytest.raises(RuntimeError, match="not supported"):
         await litellm_migrate.migrate(data_dir)
+
+
+def test_prisma_declared_nowhere_in_packaging():
+    """R2-18: the prisma dependency is gone from BOTH pyproject.toml and uv.lock.
+
+    pyproject alone is not enough -- a stale lock keeps shipping the package
+    (and its runtime query-engine download) to every `uv sync`.
+    """
+    root = Path(__file__).resolve().parents[1]
+    for name in ("pyproject.toml", "uv.lock"):
+        text = (root / name).read_text(encoding="utf-8")
+        assert "prisma" not in text.lower(), f"{name} still references prisma"

--- a/tests/test_litellm_migrate.py
+++ b/tests/test_litellm_migrate.py
@@ -1,13 +1,10 @@
-"""Tests for litellm_migrate — ensures LiteLLM's prisma Python client is
-importable before proxy start. The helper deliberately does NOT touch
-the database; LiteLLM owns its own migrations and we'd collide with
-``_prisma_migrations`` history if we ran ``prisma db push`` here.
+"""Tests for litellm_migrate — ensures LiteLLM's Postgres/prisma path is
+gated and that the proxy starts without prisma when no DATABASE_URL is set.
 """
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -38,170 +35,58 @@ async def test_migrate_noop_when_db_url_empty(tmp_path):
 
 @pytest.mark.asyncio
 async def test_migrate_skips_when_prisma_client_already_importable(tmp_path):
-    """If ``prisma.client`` imports, generate must not be invoked."""
+    """If a DATABASE_URL is present, Postgres mode is not supported without
+    the prisma package — raise a clear error regardless of client state."""
     data_dir = _write_db_url(tmp_path)
-
-    async def _fake_exec(*args, **kwargs):
-        raise AssertionError("create_subprocess_exec must not be called")
-
-    with patch.object(litellm_migrate, "_prisma_client_importable", return_value=True), \
-         patch.object(litellm_migrate.asyncio, "create_subprocess_exec", side_effect=_fake_exec):
-        assert await litellm_migrate.migrate(data_dir) == "already-generated"
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)
 
 
 @pytest.mark.asyncio
-async def test_migrate_runs_prisma_generate_when_client_missing(tmp_path):
-    """When the client is not importable, migrate must shell out to
-    ``prisma generate`` against LiteLLM's bundled schema."""
+async def test_migrate_raises_not_supported_when_db_url_set_without_prisma(tmp_path):
+    """With a DATABASE_URL configured and no prisma installed, migrate must
+    raise a clear 'not supported' error rather than attempting a runtime
+    prisma download."""
     data_dir = _write_db_url(tmp_path)
-    fake_schema = tmp_path / "schema.prisma"
-    fake_schema.write_text("// fake")
-    fake_cli = tmp_path / "fake-venv" / "bin" / "prisma"
-    fake_cli.parent.mkdir(parents=True)
-    fake_cli.write_text("#!/bin/sh\nexit 0\n")
-    fake_cli.chmod(0o755)
-
-    importable = iter([False, True])
-
-    proc_mock = MagicMock()
-    proc_mock.returncode = 0
-    proc_mock.communicate = AsyncMock(return_value=(b"Generated prisma client", b""))
-
-    captured_cmd = []
-
-    async def _fake_exec(*args, **kwargs):
-        captured_cmd.extend(args)
-        return proc_mock
-
-    with patch.object(litellm_migrate, "_schema_path", return_value=fake_schema), \
-         patch.object(litellm_migrate, "_prisma_cli", return_value=str(fake_cli)), \
-         patch.object(litellm_migrate, "_prisma_client_importable",
-                      side_effect=lambda: next(importable)), \
-         patch.object(litellm_migrate.asyncio, "create_subprocess_exec",
-                      side_effect=_fake_exec) as exec_mock:
-        assert await litellm_migrate.migrate(data_dir) == "generated"
-
-    assert exec_mock.call_count == 1
-    args, kwargs = exec_mock.call_args
-    cmd = list(args)
-    assert cmd[0] == str(fake_cli)
-    assert cmd[1] == "generate"
-    assert any(a.startswith("--schema=") for a in cmd)
-    assert "push" not in cmd
-    env = kwargs["env"]
-    venv_bin = str(fake_cli.parent)
-    assert env["PATH"].startswith(venv_bin + ":"), env["PATH"]
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)
 
 
 @pytest.mark.asyncio
 async def test_migrate_does_not_set_database_url(tmp_path):
-    """``prisma generate`` doesn't need DATABASE_URL — and setting it would
-    signal that we're about to touch the DB, which we explicitly aren't."""
+    """Postgres mode is not supported without the prisma package."""
     data_dir = _write_db_url(tmp_path)
-    fake_schema = tmp_path / "schema.prisma"
-    fake_schema.write_text("// fake")
-    fake_cli = tmp_path / "bin" / "prisma"
-    fake_cli.parent.mkdir(parents=True)
-    fake_cli.write_text("#!/bin/sh\nexit 0\n")
-    fake_cli.chmod(0o755)
-    importable = iter([False, True])
-
-    proc_mock = MagicMock()
-    proc_mock.returncode = 0
-    proc_mock.communicate = AsyncMock(return_value=(b"", b""))
-
-    async def _fake_exec(*args, **kwargs):
-        return proc_mock
-
-    with patch.object(litellm_migrate, "_schema_path", return_value=fake_schema), \
-         patch.object(litellm_migrate, "_prisma_cli", return_value=str(fake_cli)), \
-         patch.object(litellm_migrate, "_prisma_client_importable",
-                      side_effect=lambda: next(importable)), \
-         patch.object(litellm_migrate.asyncio, "create_subprocess_exec",
-                      side_effect=_fake_exec) as exec_mock, \
-         patch.dict("os.environ", {}, clear=False):
-        import os as _os
-        _os.environ.pop("DATABASE_URL", None)
+    with pytest.raises(RuntimeError, match="not supported"):
         await litellm_migrate.migrate(data_dir)
-
-    env = exec_mock.call_args.kwargs["env"]
-    assert "DATABASE_URL" not in env
 
 
 @pytest.mark.asyncio
 async def test_migrate_raises_when_generate_fails(tmp_path):
-    """A non-zero exit from prisma generate must raise so boot fails loudly."""
+    """Postgres mode is not supported without the prisma package."""
     data_dir = _write_db_url(tmp_path)
-    fake_schema = tmp_path / "schema.prisma"
-    fake_schema.write_text("// fake")
-    fake_cli = tmp_path / "bin" / "prisma"
-    fake_cli.parent.mkdir(parents=True)
-    fake_cli.write_text("#!/bin/sh\nexit 1\n")
-    fake_cli.chmod(0o755)
-
-    proc_mock = MagicMock()
-    proc_mock.returncode = 1
-    proc_mock.communicate = AsyncMock(return_value=(b"", b"boom"))
-
-    async def _fake_exec(*args, **kwargs):
-        return proc_mock
-
-    with patch.object(litellm_migrate, "_schema_path", return_value=fake_schema), \
-         patch.object(litellm_migrate, "_prisma_cli", return_value=str(fake_cli)), \
-         patch.object(litellm_migrate, "_prisma_client_importable", return_value=False), \
-         patch.object(litellm_migrate.asyncio, "create_subprocess_exec",
-                      side_effect=_fake_exec):
-        with pytest.raises(RuntimeError, match="prisma generate exited 1"):
-            await litellm_migrate.migrate(data_dir)
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)
 
 
 @pytest.mark.asyncio
 async def test_migrate_raises_when_client_still_missing_after_generate(tmp_path):
-    """If prisma generate reports success but prisma.client is still not
-    importable, raise — the environment is broken and LiteLLM will fail."""
+    """Postgres mode is not supported without the prisma package."""
     data_dir = _write_db_url(tmp_path)
-    fake_schema = tmp_path / "schema.prisma"
-    fake_schema.write_text("// fake")
-    fake_cli = tmp_path / "bin" / "prisma"
-    fake_cli.parent.mkdir(parents=True)
-    fake_cli.write_text("#!/bin/sh\nexit 0\n")
-    fake_cli.chmod(0o755)
-
-    proc_mock = MagicMock()
-    proc_mock.returncode = 0
-    proc_mock.communicate = AsyncMock(return_value=(b"", b""))
-
-    async def _fake_exec(*args, **kwargs):
-        return proc_mock
-
-    with patch.object(litellm_migrate, "_schema_path", return_value=fake_schema), \
-         patch.object(litellm_migrate, "_prisma_cli", return_value=str(fake_cli)), \
-         patch.object(litellm_migrate, "_prisma_client_importable", return_value=False), \
-         patch.object(litellm_migrate.asyncio, "create_subprocess_exec",
-                      side_effect=_fake_exec):
-        with pytest.raises(RuntimeError, match="still not importable"):
-            await litellm_migrate.migrate(data_dir)
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)
 
 
 @pytest.mark.asyncio
 async def test_migrate_raises_when_schema_missing(tmp_path):
-    """If LiteLLM isn't installed / schema.prisma missing, raise so the
-    operator sees the real cause rather than silent LiteLLM 500s."""
+    """Postgres mode is not supported without the prisma package."""
     data_dir = _write_db_url(tmp_path)
-    with patch.object(litellm_migrate, "_schema_path", return_value=None), \
-         patch.object(litellm_migrate, "_prisma_client_importable", return_value=False):
-        with pytest.raises(RuntimeError, match="cannot locate LiteLLM's schema.prisma"):
-            await litellm_migrate.migrate(data_dir)
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)
 
 
 @pytest.mark.asyncio
 async def test_migrate_raises_when_prisma_cli_missing(tmp_path):
+    """Postgres mode is not supported without the prisma package."""
     data_dir = _write_db_url(tmp_path)
-    fake_schema = tmp_path / "schema.prisma"
-    fake_schema.write_text("// fake")
-    with patch.object(litellm_migrate, "_schema_path", return_value=fake_schema), \
-         patch.object(litellm_migrate, "_prisma_client_importable", return_value=False), \
-         patch.object(litellm_migrate, "_prisma_cli",
-                      return_value=str(tmp_path / "does-not-exist")):
-        with pytest.raises(RuntimeError, match="prisma CLI not found"):
-            await litellm_migrate.migrate(data_dir)
+    with pytest.raises(RuntimeError, match="not supported"):
+        await litellm_migrate.migrate(data_dir)

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -826,7 +826,7 @@ class TestProxySelfHeal:
             "[project.optional-dependencies]\n"
             # trailing whitespace/newline in an entry must be stripped, not
             # reach pip verbatim
-            "proxy = [\"litellm[proxy]>=1.90.0\", \"prisma>=0.11.0\\n\"]\n"
+            "proxy = [\"litellm[proxy]>=1.90.0\"\n]\n"
         )
         (tmp_path / ".venv" / "bin").mkdir(parents=True)
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -853,7 +853,6 @@ class TestProxySelfHeal:
             "--no-input",
             "--disable-pip-version-check",
             "litellm[proxy]>=1.90.0",
-            "prisma>=0.11.0",
         ]
         assert "-e" not in captured["cmd"]
 

--- a/tinyagentos/litellm_migrate.py
+++ b/tinyagentos/litellm_migrate.py
@@ -1,97 +1,29 @@
-"""Ensure LiteLLM's Prisma Python client is importable at taOS startup.
+"""LiteLLM startup guard for the Postgres/prisma path.
 
-LiteLLM ships its own ``prisma/migrations/`` directory and runs ``prisma
-migrate deploy`` against it during proxy startup — that's the
-authoritative path for creating/upgrading LiteLLM's tables. Our only
-job here is to make sure ``import prisma`` works (i.e. the generated
-Python client exists under ``site-packages/prisma/``) so LiteLLM's
-own runtime can talk to the DB.
-
-Previously this module also ran ``prisma db push --accept-data-loss``
-to set up the schema ourselves. That DDLs the tables directly without
-seeding ``_prisma_migrations``, which made LiteLLM's own
-``migrate deploy`` try to apply migration #1 on top of already-existing
-objects and fail with "type JobStatus already exists" in a loop —
-leaving the proxy permanently unhealthy. The fix is to get out of the
-DB's way entirely.
-
-Must run BEFORE ``LLMProxy.start()`` so the prisma client is importable
-by the time LiteLLM's proxy boots.
+taOS never runs LiteLLM's Postgres-backed virtual-key mode, so this module
+no longer shells out to ``prisma generate``.  If a ``.litellm_db_url`` file
+is present the operator has explicitly opted into Postgres mode — that path
+is not supported without the prisma package, so we raise a clear error
+instead of attempting a runtime download.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
-import subprocess
-import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
-def _prisma_cli() -> str:
-    """Path to the ``prisma`` CLI installed in the current venv.
-
-    The pip ``prisma`` package drops a ``prisma`` binary next to
-    ``python`` in the venv's ``bin/``. Falling back to ``sys.executable
-    -m prisma`` is unreliable because the package's ``__main__`` isn't a
-    proper CLI entrypoint — the shipped binary is.
-    """
-    return str(Path(sys.executable).parent / "prisma")
-
-
-def _schema_path() -> Path | None:
-    """Locate the LiteLLM-bundled ``schema.prisma`` file.
-
-    Returns None if LiteLLM isn't installed or the schema file is
-    missing — callers log and bail.
-    """
-    try:
-        import litellm.proxy  # type: ignore
-    except Exception as exc:
-        logger.error("litellm_migrate: cannot import litellm.proxy: %s", exc)
-        return None
-    path = Path(litellm.proxy.__file__).parent / "schema.prisma"
-    if not path.exists():
-        logger.error("litellm_migrate: schema not found at %s", path)
-        return None
-    return path
-
-
-def _prisma_client_importable() -> bool:
-    """True iff ``import prisma.client`` works — i.e. generate has been run.
-
-    The ``prisma`` pip package ships an empty ``prisma/`` namespace that
-    only gains a ``client`` submodule after ``prisma generate`` writes
-    the generated artifacts. So the presence of ``prisma.client`` is a
-    reliable "client is ready" signal.
-    """
-    try:
-        import importlib
-
-        importlib.import_module("prisma.client")
-        return True
-    except ImportError:
-        return False
-
-
 async def migrate(data_dir: Path) -> str:
-    """Ensure LiteLLM's prisma Python client is importable.
+    """Gate Postgres mode and report status.
 
-    LiteLLM handles its own DB migrations on startup via
-    ``prisma migrate deploy`` — do NOT run ``prisma db push`` here; that
-    bypasses the ``_prisma_migrations`` history table and causes
-    LiteLLM's native migrator to loop on duplicate-type errors.
+    Returns:
+        "no-db-configured" — no ``.litellm_db_url`` file, nothing to do.
 
-    Returns a short status string for logging/tests:
-        - "no-db-configured"   -> no ``.litellm_db_url`` file, nothing to do
-        - "already-generated"  -> ``prisma.client`` already importable
-        - "generated"          -> ran ``prisma generate`` successfully
-
-    Raises on failure of ``prisma generate`` or if the client is still
-    not importable afterwards, so boot fails loudly instead of LiteLLM
-    silently 500ing on every request.
+    Raises:
+        RuntimeError: if ``.litellm_db_url`` exists, because Postgres mode
+        is not supported without the prisma package.
     """
     db_url_path = data_dir / ".litellm_db_url"
     if not db_url_path.exists():
@@ -102,59 +34,7 @@ async def migrate(data_dir: Path) -> str:
         logger.info("litellm_migrate: .litellm_db_url empty — skipping")
         return "no-db-configured"
 
-    if _prisma_client_importable():
-        logger.info("litellm_migrate: prisma.client already importable — skipping generate")
-        return "already-generated"
-
-    schema = _schema_path()
-    if schema is None:
-        raise RuntimeError(
-            "litellm_migrate: cannot locate LiteLLM's schema.prisma — "
-            "is litellm[proxy] installed?"
-        )
-
-    cli = _prisma_cli()
-    if not Path(cli).exists():
-        raise RuntimeError(
-            f"litellm_migrate: prisma CLI not found at {cli} — "
-            "is the 'prisma' pip package installed in this venv?"
-        )
-
-    env = os.environ.copy()
-    # Prisma's node CLI shells out to ``prisma-client-py`` via ``/bin/sh``
-    # during ``generate``. That subprocess inherits PATH, and under systemd
-    # the unit file doesn't put the venv's bin/ on PATH by default — so the
-    # generator fails with "prisma-client-py: not found". Prepend the bin
-    # directory holding the prisma binary so the child shell resolves it.
-    venv_bin = str(Path(cli).parent)
-    existing_path = env.get("PATH", "")
-    if venv_bin not in existing_path.split(os.pathsep):
-        env["PATH"] = venv_bin + os.pathsep + existing_path if existing_path else venv_bin
-
-    cmd = [cli, "generate", f"--schema={schema}"]
-    logger.info("litellm_migrate: running %s", " ".join(cmd))
-    proc = await asyncio.create_subprocess_exec(
-        *cmd,
-        env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    raise RuntimeError(
+        "litellm_migrate: Postgres/virtual-key mode is not supported "
+        "without the prisma package"
     )
-    stdout_b, stderr_b = await proc.communicate()
-    stdout = stdout_b.decode(errors="replace").strip()
-    stderr = stderr_b.decode(errors="replace").strip()
-    if stdout:
-        logger.info("litellm_migrate stdout: %s", stdout)
-    if stderr:
-        logger.info("litellm_migrate stderr: %s", stderr)
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"litellm_migrate: prisma generate exited {proc.returncode}"
-        )
-
-    if not _prisma_client_importable():
-        raise RuntimeError(
-            "litellm_migrate: prisma generate succeeded but prisma.client "
-            "is still not importable — check site-packages/prisma/"
-        )
-    logger.info("litellm_migrate: prisma client generated from %s", schema)
-    return "generated"

--- a/uv.lock
+++ b/uv.lock
@@ -1601,15 +1601,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1893,25 +1884,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
     { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
     { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
-]
-
-[[package]]
-name = "prisma"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "nodeenv" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tomlkit" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/55/d4e07cbf40d5f1ab6d1c42c23613d442bf0d06abf7f70bec280aefb28249/prisma-0.15.0.tar.gz", hash = "sha256:5cd6402aa8322625db3fc1152040404e7fc471fe7f8fa3a314fa8a99529ca107", size = 154975, upload-time = "2024-08-16T02:54:03.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/6d/84533aa3fcc395235d58c3412fb86013653b697d91fc53f379c83bbb0b79/prisma-0.15.0-py3-none-any.whl", hash = "sha256:de949cc94d3d91243615f22ff64490aa6e2d7cb81aabffce53d92bd3977c09a4", size = 173809, upload-time = "2024-08-16T02:54:02.326Z" },
 ]
 
 [[package]]
@@ -3082,7 +3054,6 @@ proxy = [
     { name = "mcp" },
     { name = "orjson" },
     { name = "polars" },
-    { name = "prisma" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pynacl" },
@@ -3152,7 +3123,6 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0" },
     { name = "pillow", marker = "extra == 'worker'", specifier = ">=10.0" },
     { name = "polars", marker = "extra == 'proxy'", specifier = ">=1.38.1,<2.0" },
-    { name = "prisma", marker = "extra == 'proxy'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic-settings", marker = "extra == 'proxy'", specifier = ">=2.14.1,<3.0" },
     { name = "pyjwt", marker = "extra == 'proxy'", specifier = ">=2.13.0,<3.0" },
@@ -3222,15 +3192,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-18 delete the LiteLLM prisma/Postgres migration path

Autonomous build of board card tsk-tspevi.

litellm_migrate no longer shells out to prisma generate; with DATABASE_URL
configured it raises a clear not-supported error, otherwise returns
no-db-configured. Drop prisma>=0.11.0 from the proxy extra and regenerate
uv.lock. Update litellm_migrate tests and the selfheal proxy-extra test.

Failing runs before fix (measured by the lead, 2026-09-08 22:2xZ):

Card RED - the pre-fix code on origin/dev shells out to prisma instead of raising, and the lock still pins prisma (test file copied onto an origin/dev worktree):

```
$ python3 -m pytest tests/test_litellm_migrate.py -k "not_supported or prisma_declared" -q
FAILED tests/test_litellm_migrate.py::test_migrate_raises_not_supported_when_db_url_set_without_prisma
FAILED tests/test_litellm_migrate.py::test_prisma_declared_nowhere_in_packaging
2 failed, 8 deselected, 2 warnings in 0.35s
```

Packaging RED - on this branch's previous head (fd94da71f, pyproject fixed but uv.lock still carrying 5 prisma references):

```
$ python3 -m pytest tests/test_litellm_migrate.py -k prisma_declared -q
FAILED tests/test_litellm_migrate.py::test_prisma_declared_nowhere_in_packaging
1 failed, 9 deselected, 2 warnings in 0.25s
```

Green run after fix (branch head, uv.lock regenerated: `uv lock` removed prisma v0.15.0 plus its transitive-only nodeenv v1.10.0 and tomlkit v0.15.0, no other pin moved):

```
$ python3 -m pytest tests/test_litellm_migrate.py -q
10 passed, 2 warnings in 0.23s
```

Note on the lock: the lane did regenerate uv.lock, but executor.sh's STRIP step reverts lockfiles to the base revision on every lane commit, so the regenerated lock never reached the PR. The lead committed it directly. `uv sync --extra proxy` exit 0 with prisma removed was confirmed in the fix-forward lane's run log (tsk-2jgqmv).

Docs-Reviewed: no routes/ or desktop/catalog manifests changed; packaging change is dependency removal only

Files:
 .../tsk-tspevi-remove-prisma-migration-path.md     |   2 +
 pyproject.toml                                     |   1 -
 tests/test_litellm_migrate.py                      | 169 ++++-----------------
 tests/test_llm_proxy.py                            |   3 +-
 tinyagentos/litellm_migrate.py                     | 150 ++----------------
 5 files changed, 45 insertions(+), 280 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - LiteLLM migration now starts cleanly when no database is configured.
  - Configured Postgres or virtual-key mode now returns a clear “not supported” error instead of attempting automatic Prisma generation.
  - Migration no longer attempts to generate database client code at runtime, avoiding related startup failures and unsupported configuration errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



Removes-Intentionally: tinyagentos/litellm_migrate.py:_prisma_cli, tinyagentos/litellm_migrate.py:_prisma_client_importable, tinyagentos/litellm_migrate.py:_schema_path, tests/test_litellm_migrate.py:test_migrate_runs_prisma_generate_when_client_missing, tests/test_litellm_migrate.py:test_migrate_runs_prisma_generate_when_client_missing._fake_exec, tests/test_litellm_migrate.py:test_migrate_does_not_set_database_url._fake_exec, tests/test_litellm_migrate.py:test_migrate_raises_when_client_still_missing_after_generate._fake_exec, tests/test_litellm_migrate.py:test_migrate_raises_when_generate_fails._fake_exec, tests/test_litellm_migrate.py:test_migrate_skips_when_prisma_client_already_importable._fake_exec
