### PR TITLE
fix-forward #2922 (tsk-o35joz): dictConfig in create_app() replaces root handlers (breaks caplog + host logging); move to an idempotent configure_logging() called from __main__

### DIFF
--- a/changelog.d/tsk-o35joz-logging-config.md
+++ b/changelog.d/tsk-o35joz-logging-config.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Added `logging.config.dictConfig()` in `create_app()` to configure the root logger with a StreamHandler and formatter carrying `%(asctime)s %(levelname)s %(name)s: %(message)s`. Added `TAOS_LOG_LEVEL` environment variable defaulting to INFO, which controls the root logger level.
+- Moved logging configuration out of `create_app()` into an idempotent `configure_logging()` in `tinyagentos/logging_config.py`, called once from the server entrypoint. `create_app()` no longer replaces the root logger's handlers, so pytest's `caplog` and host-installed handlers are preserved across factory calls.

--- a/changelog.d/tsk-o35joz-logging-config.md
+++ b/changelog.d/tsk-o35joz-logging-config.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Added `logging.config.dictConfig()` in `create_app()` to configure the root logger with a StreamHandler and formatter carrying `%(asctime)s %(levelname)s %(name)s: %(message)s`. Added `TAOS_LOG_LEVEL` environment variable defaulting to INFO, which controls the root logger level.

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,48 @@
+import logging
+import os
+
+import pytest
+
+from tinyagentos.app import create_app
+
+
+class TestLoggingConfig:
+    def test_root_logger_has_handler_after_create_app(self, tmp_path):
+        app = create_app(data_dir=tmp_path / "data")
+        handlers = logging.getLogger().handlers
+        assert handlers != [], "root logger should have at least one handler after create_app()"
+
+    def test_logging_config_has_formatter_with_asctime_levelname_name(self, tmp_path):
+        app = create_app(data_dir=tmp_path / "data")
+        root = logging.getLogger()
+        assert len(root.handlers) > 0, "root logger should have at least one handler"
+        handler = root.handlers[0]
+        assert handler.formatter is not None, "handler should have a formatter"
+        formatter = handler.formatter
+        assert "%(asctime)s" in formatter._fmt, "formatter should include %(asctime)s"
+        assert "%(levelname)s" in formatter._fmt, "formatter should include %(levelname)s"
+        assert "%(name)s" in formatter._fmt, "formatter should include %(name)s"
+
+    def test_taos_log_level_env_var(self, tmp_path):
+        # Test with TAOS_LOG_LEVEL=DEBUG
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setenv("TAOS_LOG_LEVEL", "DEBUG")
+            # Need to re-create app after env change, but create_app reads env at call time
+            # So we just verify the dictConfig reads the env var
+            app = create_app(data_dir=tmp_path / "data")
+            root = logging.getLogger()
+            # Level should be DEBUG (10) when TAOS_LOG_LEVEL=DEBUG
+            assert root.level == logging.DEBUG, (
+                f"root logger level should be DEBUG (10), got {root.level}"
+            )
+
+    def test_taos_log_level_defaults_to_info(self, tmp_path):
+        # Test default TAOS_LOG_LEVEL=INFO
+        # reset env
+        if "TAOS_LOG_LEVEL" in os.environ:
+            del os.environ["TAOS_LOG_LEVEL"]
+        app = create_app(data_dir=tmp_path / "data")
+        root = logging.getLogger()
+        assert root.level == logging.INFO, (
+            f"root logger level should be INFO (20) by default, got {root.level}"
+        )

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,48 +1,76 @@
 import logging
-import os
 
 import pytest
 
-from tinyagentos.app import create_app
+from tinyagentos.logging_config import configure_logging
 
 
-class TestLoggingConfig:
-    def test_root_logger_has_handler_after_create_app(self, tmp_path):
-        app = create_app(data_dir=tmp_path / "data")
-        handlers = logging.getLogger().handlers
-        assert handlers != [], "root logger should have at least one handler after create_app()"
+@pytest.fixture(autouse=True)
+def _isolate_root_logger():
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        root.handlers = saved_handlers
+        root.level = saved_level
 
-    def test_logging_config_has_formatter_with_asctime_levelname_name(self, tmp_path):
-        app = create_app(data_dir=tmp_path / "data")
+
+class TestConfigureLogging:
+    def test_installs_single_handler_with_expected_formatter_when_empty(self):
         root = logging.getLogger()
-        assert len(root.handlers) > 0, "root logger should have at least one handler"
+        root.handlers = []
+        root.level = logging.WARNING
+
+        configure_logging()
+
+        assert len(root.handlers) == 1
         handler = root.handlers[0]
