### PR TITLE
memory_mode 'framework' is advisory only: taOSmd is still registered and still injected

### DIFF
--- a/changelog.d/tsk-6tfpun-memory-mode-enforced.md
+++ b/changelog.d/tsk-6tfpun-memory-mode-enforced.md
@@ -1,0 +1,5 @@
+### Fixed
+- memory_mode 'framework' is now enforced: tm_agents.register_agent is skipped
+  and AGENTS.md taosmd rules are not spliced when memory_mode='framework'.
+- Deploy wizard couples memoryMode to memoryPlugin and hides the Memory Layer
+  controls when framework-only mode is selected.

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -426,6 +426,13 @@ export function DeployWizard({
     }
   }, [memoryPlugin]);
 
+  // When memory_mode is "framework", the taOSmd plugin must be disabled.
+  useEffect(() => {
+    if (memoryMode === "framework" && memoryPlugin !== null) {
+      setMemoryPlugin(null);
+    }
+  }, [memoryMode]);
+
   // Step 5 — Permissions
   const [canReadUserMemory, setCanReadUserMemory] = useState(false);
 
@@ -1361,33 +1368,35 @@ export function DeployWizard({
                 {memoryMode === "taosmd" && "All memory goes to taOSmd. Durable and searchable across the fleet. Use this when the framework has no native memory."}
               </div>
 
-              <div className="border-t border-white/5 pt-3">
-                <span className="block text-xs text-shell-text-secondary mb-2">Memory Layer</span>
-                <MemoryWizardStep
-                  memoryPlugin={memoryPlugin}
-                  setMemoryPlugin={setMemoryPlugin}
-                  memoryDeviceId={memoryDeviceId}
-                  setMemoryDeviceId={setMemoryDeviceId}
-                  memoryTierId={memoryTierId}
-                  setMemoryTierId={setMemoryTierId}
-                  memoryDefault={memoryDefault}
-                  setMemoryDefault={setMemoryDefault}
-                  memoryInstallTargets={memoryInstallTargets}
-                  setMemoryInstallTargets={setMemoryInstallTargets}
-                  memoryDevicesLoaded={memoryDevicesLoaded}
-                  setMemoryDevicesLoaded={setMemoryDevicesLoaded}
-                  memorySetupTaskId={memorySetupTaskId}
-                  setMemorySetupTaskId={setMemorySetupTaskId}
-                  memorySetupState={memorySetupState}
-                  setMemorySetupState={setMemorySetupState}
-                  memorySetupMsg={memorySetupMsg}
-                  setMemorySetupMsg={setMemorySetupMsg}
-                  memorySetupError={memorySetupError}
-                  setMemorySetupError={setMemorySetupError}
-                  memoryPickerMode={memoryPickerMode}
-                  setMemoryPickerMode={setMemoryPickerMode}
-                />
-              </div>
+              {memoryMode !== "framework" && (
+                <div className="border-t border-white/5 pt-3">
+                  <span className="block text-xs text-shell-text-secondary mb-2">Memory Layer</span>
+                  <MemoryWizardStep
+                    memoryPlugin={memoryPlugin}
+                    setMemoryPlugin={setMemoryPlugin}
+                    memoryDeviceId={memoryDeviceId}
+                    setMemoryDeviceId={setMemoryDeviceId}
+                    memoryTierId={memoryTierId}
+                    setMemoryTierId={setMemoryTierId}
+                    memoryDefault={memoryDefault}
+                    setMemoryDefault={setMemoryDefault}
+                    memoryInstallTargets={memoryInstallTargets}
+                    setMemoryInstallTargets={setMemoryInstallTargets}
+                    memoryDevicesLoaded={memoryDevicesLoaded}
+                    setMemoryDevicesLoaded={setMemoryDevicesLoaded}
+                    memorySetupTaskId={memorySetupTaskId}
+                    setMemorySetupTaskId={setMemorySetupTaskId}
+                    memorySetupState={memorySetupState}
+                    setMemorySetupState={setMemorySetupState}
+                    memorySetupMsg={memorySetupMsg}
+                    setMemorySetupMsg={setMemorySetupMsg}
+                    memorySetupError={memorySetupError}
+                    setMemorySetupError={setMemorySetupError}
+                    memoryPickerMode={memoryPickerMode}
+                    setMemoryPickerMode={setMemoryPickerMode}
+                  />
+                </div>
+              )}
             </div>
           )}
 

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -1245,14 +1245,9 @@ memory systems the framework runtime is told to use:
 | `framework` | the framework's own memory only |
 | `taosmd` | taOSmd only |
 
