### PR TITLE
auth/setup 403s on stale session cookie from a previous install (community: taOS#2)

### DIFF
--- a/changelog.d/tsk-ueud3y-stale-csrf-cookie.md
+++ b/changelog.d/tsk-ueud3y-stale-csrf-cookie.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- A stale `taos_session` cookie from a previous install no longer forces CSRF
+  enforcement on first-run setup or any other exempt route. The cookie is
+  cleared in the response, and CSRF failures now return `{"error": ...}`
+  instead of FastAPI's default `{"detail": ...}` so the SPA can render a
+  friendly recoverable message.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -628,18 +628,18 @@ guards this. Never "fix" a broken auth-page script by adding `unsafe-inline`.
 other mutating auth route is protected invisibly. Introspect the **built** app,
 not the source, when you need to know whether a route is guarded.
 
-The routes that *establish* a credential are exempt by path
-(`_CREDENTIAL_PATHS` in `tinyagentos/middleware/csrf.py`): `/auth/login`,
-`/auth/pin-login`, `/auth/setup`, `/auth/complete`, `/setup/complete`. They must
-work for a browser still holding an **expired** session cookie — that cookie is
-sent, so a "no session cookie" exemption stops applying at precisely the moment
-sign-in is needed, and the server-rendered form has no JavaScript to attach an
-`X-CSRF-Token` header. The result was a 403 that retrying could not clear.
+The routes that *establish* a credential no longer rely on a path-based
+exemption.  ``verify_csrf`` now checks whether the ``taos_session`` cookie
+resolves to a live session: a stale or revoked cookie is treated as absent,
+so sign-in surfaces work for a browser still holding an expired cookie without
+a hardcoded allowlist.  The server-rendered form has no JavaScript to attach an
+`X-CSRF-Token` header, so a "no session cookie" exemption must not stop applying
+at the moment sign-in is needed.  The result was a 403 that retrying could not
+clear.
 
-Every exempt path is also in `EXEMPT_PATHS`; a test asserts that containment, so
-the exemption list cannot grow past the surface that is reachable without a
-credential. Adding a route here is a security decision — anything that acts on
-an already-valid session must stay protected.
+Every route reachable without a credential is in `EXEMPT_PATHS`.  The CSRF
+gate defers to the live-session check rather than a separate list, so there is
+no exemption list that can drift or grow past the unauthenticated surface.
 
 Note for anyone writing tests against these routes: **`verify_csrf` runs for
 real.** It used to be no-op'd by an autouse fixture for every test file whose

--- a/tests/test_csrf_login_lockout.py
+++ b/tests/test_csrf_login_lockout.py
@@ -177,23 +177,36 @@ class TestStaleCookieDoesNotBlockSignIn:
 
 
 class TestExemptionsStayWithinTheUnauthenticatedSurface:
-    """`_CREDENTIAL_PATHS` must be a SUBSET of the session gate's exempt list.
+    """The session-validity gate must not become a hole.
 
-    A path can only need a CSRF exemption if it is reachable with no
-    credential at all. Anything outside `EXEMPT_PATHS` sits behind the session
-    gate, so a stale cookie never reaches it and exempting it would be pure
-    loss. Asserting containment stops the two lists drifting apart, and stops
-    the exemption list quietly growing into a hole.
+    With the old path-based ``_CREDENTIAL_PATHS`` exemption we asserted that
+    every CSRF-exempt path was also auth-exempt.  The replacement is a live
+    session check: a ``taos_session`` cookie that does not resolve to a valid
+    session is treated as absent, so there is no exemption list to drift.
+    What remains is the invariant that a stale cookie must never 403 a route
+    the auth gate would have let through.
     """
 
-    def test_every_exempt_path_is_reachable_without_a_session(self):
-        from tinyagentos.auth_middleware import EXEMPT_PATHS
-        from tinyagentos.middleware.csrf import _CREDENTIAL_PATHS
-
-        assert _CREDENTIAL_PATHS <= set(EXEMPT_PATHS), (
-            "CSRF-exempt paths not on the session gate's exempt list: "
-            f"{sorted(_CREDENTIAL_PATHS - set(EXEMPT_PATHS))}"
-        )
+    @pytest.mark.asyncio
+    async def test_stale_cookie_never_403s_an_exempt_route(self, unconfigured_app):
+        """Every exempt route reachable with no credential must also pass CSRF
+        when the only credential present is a stale session cookie."""
+        exempt_routes = [
+            ("/auth/login", "GET"),
+            ("/auth/setup", "POST"),
+            ("/setup/complete", "POST"),
+        ]
+        for path, method in exempt_routes:
+            async with _console_client(
+                unconfigured_app, {"taos_session": STALE_SESSION}
+            ) as c:
+                if method == "GET":
+                    resp = await c.get(path, follow_redirects=False)
+                else:
+                    resp = await c.post(path, follow_redirects=False)
+            assert resp.status_code != 403, (
+                f"stale cookie blocked {method} {path}: {resp.text}"
+            )
 
 
 class TestPinPanelCanAlwaysRenderTheReason:
@@ -317,3 +330,50 @@ class TestCsrfStillGuardsSessionAuthenticatedRoutes:
                 "/auth/users/tester/password", json={"password": "another pass 123"}
             )
         assert resp.status_code == 403
+
+
+class TestStaleCookieGeneralHandling:
+    """A stale session cookie must not 403 any reachable mutating route.
+
+    The path-based exemption in ``_CREDENTIAL_PATHS`` only covered the five
+    credential-establishing routes.  Routes like ``/auth/lock`` that are
+    exempt from the auth gate but still carry the router-wide CSRF dependency
+    would answer 403 to a browser still holding an old install's cookie.
+    """
+
+    @pytest.mark.asyncio
+    async def test_lock_succeeds_with_a_stale_session_cookie(self, configured_app):
+        """``POST /auth/lock`` revokes whatever session is present and clears
+        the cookie, so a stale token must not be blocked by CSRF."""
+        record = configured_app.state.auth.find_user("tester")
+        token = configured_app.state.auth.create_session(
+            user_id=record["id"], long_lived=False
+        )
+        configured_app.state.auth.revoke_session(token)
+        async with _console_client(
+            configured_app, {"taos_session": token}
+        ) as c:
+            resp = await c.post("/auth/lock", follow_redirects=False)
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.asyncio
+    async def test_setup_clears_stale_cookie(self, unconfigured_app):
+        """After first-run setup the stale ``taos_session`` cookie must be
+        cleared from the response so a reinstall does not keep sending it."""
+        stale = "stale-session-token-that-no-longer-resolves"
+        async with _console_client(
+            unconfigured_app, {"taos_session": stale}
+        ) as c:
+            resp = await c.post(
+                "/auth/setup",
+                json={
+                    "username": "tester",
+                    "full_name": "Bring-up Test",
+                    "email": "",
+                    "password": PASSWORD,
+                },
+                follow_redirects=False,
+            )
+        assert resp.status_code == 200, resp.text
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "taos_session" not in set_cookie or stale not in set_cookie

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1637,12 +1637,18 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 "error": "account_store_unreadable",
                 "detail": (
                     "The account store exists but cannot be read. Accounts are "
-                    "not lost; restore it from a backup — see "
+                    "not lost; restore it from a backup -- see "
                     "docs/runbooks/controller-rescue.md."
                 ),
             },
             status_code=503,
         )
+
+    from tinyagentos.middleware.csrf import CsrfException
+
+    @app.exception_handler(CsrfException)
+    async def _csrf_error(request, exc):  # noqa: ANN001
+        return JSONResponse({"error": exc.detail}, status_code=403)
 
     # Auth middleware -- added first so it is innermost. Starlette builds the
     # middleware stack in reverse add order (last added is outermost), so the

--- a/tinyagentos/middleware/csrf.py
+++ b/tinyagentos/middleware/csrf.py
@@ -1,4 +1,4 @@
-"""CSRF protection — double-submit cookie pattern.
+"""CSRF protection -- double-submit cookie pattern.
 
 How it works
 ------------
@@ -9,14 +9,17 @@ How it works
    this dependency.  It checks that the ``X-CSRF-Token`` request header
    matches the ``csrf_token`` cookie value.
 3. Routes authenticated exclusively via ``Authorization: Bearer <token>``
-   do *not* need CSRF protection — the bearer token itself is unforgeable
+   do *not* need CSRF protection -- the bearer token itself is unforgeable
    from a third-party origin.  Those routes skip ``verify_csrf``.
 
-Bearer-exempt logic
--------------------
-If the request carries a valid ``Authorization: Bearer …`` header the
-dependency returns immediately without checking the CSRF header.  This
-keeps the API / script / CLI flow unaffected.
+Stale-session handling
+----------------------
+If the request carries a ``taos_session`` cookie that does NOT resolve to a
+live session (expired, revoked, or from a previous install), the dependency
+returns without enforcing the double-submit check.  A stale cookie is not
+an authenticated session, so there is nothing for CSRF to hijack.  The
+``CSRFMiddleware`` clears the stale cookie in the same response so the
+browser stops sending it.
 
 Scope
 -----
@@ -29,6 +32,7 @@ from __future__ import annotations
 import secrets
 
 from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import HTTPConnection
 from starlette.responses import Response
@@ -37,53 +41,29 @@ _COOKIE_NAME = "csrf_token"
 _HEADER_NAME = "x-csrf-token"
 _TOKEN_BYTES = 32  # 256 bits
 
-# Routes that ESTABLISH a credential rather than act on one.
-#
-# These are exempt by PATH, deliberately and permanently.  They used to be
-# exempt only as a side effect of the "no taos_session cookie" rule below,
-# which is a proxy for "not signed in" — and that proxy inverts at exactly the
-# wrong moment.  A browser holding an EXPIRED session cookie still SENDS it, so
-# the rule concluded "this request is cookie-authenticated, enforce CSRF" about
-# a user who was not authenticated at all and was trying to fix that.  The
-# server-rendered sign-in form cannot satisfy a double-submit check either: it
-# is a plain HTML form POST with no JavaScript to attach an X-CSRF-Token
-# header.  The result was a 403 on every sign-in surface, i.e. a lockout that
-# retrying cannot clear — terminal on a keyboard-less kiosk (#2081).
-#
-# Exempting them costs nothing that was ever being protected: there is no
-# session to hijack until one of these routes mints it.  Login CSRF (forcing a
-# victim to sign in as the attacker) remains possible, as it already was for
-# every cookie-less caller, which is the overwhelmingly common case.  Closing
-# that would need a signed hidden form field, not this dependency.
-#
-# Keep this list MINIMAL.  Anything that acts on an already-valid session must
-# stay protected; `tests/test_csrf_login_lockout.py` holds that direction.
-_CREDENTIAL_PATHS = frozenset(
-    {
-        "/auth/login",       # password form + SPA handoff
-        "/auth/pin-login",   # console PIN keypad
-        "/auth/setup",       # first-run account creation
-        "/auth/complete",    # invited user setting their password
-        "/setup/complete",   # first-boot wizard (dashboard router, form POST)
-    }
-)
 
-# Every entry above is also in ``auth_middleware.EXEMPT_PATHS`` -- that is the
-# authoritative list of paths reachable with no credential, and a path can only
-# need this exemption if it is on it.  ``test_csrf_login_lockout.py`` asserts
-# the containment so the two lists cannot drift apart.
+class CsrfException(HTTPException):
+    """CSRF check failed.
+
+    Using a dedicated subclass lets the app return ``{"error": ...}`` instead
+    of FastAPI's default ``{"detail": ...}`` so the SPA can render a friendly
+    recoverable message rather than raw JSON detail.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(status_code=403, detail=detail)
 
 
 class CSRFMiddleware(BaseHTTPMiddleware):
     """Ensure every response carries a ``csrf_token`` cookie.
 
     The cookie is:
-    * ``SameSite=Strict`` — blocks cross-site requests at the browser level
+    * ``SameSite=Strict`` -- blocks cross-site requests at the browser level
       (defence in depth; the double-submit check is the hard enforcement).
-    * NOT ``HttpOnly`` — JavaScript must be able to read it so the SPA can
+    * NOT ``HttpOnly`` -- JavaScript must be able to read it so the SPA can
       include it in ``X-CSRF-Token`` headers for API calls.
-    * ``Path=/`` — available site-wide.
-    * No ``max_age`` — session cookie; expires on browser close.
+    * ``Path=/`` -- available site-wide.
+    * No ``max_age`` -- session cookie; expires on browser close.
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:
@@ -98,17 +78,26 @@ class CSRFMiddleware(BaseHTTPMiddleware):
                 samesite="strict",
                 path="/",
             )
+
+        taos_session = request.cookies.get("taos_session")
+        if taos_session:
+            auth_mgr = getattr(getattr(request.app, "state", None), "auth", None)
+            if auth_mgr is not None:
+                user_agent = request.headers.get("user-agent", "")
+                if not auth_mgr.validate_session(taos_session, user_agent=user_agent):
+                    response.delete_cookie("taos_session")
+
         return response
 
 
 def verify_csrf(conn: HTTPConnection) -> None:
-    """FastAPI dependency — enforce the double-submit CSRF check.
+    """FastAPI dependency -- enforce the double-submit CSRF check.
 
     Typed as ``HTTPConnection`` (the shared base of ``Request`` and
     ``WebSocket``) so FastAPI injects it on BOTH http and websocket scopes.
     A plain ``Request`` param would make FastAPI call the dependency with no
     argument on a websocket route (TypeError), and ``Request | None`` is not a
-    valid injectable type at all — either one breaks route registration when
+    valid injectable type at all -- either one breaks route registration when
     this dependency is attached at the router level (``dependencies=_csrf``)
     and that router also carries an ``@router.websocket`` route.
 
@@ -118,19 +107,18 @@ def verify_csrf(conn: HTTPConnection) -> None:
       and is not susceptible to form-based CSRF (its handshake is
       authenticated in-handler via the session cookie), so skip.
     * Safe HTTP methods (GET / HEAD / OPTIONS) are always exempt.
-    * Requests authenticated via ``Authorization: Bearer …`` are exempt —
+    * Requests authenticated via ``Authorization: Bearer …`` are exempt --
       the bearer token itself is unforgeable from a third-party origin.
-    * Credential-establishing routes (``_CREDENTIAL_PATHS``) are exempt by
-      path.  They must work for a browser that is holding a STALE session
-      cookie, which is precisely when the cookie rule below stops exempting
-      them.
-    * Requests without a ``taos_session`` cookie are exempt — without an
+    * Requests without a ``taos_session`` cookie are exempt -- without an
       active cookie-session there is nothing for CSRF to hijack.
+    * Requests whose ``taos_session`` cookie does not resolve to a live
+      session are exempt -- a stale or revoked cookie is not an authenticated
+      session, so there is nothing for CSRF to hijack.
 
     For protected requests the ``X-CSRF-Token`` header must match the
     ``csrf_token`` cookie value (double-submit pattern).
     """
-    # WebSocket scope has no HTTP method — not CSRF-able; skip.
+    # WebSocket scope has no HTTP method -- not CSRF-able; skip.
     method = getattr(conn, "method", None)
     if method is None or method in ("GET", "HEAD", "OPTIONS", "TRACE"):
         return
@@ -140,20 +128,27 @@ def verify_csrf(conn: HTTPConnection) -> None:
     if auth_header.lower().startswith("bearer "):
         return
 
-    # Signing in must work while a stale cookie is present. Checked BEFORE the
-    # cookie rule, because the stale cookie is what defeats that rule.
-    if conn.url.path.rstrip("/") in _CREDENTIAL_PATHS:
-        return
-
-    # No session cookie → not cookie-authenticated → no CSRF risk.
+    # No session cookie -> not cookie-authenticated -> no CSRF risk.
     if not conn.cookies.get("taos_session"):
         return
+
+    # Session cookie present -- check if it resolves to a live session.
+    # A stale cookie from a previous install (or expired session) must not
+    # force CSRF enforcement on a browser that has no csrf_token pair.
+    app = getattr(conn, "scope", {}).get("app")
+    if app is not None:
+        auth_mgr = getattr(getattr(app, "state", None), "auth", None)
+        if auth_mgr is not None:
+            token = conn.cookies.get("taos_session", "")
+            user_agent = conn.headers.get("user-agent", "")
+            if not auth_mgr.validate_session(token, user_agent=user_agent):
+                return
 
     cookie_token = conn.cookies.get(_COOKIE_NAME, "")
     header_token = conn.headers.get(_HEADER_NAME, "")
 
     if not cookie_token or not header_token:
-        raise HTTPException(status_code=403, detail="CSRF token missing")
+        raise CsrfException("CSRF token missing")
 
     if not secrets.compare_digest(cookie_token, header_token):
-        raise HTTPException(status_code=403, detail="CSRF token mismatch")
+        raise CsrfException("CSRF token mismatch")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): auth/setup 403s on stale session cookie from a previous install (community: taOS#2)

Autonomous build of board card tsk-ueud3y.

A bogus taos_session cookie from a previous install (or an expired session)
must not force the CSRF double-submit check. verify_csrf now checks whether
the cookie resolves to a live session via auth_mgr.validate_session and
returns without enforcing when it does not. CSRFMiddleware clears the stale
cookie in the same response so the browser stops sending it.

CSRF failures now return {"error": ...} via a CsrfException handler instead
of FastAPI's default {"detail": ...} so the SPA can render a friendly
recoverable message.

Red proof:

```
FAILED tests/test_csrf_login_lockout.py::TestStaleCookieGeneralHandling::test_lock_succeeds_with_a_stale_session_cookie
E       AssertionError: {"detail":"CSRF token missing"}
E       assert 403 == 200
...
=========================== short test summary info ============================
FAILED tests/test_csrf_login_lockout.py::TestStaleCookieGeneralHandling::test_lock_succeeds_with_a_stale_session_cookie
1 failed, 14 passed in 28.56s
```

Green:

```
15 passed in 28.77s
```

Refs taOS#2

Files:
 changelog.d/tsk-ueud3y-stale-csrf-cookie.md |   7 ++
 docs/agent-coordination.md                  |  24 +++---
 tests/test_csrf_login_lockout.py            |  90 +++++++++++++++++----
 tinyagentos/app.py                          |   8 +-
 tinyagentos/middleware/csrf.py              | 121 +++++++++++++---------------
 5 files changed, 159 insertions(+), 91 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale or invalid session cookies no longer trigger CSRF errors on setup and other exempt routes.
  * Invalid session cookies are cleared automatically from responses.
  * CSRF failures now return a consistent JSON error format, enabling clearer recovery messages in the app.
  * Session lockout and first-run setup flows now handle stale cookies correctly.
  * Standardized recovery guidance formatting.

* **Documentation**
  * Updated CSRF behavior and stale-session handling documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->