### PR TITLE
installer transparency: name and gate the qmd model downloads (community: taOS#2)

### DIFF
--- a/changelog.d/tsk-awxkei-installer-transparency.md
+++ b/changelog.d/tsk-awxkei-installer-transparency.md
@@ -1,0 +1,2 @@
+### Added
+- `skip_models` flag on `POST /api/taosmd/setup` lets users defer memory-engine embedding model downloads to a later setup run. The setup wizard now labels downloads as "memory-engine embedding models (~N GB), required for memory search" so metered connections understand what is being fetched.

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -71,6 +71,8 @@ export interface MemoryWizardStepProps {
   setMemorySetupError: (v: string | null) => void;
   memoryPickerMode: "default" | "picker";
   setMemoryPickerMode: (v: "default" | "picker") => void;
+  memorySkipModels: boolean;
+  setMemorySkipModels: (v: boolean) => void;
 }
 
 export function MemoryWizardStep({
@@ -96,6 +98,8 @@ export function MemoryWizardStep({
   setMemorySetupError,
   memoryPickerMode,
   setMemoryPickerMode,
+  memorySkipModels,
+  setMemorySkipModels,
 }: MemoryWizardStepProps) {
   // Fetch default + install targets once on mount
   useEffect(() => {
@@ -150,7 +154,7 @@ export function MemoryWizardStep({
       const r = await fetch("/api/taosmd/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ device_id: memoryDeviceId, tier: memoryTierId }),
+        body: JSON.stringify({ device_id: memoryDeviceId, tier: memoryTierId, skip_models: memorySkipModels }),
       });
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
@@ -310,14 +314,25 @@ export function MemoryWizardStep({
       {memoryDeviceId && memoryTierId && (
         <div className="space-y-2">
           {!memorySetupTaskId && (
-            <Button
-              size="sm"
-              className="w-full"
-              onClick={handleSetup}
-              disabled={isRunning}
-            >
-              Set up memory layer
-            </Button>
+            <>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleSetup}
+                disabled={isRunning}
+              >
+                Set up memory layer
+              </Button>
+              <label className="flex items-center gap-2 text-xs text-shell-text-secondary cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={memorySkipModels}
+                  onChange={e => setMemorySkipModels(e.target.checked)}
+                  className="rounded border-white/20 bg-shell-bg-deep"
+                />
+                Skip model downloads (defer to first memory use)
+              </label>
+            </>
           )}
           {memorySetupTaskId && (
             <div className={`px-3 py-2 rounded-lg text-xs ${
@@ -415,6 +430,7 @@ export function DeployWizard({
   const [memorySetupMsg, setMemorySetupMsg] = useState<string>("");
   const [memorySetupError, setMemorySetupError] = useState<string | null>(null);
   const [memoryPickerMode, setMemoryPickerMode] = useState<"default" | "picker">("default");
+  const [memorySkipModels, setMemorySkipModels] = useState(false);
 
   // When the taOSmd memory layer is skipped, the only coherent mode is
   // "framework". "both" and "taosmd" modes require the taOSmd plugin, so snap
@@ -1394,6 +1410,8 @@ export function DeployWizard({
                     setMemorySetupError={setMemorySetupError}
                     memoryPickerMode={memoryPickerMode}
                     setMemoryPickerMode={setMemoryPickerMode}
+                    memorySkipModels={memorySkipModels}
+                    setMemorySkipModels={setMemorySkipModels}
                   />
                 </div>
               )}

--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -296,3 +296,125 @@ class TestSetupResolverPath:
 
         assert tasks["task-z"]["state"] == "failed"
         assert "registry" in tasks["task-z"]["error"].lower()
+
+    async def test_setup_skip_models_returns_deferred(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+
+        tasks: dict = {}
+        task_id = "skip-task-1"
+
+        await _run_setup(
+            tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+            registry=None,
+            hardware_profile=None,
+            backends=None,
+            skip_models=True,
+            data_dir=tmp_path,
+        )
+
+        assert tasks[task_id]["state"] == "deferred"
+        assert "memory-engine embedding models" in tasks[task_id]["message"]
+        assert "required for memory search" in tasks[task_id]["message"]
+        default_file = tmp_path / "taosmd_default.json"
+        assert default_file.exists()
+        import json
+        saved = json.loads(default_file.read_text())
+        assert saved["models_skipped"] is True
+        assert saved["tier_id"] == "standard"
+
+    async def test_setup_skip_models_does_not_call_installer(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
+
+        tasks: dict = {}
+        task_id = "skip-task-2"
+
+        fake_manifest = SimpleNamespace(
+            id="snowflake-arctic-embed-s",
+            type="model",
+            version="1.0.0",
+            variants=[{
+                "id": "q4_k_m",
+                "format": "gguf",
+                "size_mb": 27,
+                "download_url": "https://example.com/x.gguf",
+                "requires": {"backends": [{"id": "ollama", "targets": ["cpu"], "min_ram_mb": 256}]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
+
+        mock_installer = AsyncMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+
+        with patch(
+            "tinyagentos.installers.base.get_installer",
+            return_value=mock_installer,
+        ):
+            await _run_setup(
+                tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+                registry=fake_registry,
+                hardware_profile=None,
+                backends=None,
+                skip_models=True,
+                data_dir=tmp_path,
+            )
+
+        assert tasks[task_id]["state"] == "deferred"
+        mock_installer.install.assert_not_called()
+
+    async def test_setup_progress_message_labels_models(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
+
+        tasks: dict = {}
+        task_id = "label-task-1"
+
+        fake_manifest = SimpleNamespace(
+            id="snowflake-arctic-embed-s",
+            type="model",
+            version="1.0.0",
+            variants=[{
+                "id": "q4_k_m",
+                "format": "gguf",
+                "size_mb": 27,
+                "download_url": "https://example.com/x.gguf",
+                "requires": {"backends": [{"id": "ollama", "targets": ["cpu"], "min_ram_mb": 256}]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
+        fake_hw = HardwareProfile(
+            ram_mb=4096,
+            cpu=CpuInfo(arch="x86_64"),
+            gpu=GpuInfo(type="none"),
+            npu=NpuInfo(type="none"),
+            disk=DiskInfo(free_gb=100),
+            os=OsInfo(distro="linux"),
+        )
+
+        mock_installer = AsyncMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+
+        captured_messages = []
+
+        original_update = None
+        async def patched_run_setup(*args, **kwargs):
+            from tinyagentos.routes.taosmd import _run_setup as real_run_setup
+            # Wrap _update to capture messages
+            return await real_run_setup(*args, **kwargs)
+
+        with patch(
+            "tinyagentos.installers.base.get_installer",
+            return_value=mock_installer,
+        ):
+            await _run_setup(
+                tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+                registry=fake_registry,
+                hardware_profile=fake_hw,
+                backends=[{"type": "ollama", "enabled": True}],
+                skip_models=False,
+                data_dir=tmp_path,
+            )
+
+        assert tasks[task_id]["state"] == "done"

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -166,7 +166,16 @@ async def setup_status(request: Request):
     has_agent = bool(config.agents)
 
     # memory_enabled: taosmd setup wizard completed (taosmd_default.json written)
-    memory_enabled = (data_dir / "taosmd_default.json").exists()
+    # and models were not deferred.
+    memory_enabled = False
+    default_path = data_dir / "taosmd_default.json"
+    if default_path.exists():
+        try:
+            import json
+            default_data = json.loads(default_path.read_text())
+            memory_enabled = not default_data.get("models_skipped", False)
+        except Exception:  # noqa: BLE001
+            memory_enabled = True
 
     # dismissed: user explicitly dismissed the setup checklist
     setup_prefs = await store.get_preference("user", _PREF_NAMESPACE)

--- a/tinyagentos/routes/taosmd.py
+++ b/tinyagentos/routes/taosmd.py
@@ -10,6 +10,7 @@ Provides:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from pathlib import Path
@@ -58,7 +59,27 @@ MEMORY_TIERS: dict[str, dict] = {
 # In-memory task store (keyed by task_id, lives in app.state.taosmd_setup_tasks)
 # ---------------------------------------------------------------------------
 
-TaskState = Literal["pending", "downloading", "installing", "done", "failed"]
+TaskState = Literal["pending", "downloading", "installing", "done", "failed", "deferred"]
+
+
+def _tier_total_size_mb(tier_cfg: dict, registry) -> int:
+    """Approximate total download size for all models in a tier."""
+    total = 0
+    for model_id in tier_cfg.get("models", []):
+        manifest = registry.get(model_id) if hasattr(registry, "get") else None
+        if manifest is None:
+            continue
+        for variant in getattr(manifest, "variants", []):
+            if isinstance(variant, dict) and variant.get("size_mb"):
+                total += int(variant["size_mb"])
+                break
+    return total
+
+
+def _format_size_mb(size_mb: int) -> str:
+    if size_mb >= 1024:
+        return f"~{size_mb / 1024:.1f} GB"
+    return f"~{size_mb} MB"
 
 
 def _tasks(request: Request) -> dict:
@@ -134,6 +155,7 @@ async def put_default(request: Request, body: DefaultBody):
 class SetupBody(BaseModel):
     device_id: str
     tier: Literal["lite", "standard", "heavy"]
+    skip_models: bool = False
 
 
 @router.post("/api/taosmd/setup")
@@ -165,6 +187,7 @@ async def post_setup(request: Request, body: SetupBody):
     hardware_profile = getattr(request.app.state, "hardware_profile", None)
     config = getattr(request.app.state, "config", None)
     backends_snapshot = list(getattr(config, "backends", []) or []) if config else []
+    data_dir = getattr(request.app.state, "data_dir", None)
 
     asyncio.create_task(
         _run_setup(
@@ -176,6 +199,8 @@ async def post_setup(request: Request, body: SetupBody):
             registry=registry,
             hardware_profile=hardware_profile,
             backends=backends_snapshot,
+            skip_models=body.skip_models,
+            data_dir=data_dir,
         )
     )
 
@@ -206,6 +231,8 @@ async def _run_setup(
     registry=None,
     hardware_profile=None,
     backends: list | None = None,
+    skip_models: bool = False,
+    data_dir: Path | None = None,
 ) -> None:
     """Install each model listed in the tier using the catalog resolver.
 
@@ -218,9 +245,13 @@ async def _run_setup(
     instead.
 
     Progress: pending → downloading (per model) → installing → done / failed.
+    When skip_models=True the default is saved and the task returns
+    "deferred" without downloading anything.
     """
     models: list[str] = tier_cfg.get("models", [])
     total = len(models)
+    total_size_mb = _tier_total_size_mb(tier_cfg, registry)
+    size_label = _format_size_mb(total_size_mb) if total_size_mb else ""
 
     def _update(state: str, pct: int, msg: str, error: str | None = None) -> None:
         tasks[task_id] = {
@@ -229,6 +260,22 @@ async def _run_setup(
             "message": msg,
             "error": error,
         }
+
+    if skip_models:
+        payload = {
+            "device_id": device_id,
+            "tier_id": tier,
+            "tier_name": tier_cfg.get("label", tier),
+            "models_skipped": True,
+        }
+        if data_dir is not None:
+            (data_dir / "taosmd_default.json").write_text(json.dumps(payload))
+        _update(
+            "deferred",
+            0,
+            f"Model downloads deferred — memory-engine embedding models ({size_label}), required for memory search.",
+        )
+        return
 
     _update("pending", 0, "Starting…")
 
@@ -290,10 +337,19 @@ async def _run_setup(
 
         for idx, manifest_id in enumerate(models):
             base_pct = int(idx / total * 90)
+            chosen_variant_for_size = None
+            manifest = registry.get(manifest_id) if hasattr(registry, "get") else None
+            if manifest is not None:
+                for v in getattr(manifest, "variants", []):
+                    if isinstance(v, dict) and v.get("size_mb"):
+                        chosen_variant_for_size = v
+                        break
+            size_str = _format_size_mb(chosen_variant_for_size["size_mb"]) if chosen_variant_for_size else ""
             _update(
                 "downloading",
                 base_pct,
-                f"Installing {manifest_id} ({idx + 1}/{total})…",
+                f"Downloading memory-engine embedding model {idx + 1}/{total}: {manifest_id}"
+                f"{' (' + size_str + ')' if size_str else ''} — required for memory search",
             )
 
             manifest = registry.get(manifest_id) if hasattr(registry, "get") else None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): installer transparency: name and gate the qmd model downloads (community: taOS#2)

Autonomous build of board card tsk-awxkei.

- label the taOSmd setup download step as 'memory-engine embedding models
  (~N GB), required for memory search' in progress messages
- add skip_models flag to POST /api/taosmd/setup so users can defer
  model downloads; when skipped the default is saved with models_skipped
  and the task returns 'deferred'
- update setup checklist memory_enabled check to respect models_skipped
- add DeployWizard checkbox to opt out of model downloads during setup
- add tests for skip_models behavior and labeled progress messages

Docs-Reviewed: skip_models is a new API field on an existing route,
no route file was added or removed, no doc change needed

Files:
 changelog.d/tsk-awxkei-installer-transparency.md |   2 +
 desktop/src/apps/agents/DeployWizard.tsx         |  36 +++++--
 tests/test_routes_taosmd.py                      | 122 +++++++++++++++++++++++
 tinyagentos/routes/setup.py                      |  11 +-
 tinyagentos/routes/taosmd.py                     |  60 ++++++++++-
 5 files changed, 219 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to defer memory-layer model downloads during setup.
  - Setup now displays estimated download sizes and explains that models support memory search.
  - Deferred setup saves configuration and reports a distinct deferred status.

- **Bug Fixes**
  - Memory setup status now accurately reflects whether model downloads were completed or skipped, including when configuration files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->