-- **`framework` is ADVISORY today, not enforced.** The mode tells the agent
-  runtime what to use; it does **not** yet stop the controller from involving
-  taOSmd. A `framework`-mode deploy still registers the agent with taOSmd
-  (`routes/agents.py`) and still splices taOSmd rules into `AGENTS.md`
-  (`deployer.py`, gated on the agent FRAMEWORK, not on this field). So a taOSmd
-  outage can still block a `framework` deploy, and the agent still receives
-  taOSmd rules. **Do not choose `framework` expecting isolation from taOSmd.**
-  Tracked as `tsk-6tfpun`; this note comes out when the mode is enforced.
+- `framework` is enforced at deploy time. When `memory_mode` is `framework`, the
+  controller skips `tm_agents.register_agent` and does not splice taOSmd rules
+  into `AGENTS.md`. The framework's own memory is used exclusively.
 - `POST /api/agents/deploy` takes `memory_mode` on the body, defaulting to
   `both`. It is persisted on the agent record and **injected into the agent's
   environment as `TAOS_MEMORY_MODE`** at deploy time, so the runtime honours it

--- a/tests/test_memory_mode.py
+++ b/tests/test_memory_mode.py
@@ -320,3 +320,84 @@ class TestMemoryModeConflictRule:
         assert durable != working
         assert durable == "taOSmd"
         assert working == "framework"
+
+
+@pytest.mark.asyncio
+class TestMemoryModeFrameworkIsolation:
+    """memory_mode='framework' must actually exclude taOSmd from the deploy.
+
+    The bug: selecting 'framework' does not stop taOSmd from being involved.
+    register_agent is called unconditionally, and AGENTS.md is spliced with
+    taosmd rules regardless of memory_mode.
+    """
+
+    async def test_framework_mode_skips_register_agent(self, client, app):
+        """tm_agents.register_agent must NOT be called when memory_mode='framework'."""
+        app.state.archive = MagicMock(
+            record=AsyncMock(), query=AsyncMock(return_value=[{}])
+        )
+        with patch("tinyagentos.routes.agents.tm_agents.register_agent") as mock_reg:
+            resp = await client.post("/api/agents/deploy", json={
+                "name": "FW-No-Reg",
+                "framework": "openclaw",
+                "memory_mode": "framework",
+            })
+            assert resp.status_code == 200
+            mock_reg.assert_not_called()
+
+    async def test_framework_mode_skips_agents_md_taosmd_splice(self, tmp_path):
+        """No taosmd block must be spliced into AGENTS.md when memory_mode='framework'."""
+        from pathlib import Path
+        from tinyagentos.deployer import deploy_agent, DeployRequest
+
+        pushed: list[tuple[str, str]] = []
+
+        async def fake_push_file(container, src, dst):
+            try:
+                with open(src) as fh:
+                    pushed.append((dst, fh.read()))
+            except FileNotFoundError:
+                pushed.append((dst, ""))
+            return 0, ""
+
+        async def mock_exec(name, cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "hostname -I" in cmd_str:
+                return (0, "10.0.0.5")
+            return (0, "ok")
+
+        fake_rules = "Follow the taosmd librarian protocol.\nAgent: <your-agent-name>"
+        import types
+        import sys
+        fake_taosmd = types.ModuleType("taosmd")
+        fake_taosmd.agent_rules = lambda: fake_rules
+        sys.modules["taosmd"] = fake_taosmd
+        try:
+            with patch("tinyagentos.deployer.create_container", new_callable=AsyncMock) as mock_create, \
+                 patch("tinyagentos.deployer.exec_in_container", side_effect=mock_exec), \
+                 patch("tinyagentos.deployer.push_file", side_effect=fake_push_file), \
+                 patch("tinyagentos.deployer.add_proxy_device", new_callable=AsyncMock, return_value={"success": True, "output": ""}):
+                mock_create.return_value = {"success": True, "name": "taos-agent-fw-no-md"}
+                req = DeployRequest(
+                    name="fw-no-md",
+                    framework="openclaw",
+                    model=None,
+                    data_dir=tmp_path,
+                    memory_mode="framework",
+                )
+                result = await deploy_agent(req)
+                assert result["success"] is True
+        finally:
+            sys.modules.pop("taosmd", None)
+
+        agents_md_entries = [
+            (dst, content) for dst, content in pushed
+            if dst.endswith("AGENTS.md")
+        ]
+        for dst, content in agents_md_entries:
+            assert "<!-- taosmd:rules-begin -->" not in content, (
+                f"taosmd rules block found in {dst} for framework-mode deploy"
+            )
+            assert "<!-- taosmd:rules-end -->" not in content, (
+                f"taosmd rules block found in {dst} for framework-mode deploy"
+            )

--- a/tinyagentos/deployer.py
+++ b/tinyagentos/deployer.py
@@ -682,7 +682,10 @@ async def deploy_agent(req: DeployRequest) -> dict:
         # sentinels so it never conflicts with a user-supplied template.  If
         # the file already exists (from the Store or hand-crafted), we splice
         # only our block in; everything outside the sentinels is preserved.
-        if req.framework in AGENTS_MD_PATHS:
+        #
+        # Skipped entirely when memory_mode='framework' because that mode
+        # explicitly opts out of taOSmd.
+        if req.framework in AGENTS_MD_PATHS and req.memory_mode != "framework":
             target_path = AGENTS_MD_PATHS[req.framework]
             try:
                 import taosmd as _taosmd

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -644,18 +644,20 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 idempotency_cache.set(scoped_key, json.loads(remote_err.body))
             return remote_err
 
-        # Register the agent with taosmd BEFORE mutating config so a failure
-        # here aborts cleanly with no half-state.
-        try:
-            tm_agents.register_agent(unique_slug)
-        except tm_agents.AgentExistsError:
-            pass  # idempotent — agent already registered, proceed normally
-        except Exception as e:
-            logger.exception("register_agent(%s) failed", unique_slug)
-            err_body = {"error": f"Could not register agent with taosmd: {e}"}
-            if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, err_body)
-            return JSONResponse(err_body, status_code=500)
+        # Register the agent with taOSmd BEFORE mutating config so a failure
+        # here aborts cleanly with no half-state. Skipped for memory_mode='framework'
+        # because that mode explicitly opts out of taOSmd.
+        if body.memory_mode != "framework":
+            try:
+                tm_agents.register_agent(unique_slug)
+            except tm_agents.AgentExistsError:
+                pass  # idempotent — agent already registered, proceed normally
+            except Exception as e:
+                logger.exception("register_agent(%s) failed", unique_slug)
+                err_body = {"error": f"Could not register agent with taosmd: {e}"}
+                if scoped_key and idempotency_cache is not None:
+                    idempotency_cache.set(scoped_key, err_body)
+                return JSONResponse(err_body, status_code=500)
 
         # Register the agent in the agent registry, minting a canonical_id.
         # Every deploy creates a NEW agent entry (slugs are made unique above),


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): memory_mode 'framework' is advisory only: taOSmd is still registered and still injected

