### PR TITLE
[lib-audit] Backend INFO logging is discarded: no dictConfig anywhere

### DIFF
--- a/changelog.d/tsk-o35joz-logging-config.md
+++ b/changelog.d/tsk-o35joz-logging-config.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added `logging.config.dictConfig()` in `create_app()` to configure the root logger with a StreamHandler and formatter carrying `%(asctime)s %(levelname)s %(name)s: %(message)s`. Added `TAOS_LOG_LEVEL` environment variable defaulting to INFO, which controls the root logger level.

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,48 @@
+import logging
+import os
+
+import pytest
+
+from tinyagentos.app import create_app
+
+
+class TestLoggingConfig:
+    def test_root_logger_has_handler_after_create_app(self, tmp_path):
+        app = create_app(data_dir=tmp_path / "data")
+        handlers = logging.getLogger().handlers
+        assert handlers != [], "root logger should have at least one handler after create_app()"
+
+    def test_logging_config_has_formatter_with_asctime_levelname_name(self, tmp_path):
+        app = create_app(data_dir=tmp_path / "data")
+        root = logging.getLogger()
+        assert len(root.handlers) > 0, "root logger should have at least one handler"
+        handler = root.handlers[0]
+        assert handler.formatter is not None, "handler should have a formatter"
+        formatter = handler.formatter
+        assert "%(asctime)s" in formatter._fmt, "formatter should include %(asctime)s"
+        assert "%(levelname)s" in formatter._fmt, "formatter should include %(levelname)s"
+        assert "%(name)s" in formatter._fmt, "formatter should include %(name)s"
+
+    def test_taos_log_level_env_var(self, tmp_path):
+        # Test with TAOS_LOG_LEVEL=DEBUG
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setenv("TAOS_LOG_LEVEL", "DEBUG")
+            # Need to re-create app after env change, but create_app reads env at call time
+            # So we just verify the dictConfig reads the env var
+            app = create_app(data_dir=tmp_path / "data")
+            root = logging.getLogger()
+            # Level should be DEBUG (10) when TAOS_LOG_LEVEL=DEBUG
+            assert root.level == logging.DEBUG, (
+                f"root logger level should be DEBUG (10), got {root.level}"
+            )
+
+    def test_taos_log_level_defaults_to_info(self, tmp_path):
+        # Test default TAOS_LOG_LEVEL=INFO
+        # reset env
+        if "TAOS_LOG_LEVEL" in os.environ:
+            del os.environ["TAOS_LOG_LEVEL"]
+        app = create_app(data_dir=tmp_path / "data")
+        root = logging.getLogger()
+        assert root.level == logging.INFO, (
+            f"root logger level should be INFO (20) by default, got {root.level}"
+        )

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -167,6 +167,30 @@ def _resolve_browser_cookie_key(data_dir: "Path") -> str:
 
 
 def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) -> FastAPI:
+    import logging
+    import logging.config
+
+    log_level = os.environ.get("TAOS_LOG_LEVEL", "INFO").upper()
+    logging.config.dictConfig({
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            },
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+            },
+        },
+        "root": {
+            "handlers": ["default"],
+            "level": log_level,
+        },
+    })
+
     from tinyagentos.registry import AppRegistry
     from tinyagentos.hardware import get_hardware_profile
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Backend INFO logging is discarded: no dictConfig anywhere

Autonomous build of board card tsk-o35joz.

- root logger has a handler after create_app()
- INFO lines from tinyagentos loggers reach journald with timestamp and name
- TAOS_LOG_LEVEL tunes log level, defaults to INFO

FAILED tests/test_logging_config.py::TestLoggingConfig::test_root_logger_has_handler_after_create_app - AssertionError: assert [] != []
FAILED tests/test_logging_config.py::TestLoggingConfig - 3 failed, 0 passed

PASS tests/test_logging_config.py - 4 passed, 0 failed

Files:
 changelog.d/tsk-o35joz-logging-config.md |  3 ++
 tests/test_logging_config.py             | 48 ++++++++++++++++++++++++++++++++
 tinyagentos/app.py                       | 24 ++++++++++++++++
 3 files changed, 75 insertions(+)