### PR TITLE
[lib-audit] Hours-less WebVTT yields an empty transcript, as success

### DIFF
--- a/changelog.d/tsk-t4wzqs-webvtt-optional-hours.md
+++ b/changelog.d/tsk-t4wzqs-webvtt-optional-hours.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- WebVTT captions emitted with hours-less timestamps (`MM:SS.mmm`, the form YouTube caption tools and other editors produce for sub-hour media) now parse. The old parser required `HH:MM:SS.mmm` on every timestamp and silently indexed such files as "no captions".
+- HTML entities in cue text (e.g. `&#39;`, `&amp;`) are now unescaped before indexing, so apostrophes and ampersands survive into the transcript instead of their raw entity form.
+- A caption blob that is not a WebVTT file (no `WEBVTT` header) now makes the fetcher log a warning instead of returning an empty transcript reported as success; `parse_vtt` raises `ValueError` for non-empty non-WebVTT input.
+- `download_video()` now reads its output path from yt-dlp's `--print after_move:filepath` machine-readable route instead of scraping the human-readable `[download] Destination:` stdout line.

--- a/tests/knowledge_fetchers/test_youtube_vtt.py
+++ b/tests/knowledge_fetchers/test_youtube_vtt.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Tests for tinyagentos.knowledge_fetchers.youtube VTT parsing (tsk-t4wzqs).
+
+Covers the three acceptance criteria for the hours-less WebVTT fix:
+  * an MM:SS.mmm (hours-less) caption file parses,
+  * an unparseable caption file raises or logs rather than being reported as
+    an empty transcript,
+  * HTML entities are unescaped before indexing.
+"""
+
+import logging
+
+from tinyagentos.knowledge_fetchers.youtube import parse_vtt
+
+
+# WebVTT timestamps with the optional hours component omitted (MM:SS.mmm), the
+# form caption tools emit for sub-hour media. The WebVTT spec makes hours
+# optional (§4.1 / §4.2), but the old parser required HH:MM:SS and silently
+# treated these files as "no captions".
+VTT_HOURS_LESS = """\
+WEBVTT
+
+00:01.000 --> 00:02.000
+First cue
+
+00:02.000 --> 00:03.000
+Second cue
+
+00:03.000 --> 00:04.000
+Third cue
+"""
+
+
+VTT_ENTITIES = """\
+WEBVTT
+
+00:00:01.000 --> 00:00:02.000
+it&#39;s &amp; cool
+"""
+
+
+# A blob that is not a WebVTT file at all: no signature, no cues. The old parser
+# walked the whole document, matched nothing, and returned [] -- indistinguishable
+# from a video that genuinely has no captions.
+GARBAGE_VTT = """\
+this is not a WebVTT file
+no cues, no header, just text
+"""
+
+
+def test_parses_an_hours_less_webvtt_file():
+    cues = parse_vtt(VTT_HOURS_LESS)
+    assert len(cues) == 3
+    assert cues[0]["text"] == "First cue"
+    assert cues[0]["start"] == 1.0
+    assert cues[0]["end"] == 2.0
+    assert cues[2]["start"] == 3.0
+    assert cues[2]["text"] == "Third cue"
+
+
+def test_unparseable_vtt_does_not_silently_succeed(caplog):
+    """An unparseable caption file must raise or log, never return [] as success."""
+    with caplog.at_level(
+        logging.WARNING,
+        logger="tinyagentos.knowledge_fetchers.youtube",
+    ):
+        try:
+            result = parse_vtt(GARBAGE_VTT)
+        except ValueError:
+            return  # raised -- acceptable per DONE-WHEN ("raises or logs")
+    # If it returned instead of raising, a warning must have been logged; an
+    # empty transcript reported as success is exactly the silent failure we
+    # guard against.
+    logged = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert result or logged, (
+        f"expected a raised error or a logged warning, got {result!r}"
+    )
+
+
+def test_html_entities_are_unescaped_in_cue_text():
+    cues = parse_vtt(VTT_ENTITIES)
+    assert len(cues) == 1
+    assert cues[0]["text"] == "it's & cool"

--- a/tests/test_knowledge_fetcher_youtube.py
+++ b/tests/test_knowledge_fetcher_youtube.py
@@ -226,7 +226,8 @@ async def test_fetch_metadata_error_raises(tmp_path):
 
 @pytest.mark.asyncio
 async def test_download_video_mocked_720(tmp_path):
-    stdout_text = b"[download] Destination: /some/path/test123.mp4\n"
+    # --print after_move:filepath writes the final path, one line per download.
+    stdout_text = b"/some/path/test123.mp4\n"
     dl_proc = _make_mock_proc(stdout=stdout_text)
 
     with patch("shutil.which", return_value="/usr/bin/yt-dlp"):
@@ -242,12 +243,15 @@ async def test_download_video_mocked_720(tmp_path):
     assert "-f" in args
     fmt_idx = list(args).index("-f")
     assert "height<=720" in args[fmt_idx + 1]
+    # Uses the machine-readable --print route, not stdout scraping
+    assert "--print" in args
+    assert "after_move:filepath" in args
     assert result == "/some/path/test123.mp4"
 
 
 @pytest.mark.asyncio
 async def test_download_video_mocked_best(tmp_path):
-    stdout_text = b"[download] Destination: /some/path/test123.webm\n"
+    stdout_text = b"/some/path/test123.webm\n"
     dl_proc = _make_mock_proc(stdout=stdout_text)
 
     with patch("shutil.which", return_value="/usr/bin/yt-dlp"):
@@ -261,6 +265,8 @@ async def test_download_video_mocked_best(tmp_path):
     args = mock_exec.call_args[0]
     fmt_idx = list(args).index("-f")
     assert args[fmt_idx + 1] == "bestvideo+bestaudio/best"
+    assert "--print" in args
+    assert "after_move:filepath" in args
 
 
 @pytest.mark.asyncio
@@ -278,9 +284,9 @@ async def test_download_video_failure_returns_none(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_download_video_no_destination_line_returns_none(tmp_path):
-    """If yt-dlp succeeds but prints no 'Destination:' line, return None."""
-    proc = _make_mock_proc(stdout=b"some other output\n")
+async def test_download_video_no_filepath_printed_returns_none(tmp_path):
+    """If yt-dlp succeeds but --print yields no filepath, return None."""
+    proc = _make_mock_proc(stdout=b"")
 
     with patch("shutil.which", return_value="/usr/bin/yt-dlp"):
         with patch("asyncio.create_subprocess_exec", return_value=proc):

--- a/tinyagentos/knowledge_fetchers/youtube.py
+++ b/tinyagentos/knowledge_fetchers/youtube.py
@@ -7,6 +7,7 @@ and optionally download video files.
 """
 
 import asyncio