-        assert handler.formatter is not None, "handler should have a formatter"
-        formatter = handler.formatter
-        assert "%(asctime)s" in formatter._fmt, "formatter should include %(asctime)s"
-        assert "%(levelname)s" in formatter._fmt, "formatter should include %(levelname)s"
-        assert "%(name)s" in formatter._fmt, "formatter should include %(name)s"
+        assert isinstance(handler, logging.StreamHandler)
+        assert handler.formatter is not None
+        fmt = handler.formatter._fmt
+        assert "%(asctime)s" in fmt
+        assert "%(levelname)s" in fmt
+        assert "%(name)s" in fmt
 
-    def test_taos_log_level_env_var(self, tmp_path):
-        # Test with TAOS_LOG_LEVEL=DEBUG
-        with pytest.MonkeyPatch().context() as mp:
-            mp.setenv("TAOS_LOG_LEVEL", "DEBUG")
-            # Need to re-create app after env change, but create_app reads env at call time
-            # So we just verify the dictConfig reads the env var
-            app = create_app(data_dir=tmp_path / "data")
-            root = logging.getLogger()
-            # Level should be DEBUG (10) when TAOS_LOG_LEVEL=DEBUG
-            assert root.level == logging.DEBUG, (
-                f"root logger level should be DEBUG (10), got {root.level}"
-            )
-
-    def test_taos_log_level_defaults_to_info(self, tmp_path):
-        # Test default TAOS_LOG_LEVEL=INFO
-        # reset env
-        if "TAOS_LOG_LEVEL" in os.environ:
-            del os.environ["TAOS_LOG_LEVEL"]
-        app = create_app(data_dir=tmp_path / "data")
+    def test_idempotent_does_not_add_second_handler(self):
         root = logging.getLogger()
-        assert root.level == logging.INFO, (
-            f"root logger level should be INFO (20) by default, got {root.level}"
-        )
+        root.handlers = []
+        root.level = logging.WARNING
+
+        configure_logging()
+        configure_logging()
+
+        assert len(root.handlers) == 1
+
+    def test_preserves_pre_existing_handler(self):
+        root = logging.getLogger()
+        root.handlers = []
+        root.level = logging.WARNING
+        null_handler = logging.NullHandler()
+        root.addHandler(null_handler)
+
+        configure_logging()
+
+        assert null_handler in root.handlers
+
+    def test_debug_env_sets_root_level_debug(self, monkeypatch):
+        monkeypatch.setenv("TAOS_LOG_LEVEL", "DEBUG")
+        root = logging.getLogger()
+        root.handlers = []
+        root.level = logging.WARNING
+
+        configure_logging()
+
+        assert root.level == logging.DEBUG
+
+    def test_unset_env_defaults_root_level_info(self, monkeypatch):
+        monkeypatch.delenv("TAOS_LOG_LEVEL", raising=False)
+        root = logging.getLogger()
+        root.handlers = []
+        root.level = logging.WARNING
+
+        configure_logging()
+
+        assert root.level == logging.INFO

--- a/tinyagentos/__main__.py
+++ b/tinyagentos/__main__.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 
 from tinyagentos.app import PROJECT_DIR, create_app, load_config
+from tinyagentos.logging_config import configure_logging
 
 # Bound uvicorn's graceful-shutdown wait for open connections on SIGTERM.
 # Long-lived SSE streams + cluster heartbeats would otherwise keep uvicorn
@@ -64,9 +65,11 @@ def main() -> None:
             app.state.browser_proxy_port = 0
         import uvicorn
 
-        # backlog=128 — see issue #323. Keeps the kernel accept queue from
+        configure_logging()
+
+        # backlog=128 -- see issue #323. Keeps the kernel accept queue from
         # silently growing into the thousands if the event loop ever wedges.
