### PR TITLE
tests: sweep bare-digit substring assertions against random/encoded output (same class as the #2811 '41' flake)

### DIFF
--- a/changelog.d/tsk-qowl3b-bare-digit-assert-sweep.md
+++ b/changelog.d/tsk-qowl3b-bare-digit-assert-sweep.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `tests/test_auth_pin.py::TestPinStore::test_pin_is_hashed_not_stored_in_clear` now parses the JSON store and asserts on the `pin_hash` field directly (`$argon2` prefix, not equal to the PIN value) instead of checking that the bare PIN string does not appear anywhere in the raw file. The old assertion could flake when a runtime-generated argon2 salt or hash happened to contain the PIN digits as a base64 substring. Added a deterministic regression test that monkeypatches the hasher to embed the PIN in the encoded hash and proves the new assertion holds while the old one fails.

--- a/tests/test_auth_pin.py
+++ b/tests/test_auth_pin.py
@@ -7,6 +7,8 @@ PIN being REFUSED off-console does.
 """
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from tinyagentos.auth import (
@@ -190,9 +192,27 @@ class TestPinStore:
 
     def test_pin_is_hashed_not_stored_in_clear(self, mgr, tmp_path):
         mgr.set_pin("tester", "4913")
+        data = json.loads((tmp_path / ".auth_user.json").read_text())
+        pin_hash = data["users"][0]["pin_hash"]
+        assert pin_hash.startswith("$argon2")
+        assert pin_hash != "4913"
+
+    def test_bare_digit_assertion_flakes_when_hash_contains_pin(self, mgr, tmp_path, monkeypatch):
+        fake_hash = "$argon2id$v=19$m=65536,t=3,p=4$4913salt$4913hash"
+
+        class FakeHasher:
+            def hash(self, secret):
+                return fake_hash
+
+        monkeypatch.setattr("tinyagentos.auth._ph", FakeHasher())
+        mgr.set_pin("tester", "4913")
         raw = (tmp_path / ".auth_user.json").read_text()
-        assert "4913" not in raw
-        assert "$argon2" in raw
+        with pytest.raises(AssertionError):
+            assert "4913" not in raw
+        data = json.loads(raw)
+        pin_hash = data["users"][0]["pin_hash"]
+        assert pin_hash.startswith("$argon2")
+        assert pin_hash != "4913"
 
     def test_pin_hash_never_reaches_the_public_profile(self, mgr):
         mgr.set_pin("tester", "4913")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): tests: sweep bare-digit substring assertions against random/encoded output (same class as the #2811 '41' flake)

Autonomous build of board card tsk-qowl3b.

test_pin_is_hashed_not_stored_in_clear used `assert "4913" not in raw`
where raw is the JSON file containing an argon2 hash with a random salt
(base64). A runtime-generated salt or hash can coincidentally contain the
PIN digits as a substring, causing the assertion to flake.

Fix: parse the JSON and assert on the pin_hash field directly
(pin_hash.startswith("$argon2") and pin_hash != "4913").

RED proof: test_bare_digit_assertion_flakes_when_hash_contains_pin
monkeypatches tinyagentos.auth._ph to return a fake argon2 hash
containing "4913" in the salt and hash parts. The old
`assert "4913" not in raw` raises AssertionError, while the new
field-level assertions pass.

Sweep: tests/test_log_redaction.py:113, 134 and
tests/test_merge_attribution.py:452 are static/deterministic inputs,
not random encoded output. No other hits.

Files:
 changelog.d/tsk-qowl3b-bare-digit-assert-sweep.md |  3 +++
 tests/test_auth_pin.py                            | 24 +++++++++++++++++++++--
 2 files changed, 25 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication PIN storage tests to verify that PINs are stored as Argon2 hashes rather than plaintext.
  * Added regression coverage for hashes that contain the original PIN digits, preventing false test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->