+import html
 import json
 import logging
 import re
@@ -40,13 +41,32 @@ def parse_vtt(vtt_text: str) -> list[dict]:
     Returns a list of dicts: [{"start": float, "end": float, "text": str}].
     Consecutive identical text entries are deduplicated (YouTube auto-captions
     repeat the same line across multiple cues).
+
+    Raises:
+        ValueError: if a non-empty input is not a WebVTT file (no signature),
+            so a caption blob is never silently indexed as "no captions".
     """
     segments: list[dict] = []
     lines = vtt_text.splitlines()
 
-    # Timestamp pattern: HH:MM:SS.mmm --> HH:MM:SS.mmm (with optional position tags)
+    # Per the WebVTT spec the *hours* component of a timestamp is optional, but
+    # the file as a whole must still begin with the "WEBVTT" signature (after an
+    # optional BOM). A non-empty blob that has no signature is not a caption file
+    # at all; surface that instead of silently indexing it as "no captions".
+    if vtt_text.lstrip("\ufeff").strip():
+        first_line = next(
+            (ln.lstrip("\ufeff") for ln in lines if ln.strip()), ""
+        ).strip()
+        # Spec: the signature is "WEBVTT" followed by end-of-line or whitespace
+        # before optional file metadata. Reject anything that is not it.
+        if not re.match(r"WEBVTT(\s|$)", first_line):
+            raise ValueError("not a valid WebVTT file: missing WEBVTT header")
+
+    # Timestamp pattern: HH:MM:SS.mmm or MM:SS.mmm (hours optional), with the
+    # optional cue settings trailing the end timestamp.
     ts_re = re.compile(
-        r"(\d{2}:\d{2}:\d{2}[.,]\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}[.,]\d{3})"
+        r"((?:\d{2}:)?\d{2}:\d{2}[.,]\d{3})\s*-->\s*"
+        r"((?:\d{2}:)?\d{2}:\d{2}[.,]\d{3})"
     )
 
     i = 0
@@ -63,6 +83,9 @@ def parse_vtt(vtt_text: str) -> list[dict]:
                 raw = lines[i].strip()
                 # Strip VTT inline tags like <00:00:01.000><c>word</c>
                 raw = re.sub(r"<[^>]+>", "", raw).strip()
+                # Escaped apostrophes/ampersands survive the tag strip; unescape
+                # before indexing so "it&#39;s" becomes "it's".
+                raw = html.unescape(raw)
                 if raw:
                     text_lines.append(raw)
                 i += 1
@@ -85,12 +108,17 @@ def parse_vtt(vtt_text: str) -> list[dict]:
 
 
 def _vtt_ts_to_seconds(ts: str) -> float:
-    """Convert a VTT timestamp (HH:MM:SS.mmm or HH:MM:SS,mmm) to float seconds."""
+    """Convert a VTT timestamp (HH:MM:SS.mmm or MM:SS.mmm, . or ,) to float seconds."""
     ts = ts.replace(",", ".")
     parts = ts.split(":")
-    h = int(parts[0])
-    m = int(parts[1])
-    s = float(parts[2])
+    if len(parts) == 3:
+        h = int(parts[0])
+        m = int(parts[1])
+        s = float(parts[2])
+    else:  # Hours omitted: MM:SS.mmm (WebVTT makes hours optional)
+        h = 0
+        m = int(parts[0])
+        s = float(parts[1])
     return h * 3600 + m * 60 + s
 
 
@@ -268,6 +296,12 @@ async def download_video(
         proc = await asyncio.create_subprocess_exec(
             ytdlp,
             "-f", fmt,
+            # Machine-readable route: yt-dlp prints the final output path (one
+            # line per download) after the file has been moved into place, rather
+            # than emitting human-readable "[download] Destination:" lines.
+            # `after_move` is a late WHEN, so --print does not imply --simulate
+            # and the download still happens.
+            "--print", "after_move:filepath",
             "-o", output_template,
             url,
             stdout=asyncio.subprocess.PIPE,
@@ -281,12 +315,13 @@ async def download_video(
             logger.warning("yt-dlp download failed for %s: %s", url, err)
             return None
 
-        # Try to find the downloaded file by parsing yt-dlp output
-        output_text = stdout.decode(errors="replace")
-        # yt-dlp prints lines like: [download] Destination: path/to/file.ext
-        m = re.search(r"\[download\] Destination: (.+)", output_text)
-        if m:
-            return m.group(1).strip()
+        # The --print after_move:filepath route writes the final file path, one
+        # per downloaded video. Take the last non-empty line as the path.
+        output_lines = stdout.decode(errors="replace").splitlines()
+        for line in reversed(output_lines):
+            candidate = line.strip()
+            if candidate:
+                return candidate
 
         # Fallback: return None -- caller can scan output_dir for new files
         return None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Hours-less WebVTT yields an empty transcript, as success

Autonomous build of board card tsk-t4wzqs.

tsk-t4wzqs, lib-audit R18. The WebVTT parser required hours in every
timestamp, so caption files using MM:SS.mmm for sub-hour media silently
parsed as an empty transcript and were reported as success,
indistinguishable from a video with no captions.

- parse_vtt now accepts the optional hours component (HH:MM:SS.mmm or
  MM:SS.mmm, the latter spec-valid for sub-hour media) on both sides of
  the arrow.
- parse_vtt raises ValueError when a non-empty input lacks the WEBVTT
  signature, so a caption blob is never silently indexed as "no
  captions". fetch() already wraps parse_vtt in try/except and logs, so
  the failure is surfaced rather than swallowed.
- html.unescape() is applied to each cue line after the inline-tag strip,
  so escaped apostrophes and ampersands (it&#39;s, &amp;) are indexed
  in plain text.
- download_video() now reads its output path from yt-dlp's
  --print after_move:filepath machine-readable route instead of scraping
  the human-readable "[download] Destination:" stdout line.
- _vtt_ts_to_seconds handles the 2-part MM:SS.mmm form.
- The YouTube-specific consecutive-duplicate dedup pass is preserved.
- Added changelog.d/tsk-t4wzqs-webvtt-optional-hours.md.

Tests:
- New tests/knowledge_fetchers/test_youtube_vtt.py covers the three
  DONE-WHEN criteria: hours-less parse, unparseable raise/log, and
  entity unescape. Existing parse_vtt tests (basic, dedup, empty,
  inline tags) and fetch tests still pass.
- Updated tests/test_knowledge_fetcher_youtube.py download_video tests
  to the --print after_move:filepath contract and assert the route is
  used.

RED (tests/knowledge_fetchers/test_youtube_vtt.py, fix not yet applied):
```
FAILED tests/knowledge_fetchers/test_youtube_vtt.py::test_parses_an_hours_less_webvtt_file
FAILED tests/knowledge_fetchers/test_youtube_vtt.py::test_unparseable_vtt_does_not_silently_succeed
FAILED tests/knowledge_fetchers/test_youtube_vtt.py::test_html_entities_are_unescaped_in_cue_text
3 failed in 0.58s
```

GREEN (after fix):
```
tests/knowledge_fetchers/test_youtube_vtt.py::test_parses_an_hours_less_webvtt_file PASSED [ 33%]
tests/knowledge_fetchers/test_youtube_vtt.py::test_unparseable_vtt_does_not_silently_succeed PASSED [ 66%]
tests/knowledge_fetchers/test_youtube_vtt.py::test_html_entities_are_unescaped_in_cue_text PASSED [100%]

============================== 3 passed in 0.25s ==============================
```

Files:
 changelog.d/tsk-t4wzqs-webvtt-optional-hours.md |  6 ++
 tests/knowledge_fetchers/test_youtube_vtt.py    | 84 +++++++++++++++++++++++++
 tests/test_knowledge_fetcher_youtube.py         | 16 +++--
 tinyagentos/knowledge_fetchers/youtube.py       | 59 +++++++++++++----
 4 files changed, 148 insertions(+), 17 deletions(-)


Removes-Intentionally: tests/test_knowledge_fetcher_youtube.py:test_download_video_no_destination_line_returns_none