-        # timeout_graceful_shutdown — without it uvicorn waits indefinitely for
+        # timeout_graceful_shutdown -- without it uvicorn waits indefinitely for
         # long-lived connections (SSE streams, cluster heartbeats) to close on
         # SIGTERM, so a restart hung the full 45s systemd stop timeout. Bound it
         # so the lifespan shutdown actually runs and the process exits fast.

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -131,7 +131,7 @@ def _resolve_browser_cookie_key(data_dir: "Path") -> str:
     """Resolve the SQLCipher key for the browser cookie store.
 
     Precedence:
-      1. TAOS_BROWSER_COOKIE_KEY_HEX env var (must be 64 hex chars) — for
+       1. TAOS_BROWSER_COOKIE_KEY_HEX env var (must be 64 hex chars) -- for
          recovery / pinned-key deployments.
       2. data_dir / "browser_cookie_key.hex" — read existing per-install
          random key, or create a new one with secrets.token_hex(32) if
@@ -167,30 +167,6 @@ def _resolve_browser_cookie_key(data_dir: "Path") -> str:
 
 
 def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) -> FastAPI:
-    import logging
-    import logging.config
-
-    log_level = os.environ.get("TAOS_LOG_LEVEL", "INFO").upper()
-    logging.config.dictConfig({
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "default": {
-                "format": "%(asctime)s %(levelname)s %(name)s: %(message)s",
-            },
-        },
-        "handlers": {
-            "default": {
-                "class": "logging.StreamHandler",
-                "formatter": "default",
-            },
-        },
-        "root": {
-            "handlers": ["default"],
-            "level": log_level,
-        },
-    })
-
     from tinyagentos.registry import AppRegistry
     from tinyagentos.hardware import get_hardware_profile
 

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -167,6 +167,30 @@ def _resolve_browser_cookie_key(data_dir: "Path") -> str:
 
 
 def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) -> FastAPI:
+    import logging
+    import logging.config
+
+    log_level = os.environ.get("TAOS_LOG_LEVEL", "INFO").upper()
+    logging.config.dictConfig({
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s %(levelname)s %(name)s: %(message)s",
+            },
+        },
+        "handlers": {
+            "default": {
+                "class": "logging.StreamHandler",
+                "formatter": "default",
+            },
+        },
+        "root": {
+            "handlers": ["default"],
+            "level": log_level,
+        },
+    })
+
     from tinyagentos.registry import AppRegistry
     from tinyagentos.hardware import get_hardware_profile
 

--- a/tinyagentos/logging_config.py
+++ b/tinyagentos/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+
+def configure_logging() -> None:
+    root = logging.getLogger()
+    log_level = os.environ.get("TAOS_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, log_level, logging.INFO)
+    if not root.handlers:
+        logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    else:
+        root.setLevel(level)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2922 (tsk-o35joz): dictConfig in create_app() replaces root handlers (breaks caplog + host logging); move to an idempotent configure_logging() called from __main__

Autonomous build of board card tsk-4lc4t6.

REVISION: built on `exec/tsk-o35joz` (cut at `35ed257e2a8a121ca91b4d0d0ed589c3cfe8c9be`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Root cause: logging.config.dictConfig({... "root": {"handlers": ["default"]}})
in create_app() replaced the root logger's handler list on every call.
That discarded pytest's caplog handler (breaking test_app_starts_with_no_runtime_logs_warning)
and, in production, discarded whatever handler the host process installed.
A factory that tests call dozens of times must not reconfigure process-wide logging.

Fix:
- Added tinyagentos/logging_config.py with configure_logging() that uses
  logging.basicConfig() only when root.handlers is empty, otherwise only
  sets the root level. This is idempotent and never calls dictConfig with
  a root handler list from library code.
- Removed the dictConfig block from create_app() entirely.
- Call configure_logging() once from tinyagentos/__main__.py:main() before
  uvicorn.run() so the server entrypoint configures logging exactly once.
- Rewrote tests/test_logging_config.py to test configure_logging() directly:
  (a) installs exactly one handler with the expected formatter when root is empty,
  (b) called twice does not add a second handler,
  (c) pre-existing handlers (e.g. NullHandler) are preserved,
  (d) TAOS_LOG_LEVEL=DEBUG sets root level DEBUG, unset defaults to INFO.
- Updated changelog.d/tsk-o35joz-logging-config.md to reflect the new location.

```text
FAILED tests/test_container_detection.py::TestAppStartupNoRuntime::test_app_starts_with_no_runtime_logs_warning
1 failed, 17 passed in 11.16s
```

On the base commit, the new tests/test_logging_config.py would fail with
ImportError because tinyagentos.logging_config does not exist there.

```text
19 passed in 2.92s
```

Files:
 changelog.d/tsk-o35joz-logging-config.md |  3 ++
 tests/test_logging_config.py             | 76 ++++++++++++++++++++++++++++++++
 tinyagentos/__main__.py                  |  7 ++-
 tinyagentos/app.py                       |  2 +-
 tinyagentos/logging_config.py            | 12 +++++
 5 files changed, 97 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging configuration to preserve existing handlers across application factory calls.
  * Logging setup is now applied consistently when starting the server.
  * The `TAOS_LOG_LEVEL` environment setting is respected, with a fallback to `INFO`.

* **Tests**
  * Added coverage for logging levels, handler preservation, formatting, isolation, and repeated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->