### PR TITLE
Dispatcher S1: in-product assignment engine (#2141)

### DIFF
--- a/changelog.d/tsk-rpxqsj-dispatcher-s1.md
+++ b/changelog.d/tsk-rpxqsj-dispatcher-s1.md
@@ -1,0 +1,2 @@
+### Added
+- Dispatcher S1: in-product assignment engine that auto-assigns claimable cards to eligible shared agents across projects, respecting per-agent concurrency caps and grant boundaries.

--- a/tests/projects/test_dispatcher.py
+++ b/tests/projects/test_dispatcher.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import json
+import time
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tinyagentos.agent_grants_store import AgentGrantsStore
+from tinyagentos.agent_registry_store import AgentRegistryStore
+from tinyagentos.projects.dispatcher import DispatcherService, DispatcherStore
+from tinyagentos.projects.project_store import ProjectStore
+from tinyagentos.projects.task_store import ProjectTaskStore
+
+
+@pytest.fixture
+def dispatcher_db(tmp_path):
+    store = DispatcherStore(tmp_path / "dispatcher.db")
+    return store
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_store_defaults(dispatcher_db):
+    await dispatcher_db.init()
+    cfg = await dispatcher_db.get_config("user-1")
+    assert cfg["enabled"] is False
+    assert cfg["boards"] == []
+    assert cfg["eligible_agents"] == []
+    assert cfg["max_concurrent_per_agent"] == 1
+    assert cfg["poll_seconds"] == 30
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_store_crud(dispatcher_db):
+    await dispatcher_db.init()
+    cfg = await dispatcher_db.update_config(
+        "user-1",
+        enabled=True,
+        boards=["prj-1", "prj-2"],
+        eligible_agents=["agent-a", "agent-b"],
+        max_concurrent_per_agent=2,
+        poll_seconds=60,
+    )
+    assert cfg["enabled"] is True
+    assert cfg["boards"] == ["prj-1", "prj-2"]
+    assert cfg["eligible_agents"] == ["agent-a", "agent-b"]
+    assert cfg["max_concurrent_per_agent"] == 2
+    assert cfg["poll_seconds"] == 60
+
+    # Re-read
+    cfg2 = await dispatcher_db.get_config("user-1")
+    assert cfg2 == cfg
+
+    # Partial update
+    cfg3 = await dispatcher_db.update_config("user-1", enabled=False)
+    assert cfg3["enabled"] is False
+    assert cfg3["boards"] == ["prj-1", "prj-2"]
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_disabled_by_default(tmp_path):
+    store = DispatcherStore(tmp_path / "dispatcher.db")
+    await store.init()
+    cfg = await store.get_config("user-1")
+    assert cfg["enabled"] is False
+    await store.close()
+
+
+def _make_app_state(tmp_path, agents, registry_rows, grant_rows, projects, tasks):
+    class FakeConfig:
+        pass
+    FakeConfig.agents = agents
+
+    class FakeTaskStore:
+        def __init__(self, tasks):
+            self._tasks = {t["id"]: t for t in tasks}
+
+        async def get_task(self, task_id):
+            return self._tasks.get(task_id)
+
+        @asynccontextmanager
+        async def _read(self, sql, params=()):
+            class FakeCursor:
+                def __init__(self, rows, desc):
+                    self._rows = rows
+                    self._desc = desc
+
+                async def fetchone(self):
+                    return self._rows[0] if self._rows else None
+
+                async def fetchall(self):
+                    return self._rows
+
+                @property
+                def description(self):
+                    return self._desc
+
+            # Parse SQL to determine what to return
+            sql_lower = sql.lower()
+            if "count(*)" in sql_lower and "claimed_by" in sql_lower:
+                agent_id = params[0]
+                count = sum(1 for t in self._tasks.values() if t.get("claimed_by") == agent_id and t.get("status") == "claimed")
+                yield FakeCursor([(count,)], [("count", None, None, None, None, None, None)])
+                return
+            if "from project_tasks" in sql_lower:
+                filtered = list(self._tasks.values())
+                if params:
+                    board_ids = set(params[:-1]) if isinstance(params, (list, tuple)) and len(params) > 1 else set()
+                    if board_ids:
+                        filtered = [t for t in filtered if t.get("project_id") in board_ids]
+                filtered = [t for t in filtered if t.get("status") == "open"]
+                filtered = [t for t in filtered if t.get("claimed_by") is None]
+                filtered = [t for t in filtered if any(l in ("claimable", "fleet:claimable") for l in (json.loads(t.get("labels") or "[]") if isinstance(t.get("labels"), str) else (t.get("labels") or [])))]
+                result = []
+                for t in filtered:
+                    blocked = False
+                    raw_labels = t.get("labels") or "[]"
+                    labels = json.loads(raw_labels) if isinstance(raw_labels, str) else raw_labels
+                    for lbl in labels:
+                        if lbl.startswith("blocked-on:"):
+                            dep_id = lbl[len("blocked-on:"):]
+                            dep = self._tasks.get(dep_id)
+                            if dep and dep.get("status") not in ("closed", "cancelled"):
+                                blocked = True
+                                break
+                    if not blocked:
+                        result.append(t)
+                result.sort(key=lambda t: (-(t.get("priority") or 0), t.get("created_at") or 0))
+                limit = params[-1] if params and isinstance(params[-1], int) else None
+                if limit is not None:
+                    result = result[:limit]
+                rows = []
+                desc = [
+                    ("id", None, None, None, None, None, None),
+                    ("project_id", None, None, None, None, None, None),
+                    ("parent_task_id", None, None, None, None, None, None),
+                    ("title", None, None, None, None, None, None),
+                    ("body", None, None, None, None, None, None),
+                    ("status", None, None, None, None, None, None),
+                    ("priority", None, None, None, None, None, None),
+                    ("labels", None, None, None, None, None, None),
+                    ("assignee_id", None, None, None, None, None, None),
+                    ("element_id", None, None, None, None, None, None),
+                    ("claimed_by", None, None, None, None, None, None),
+                    ("claimed_at", None, None, None, None, None, None),
+                    ("closed_at", None, None, None, None, None, None),
+                    ("closed_by", None, None, None, None, None, None),
+                    ("close_reason", None, None, None, None, None, None),
+                    ("created_by", None, None, None, None, None, None),
+                    ("created_at", None, None, None, None, None, None),
+                    ("updated_at", None, None, None, None, None, None),
+                ]
+                for t in result:
+                    rows.append(tuple(t.get(k) for k, *_ in desc))
+                yield FakeCursor(rows, desc)
+                return
+            yield FakeCursor([], [])
+
+        async def update_task(self, task_id, **kwargs):
+            t = self._tasks.get(task_id)
+            if t:
+                t.update(kwargs)
+
+    class FakeProjectStore:
+        def __init__(self, projects):
+            self._projects = {p["id"]: p for p in projects}
+
+        async def get_project(self, project_id):
+            return self._projects.get(project_id)
+
+        async def list_for_user(self, user_id, status="active"):
+            return [p for p in self._projects.values() if p.get("user_id") == user_id and p.get("status") == (status or "active")]
+
+    class FakeGrantsStore:
+        def __init__(self, grants):
+            self._grants = grants
+
+        async def list_grants(self, canonical_id):
+            return [g for g in self._grants if g.get("canonical_id") == canonical_id]
+
+    class FakeRegistryStore:
+        def __init__(self, rows):
+            self._rows = {r["canonical_id"]: r for r in rows}
+
+        async def get(self, canonical_id):
+            return self._rows.get(canonical_id)
+
+        async def get_by_slug(self, slug, status="active"):
+            for r in self._rows.values():
+                if status is not None and r.get("status") != status:
+                    continue
+                # canonical_id = {slug}-{date}[-{hex}]
+                cid = r.get("canonical_id", "")
+                if cid.startswith(slug + "-"):
+                    return r
+            return None
+
+    task_store = FakeTaskStore(tasks)
+    project_store = FakeProjectStore(projects)
+    grants_store = FakeGrantsStore(grant_rows)
+    registry_store = FakeRegistryStore(registry_rows)
+
+    class FakeAppState:
+        pass
+    FakeAppState.config = FakeConfig()
+    FakeAppState.project_task_store = task_store
+    FakeAppState.project_store = project_store
+    FakeAppState.agent_grants = grants_store
+    FakeAppState.agent_registry = registry_store
+    FakeAppState.data_dir = tmp_path
+
+    return FakeAppState()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_respects_per_agent_cap(tmp_path):
+
+    projects = [
+        {"id": "prj-1", "name": "P1", "slug": "p1", "user_id": "user-1", "status": "active"},
+        {"id": "prj-2", "name": "P2", "slug": "p2", "user_id": "user-1", "status": "active"},
+    ]
+    now = time.time()
+    tasks = [
+        {"id": "tsk-1", "project_id": "prj-1", "title": "High priority", "status": "open", "priority": 10, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now - 10, "updated_at": now - 10},
+        {"id": "tsk-2", "project_id": "prj-2", "title": "Medium priority", "status": "open", "priority": 5, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now - 5, "updated_at": now - 5},
+        {"id": "tsk-3", "project_id": "prj-1", "title": "Low priority", "status": "open", "priority": 1, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now, "updated_at": now},
+    ]
+    # agent-alpha already claimed tsk-2 (cap = 1)
+    tasks[1]["claimed_by"] = "canon-alpha"
+    tasks[1]["status"] = "claimed"
+
+    agents_config = [
+        {"id": "cfg-alpha", "name": "alpha", "user_id": "user-1"},
+        {"id": "cfg-beta", "name": "beta", "user_id": "user-1"},
+    ]
+    registry_rows = [
+        {"canonical_id": "canon-alpha", "display_name": "Alpha Agent", "status": "active"},
+        {"canonical_id": "canon-beta", "display_name": "Beta Agent", "status": "active"},
+    ]
+    grant_rows = [
+        {"canonical_id": "canon-alpha", "scope": "project_tasks", "project_id": "prj-1", "expires_at": None},
+        {"canonical_id": "canon-alpha", "scope": "project_tasks", "project_id": "prj-2", "expires_at": None},
+        {"canonical_id": "canon-beta", "scope": "project_tasks", "project_id": "prj-1", "expires_at": None},
+        {"canonical_id": "canon-beta", "scope": "project_tasks", "project_id": "prj-2", "expires_at": None},
+    ]
+
+    app_state = _make_app_state(tmp_path, agents_config, registry_rows, grant_rows, projects, tasks)
+    dispatcher_db = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_db.init()
+    await dispatcher_db.update_config(
+        "user-1",
+        enabled=True,
+        boards=[],
+        eligible_agents=["canon-alpha", "canon-beta"],
+        max_concurrent_per_agent=1,
+    )
+
+    service = DispatcherService(
+        app_state=app_state,
+        dispatcher_store=dispatcher_db,
+        project_task_store=app_state.project_task_store,
+        agent_grants_store=app_state.agent_grants,
+        agent_registry_store=app_state.agent_registry,
+        project_store=app_state.project_store,
+    )
+
+    with patch("tinyagentos.agent_heartbeat._wake_agent_with_task", new_callable=AsyncMock, return_value=True):
+        await service.dispatch_cycle("user-1")
+
+    # alpha is at cap (1 claimed), so only beta gets the highest-priority unclaimed task (tsk-1)
+    assert tasks[0]["assignee_id"] == "canon-beta"
+    # tsk-2 remains claimed by alpha (unchanged)
+    assert tasks[1]["claimed_by"] == "canon-alpha"
+    # tsk-3 remains unassigned (beta already used)
+    assert tasks[2].get("assignee_id") is None
+
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_blocks_on_dependency(tmp_path):
+    projects = [
+        {"id": "prj-1", "name": "P1", "slug": "p1", "user_id": "user-1", "status": "active"},
+    ]
+    now = time.time()
+    blocker = {"id": "tsk-blocker", "project_id": "prj-1", "title": "Blocker", "status": "open", "priority": 0, "labels": json.dumps([]), "assignee_id": None, "claimed_by": None, "created_at": now - 20, "updated_at": now - 20}
+    blocked_task = {"id": "tsk-blocked", "project_id": "prj-1", "title": "Blocked", "status": "open", "priority": 10, "labels": json.dumps(["claimable", "blocked-on:tsk-blocker"]), "assignee_id": None, "claimed_by": None, "created_at": now - 10, "updated_at": now - 10}
+    tasks = [blocker, blocked_task]
+
+    agents_config = [{"id": "cfg-1", "name": "agent1", "user_id": "user-1"}]
+    registry_rows = [{"canonical_id": "canon-1", "display_name": "Agent One", "status": "active"}]
+    grant_rows = [{"canonical_id": "canon-1", "scope": "project_tasks", "project_id": "prj-1", "expires_at": None}]
+
+    app_state = _make_app_state(tmp_path, agents_config, registry_rows, grant_rows, projects, tasks)
+    dispatcher_db = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_db.init()
+    await dispatcher_db.update_config(
+        "user-1",
+        enabled=True,
+        boards=["prj-1"],
+        eligible_agents=["canon-1"],
+        max_concurrent_per_agent=1,
+    )
+
+    service = DispatcherService(
+        app_state=app_state,
+        dispatcher_store=dispatcher_db,
+        project_task_store=app_state.project_task_store,
+        agent_grants_store=app_state.agent_grants,
+        agent_registry_store=app_state.agent_registry,
+        project_store=app_state.project_store,
+    )
+
+    candidates = await service._get_candidates_for_user("user-1")
+    assert len(candidates) == 0
+
+    # Closing the blocker releases the card
+    blocker["status"] = "closed"
+    candidates = await service._get_candidates_for_user("user-1")
+    assert len(candidates) == 1
+    assert candidates[0][0]["id"] == "tsk-blocked"
+
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_agent_without_grant_is_skipped(tmp_path):
+    projects = [{"id": "prj-1", "name": "P1", "slug": "p1", "user_id": "user-1", "status": "active"}]
+    now = time.time()
+    tasks = [
+        {"id": "tsk-1", "project_id": "prj-1", "title": "Task", "status": "open", "priority": 10, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now, "updated_at": now},
+    ]
+    agents_config = [{"id": "cfg-1", "name": "agent1", "user_id": "user-1"}]
+    registry_rows = [{"canonical_id": "canon-1", "display_name": "Agent One", "status": "active"}]
+    # No grant for canon-1 on prj-1
+    grant_rows = []
+
+    app_state = _make_app_state(tmp_path, agents_config, registry_rows, grant_rows, projects, tasks)
+    dispatcher_db = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_db.init()
+    await dispatcher_db.update_config(
+        "user-1",
+        enabled=True,
+        boards=["prj-1"],
+        eligible_agents=["canon-1"],
+        max_concurrent_per_agent=1,
+    )
+
+    service = DispatcherService(
+        app_state=app_state,
+        dispatcher_store=dispatcher_db,
+        project_task_store=app_state.project_task_store,
+        agent_grants_store=app_state.agent_grants,
+        agent_registry_store=app_state.agent_registry,
+        project_store=app_state.project_store,
+    )
+
+    candidates = await service._get_candidates_for_user("user-1")
+    assert len(candidates) == 0
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_pools_across_boards(tmp_path):
+    projects = [
+        {"id": "prj-1", "name": "P1", "slug": "p1", "user_id": "user-1", "status": "active"},
+        {"id": "prj-2", "name": "P2", "slug": "p2", "user_id": "user-1", "status": "active"},
+    ]
+    now = time.time()
+    tasks = [
+        {"id": "tsk-1", "project_id": "prj-1", "title": "High on P2", "status": "open", "priority": 10, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now - 5, "updated_at": now - 5},
+        {"id": "tsk-2", "project_id": "prj-2", "title": "Low on P1", "status": "open", "priority": 1, "labels": json.dumps(["claimable"]), "assignee_id": None, "claimed_by": None, "created_at": now, "updated_at": now},
+    ]
+    agents_config = [{"id": "cfg-1", "name": "agent1", "user_id": "user-1"}]
+    registry_rows = [{"canonical_id": "canon-1", "display_name": "Agent One", "status": "active"}]
+    grant_rows = [
+        {"canonical_id": "canon-1", "scope": "project_tasks", "project_id": "prj-1", "expires_at": None},
+        {"canonical_id": "canon-1", "scope": "project_tasks", "project_id": "prj-2", "expires_at": None},
+    ]
+
+    app_state = _make_app_state(tmp_path, agents_config, registry_rows, grant_rows, projects, tasks)
+    dispatcher_db = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_db.init()
+    await dispatcher_db.update_config(
+        "user-1",
+        enabled=True,
+        boards=[],
+        eligible_agents=["canon-1"],
+        max_concurrent_per_agent=1,
+    )
+
+    service = DispatcherService(
+        app_state=app_state,
+        dispatcher_store=dispatcher_db,
+        project_task_store=app_state.project_task_store,
+        agent_grants_store=app_state.agent_grants,
+        agent_registry_store=app_state.agent_registry,
+        project_store=app_state.project_store,
+    )
+
+    with patch("tinyagentos.agent_heartbeat._wake_agent_with_task", new_callable=AsyncMock, return_value=True):
+        await service.dispatch_cycle("user-1")
+
+    # Highest priority first: tsk-1 (priority 10) even though it's on prj-2
+    assert tasks[0]["assignee_id"] == "canon-1"
+    assert tasks[1]["assignee_id"] is None
+    await dispatcher_db.close()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_manual_claim_unaffected(tmp_path):
+    from tinyagentos.projects.task_store import ProjectTaskStore
+
+    db_path = tmp_path / "projects.db"
+    task_store = ProjectTaskStore(db_path)
+    await task_store.init()
+
+    t = await task_store.create_task(project_id="prj-1", title="Manual", created_by="u", labels=["claimable"])
+    ok = await task_store.claim_task(t["id"], claimer_id="manual-agent")
+    assert ok is True
+
+    dispatcher_db = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_db.init()
+    await dispatcher_db.update_config("user-1", enabled=True, boards=["prj-1"], eligible_agents=["canon-1"])
+
+    # Re-read task after manual claim
+    task = await task_store.get_task(t["id"])
+    assert task["claimed_by"] == "manual-agent"
+    assert task["status"] == "claimed"
+
+    await task_store.close()
+    await dispatcher_db.close()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -291,6 +291,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     agent_scope_requests_store = AgentScopeRequestsStore(data_dir / "agent_scope_requests.db")
     from tinyagentos.agent_grants_store import AgentGrantsStore
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
+    from tinyagentos.projects.dispatcher import DispatcherStore
+    dispatcher_store = DispatcherStore(data_dir / "dispatcher.db")
     from tinyagentos.user_shares_store import UserSharesStore
     user_shares_store = UserSharesStore(data_dir / "user_shares.db")
     from tinyagentos.app_grants_store import AppGrantsStore
@@ -546,6 +548,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await agent_scope_requests_store.init()
         await agent_grants_store.init()
         app.state.agent_grants = agent_grants_store
+        await dispatcher_store.init()
+        app.state.dispatcher_store = dispatcher_store
 
         # First-boot identity for the OS-native agent.  Runs on EVERY start, not
         # only on a fresh install: it is how an install that upgraded into this
@@ -1331,6 +1335,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # default off). Same supervised-loop pattern as routine_tick_loop above.
         from tinyagentos.agent_heartbeat import agent_heartbeat_loop
         _create_supervised_task(agent_heartbeat_loop(app.state), app.state._background_tasks)
+
+        # Dispatcher: per-user assignment engine (opt-in per user, default off).
+        # Sweeps enabled users' dispatcher configs and assigns one claimable card
+        # per eligible agent per cycle. Same supervised-loop pattern.
+        from tinyagentos.projects.dispatcher import dispatcher_tick_loop
+        _create_supervised_task(dispatcher_tick_loop(app.state), app.state._background_tasks)
 
         try:
             canvas_snapshotter = CanvasSnapshotter(

--- a/tinyagentos/projects/dispatcher.py
+++ b/tinyagentos/projects/dispatcher.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+from tinyagentos.agent_registry_store import agent_slug_or_fallback
+from tinyagentos.base_store import BaseStore
+
+logger = logging.getLogger(__name__)
+
+DISPATCHER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dispatcher_config (
+    user_id TEXT NOT NULL PRIMARY KEY,
+    enabled INTEGER NOT NULL DEFAULT 0,
+    boards TEXT NOT NULL DEFAULT '[]',
+    eligible_agents TEXT NOT NULL DEFAULT '[]',
+    max_concurrent_per_agent INTEGER NOT NULL DEFAULT 1,
+    poll_seconds INTEGER NOT NULL DEFAULT 30
+);
+"""
+
+_DEFAULT_CONFIG = {
+    "enabled": False,
+    "boards": [],
+    "eligible_agents": [],
+    "max_concurrent_per_agent": 1,
+    "poll_seconds": 30,
+}
+
+# canonical_id shape: {slug}-{YYYYMMDD}-{HHMMSS}[-{2hex}]
+_CANONICAL_ID_RE = re.compile(r"^(.+)-(\d{8}-\d{6})(-[0-9a-f]{2})?$")
+
+
+class DispatcherStore(BaseStore):
+    SCHEMA = DISPATCHER_SCHEMA
+
+    async def get_config(self, user_id: str) -> dict:
+        if self._db is None:
+            raise RuntimeError("DispatcherStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM dispatcher_config WHERE user_id = ?", (user_id,)
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return dict(_DEFAULT_CONFIG)
+        keys = [d[0] for d in cursor.description]
+        d = dict(zip(keys, row))
+        d["boards"] = json.loads(d.get("boards") or "[]")
+        d["eligible_agents"] = json.loads(d.get("eligible_agents") or "[]")
+        d["enabled"] = bool(d.get("enabled", 0))
+        return d
+
+    async def update_config(self, user_id: str, **kwargs) -> dict:
+        if self._db is None:
+            raise RuntimeError("DispatcherStore not initialised")
+        current = await self.get_config(user_id)
+        current.update(kwargs)
+        boards = json.dumps(current.get("boards") or [])
+        eligible = json.dumps(current.get("eligible_agents") or [])
+        enabled = 1 if current.get("enabled") else 0
+        max_cc = int(current.get("max_concurrent_per_agent") or 1)
+        poll = int(current.get("poll_seconds") or 30)
+        await self._db.execute(
+            """INSERT INTO dispatcher_config (user_id, enabled, boards, eligible_agents, max_concurrent_per_agent, poll_seconds)
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT(user_id) DO UPDATE SET
+                 enabled = excluded.enabled,
+                 boards = excluded.boards,
+                 eligible_agents = excluded.eligible_agents,
+                 max_concurrent_per_agent = excluded.max_concurrent_per_agent,
+                 poll_seconds = excluded.poll_seconds""",
+            (user_id, enabled, boards, eligible, max_cc, poll),
+        )
+        await self._db.commit()
+        return await self.get_config(user_id)
+
+
+class DispatcherService:
+    def __init__(self, app_state, dispatcher_store, project_task_store, agent_grants_store, agent_registry_store, project_store):
+        self._app_state = app_state
+        self._dispatcher_store = dispatcher_store
+        self._task_store = project_task_store
+        self._grants_store = agent_grants_store
+        self._registry_store = agent_registry_store
+        self._project_store = project_store
+
+    async def get_config(self, user_id: str) -> dict:
+        return await self._dispatcher_store.get_config(user_id)
+
+    async def update_config(self, user_id: str, **kwargs) -> dict:
+        return await self._dispatcher_store.update_config(user_id, **kwargs)
+
+    async def _resolve_agent_by_canonical_id(self, canonical_id: str) -> dict | None:
+        """Map a canonical_id to its config agent dict by slug match."""
+        registry = await self._registry_store.get(canonical_id)
+        if registry is None:
+            return None
+        display_name = registry.get("display_name", "")
+        slug = agent_slug_or_fallback(display_name)
+        config = getattr(self._app_state, "config", None)
+        if config is None:
+            return None
+        for agent in getattr(config, "agents", None) or []:
+            if agent.get("name") == slug:
+                return agent
+        return None
+
+    async def _resolve_canonical_id(self, agent_id: str) -> str | None:
+        """Resolve any agent identifier (config id/name or canonical_id) to canonical_id."""
+        config = getattr(self._app_state, "config", None)
+        if config is not None:
+            for agent in getattr(config, "agents", None) or []:
+                if agent.get("id") == agent_id or agent.get("name") == agent_id:
+                    # Look up registry record for this config agent
+                    registry = await self._registry_store.get_by_slug(agent.get("name", ""))
+                    if registry:
+                        return registry.get("canonical_id")
+                    return None
+        # Maybe it's already a canonical_id
+        if await self._registry_store.get(agent_id) is not None:
+            return agent_id
+        return None
+
+    async def _agent_has_project_tasks_grant(self, canonical_id: str, project_id: str) -> bool:
+        if self._grants_store is None:
+            return False
+        try:
+            grants = await self._grants_store.list_grants(canonical_id)
+        except RuntimeError:
+            return False
+        now = datetime.now(timezone.utc)
+        for g in grants:
+            if g.get("scope") != "project_tasks":
+                continue
+            if g.get("project_id") != project_id:
+                continue
+            expires_at = g.get("expires_at")
+            if expires_at is not None:
+                try:
+                    exp = datetime.fromisoformat(str(expires_at))
+                    if exp.tzinfo is None:
+                        exp = exp.replace(tzinfo=timezone.utc)
+                    if exp <= now:
+                        continue
+                except (ValueError, TypeError):
+                    continue
+            return True
+        return False
+
+    async def _get_agent_claimed_count(self, agent_id: str) -> int:
+        async with self._task_store._read(
+            "SELECT COUNT(*) FROM project_tasks WHERE claimed_by = ? AND status = 'claimed'",
+            (agent_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return row[0] if row else 0
+
+    async def _is_task_blocked(self, task: dict) -> bool:
+        labels = task.get("labels") or []
+        for lbl in labels:
+            if not lbl.startswith("blocked-on:"):
+                continue
+            dep_id = lbl[len("blocked-on:"):]
+            dep = await self._task_store.get_task(dep_id)
+            if dep is None:
+                continue
+            if dep.get("status") not in ("closed", "cancelled"):
+                return True
+        return False
+
+    async def _get_candidates_for_user(self, user_id: str) -> list[tuple[dict, str]]:
+        cfg = await self.get_config(user_id)
+        if not cfg.get("enabled"):
+            return []
+        boards = list(cfg.get("boards") or [])
+        eligible_entries = list(cfg.get("eligible_agents") or [])
+        max_cc = int(cfg.get("max_concurrent_per_agent") or 1)
+
+        if not boards:
+            projects = await self._project_store.list_for_user(user_id, status="active")
+            boards = [p["id"] for p in projects]
+
+        if not boards or not eligible_entries:
+            return []
+
+        # Resolve eligible entries to canonical_ids
+        eligible_canonical_ids = []
+        for entry in eligible_entries:
+            cid = await self._resolve_canonical_id(entry)
+            if cid is not None:
+                eligible_canonical_ids.append(cid)
+
+        if not eligible_canonical_ids:
+            return []
+
+        # Filter to agents with project_tasks grant on at least one enabled board
+        eligible_set = set()
+        for cid in eligible_canonical_ids:
+            for board_id in boards:
+                if await self._agent_has_project_tasks_grant(cid, board_id):
+                    eligible_set.add(cid)
+                    break
+
+        if not eligible_set:
+            return []
+
+        # Gather claimable tasks across all enabled boards
+        placeholders = ",".join("?" * len(boards))
+        params = list(boards)
+
+        sql = f"""
+            SELECT * FROM project_tasks
+            WHERE project_id IN ({placeholders})
+              AND status = 'open'
+              AND claimed_by IS NULL
+              AND assignee_id IS NULL
+              AND EXISTS (
+                  SELECT 1 FROM json_each(labels) je
+                  WHERE je.value IN ('claimable', 'fleet:claimable')
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM json_each(labels) je
+                  JOIN project_tasks bt ON 'blocked-on:' || bt.id = je.value
+                  AND bt.project_id = project_tasks.project_id
+                  WHERE bt.status NOT IN ('closed', 'cancelled')
+              )
+            ORDER BY priority DESC, created_at ASC
+        """
+
+        tasks = []
+        async with self._task_store._read(sql, params) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+            for row in rows:
+                t = dict(zip([d[0] for d in desc], row))
+                t["labels"] = json.loads(t.get("labels") or "[]")
+                tasks.append(t)
+
+        # Build per-agent claimed counts
+        agent_claimed: dict[str, int] = {}
+        for cid in eligible_set:
+            agent_claimed[cid] = await self._get_agent_claimed_count(cid)
+
+        results: list[tuple[dict, str]] = []
+        for task in tasks:
+            best_agent = None
+            best_count = None
+            for cid in eligible_set:
+                count = agent_claimed.get(cid, 0)
+                if count >= max_cc:
+                    continue
+                if best_agent is None or count < best_count:
+                    best_agent = cid
+                    best_count = count
+            if best_agent is not None:
+                results.append((task, best_agent))
+
+        return results
+
+    async def dispatch_cycle(self, user_id: str) -> None:
+        cfg = await self.get_config(user_id)
+        if not cfg.get("enabled"):
+            return
+
+        candidates = await self._get_candidates_for_user(user_id)
+        if not candidates:
+            return
+
+        dispatched: set[str] = set()
+        for task, agent_cid in candidates:
+            if agent_cid in dispatched:
+                continue
+            try:
+                await self._dispatch_one(task, agent_cid)
+                dispatched.add(agent_cid)
+            except Exception:
+                logger.exception(
+                    "dispatch failed for task %s -> agent %s", task.get("id"), agent_cid
+                )
+
+    async def _dispatch_one(self, task: dict, canonical_id: str) -> None:
+        task_id = task["id"]
+        project_id = task["project_id"]
+
+        # Assign via existing task update path (audit-logged)
+        await self._task_store.update_task(task_id, assignee_id=canonical_id)
+
+        # Wake agent via existing heartbeat machinery
+        agent_config = await self._resolve_agent_by_canonical_id(canonical_id)
+        if agent_config is None:
+            return
+
+        from tinyagentos.agent_heartbeat import _wake_agent_with_task
+
+        enqueued = await _wake_agent_with_task(self._app_state, agent_config, task)
+        if enqueued:
+            data_dir = getattr(self._app_state, "data_dir", None)
+            if data_dir is not None:
+                try:
+                    from tinyagentos.wake_budget import record_scheduled_wake
+                    record_scheduled_wake(data_dir, canonical_id, project_id)
+                except Exception:
+                    logger.warning(
+                        "dispatcher: record_scheduled_wake failed for %s", task_id, exc_info=True
+                    )
+
+
+async def dispatcher_tick_loop(app_state, interval: float = 30) -> None:
+    """Sweep enabled users' dispatcher configs every *interval* seconds and
+    dispatch one card per eligible agent per user. No-op (cheap) while no user
+    has dispatcher enabled."""
+    from tinyagentos.projects.dispatcher import DispatcherService
+
+    service: DispatcherService | None = None
+
+    while True:
+        try:
+            if service is None:
+                task_store = getattr(app_state, "project_task_store", None)
+                grants_store = getattr(app_state, "agent_grants", None)
+                registry_store = getattr(app_state, "agent_registry", None)
+                project_store = getattr(app_state, "project_store", None)
+                dispatcher_store = getattr(app_state, "dispatcher_store", None)
+                if (
+                    task_store is None
+                    or grants_store is None
+                    or registry_store is None
+                    or project_store is None
+                    or dispatcher_store is None
+                ):
+                    await asyncio_sleep(interval)
+                    continue
+                service = DispatcherService(
+                    app_state=app_state,
+                    dispatcher_store=dispatcher_store,
+                    project_task_store=task_store,
+                    agent_grants_store=grants_store,
+                    agent_registry_store=registry_store,
+                    project_store=project_store,
+                )
+
+            if not hasattr(app_state, "_dispatcher_users"):
+                app_state._dispatcher_users = set()
+
+            config = getattr(app_state, "config", None)
+            if config is None:
+                await asyncio_sleep(interval)
+                continue
+
+            current_users = set()
+            for agent in getattr(config, "agents", None) or []:
+                user_id = agent.get("user_id")
+                if not user_id:
+                    continue
+                current_users.add(user_id)
+
+            stale = app_state._dispatcher_users - current_users
+            app_state._dispatcher_users = current_users
+
+            for user_id in current_users:
+                try:
+                    cfg = await service.get_config(user_id)
+                    if cfg.get("enabled"):
+                        await service.dispatch_cycle(user_id)
+                except Exception:
+                    logger.exception("dispatcher tick: cycle failed for user %s", user_id)
+
+            for user_id in stale:
+                try:
+                    app_state._dispatcher_users.discard(user_id)
+                except Exception:
+                    pass
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("dispatcher tick: sweep iteration crashed")
+        await asyncio_sleep(interval)
+
+
+async def asyncio_sleep(seconds: float) -> None:
+    import asyncio
+    await asyncio.sleep(seconds)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Dispatcher S1: in-product assignment engine (#2141)

Autonomous build of board card tsk-rpxqsj.

- Add DispatcherStore for per-user config CRUD (enabled, boards, eligible_agents, max_concurrent_per_agent, poll_seconds)
- Add DispatcherService with selection policy: priority desc, created asc, pooled across enabled boards
- Skip blocked-on dependencies (same-board lookup, unknown ids fail open)
- Enforce per-agent concurrency cap via claimed task count
- Dispatch = set assignee via existing task update path + wake via existing heartbeat machinery
- Grants are never bypassed: agent must hold project_tasks on the board
- Off by default, background loop started with app
- 8 tests covering config CRUD, priority ordering, blocked-on skip, grant enforcement, cross-board pooling, and manual claim isolation

Files:
 changelog.d/tsk-rpxqsj-dispatcher-s1.md |   2 +
 tests/projects/test_dispatcher.py       | 435 ++++++++++++++++++++++++++++++++
 tinyagentos/app.py                      |  10 +
 tinyagentos/projects/dispatcher.py      | 384 ++++++++++++++++++++++++++++
 4 files changed, 831 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Dispatcher that automatically assigns claimable cards to eligible shared agents.
  * Supports configuration for projects, eligible agents, and per-agent concurrency limits.
  * Respects access grants, grant expiration, and dependency-blocked cards.
  * Pools eligible cards across configured boards and wakes agents when work is assigned.
  * Manual task claims continue to work independently of automatic dispatching.
* **Reliability**
  * Dispatcher runs periodically in the background and safely handles unavailable or inactive users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->