### PR TITLE
[lib-audit] mDNS never publishes on a host with no default route

### DIFF
--- a/changelog.d/tsk-ghpkit-mdns-default-route-fallback.md
+++ b/changelog.d/tsk-ghpkit-mdns-default-route-fallback.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- mDNS publisher now advertises all non-loopback IPv4 addresses via ifaddr, fixing publish on hosts with no default route and on multi-homed hosts.

--- a/tests/services/test_mdns_publisher.py
+++ b/tests/services/test_mdns_publisher.py
@@ -1,0 +1,111 @@
+"""Tests for the ifaddr fallback in mdns_publisher."""
+from __future__ import annotations
+
+import socket
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.services import mdns_publisher as mp
+from tinyagentos.services.mdns_publisher import MdnsPublisher
+
+
+class _FakeIPEntry:
+    def __init__(self, ip: str) -> None:
+        self.ip = ip
+        self.network_prefix = 24
+
+
+class _FakeAdapter:
+    def __init__(self, ips: list[_FakeIPEntry]) -> None:
+        self.ips = ips
+        self.nice_name = "eth0"
+        self.index = 2
+
+
+def _make_fake_ifaddr(adapters: list[_FakeAdapter]) -> MagicMock:
+    fake_mod = MagicMock()
+    fake_mod.get_adapters = MagicMock(return_value=adapters)
+    return fake_mod
+
+
+class _FailingSocket:
+    def __init__(self, *a, **kw):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+    def connect(self, addr):
+        raise OSError(101, "Network is unreachable")
+
+    def getsockname(self):
+        return ("0.0.0.0", 0)
+
+
+class _SuccessfulSocket:
+    def __init__(self, *a, **kw):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+    def connect(self, addr):
+        pass
+
+    def getsockname(self):
+        return ("192.168.1.42", 0)
+
+
+@pytest.mark.asyncio
+async def test_publishes_when_default_route_is_absent(monkeypatch):
+    monkeypatch.setattr(mp.socket, "socket", _FailingSocket)
+
+    fake_ifaddr = _make_fake_ifaddr([_FakeAdapter([_FakeIPEntry("192.168.1.42")])])
+    monkeypatch.setitem(sys.modules, "ifaddr", fake_ifaddr)
+
+    zc_instance = MagicMock()
+    zc_instance.async_register_service = AsyncMock()
+    zc_instance.async_unregister_service = AsyncMock()
+    zc_instance.async_close = AsyncMock()
+    monkeypatch.setattr(mp, "AsyncZeroconf", MagicMock(return_value=zc_instance))
+
+    pub = MdnsPublisher(port=6969)
+    await pub.start()
+
+    addresses = []
+    if zc_instance.async_register_service.await_args is not None:
+        info = zc_instance.async_register_service.await_args.args[0]
+        addresses = [addr.hex() for addr in info.addresses]
+    assert addresses != []
+
+
+@pytest.mark.asyncio
+async def test_multi_homed_host_advertises_every_non_loopback_ipv4(monkeypatch):
+    monkeypatch.setattr(mp.socket, "socket", _SuccessfulSocket)
+
+    fake_ifaddr = _make_fake_ifaddr([
+        _FakeAdapter([_FakeIPEntry("192.168.1.42"), _FakeIPEntry("10.0.0.5")]),
+    ])
+    monkeypatch.setitem(sys.modules, "ifaddr", fake_ifaddr)
+
+    zc_instance = MagicMock()
+    zc_instance.async_register_service = AsyncMock()
+    zc_instance.async_unregister_service = AsyncMock()
+    zc_instance.async_close = AsyncMock()
+    monkeypatch.setattr(mp, "AsyncZeroconf", MagicMock(return_value=zc_instance))
+
+    pub = MdnsPublisher(port=6969)
+    await pub.start()
+
+    info = zc_instance.async_register_service.await_args.args[0]
+    assert len(info.addresses) == 2
+    assert socket.inet_aton("192.168.1.42") in info.addresses
+    assert socket.inet_aton("10.0.0.5") in info.addresses

--- a/tests/test_mdns_publisher.py
+++ b/tests/test_mdns_publisher.py
@@ -18,7 +18,7 @@ def fake_zc(monkeypatch):
     zc_instance.async_close = AsyncMock()
     factory = MagicMock(return_value=zc_instance)
     monkeypatch.setattr(mp, "AsyncZeroconf", factory)
-    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: ["192.168.1.42"])
     return zc_instance, factory
 
 
