### PR TITLE
[lib-audit] Agent desktop-control SSE never reconnects after a 401

### DIFF
--- a/changelog.d/tsk-na2i3i-sse-reconnect.md
+++ b/changelog.d/tsk-na2i3i-sse-reconnect.md
@@ -1,0 +1,2 @@
+### Fixed
+- **desktop-command SSE stream never reconnects after a 401 or controller restart**: promoted the reconnect + backoff + dedupe logic from `use-os-events.ts` into a shared `lib/sse.ts` and pointed all eight SSE consumers (`use-desktop-command-stream`, `use-event-stream`, `use-os-events`, canvas SSE, project events, FilesApp watch, MCP logs, and SettingsApp logs) at it. Added RED tests proving the desktop-command stream reconnects after a hard close and that backoff is no longer duplicated across hooks.

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -38,6 +38,7 @@ import { projectsApi, type DocReviewState } from "@/lib/projects";
 import { useDragSource } from "@/shell/dnd/use-drag-source";
 import { DocViewer } from "@/apps/ProjectsApp/files/DocViewer";
 import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
+import { createSseConnection } from "@/lib/sse";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -695,29 +696,19 @@ export function FilesApp({
   useEffect(() => {
     const url = workspaceWatchUrl(location, currentPath);
     if (!url) return;
-    let eventSource: EventSource | null = null;
-    try {
-      eventSource = new EventSource(url);
-    } catch {
-      return;
-    }
-    const es = eventSource;
-    es.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        if (Array.isArray(data)) {
-          setFiles(data);
+    return createSseConnection({
+      url,
+      onMessage: (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (Array.isArray(data)) {
+            setFiles(data);
+          }
+        } catch {
+          // Ignore malformed events
         }
-      } catch {
-        // Ignore malformed events
-      }
-    };
-    es.onerror = () => {
-      // Silently let the browser retry
-    };
-    return () => {
-      es.close();
-    };
+      },
+    });
   }, [currentPath, location]);
 
   useEffect(() => {

--- a/desktop/src/apps/MCPApp.tsx
+++ b/desktop/src/apps/MCPApp.tsx
@@ -26,6 +26,7 @@ import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useProcessStore } from "@/stores/process-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { getApp } from "@/registry/app-registry";
+import { createSseConnection } from "@/lib/sse";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -1128,21 +1129,21 @@ function LogsTab({ serverId }: { serverId: string }) {
   const [copied, setCopied] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const pausedRef = useRef(false);
-  const esRef = useRef<EventSource | null>(null);
 
   pausedRef.current = paused;
 
   useEffect(() => {
-    const es = new EventSource(`/api/mcp/servers/${encodeURIComponent(serverId)}/logs/stream`);
-    esRef.current = es;
-    es.onopen = () => setConnected(true);
-    es.onerror = () => setConnected(false);
-    es.onmessage = (e) => {
-      if (!pausedRef.current) {
-        setLines((prev) => [...prev.slice(-500), e.data]);
-      }
-    };
-    return () => { es.close(); esRef.current = null; };
+    const cleanup = createSseConnection({
+      url: `/api/mcp/servers/${encodeURIComponent(serverId)}/logs/stream`,
+      onOpen: () => setConnected(true),
+      onError: () => setConnected(false),
+      onMessage: (e) => {
+        if (!pausedRef.current) {
+          setLines((prev) => [...prev.slice(-500), e.data]);
+        }
+      },
+    });
+    return cleanup;
   }, [serverId]);
 
   useEffect(() => {

--- a/desktop/src/apps/ProjectsApp/canvas/canvas-sse.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/canvas-sse.ts
@@ -1,6 +1,7 @@
 import type { CanvasState } from "./canvas-store";
 import type { StoreApi } from "zustand";
 import type { CanvasElement } from "./canvas-api";
+import { createSseConnection } from "@/lib/sse";
 
 export interface CanvasEvent {
   type:
@@ -18,29 +19,26 @@ export function subscribeCanvasStream(
   store: StoreApi<CanvasState>,
   onPermissionChanged?: (agentId: string, canEdit: boolean) => void,
 ): () => void {
-  const es = new EventSource(`/api/projects/${projectId}/canvas/stream`);
-  es.onmessage = (msg) => {
-    let evt: CanvasEvent;
-    try {
-      evt = JSON.parse(msg.data) as CanvasEvent;
-    } catch {
-      return;
-    }
-    if (evt.type === "canvas.element_added" || evt.type === "canvas.element_updated") {
-      const el = evt.payload.element as CanvasElement | undefined;
-      if (el) store.getState().upsert(el);
-    } else if (evt.type === "canvas.element_deleted") {
-      const id = evt.payload.element_id as string | undefined;
-      if (id) store.getState().remove(id);
-    } else if (evt.type === "canvas.permission_changed") {
-      const agentId = evt.payload.agent_id as string | undefined;
-      const canEdit = !!evt.payload.can_edit_canvas;
-      if (agentId && onPermissionChanged) onPermissionChanged(agentId, canEdit);
-    }
-  };
-  es.onerror = () => {
-    // Browser auto-reconnects on transient errors; close on hard failure
-    // and let the caller open a fresh subscription on remount.
-  };
-  return () => es.close();
+  return createSseConnection({
+    url: `/api/projects/${projectId}/canvas/stream`,
+    onMessage: (msg) => {
+      let evt: CanvasEvent;
+      try {
+        evt = JSON.parse(msg.data) as CanvasEvent;
+      } catch {
+        return;
+      }
+      if (evt.type === "canvas.element_added" || evt.type === "canvas.element_updated") {
+        const el = evt.payload.element as CanvasElement | undefined;
+        if (el) store.getState().upsert(el);
+      } else if (evt.type === "canvas.element_deleted") {
+        const id = evt.payload.element_id as string | undefined;
+        if (id) store.getState().remove(id);
+      } else if (evt.type === "canvas.permission_changed") {
+        const agentId = evt.payload.agent_id as string | undefined;
+        const canEdit = !!evt.payload.can_edit_canvas;
+        if (agentId && onPermissionChanged) onPermissionChanged(agentId, canEdit);
+      }
+    },
+  });
 }

--- a/desktop/src/apps/SettingsApp/LogsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { ScrollText, RefreshCw, Radio } from "lucide-react";
 import { Button, Card, Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui";
 import { safeFetch } from "@/apps/SettingsApp/_shared";
+import { createSseConnection } from "@/lib/sse";
 
 interface ClientLog {
   id: string;
@@ -139,7 +140,7 @@ function SystemLogsTab({ source }: { source: SystemLogSource }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tailing, setTailing] = useState(false);
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<(() => void) | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -161,36 +162,33 @@ function SystemLogsTab({ source }: { source: SystemLogSource }) {
   useEffect(() => { load(); }, [load]);
 
   useEffect(() => {
-    return () => eventSourceRef.current?.close();
+    return () => eventSourceRef.current?.();
   }, []);
 
   const toggleTail = useCallback(() => {
     if (tailing) {
-      eventSourceRef.current?.close();
+      eventSourceRef.current?.();
       eventSourceRef.current = null;
       setTailing(false);
       return;
     }
-    const es = new EventSource(`/api/system-logs/${source.id}/stream`);
-    es.onmessage = (msg) => {
-      let payload: { line?: string; error?: string } | null;
-      try {
-        payload = JSON.parse(msg.data);
-      } catch {
-        return;
-      }
-      if (!payload) return;
-      if (payload.line) {
-        setLiveLines((prev) => [payload.line as string, ...prev].slice(0, MAX_LIVE_LINES));
-      } else if (payload.error) {
-        setError(payload.error);
-      }
-    };
-    es.onerror = () => {
-      // Transient network errors: leave the connection to the browser's
-      // built-in reconnect. Closing here would fight it.
-    };
-    eventSourceRef.current = es;
+    eventSourceRef.current = createSseConnection({
+      url: `/api/system-logs/${source.id}/stream`,
+      onMessage: (msg) => {
+        let payload: { line?: string; error?: string } | null;
+        try {
+          payload = JSON.parse(msg.data);
+        } catch {
+          return;
+        }
+        if (!payload) return;
+        if (payload.line) {
+          setLiveLines((prev) => [payload.line as string, ...prev].slice(0, MAX_LIVE_LINES));
+        } else if (payload.error) {
+          setError(payload.error);
+        }
+      },
+    });
     setTailing(true);
   }, [tailing, source.id]);
 

--- a/desktop/src/hooks/__tests__/use-desktop-command-stream.test.ts
+++ b/desktop/src/hooks/__tests__/use-desktop-command-stream.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDesktopCommandStream } from "../use-desktop-command-stream";
+
+function makeEventSourceMock() {
+  const instances: EventSourceLike[] = [];
+  let capturedOnError: ((ev: Event) => void) | undefined;
+  let capturedOnMessage: ((ev: MessageEvent) => void) | undefined;
+
+  const mock = vi.fn(function (this: unknown, _url: string) {
+    const es: EventSourceLike = {
+      readyState: EventSource.OPEN,
+      CONNECTING: EventSource.CONNECTING,
+      OPEN: EventSource.OPEN,
+      CLOSED: EventSource.CLOSED,
+      close: vi.fn(),
+      set onerror(handler: (this: EventSource, ev: Event) => void) {
+        capturedOnError = handler as unknown as (ev: Event) => void;
+      },
+      get onerror() {
+        return undefined;
+      },
+      set onmessage(handler: (this: EventSource, ev: MessageEvent) => void) {
+        capturedOnMessage = handler as unknown as (ev: MessageEvent) => void;
+      },
+      get onmessage() {
+        return undefined;
+      },
+      set onopen(_handler: (this: EventSource, ev: Event) => void) {},
+      get onopen() {
+        return undefined;
+      },
+    };
+    instances.push(es);
+    return es;
+  });
+
+  return { mock, instances, get capturedOnError() { return capturedOnError; }, get capturedOnMessage() { return capturedOnMessage; } };
+}
+
+type EventSourceLike = {
+  readyState: number;
+  CONNECTING: number;
+  OPEN: number;
+  CLOSED: number;
+  close: ReturnType<typeof vi.fn>;
+};
+
+describe("useDesktopCommandStream (RED-first)", () => {
+  let eventSourceMock: ReturnType<typeof vi.fn>;
+  let instances: EventSourceLike[];
+  let setup: ReturnType<typeof makeEventSourceMock>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setup = makeEventSourceMock();
+    eventSourceMock = setup.mock;
+    instances = setup.instances;
+    vi.stubGlobal("EventSource", eventSourceMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reconnects after the server closes with a 401", () => {
+    renderHook(() => useDesktopCommandStream());
+
+    expect(eventSourceMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      if (setup.capturedOnError) {
+        instances[0].readyState = EventSource.CLOSED;
+        setup.capturedOnError(new Event("error"));
+      }
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(eventSourceMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reconnects after a controller restart", () => {
+    const commands: string[] = [];
+    const dispatchSpy = vi.fn((event: Event) => {
+      if (event instanceof CustomEvent && event.type === "taos:open-app") {
+        commands.push((event as CustomEvent).detail?.app as string ?? "unknown");
+      }
+    });
+    Object.defineProperty(window, "dispatchEvent", {
+      configurable: true,
+      writable: true,
+      value: dispatchSpy,
+    });
+
+    renderHook(() => useDesktopCommandStream());
+
+    act(() => {
+      if (setup.capturedOnMessage) setup.capturedOnMessage(new MessageEvent("message", {
+        data: JSON.stringify({ kind: "open-app", payload: { app: "first" } }),
+      }));
+    });
+    expect(commands).toContain("first");
+    expect(eventSourceMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      if (setup.capturedOnError) {
+        instances[0].readyState = EventSource.CLOSED;
+        setup.capturedOnError(new Event("error"));
+      }
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(eventSourceMock).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      if (setup.capturedOnMessage) setup.capturedOnMessage(new MessageEvent("message", {
+        data: JSON.stringify({ kind: "open-app", payload: { app: "second" } }),
+      }));
+    });
+    expect(commands).toContain("second");
+  });
+
+  it("backoff is shared, not duplicated per hook", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+
+    const baseDir = path.resolve(import.meta.dirname, "..");
+
+    const desktopStreamSrc = fs.readFileSync(
+      path.join(baseDir, "use-desktop-command-stream.ts"),
+      "utf-8",
+    );
+    const eventStreamSrc = fs.readFileSync(
+      path.join(baseDir, "use-event-stream.ts"),
+      "utf-8",
+    );
+    const osEventsSrc = fs.readFileSync(
+      path.join(baseDir, "use-os-events.ts"),
+      "utf-8",
+    );
+
+    const localDefs = [
+      ...desktopStreamSrc.match(/const\s+RECONNECT_DELAY_MS\s*=/g) || [],
+      ...eventStreamSrc.match(/const\s+RECONNECT_DELAY_MS\s*=/g) || [],
+      ...osEventsSrc.match(/const\s+RECONNECT_DELAY_MS\s*=/g) || [],
+    ];
+
+    expect(localDefs.length).toBe(0);
+  });
+});

--- a/desktop/src/hooks/use-desktop-command-stream.ts
+++ b/desktop/src/hooks/use-desktop-command-stream.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { createSseConnection } from "@/lib/sse";
 
 /**
  * Subscribes to the controller's desktop-command SSE channel and re-dispatches
@@ -92,33 +93,28 @@ async function reportLayout(requestId: string): Promise<void> {
 
 export function useDesktopCommandStream(): void {
   useEffect(() => {
-    const es = new EventSource("/api/desktop/stream");
-    es.onmessage = (msg) => {
-      let cmd: { kind?: string; payload?: Record<string, unknown> } | null;
-      try {
-        cmd = JSON.parse(msg.data);
-      } catch {
-        return;
-      }
-      // JSON.parse can legally return null (or a non-object); guard before
-      // reading .kind so a stray payload can't throw and kill the listener.
-      if (!cmd || typeof cmd !== "object") return;
-      if (cmd.kind === "open-app") {
-        window.dispatchEvent(new CustomEvent("taos:open-app", { detail: cmd.payload ?? {} }));
-      } else if (cmd.kind === "window") {
-        window.dispatchEvent(new CustomEvent("taos:window", { detail: cmd.payload ?? {} }));
-      } else if (cmd.kind === "screenshot") {
-        const requestId = (cmd.payload?.request_id as string) ?? "";
-        if (requestId) void captureAndReport(requestId);
-      } else if (cmd.kind === "layout") {
-        const requestId = (cmd.payload?.request_id as string) ?? "";
-        if (requestId) void reportLayout(requestId);
-      }
-    };
-    es.onerror = () => {
-      // Transient errors: the browser reconnects automatically. On a hard close
-      // the effect's cleanup runs and a remount opens a fresh subscription.
-    };
-    return () => es.close();
+    return createSseConnection({
+      url: "/api/desktop/stream",
+      onMessage: (msg) => {
+        let cmd: { kind?: string; payload?: Record<string, unknown> } | null;
+        try {
+          cmd = JSON.parse(msg.data);
+        } catch {
+          return;
+        }
+        if (!cmd || typeof cmd !== "object") return;
+        if (cmd.kind === "open-app") {
+          window.dispatchEvent(new CustomEvent("taos:open-app", { detail: cmd.payload ?? {} }));
+        } else if (cmd.kind === "window") {
+          window.dispatchEvent(new CustomEvent("taos:window", { detail: cmd.payload ?? {} }));
+        } else if (cmd.kind === "screenshot") {
+          const requestId = (cmd.payload?.request_id as string) ?? "";
+          if (requestId) void captureAndReport(requestId);
+        } else if (cmd.kind === "layout") {
+          const requestId = (cmd.payload?.request_id as string) ?? "";
+          if (requestId) void reportLayout(requestId);
+        }
+      },
+    });
   }, []);
 }

--- a/desktop/src/hooks/use-event-stream.ts
+++ b/desktop/src/hooks/use-event-stream.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useDecisionEventsStore } from "@/stores/decision-events-store";
 import { mapRow, ServerNotificationRow } from "@/lib/server-notifications";
+import { createSseConnection, MAX_SEEN_IDS } from "@/lib/sse";
 
 type EventPayload = Record<string, unknown>;
 type EventHandler = (payload: EventPayload) => void;
@@ -33,28 +34,13 @@ const handlers: Record<string, EventHandler> = {
  * incoming event by its ``type`` field through the dispatch table.
  *
  * Mount once in the app shell (App.tsx) so there is exactly one connection
- * per session.  The browser only auto-reconnects EventSource on transient
- * network drops; an HTTP error response (e.g. a 401 after session expiry)
- * closes the connection for good, so that case is reconnected manually.
- * Unmount closes the connection cleanly and cancels any pending reconnect.
+ * per session.  On a hard close (e.g. HTTP error response) the shared
+ * `createSseConnection` reconnects manually with backoff. Unmount closes the
+ * connection cleanly and cancels any pending reconnect.
  */
-const RECONNECT_DELAY_MS = 5000;
-
-// Replay on (re)connect is best-effort (see event_stream.py docstring): the
-// server cannot filter by Last-Event-ID, so the same buffered events can
-// arrive again. De-dupe by the event's stable id (trace_id) instead, bounded
-// so the set can't grow without limit over a long session.
-const MAX_SEEN_IDS = 128;
-
-// Reconnect backoff so a permanently-down backend is not hit every 5s forever.
-const MAX_RECONNECT_DELAY_MS = 30000;
 
 export function useEventStream(): void {
   useEffect(() => {
-    let es: EventSource | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    let reconnectAttempts = 0;
-    let stopped = false;
     const seenIds: string[] = [];
     const seen = new Set<string>();
 
@@ -70,15 +56,18 @@ export function useEventStream(): void {
       return false;
     };
 
-    const connect = () => {
-      es = new EventSource("/api/events/stream");
-
-      es.onopen = () => {
-        // A clean open means the backend is healthy again; reset the backoff.
-        reconnectAttempts = 0;
-      };
-
-      es.onmessage = (msg) => {
+    return createSseConnection({
+      url: "/api/events/stream",
+      getMessageId: (msg) => {
+        let event: { id?: string } | null;
+        try {
+          event = JSON.parse(msg.data as string);
+        } catch {
+          return undefined;
+        }
+        return event?.id;
+      },
+      onMessage: (msg) => {
         let event: { type?: string; payload?: EventPayload; id?: string } | null;
         try {
           event = JSON.parse(msg.data as string);
@@ -91,31 +80,7 @@ export function useEventStream(): void {
         if (handler && event.payload !== undefined) {
           handler(event.payload as EventPayload);
         }
-      };
-
-      es.onerror = () => {
-        // Transient network errors: the browser reconnects automatically.
-        // A hard close (e.g. HTTP error response) leaves readyState CLOSED
-        // and the browser gives up, so reconnect manually after a backoff.
-        if (!stopped && es?.readyState === EventSource.CLOSED) {
-          const delay = Math.min(
-            RECONNECT_DELAY_MS * 2 ** reconnectAttempts,
-            MAX_RECONNECT_DELAY_MS,
-          );
-          reconnectAttempts += 1;
-          reconnectTimer = setTimeout(() => {
-            if (!stopped) connect();
-          }, delay);
-        }
-      };
-    };
-
-    connect();
-
-    return () => {
-      stopped = true;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      es?.close();
-    };
+      },
+    });
   }, []);
 }

--- a/desktop/src/hooks/use-os-events.ts
+++ b/desktop/src/hooks/use-os-events.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useSyncExternalStore } from "react";
+import { ReconnectManager, MAX_SEEN_IDS } from "@/lib/sse";
 
 export type OsEvent = {
   kind: string;
@@ -10,10 +11,6 @@ export type OsEvent = {
 export const LAGGED_KIND = "events.lagged";
 
 type OsEventHandler = (event: OsEvent) => void;
-
-const RECONNECT_DELAY_MS = 5000;
-const MAX_RECONNECT_DELAY_MS = 30000;
-const MAX_SEEN_IDS = 128;
 
 type Subscriber = {
   kinds: string[];
@@ -55,8 +52,7 @@ let targetKinds: Coverage = [];
 let servedKinds: Coverage = [];
 // What the in-flight widened stream is aiming at.
 let pendingKinds: Coverage = [];
-let reconnectAttempts = 0;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+const reconnectManager = new ReconnectManager(startConnection);
 const listeners = new Set<() => void>();
 let stopScheduled = false;
 
@@ -166,7 +162,7 @@ function openStream(kinds: Coverage): EventSource {
   es.onmessage = handleMessage;
 
   es.onopen = () => {
-    reconnectAttempts = 0;
+    reconnectManager.reset();
     if (es === pendingEs) {
       // The widened stream is live, so the narrow one can go now -- not before.
       // Overlapping the two is what keeps delivery unbroken across a filter
@@ -190,17 +186,14 @@ function openStream(kinds: Coverage): EventSource {
         es.close();
         pendingEs = null;
         pendingKinds = [];
-        if (!sharedEs) scheduleReconnect();
+        if (!sharedEs) reconnectManager.schedule();
       }
       return;
     }
     // A stream we already handed off from has nothing left to say.
     if (es !== sharedEs) return;
 
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
+    reconnectManager.cancel();
     // An `error` means the stream is down RIGHT NOW, whether or not the browser
     // means to retry it. Nothing resumes the gap -- the endpoint sends no SSE
     // `id:` line and ignores `Last-Event-ID` -- so a subscriber told it is
@@ -214,26 +207,11 @@ function openStream(kinds: Coverage): EventSource {
       // A widened stream is already on its way and covers everything this one
       // did, so it IS the reconnect. Scheduling another on top would open a
       // stream the handoff then immediately closes.
-      if (!pendingEs) scheduleReconnect();
+      if (!pendingEs) reconnectManager.schedule();
     }
   };
 
   return es;
-}
-
-function scheduleReconnect() {
-  if (reconnectTimer) return;
-  const delay = Math.min(
-    RECONNECT_DELAY_MS * 2 ** reconnectAttempts,
-    MAX_RECONNECT_DELAY_MS,
-  );
-  reconnectAttempts += 1;
-  reconnectTimer = setTimeout(() => {
-    // Clear the handle FIRST: startConnection reads it, and a fired timer
-    // whose handle is still set would refuse its own reconnect.
-    reconnectTimer = null;
-    startConnection();
-  }, delay);
 }
 
 // Widen the server-side filter to cover everything subscribed, without a gap.
@@ -275,17 +253,14 @@ function startConnection() {
   // let it run: cancelling it and connecting immediately would make a view
   // that mounts callers in a loop retry at mount frequency against a down
   // endpoint instead of at the intended 5s -> 30s spacing.
-  if (reconnectTimer) return;
+  if (reconnectManager.hasTimer) return;
 
   servedKinds = targetKinds;
   sharedEs = openStream(targetKinds);
 }
 
 function stopConnection() {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
+  reconnectManager.cancel();
   pendingEs?.close();
   pendingEs = null;
   sharedEs?.close();
@@ -293,7 +268,6 @@ function stopConnection() {
   targetKinds = [];
   servedKinds = [];
   pendingKinds = [];
-  reconnectAttempts = 0;
   setStatus(false, true);
 }
 

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -1,4 +1,5 @@
 import { withCsrf } from "@/lib/csrf";
+import { createSseConnection } from "@/lib/sse";
 
 export type Project = {
   id: string;
@@ -449,11 +450,12 @@ export const projectsApi = {
   },
 
   subscribeEvents(projectId: string, onEvent: (ev: ProjectEvent) => void): () => void {
-    const es = new EventSource(`/api/projects/${projectId}/events`);
-    es.onmessage = (e) => {
-      try { onEvent(JSON.parse(e.data) as ProjectEvent); } catch { /* heartbeat / malformed — skip */ }
-    };
-    return () => es.close();
+    return createSseConnection({
+      url: `/api/projects/${projectId}/events`,
+      onMessage: (e) => {
+        try { onEvent(JSON.parse(e.data) as ProjectEvent); } catch { /* heartbeat / malformed — skip */ }
+      },
+    });
   },
 
   // Community View (Milestone F)

--- a/desktop/src/lib/sse.ts
+++ b/desktop/src/lib/sse.ts
@@ -1,0 +1,102 @@
+export const RECONNECT_DELAY_MS = 5000;
+export const MAX_RECONNECT_DELAY_MS = 30000;
+export const MAX_SEEN_IDS = 128;
+
+export type SseStatus = { connected: boolean; stale: boolean };
+
+export class ReconnectManager {
+  private attempts = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly onReconnect: () => void) {}
+
+  get hasTimer(): boolean {
+    return this.timer !== null;
+  }
+
+  schedule(): number {
+    if (this.timer) return this.attempts;
+    const delay = Math.min(
+      RECONNECT_DELAY_MS * 2 ** this.attempts,
+      MAX_RECONNECT_DELAY_MS,
+    );
+    this.attempts += 1;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.onReconnect();
+    }, delay);
+    return delay;
+  }
+
+  reset() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.attempts = 0;
+  }
+
+  cancel() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+export function createSseConnection(opts: {
+  url: string;
+  onMessage: (msg: MessageEvent) => void;
+  onOpen?: () => void;
+  onError?: () => void;
+  getMessageId?: (msg: MessageEvent) => string | undefined;
+}): () => void {
+  const manager = new ReconnectManager(() => connect());
+  let es: EventSource | null = null;
+  let stopped = false;
+  const seenIds: string[] = [];
+  const seen = new Set<string>();
+
+  const alreadySeen = (id: string | undefined): boolean => {
+    if (!id) return false;
+    if (seen.has(id)) return true;
+    seen.add(id);
+    seenIds.push(id);
+    if (seenIds.length > MAX_SEEN_IDS) {
+      const oldest = seenIds.shift();
+      if (oldest) seen.delete(oldest);
+    }
+    return false;
+  };
+
+  const connect = () => {
+    if (stopped) return;
+    es = new EventSource(opts.url);
+
+    es.onopen = () => {
+      manager.reset();
+      opts.onOpen?.();
+    };
+
+    es.onmessage = (msg: MessageEvent) => {
+      if (opts.getMessageId && alreadySeen(opts.getMessageId(msg))) return;
+      opts.onMessage(msg);
+    };
+
+    es.onerror = () => {
+      opts.onError?.();
+      if (stopped) return;
+      if (es?.readyState === EventSource.CLOSED) {
+        manager.schedule();
+      }
+    };
+  };
+
+  connect();
+
+  return () => {
+    stopped = true;
+    manager.cancel();
+    es?.close();
+  };
+}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Agent desktop-control SSE never reconnects after a 401

Autonomous build of board card tsk-na2i3i.

RED run on origin/dev (test file only, no fix):
```
FAIL  desktop/src/hooks/__tests__/use-desktop-command-stream.test.ts
  > reconnects after the server closes with a 401
    AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
  > reconnects after a controller restart
    AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
  > backoff is shared, not duplicated per hook
    AssertionError: expected 2 to be +0 // Object.is equality
  3 failed, 0 passed
exit 1
```

GREEN run (after fix):
```
Test Files  1 passed (1)
      Tests  3 passed (3)
```

Files:
 desktop/src/apps/SettingsApp/LogsPanel.tsx         |  44 +++---
 .../__tests__/use-desktop-command-stream.test.ts   | 157 +++++++++++++++++++++
 desktop/src/hooks/use-desktop-command-stream.ts    |  52 ++++---
 desktop/src/hooks/use-event-stream.ts              |  71 +++-------
 desktop/src/hooks/use-os-events.ts                 |  42 ++----
 desktop/src/lib/projects.ts                        |  12 +-
 desktop/src/lib/sse.ts                             | 102 +++++++++++++
 11 files changed, 387 insertions(+), 201 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSE live updates now automatically reconnect after connection failures, authorization issues, or controller restarts.
  * Reconnection uses consistent backoff behavior across desktop commands, events, canvas updates, file watching, project events, and application logs.
  * Duplicate streamed messages are filtered to prevent repeated updates.

* **Tests**
  * Added coverage verifying reconnection and continued message delivery after stream interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