Autonomous build of board card tsk-6tfpun.

RED-FIRST proof:

```
FAILED tests/test_memory_mode.py::TestMemoryModeFrameworkIsolation::test_framework_mode_skips_register_agent - AssertionError: Expected 'register_agent' to not have been called. Called 1 times.
FAILED tests/test_memory_mode.py::TestMemoryModeFrameworkIsolation::test_framework_mode_skips_agents_md_taosmd_splice - AssertionError: taosmd rules block found in /root/.openclaw/AGENTS.md for framework-mode deploy
2 failed in 3.92s
```

After fix:

```
2 passed in 3.92s
```

Changes:
- tinyagentos/routes/agents.py: skip tm_agents.register_agent when memory_mode='framework'
- tinyagentos/deployer.py: skip AGENTS.md taosmd splice when memory_mode='framework'
- desktop/src/apps/agents/DeployWizard.tsx: hide Memory Layer controls for framework mode
- docs/agent-coordination.md: update to say mode is now enforced
- tests/test_memory_mode.py: add red-first tests for both behaviours
- changelog.d: tsk-6tfpun-memory-mode-enforced.md

Files:
 changelog.d/tsk-6tfpun-memory-mode-enforced.md |  5 ++
 desktop/src/apps/agents/DeployWizard.tsx       | 63 +++++++++++---------
 docs/agent-coordination.md                     | 11 +---
 tests/test_memory_mode.py                      | 81 ++++++++++++++++++++++++++
 tinyagentos/deployer.py                        |  5 +-
 tinyagentos/routes/agents.py                   | 26 +++++----
 6 files changed, 143 insertions(+), 48 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Framework-only memory mode now hides Memory Layer settings in the deployment wizard.
  * Memory mode and memory plugin selections remain synchronized during deployment.

* **Bug Fixes**
  * Framework-only deployments no longer register the taOSmd agent or inject taOSmd rules into `AGENTS.md`.
  * Other memory modes retain their existing registration behavior.

* **Documentation**
  * Updated agent coordination guidance to describe enforced framework-only memory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->