### PR TITLE
[lib-audit] OTel span ids random, parent refs derived: no trace nests

### DIFF
--- a/changelog.d/tsk-mvbc4d-span-id-derivation.md
+++ b/changelog.d/tsk-mvbc4d-span-id-derivation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- OTel span IDs are now derived deterministically from the envelope id using SHA-256, so child spans whose parentSpanId is derived from parent_id can correctly reference their parents. Traces emitted by the OTLP emitter now nest properly in Jaeger, Tempo, and Grafana.

--- a/tests/otel/test_emitter_nesting.py
+++ b/tests/otel/test_emitter_nesting.py
@@ -1,0 +1,70 @@
+"""RED-FIRST tests for OTel span nesting.
+
+These tests assert that a child span's parentSpanId matches its parent's spanId,
+and that a multi-level chain produces nested (not flat) spans.
+"""
+from __future__ import annotations
+
+import hashlib
+import time
+
+from tinyagentos.otel.emitter import _build_otlp_span
+
+
+def _sha256_span_id(env_id: str) -> str:
+    return hashlib.sha256(env_id.encode()).digest()[:8].hex()
+
+
+def _make_envelope(id_str: str, parent_id: str | None, kind: str = "llm_call") -> dict:
+    return {
+        "v": 1,
+        "id": id_str,
+        "trace_id": "trace-nest",
+        "parent_id": parent_id,
+        "created_at": time.time(),
+        "agent_name": "nest-agent",
+        "kind": kind,
+        "channel_id": None,
+        "thread_id": "conv-nest",
+        "backend_name": "test-provider",
+        "model": "test-model",
+        "duration_ms": 10,
+        "tokens_in": 1,
+        "tokens_out": 1,
+        "cost_usd": None,
+        "error": None,
+        "payload": {"status": "success", "messages": [], "response": "ok", "metadata": {}},
+    }
+
+
+def test_child_parent_span_id_matches_parent_span_id():
+    parent_env = _make_envelope("env-parent", parent_id=None)
+    child_env = _make_envelope("env-child", parent_id="env-parent")
+
+    parent_span = _build_otlp_span(parent_env)
+    child_span = _build_otlp_span(child_env)
+
+    assert parent_span is not None
+    assert child_span is not None
+    assert child_span.get("parentSpanId") == parent_span["spanId"]
+
+
+def test_three_level_chain_nests():
+    parent_env = _make_envelope("env-grandparent", parent_id=None)
+    child_env = _make_envelope("env-parent", parent_id="env-grandparent")
+    grandchild_env = _make_envelope("env-child", parent_id="env-parent")
+
+    parent_span = _build_otlp_span(parent_env)
+    child_span = _build_otlp_span(child_env)
+    grandchild_span = _build_otlp_span(grandchild_env)
+
+    assert parent_span is not None
+    assert child_span is not None
+    assert grandchild_span is not None
+
+    spans = [parent_span, child_span, grandchild_span]
+    roots = [s for s in spans if "parentSpanId" not in s]
+    assert len(roots) == 1, f"3 spans emitted, {len(roots)} roots found, expected 1"
+
+    assert child_span["parentSpanId"] == parent_span["spanId"]
+    assert grandchild_span["parentSpanId"] == child_span["spanId"]

--- a/tinyagentos/otel/emitter.py
+++ b/tinyagentos/otel/emitter.py
@@ -26,7 +26,6 @@ import hashlib
 import json
 import logging
 import os
-import secrets
 import time
 from typing import Any
 
@@ -44,11 +43,6 @@ _SPAN_KIND_CLIENT = 3
 _STATUS_OK = "STATUS_CODE_OK"
 _STATUS_ERROR = "STATUS_CODE_ERROR"
 _STATUS_UNSET = "STATUS_CODE_UNSET"
-
-
-def _make_span_id() -> str:
-    """Mint a random 64-bit OTel spanId (16 hex chars)."""
-    return secrets.token_bytes(8).hex()
 
 
 def _ns_from_envelope(env: dict, *, use_end: bool = False) -> int:
@@ -101,7 +95,9 @@ def _build_otlp_span(env: dict) -> dict | None:  # noqa: C901  (complexity is ma
     # Stable conversation/trace ids
     conversation_id = env.get("thread_id") or env.get("trace_id")
     trace_id = _make_trace_id(conversation_id)
-    span_id = _make_span_id()
+    span_id = hashlib.sha256(
+        env["id"].encode()
+    ).digest()[:8].hex()
 
     # Parent span id (from envelope parent_id; we treat it as a spanId hint)
     parent_span_id: str | None = None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] OTel span ids random, parent refs derived: no trace nests

Autonomous build of board card tsk-mvbc4d.

Before this change the emitter minted random span IDs via secrets.token_bytes,
while parentSpanId was derived from the parent envelope id with sha256.
No parent spanId could ever match a random child spanId, so every span
appeared as a root in Jaeger/Tempo/Grafana.

After this change spanId is derived from env["id"] the same way
parentSpanId is derived from env["parent_id"].  Child.parentSpanId now
matches Parent.spanId and traces nest correctly.

RED-FIRST proof:

```
FAILED tests/otel/test_emitter_nesting.py::test_child_parent_span_id_matches_parent_span_id - AssertionError: assert '5ab7c3728647e7e1' == '197b728ae69f8e28'
FAILED tests/otel/test_emitter_nesting.py::test_three_level_chain_nests - AssertionError: assert '6029f30396aaa6ae' == 'a8fd963749d62aec'
2 failed in 0.28s
```

GREEN after fix:

```
2 passed in 0.63s
```

Also verified receiver.py and span_store.py round-trip the ids unchanged.

Files:
 changelog.d/tsk-mvbc4d-span-id-derivation.md |  3 ++
 tests/otel/test_emitter_nesting.py           | 70 ++++++++++++++++++++++++++++
 tinyagentos/otel/emitter.py                  | 10 ++--
 3 files changed, 76 insertions(+), 7 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenTelemetry trace nesting by deriving stable span IDs from envelope IDs.
  - Child spans now correctly reference their parent spans, producing accurate trace hierarchies in Jaeger, Tempo, and Grafana.

- **Tests**
  - Added coverage for parent-child span relationships and multi-level trace nesting.

- **Documentation**
  - Documented the updated span ID and trace nesting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Removes-Intentionally: tinyagentos/otel/emitter.py:_make_span_id