@@ -57,7 +57,7 @@ async def test_failed_register_closes_zeroconf_instance(monkeypatch):
     """If async_register_service raises after AsyncZeroconf() is built,
     the half-initialised instance must be closed — otherwise its sockets
     and multicast subscriptions leak. Caught by kilo-code-bot on #449."""
-    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: ["192.168.1.42"])
     zc_instance = MagicMock()
     zc_instance.async_register_service = AsyncMock(
         side_effect=RuntimeError("port in use")
@@ -74,7 +74,7 @@ async def test_failed_register_closes_zeroconf_instance(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_start_swallows_exceptions_and_stop_is_noop(monkeypatch):
-    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: "192.168.1.42")
+    monkeypatch.setattr(mp, "_detect_primary_ipv4", lambda: ["192.168.1.42"])
 
     def _boom(*_a, **_kw):
         raise RuntimeError("multicast disabled")

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -705,7 +705,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         try:
             from tinyagentos.services.mdns_publisher import _detect_primary_ipv4
             from tinyagentos.browser_sessions import wire_browser_runtime
-            _host_ip = _detect_primary_ipv4() or "127.0.0.1"
+            _host_ips = _detect_primary_ipv4()
+            _host_ip = _host_ips[0] if _host_ips else "127.0.0.1"
             await wire_browser_runtime(
                 app.state, hardware_profile, agent_browsers, browser_sessions,
                 host_ip=_host_ip,

--- a/tinyagentos/services/mdns_publisher.py
+++ b/tinyagentos/services/mdns_publisher.py
@@ -49,8 +49,10 @@ def _detect_primary_ipv4() -> list[str]:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.connect(("8.8.8.8", 80))
             primary = sock.getsockname()[0]
-    except OSError:
-        pass
+    except OSError as exc:
+        # No default route (offline LAN, gateway-less switch): the ifaddr
+        # enumeration below still finds the interfaces.
+        logger.debug("mDNS: default-route probe failed, using ifaddr: %s", exc)
 
     try:
         import ifaddr
@@ -118,6 +120,11 @@ class MdnsPublisher:
             try:
                 await zc.async_register_service(info, allow_name_change=True)
             except Exception:
+                # async_register_service can raise after the AsyncZeroconf
+                # is constructed (port conflict, multicast disabled mid-init,
+                # etc.). Close the half-built instance so its sockets and
+                # multicast subscriptions don't leak; re-raise into the
+                # outer except for logging.
                 try:
                     await zc.async_close()
                 except Exception:

--- a/tinyagentos/services/mdns_publisher.py
+++ b/tinyagentos/services/mdns_publisher.py
@@ -20,6 +20,7 @@ If two taOS instances run on the same LAN both claiming ``taos.local``,
 zeroconf resolves the collision by suffixing the second one
 (``taos-2.local`` etc.). No special-case code needed here — the library
 handles it via ``allow_name_change``.
+
 """
 from __future__ import annotations
 
@@ -34,20 +35,49 @@ logger = logging.getLogger(__name__)
 _SERVICE_TYPE = "_http._tcp.local."
 
 
-def _detect_primary_ipv4() -> str | None:
-    """Pick the LAN IPv4 the kernel would use for default-route traffic.
+def _detect_primary_ipv4() -> list[str]:
+    """Return all non-loopback, non-link-local IPv4 addresses.
 
-    Opens a UDP socket "to" 8.8.8.8 and reads ``getsockname()`` — no
-    packets are actually sent, so this works fine on air-gapped
-    networks (the kernel still resolves the source interface).
+    Tries the kernel's default-route probe first (a UDP connect to 8.8.8.8
+    with no packets sent) and includes the result first when it matches an
+    ifaddr address.  Falls back to ``ifaddr.get_adapters()`` which
+    enumerates every interface without requiring network I/O, so the
+    service still publishes on hosts with no default route.
     """
+    primary: str | None = None
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.connect(("8.8.8.8", 80))
-            return sock.getsockname()[0]
-    except OSError as exc:
-        logger.warning("mDNS: could not detect primary LAN IPv4: %s", exc)
-        return None
+            primary = sock.getsockname()[0]
+    except OSError:
+        pass
+
+    try:
+        import ifaddr
+    except ImportError:
+        return [primary] if primary else []
+
+    addrs: list[str] = []
+    for adapter in ifaddr.get_adapters():
+        for ip_entry in adapter.ips:
+            ip = ip_entry.ip
+            if not isinstance(ip, str):
+                continue
+            parts = ip.split(".")
+            if len(parts) != 4:
+                continue
+            if parts[0] == "127":
+                continue
+            if parts[0] == "169" and parts[1] == "254":
+                continue
+            addrs.append(ip)
+
+    if primary and primary in addrs:
+        addrs.remove(primary)
+        addrs.insert(0, primary)
+    elif primary:
+        addrs.insert(0, primary)
+    return addrs
 
 
 class MdnsPublisher:
@@ -70,8 +100,8 @@ class MdnsPublisher:
     async def start(self) -> None:
         """Register the service. Never raises into the caller."""
         try:
-            ip = _detect_primary_ipv4()
-            if ip is None:
+            addresses = _detect_primary_ipv4()
+            if not addresses:
                 logger.warning(
                     "mDNS: skipping publish — no LAN IPv4 detected"
                 )
@@ -79,7 +109,7 @@ class MdnsPublisher:
             info = ServiceInfo(
                 _SERVICE_TYPE,
                 f"{self._service_name}.{_SERVICE_TYPE}",
-                addresses=[socket.inet_aton(ip)],
+                addresses=[socket.inet_aton(ip) for ip in addresses],
                 port=self._port,
                 properties={"path": "/"},
                 server=self._hostname,
@@ -88,11 +118,6 @@ class MdnsPublisher:
             try:
                 await zc.async_register_service(info, allow_name_change=True)
             except Exception:
-                # async_register_service can raise after the AsyncZeroconf
-                # is constructed (port conflict, multicast disabled mid-init,
-                # etc.). Close the half-built instance so its sockets and
-                # multicast subscriptions don't leak; re-raise into the
-                # outer except for logging.
                 try:
                     await zc.async_close()
                 except Exception:
@@ -104,11 +129,11 @@ class MdnsPublisher:
             self._info = info
             self._active = True
             logger.info(
-                "mDNS: published %s at http://%s:%d/ (ip=%s)",
+                "mDNS: published %s at http://%s:%d/ (ips=%s)",
                 self._service_name,
                 self._hostname.rstrip("."),
                 self._port,
-                ip,
+                ", ".join(addresses),
             )
         except Exception:
             logger.exception("mDNS: publish failed — continuing without")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] mDNS never publishes on a host with no default route

Autonomous build of board card tsk-ghpkit.

_detect_primary_ipv4 now returns all non-loopback, non-link-local IPv4
addresses. The existing UDP probe to 8.8.8.8 is tried first and its
result is prepended when it matches an ifaddr address, preserving the
primary-route ordering on normal networks. When the probe fails, e.g. on
a host with no default route, ifaddr.get_adapters() enumerates every
interface with no network I/O and supplies the complete address list.

MdnsPublisher.start() passes the full list to ServiceInfo so a
multi-homed host advertises every address. app.py updated to handle the
list return type.

Tests updated to match the new list-returning API. Two new tests in
tests/services/test_mdns_publisher.py cover the offline and multi-homed
cases.

RED:

FAILED tests/services/test_mdns_publisher.py::test_publishes_when_default_route_is_absent - AssertionError
FAILED tests/services/test_mdns_publisher.py::test_multi_homed_host_advertises_every_non_loopback_ipv4 - AssertionError
2 failed, 0 passed

GREEN:

6 passed in 0.38s

Docs-Reviewed: changelog fragment added for user-visible behaviour change

Files:
 .../tsk-ghpkit-mdns-default-route-fallback.md      |   3 +
 tests/services/__init__.py                         |   0
 tests/services/test_mdns_publisher.py              | 111 +++++++++++++++++++++
 tests/test_mdns_publisher.py                       |   6 +-
 tinyagentos/app.py                                 |   3 +-
 tinyagentos/services/mdns_publisher.py             |  63 ++++++++----
 6 files changed, 163 insertions(+), 23 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mDNS service discovery on hosts without a default network route by using available local IPv4 addresses as a fallback.
  - mDNS now advertises all available non-loopback, non-link-local IPv4 addresses on multi-homed hosts, improving connectivity across network interfaces.
  - Browser runtime host detection now reliably selects the first available local IPv4 address, with a loopback fallback when none are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

RED (origin/dev, before fix; re-measured by the lead in a scratch worktree 2026-09-09 00:2xZ):
```
FAILED tests/services/test_mdns_publisher.py::test_publishes_when_default_route_is_absent
FAILED tests/services/test_mdns_publisher.py::test_multi_homed_host_advertises_every_non_loopback_ipv4
2 failed in 0.38s
```

GREEN (HEAD b4c391458):
```
6 passed in 0.75s
```
