### PR TITLE
fix-forward #2936 (tsk-awxkei): deferred taOSmd models must self-heal on first use - deploy with models_skipped pulls or 409s, never a memory-less agent (community taOS#2)

### DIFF
--- a/changelog.d/tsk-awxkei-installer-transparency.md
+++ b/changelog.d/tsk-awxkei-installer-transparency.md
@@ -1,2 +1,3 @@
 ### Added
 - `skip_models` flag on `POST /api/taosmd/setup` lets users defer memory-engine embedding model downloads to a later setup run. The setup wizard now labels downloads as "memory-engine embedding models (~N GB), required for memory search" so metered connections understand what is being fetched.
+- Deploying an agent with taOSmd memory after a deferred setup now self-heals: if `taosmd_default.json` has `models_skipped=true`, the deploy endpoint starts the deferred model pull before the agent is marked ready, returning 409 if the registry is unavailable.

--- a/changelog.d/tsk-awxkei-installer-transparency.md
+++ b/changelog.d/tsk-awxkei-installer-transparency.md
@@ -1,0 +1,2 @@
+### Added
+- `skip_models` flag on `POST /api/taosmd/setup` lets users defer memory-engine embedding model downloads to a later setup run. The setup wizard now labels downloads as "memory-engine embedding models (~N GB), required for memory search" so metered connections understand what is being fetched.

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -71,6 +71,8 @@ export interface MemoryWizardStepProps {
   setMemorySetupError: (v: string | null) => void;
   memoryPickerMode: "default" | "picker";
   setMemoryPickerMode: (v: "default" | "picker") => void;
+  memorySkipModels: boolean;
+  setMemorySkipModels: (v: boolean) => void;
 }
 
 export function MemoryWizardStep({
@@ -96,6 +98,8 @@ export function MemoryWizardStep({
   setMemorySetupError,
   memoryPickerMode,
   setMemoryPickerMode,
+  memorySkipModels,
+  setMemorySkipModels,
 }: MemoryWizardStepProps) {
   // Fetch default + install targets once on mount
   useEffect(() => {
@@ -150,7 +154,7 @@ export function MemoryWizardStep({
       const r = await fetch("/api/taosmd/setup", {
         method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json" },
-        body: JSON.stringify({ device_id: memoryDeviceId, tier: memoryTierId }),
+        body: JSON.stringify({ device_id: memoryDeviceId, tier: memoryTierId, skip_models: memorySkipModels }),
       });
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
@@ -310,14 +314,25 @@ export function MemoryWizardStep({
       {memoryDeviceId && memoryTierId && (
         <div className="space-y-2">
           {!memorySetupTaskId && (
-            <Button
-              size="sm"
-              className="w-full"
-              onClick={handleSetup}
-              disabled={isRunning}
-            >
-              Set up memory layer
-            </Button>
+            <>
+              <Button
+                size="sm"
+                className="w-full"
+                onClick={handleSetup}
+                disabled={isRunning}
+              >
+                Set up memory layer
+              </Button>
+              <label className="flex items-center gap-2 text-xs text-shell-text-secondary cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={memorySkipModels}
+                  onChange={e => setMemorySkipModels(e.target.checked)}
+                  className="rounded border-white/20 bg-shell-bg-deep"
+                />
+                Skip model downloads (defer to first memory use)
+              </label>
+            </>
           )}
           {memorySetupTaskId && (
             <div className={`px-3 py-2 rounded-lg text-xs ${
@@ -415,6 +430,7 @@ export function DeployWizard({
   const [memorySetupMsg, setMemorySetupMsg] = useState<string>("");
   const [memorySetupError, setMemorySetupError] = useState<string | null>(null);
   const [memoryPickerMode, setMemoryPickerMode] = useState<"default" | "picker">("default");
+  const [memorySkipModels, setMemorySkipModels] = useState(false);
 
   // When the taOSmd memory layer is skipped, the only coherent mode is
   // "framework". "both" and "taosmd" modes require the taOSmd plugin, so snap
@@ -1394,6 +1410,8 @@ export function DeployWizard({
                     setMemorySetupError={setMemorySetupError}
                     memoryPickerMode={memoryPickerMode}
                     setMemoryPickerMode={setMemoryPickerMode}
+                    memorySkipModels={memorySkipModels}
+                    setMemorySkipModels={setMemorySkipModels}
                   />
                 </div>
               )}

--- a/desktop/src/apps/agents/DeployWizard.tsx
+++ b/desktop/src/apps/agents/DeployWizard.tsx
@@ -55,8 +55,8 @@ export interface MemoryWizardStepProps {
   setMemoryDeviceId: (v: string | null) => void;
   memoryTierId: string | null;
   setMemoryTierId: (v: string | null) => void;
-  memoryDefault: { device_id: string; tier_id: string; tier_name: string } | null | "none";
-  setMemoryDefault: (v: { device_id: string; tier_id: string; tier_name: string } | null | "none") => void;
+  memoryDefault: { device_id: string; tier_id: string; tier_name: string; models_skipped?: boolean } | null | "none";
+  setMemoryDefault: (v: { device_id: string; tier_id: string; tier_name: string; models_skipped?: boolean } | null | "none") => void;
   memoryInstallTargets: Array<{ name: string; friendly_name: string; tier_id: string }>;
   setMemoryInstallTargets: (v: Array<{ name: string; friendly_name: string; tier_id: string }>) => void;
   memoryDevicesLoaded: boolean;
@@ -108,7 +108,7 @@ export function MemoryWizardStep({
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data?.device_id) {
-          setMemoryDefault(data as { device_id: string; tier_id: string; tier_name: string });
+          setMemoryDefault(data as { device_id: string; tier_id: string; tier_name: string; models_skipped?: boolean });
         } else {
           setMemoryDefault("none");
           setMemoryPickerMode("picker");
@@ -181,6 +181,37 @@ export function MemoryWizardStep({
   // "Has default" mode
   if (memoryPlugin !== null && memoryPickerMode === "default" && memoryDefault !== null && memoryDefault !== "none") {
     const def = memoryDefault;
+    if (def.models_skipped) {
+      return (
+        <div className="space-y-3">
+          <span className="block text-xs text-shell-text-secondary mb-2">Memory Layer</span>
+          <div className="px-4 py-3 rounded-lg border border-yellow-500/30 bg-yellow-500/5 flex items-start justify-between gap-2">
+            <div>
+              <div className="text-sm font-medium">Models deferred</div>
+              <div className="text-xs text-shell-text-secondary mt-0.5">
+                {def.tier_name} on {def.device_id} — download now to enable memory search
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              <button
+                type="button"
+                onClick={() => setMemoryPickerMode("picker")}
+                className="text-xs text-accent hover:underline"
+              >
+                Download now
+              </button>
+              <button
+                type="button"
+                onClick={() => setMemoryPlugin(null)}
+                className="text-xs text-shell-text-tertiary hover:text-shell-text"
+              >
+                Skip memory for this agent
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="space-y-3">
         <span className="block text-xs text-shell-text-secondary mb-2">Memory Layer</span>
@@ -422,7 +453,7 @@ export function DeployWizard({
   const [memoryDeviceId, setMemoryDeviceId] = useState<string | null>(null);
   const [memoryTierId, setMemoryTierId] = useState<string | null>(null);
   // null = loading; "none" = no default; object = has default
-  const [memoryDefault, setMemoryDefault] = useState<{ device_id: string; tier_id: string; tier_name: string } | null | "none">(null);
+  const [memoryDefault, setMemoryDefault] = useState<{ device_id: string; tier_id: string; tier_name: string; models_skipped?: boolean } | null | "none">(null);
   const [memoryInstallTargets, setMemoryInstallTargets] = useState<Array<{ name: string; friendly_name: string; tier_id: string }>>([]);
   const [memoryDevicesLoaded, setMemoryDevicesLoaded] = useState(false);
   const [memorySetupTaskId, setMemorySetupTaskId] = useState<string | null>(null);

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -2059,3 +2059,46 @@ class TestAgentWakeBudget:
 def _today_str() -> str:
     import datetime
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+
+@pytest.mark.asyncio
+class TestDeployDeferredModelsSelfHeal:
+    """Deploying an agent with taOSmd memory when models were deferred must
+    either start the deferred pull or return 409 if it cannot."""
+
+    async def test_deploy_deferred_models_no_registry_returns_409(
+        self, client, app, tmp_data_dir
+    ):
+        """When taosmd_default.json has models_skipped=true and there is no
+        model registry, deploying with memory_plugin='taosmd' must return 409
+        so the caller knows the deferred downloads cannot start."""
+        import json
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        # Remove registry so the deferred pull cannot start.
+        app.state.registry = None
+        app.state.cluster_manager._workers.clear()
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+
+        resp = await client.post("/api/agents/deploy", json={
+            "name": "deferred-no-registry",
+            "framework": "none",
+            "model": "test-model",
+            "memory_plugin": "taosmd",
+            "memory_config": None,
+        })
+        assert resp.status_code == 409
+        data = resp.json()
+        assert "deferred" in data["error"].lower() or "download" in data["error"].lower()

--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -296,3 +296,125 @@ class TestSetupResolverPath:
 
         assert tasks["task-z"]["state"] == "failed"
         assert "registry" in tasks["task-z"]["error"].lower()
+
+    async def test_setup_skip_models_returns_deferred(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+
+        tasks: dict = {}
+        task_id = "skip-task-1"
+
+        await _run_setup(
+            tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+            registry=None,
+            hardware_profile=None,
+            backends=None,
+            skip_models=True,
+            data_dir=tmp_path,
+        )
+
+        assert tasks[task_id]["state"] == "deferred"
+        assert "memory-engine embedding models" in tasks[task_id]["message"]
+        assert "required for memory search" in tasks[task_id]["message"]
+        default_file = tmp_path / "taosmd_default.json"
+        assert default_file.exists()
+        import json
+        saved = json.loads(default_file.read_text())
+        assert saved["models_skipped"] is True
+        assert saved["tier_id"] == "standard"
+
+    async def test_setup_skip_models_does_not_call_installer(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
+
+        tasks: dict = {}
+        task_id = "skip-task-2"
+
+        fake_manifest = SimpleNamespace(
+            id="snowflake-arctic-embed-s",
+            type="model",
+            version="1.0.0",
+            variants=[{
+                "id": "q4_k_m",
+                "format": "gguf",
+                "size_mb": 27,
+                "download_url": "https://example.com/x.gguf",
+                "requires": {"backends": [{"id": "ollama", "targets": ["cpu"], "min_ram_mb": 256}]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
+
+        mock_installer = AsyncMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+
+        with patch(
+            "tinyagentos.installers.base.get_installer",
+            return_value=mock_installer,
+        ):
+            await _run_setup(
+                tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+                registry=fake_registry,
+                hardware_profile=None,
+                backends=None,
+                skip_models=True,
+                data_dir=tmp_path,
+            )
+
+        assert tasks[task_id]["state"] == "deferred"
+        mock_installer.install.assert_not_called()
+
+    async def test_setup_progress_message_labels_models(self, tmp_path):
+        from tinyagentos.routes.taosmd import _run_setup, MEMORY_TIERS
+        from types import SimpleNamespace
+
+        tasks: dict = {}
+        task_id = "label-task-1"
+
+        fake_manifest = SimpleNamespace(
+            id="snowflake-arctic-embed-s",
+            type="model",
+            version="1.0.0",
+            variants=[{
+                "id": "q4_k_m",
+                "format": "gguf",
+                "size_mb": 27,
+                "download_url": "https://example.com/x.gguf",
+                "requires": {"backends": [{"id": "ollama", "targets": ["cpu"], "min_ram_mb": 256}]},
+            }],
+            context_window=0,
+        )
+        fake_registry = SimpleNamespace(get=lambda _id: fake_manifest)
+        fake_hw = HardwareProfile(
+            ram_mb=4096,
+            cpu=CpuInfo(arch="x86_64"),
+            gpu=GpuInfo(type="none"),
+            npu=NpuInfo(type="none"),
+            disk=DiskInfo(free_gb=100),
+            os=OsInfo(distro="linux"),
+        )
+
+        mock_installer = AsyncMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+
+        captured_messages = []
+
+        original_update = None
+        async def patched_run_setup(*args, **kwargs):
+            from tinyagentos.routes.taosmd import _run_setup as real_run_setup
+            # Wrap _update to capture messages
+            return await real_run_setup(*args, **kwargs)
+
+        with patch(
+            "tinyagentos.installers.base.get_installer",
+            return_value=mock_installer,
+        ):
+            await _run_setup(
+                tasks, task_id, "local", "standard", MEMORY_TIERS["standard"],
+                registry=fake_registry,
+                hardware_profile=fake_hw,
+                backends=[{"type": "ollama", "enabled": True}],
+                skip_models=False,
+                data_dir=tmp_path,
+            )
+
+        assert tasks[task_id]["state"] == "done"

--- a/tests/test_routes_taosmd.py
+++ b/tests/test_routes_taosmd.py
@@ -70,6 +70,26 @@ class TestDefault:
         assert resp.status_code == 200
         assert resp.json()["tier_name"] == "custom-tier"
 
+    async def test_get_default_returns_models_skipped_when_deferred(self, client, tmp_data_dir):
+        """GET /api/taosmd/default must expose models_skipped so the wizard
+        can show the deferred state."""
+        import json
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        default_path = tmp_data_dir / "taosmd_default.json"
+        default_path.write_text(json.dumps(default_data))
+
+        resp = await client.get("/api/taosmd/default")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["device_id"] == "local"
+        assert data["tier_id"] == "standard"
+        assert data["models_skipped"] is True
+
 
 @pytest.mark.asyncio
 class TestSetup:

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -497,6 +497,19 @@ def _memory_selection_error(memory_plugin: str | None, memory_mode: str | None) 
     return None
 
 
+def _read_taosmd_default(data_dir):
+    import json
+    if data_dir is None:
+        return None
+    p = data_dir / "taosmd_default.json"
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
 class DeployAgentRequest(BaseModel):
     name: str
     framework: str = "none"
@@ -644,6 +657,64 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 idempotency_cache.set(scoped_key, json.loads(remote_err.body))
             return remote_err
 
+        data_dir = request.app.state.data_dir
+
+        # Self-heal deferred taOSmd model downloads.
+        # If the user deferred model pulls during setup and now deploys an
+        # agent with taOSmd memory (memory_config None or matching the
+        # deferred default), start the pull before the agent is marked ready.
+        # If we cannot start the pull (no registry / offline) return 409
+        # so the caller knows the agent cannot have memory search until the
+        # downloads complete.
+        self_heal_setup_task_id = None
+        if body.memory_plugin == "taosmd" and body.memory_mode != "framework":
+            default_data = _read_taosmd_default(data_dir)
+            if default_data and default_data.get("models_skipped"):
+                agent_cfg = body.memory_config or {}
+                if not body.memory_config or (
+                    agent_cfg.get("device_id") == default_data.get("device_id")
+                    and agent_cfg.get("tier_id") == default_data.get("tier_id")
+                ):
+                    registry = getattr(request.app.state, "registry", None)
+                    if registry is None:
+                        err_body = {
+                            "error": (
+                                "Cannot deploy with taOSmd memory: deferred model downloads "
+                                "require the model registry. Complete memory setup first."
+                            )
+                        }
+                        if scoped_key and idempotency_cache is not None:
+                            idempotency_cache.set(scoped_key, err_body)
+                        return JSONResponse(err_body, status_code=409)
+
+                    tier_id = default_data.get("tier_id", "standard")
+                    from tinyagentos.routes.taosmd import MEMORY_TIERS, _run_setup, _tasks
+                    tier_cfg = MEMORY_TIERS.get(tier_id)
+                    if tier_cfg is not None:
+                        task_id = str(uuid.uuid4())
+                        tasks = _tasks(request)
+                        tasks[task_id] = {
+                            "state": "pending",
+                            "progress_pct": 0,
+                            "message": "Queued…",
+                            "error": None,
+                        }
+                        asyncio.create_task(
+                            _run_setup(
+                                tasks,
+                                task_id,
+                                default_data.get("device_id", "local"),
+                                tier_id,
+                                tier_cfg,
+                                registry=registry,
+                                hardware_profile=getattr(request.app.state, "hardware_profile", None),
+                                backends=list(getattr(config, "backends", []) or []) if config else [],
+                                skip_models=False,
+                                data_dir=data_dir,
+                            )
+                        )
+                        self_heal_setup_task_id = task_id
+
         # Register the agent with taOSmd BEFORE mutating config so a failure
         # here aborts cleanly with no half-state. Skipped for memory_mode='framework'
         # because that mode explicitly opts out of taOSmd.
@@ -740,12 +811,59 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         deploy_tasks[body.name] = {"status": "deploying", "name": body.name}
 
         from tinyagentos.deployer import deploy_agent, DeployRequest
-        data_dir = request.app.state.data_dir
         llm_proxy = getattr(request.app.state, "llm_proxy", None)
         secrets_store = getattr(request.app.state, "secrets", None)
 
         async def _background_deploy():
             try:
+                # Wait for deferred model pull if one was started.
+                if self_heal_setup_task_id is not None:
+                    setup_tasks = getattr(request.app.state, "taosmd_setup_tasks", {})
+                    setup_task = setup_tasks.get(self_heal_setup_task_id)
+                    if setup_task is not None:
+                        terminal = {"done", "failed"}
+                        if setup_task.get("state") not in terminal:
+                            for _ in range(300):
+                                await asyncio.sleep(1)
+                                setup_task = setup_tasks.get(self_heal_setup_task_id)
+                                if setup_task is None or setup_task.get("state") in terminal:
+                                    break
+                            else:
+                                setup_task = {
+                                    "state": "failed",
+                                    "message": "timed out waiting for model download",
+                                }
+
+                        if not setup_task or setup_task.get("state") != "done":
+                            agent = find_agent(config, body.name)
+                            if agent is not None:
+                                agent["status"] = "failed"
+                            err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
+                            deploy_tasks[body.name] = {
+                                "status": "failed",
+                                "name": body.name,
+                                "error": err_msg,
+                            }
+                            notif = getattr(request.app.state, "notifications", None)
+                            if notif:
+                                await notif.add(
+                                    title=f"Deploy failed: {body.name}",
+                                    message=f"Deploy failed for {body.name}: {err_msg}",
+                                    level="error",
+                                    source="agents.deploy",
+                                )
+                            await save_config_locked(config, config.config_path)
+                            return
+
+                        # Setup succeeded: clear models_skipped so future deploys
+                        # don't re-trigger the pull.
+                        current_default = _read_taosmd_default(data_dir)
+                        if current_default and current_default.get("models_skipped"):
+                            current_default["models_skipped"] = False
+                            import json
+                            p = data_dir / "taosmd_default.json"
+                            p.write_text(json.dumps(current_default))
+
                 # Prefetch the base onto the worker here (not in the request
                 # path) so a cold ~300-500MB import never blocks POST /deploy.
                 if deploy_remote:

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -166,7 +166,16 @@ async def setup_status(request: Request):
     has_agent = bool(config.agents)
 
     # memory_enabled: taosmd setup wizard completed (taosmd_default.json written)
-    memory_enabled = (data_dir / "taosmd_default.json").exists()
+    # and models were not deferred.
+    memory_enabled = False
+    default_path = data_dir / "taosmd_default.json"
+    if default_path.exists():
+        try:
+            import json
+            default_data = json.loads(default_path.read_text())
+            memory_enabled = not default_data.get("models_skipped", False)
+        except Exception:  # noqa: BLE001
+            memory_enabled = True
 
     # dismissed: user explicitly dismissed the setup checklist
     setup_prefs = await store.get_preference("user", _PREF_NAMESPACE)

--- a/tinyagentos/routes/taosmd.py
+++ b/tinyagentos/routes/taosmd.py
@@ -10,6 +10,7 @@ Provides:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from pathlib import Path
@@ -58,7 +59,27 @@ MEMORY_TIERS: dict[str, dict] = {
 # In-memory task store (keyed by task_id, lives in app.state.taosmd_setup_tasks)
 # ---------------------------------------------------------------------------
 
-TaskState = Literal["pending", "downloading", "installing", "done", "failed"]
+TaskState = Literal["pending", "downloading", "installing", "done", "failed", "deferred"]
+
+
+def _tier_total_size_mb(tier_cfg: dict, registry) -> int:
+    """Approximate total download size for all models in a tier."""
+    total = 0
+    for model_id in tier_cfg.get("models", []):
+        manifest = registry.get(model_id) if hasattr(registry, "get") else None
+        if manifest is None:
+            continue
+        for variant in getattr(manifest, "variants", []):
+            if isinstance(variant, dict) and variant.get("size_mb"):
+                total += int(variant["size_mb"])
+                break
+    return total
+
+
+def _format_size_mb(size_mb: int) -> str:
+    if size_mb >= 1024:
+        return f"~{size_mb / 1024:.1f} GB"
+    return f"~{size_mb} MB"
 
 
 def _tasks(request: Request) -> dict:
@@ -134,6 +155,7 @@ async def put_default(request: Request, body: DefaultBody):
 class SetupBody(BaseModel):
     device_id: str
     tier: Literal["lite", "standard", "heavy"]
+    skip_models: bool = False
 
 
 @router.post("/api/taosmd/setup")
@@ -165,6 +187,7 @@ async def post_setup(request: Request, body: SetupBody):
     hardware_profile = getattr(request.app.state, "hardware_profile", None)
     config = getattr(request.app.state, "config", None)
     backends_snapshot = list(getattr(config, "backends", []) or []) if config else []
+    data_dir = getattr(request.app.state, "data_dir", None)
 
     asyncio.create_task(
         _run_setup(
@@ -176,6 +199,8 @@ async def post_setup(request: Request, body: SetupBody):
             registry=registry,
             hardware_profile=hardware_profile,
             backends=backends_snapshot,
+            skip_models=body.skip_models,
+            data_dir=data_dir,
         )
     )
 
@@ -206,6 +231,8 @@ async def _run_setup(
     registry=None,
     hardware_profile=None,
     backends: list | None = None,
+    skip_models: bool = False,
+    data_dir: Path | None = None,
 ) -> None:
     """Install each model listed in the tier using the catalog resolver.
 
@@ -218,9 +245,13 @@ async def _run_setup(
     instead.
 
     Progress: pending → downloading (per model) → installing → done / failed.
+    When skip_models=True the default is saved and the task returns
+    "deferred" without downloading anything.
     """
     models: list[str] = tier_cfg.get("models", [])
     total = len(models)
+    total_size_mb = _tier_total_size_mb(tier_cfg, registry)
+    size_label = _format_size_mb(total_size_mb) if total_size_mb else ""
 
     def _update(state: str, pct: int, msg: str, error: str | None = None) -> None:
         tasks[task_id] = {
@@ -229,6 +260,22 @@ async def _run_setup(
             "message": msg,
             "error": error,
         }
+
+    if skip_models:
+        payload = {
+            "device_id": device_id,
+            "tier_id": tier,
+            "tier_name": tier_cfg.get("label", tier),
+            "models_skipped": True,
+        }
+        if data_dir is not None:
+            (data_dir / "taosmd_default.json").write_text(json.dumps(payload))
+        _update(
+            "deferred",
+            0,
+            f"Model downloads deferred — memory-engine embedding models ({size_label}), required for memory search.",
+        )
+        return
 
     _update("pending", 0, "Starting…")
 
@@ -290,10 +337,19 @@ async def _run_setup(
 
         for idx, manifest_id in enumerate(models):
             base_pct = int(idx / total * 90)
+            chosen_variant_for_size = None
+            manifest = registry.get(manifest_id) if hasattr(registry, "get") else None
+            if manifest is not None:
+                for v in getattr(manifest, "variants", []):
+                    if isinstance(v, dict) and v.get("size_mb"):
+                        chosen_variant_for_size = v
+                        break
+            size_str = _format_size_mb(chosen_variant_for_size["size_mb"]) if chosen_variant_for_size else ""
             _update(
                 "downloading",
                 base_pct,
-                f"Installing {manifest_id} ({idx + 1}/{total})…",
+                f"Downloading memory-engine embedding model {idx + 1}/{total}: {manifest_id}"
+                f"{' (' + size_str + ')' if size_str else ''} — required for memory search",
             )
 
             manifest = registry.get(manifest_id) if hasattr(registry, "get") else None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2936 (tsk-awxkei): deferred taOSmd models must self-heal on first use - deploy with models_skipped pulls or 409s, never a memory-less agent (community taOS#2)

Autonomous build of board card tsk-jmdy3d.

REVISION: built on `exec/tsk-awxkei` (cut at `533f43e3ee98fb34ed1e0fe16285f11fa1bb97ec`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

When taosmd_default.json has models_skipped=true and an agent is deployed
with memory_plugin='taosmd' (memory_config None or matching the default
tier), POST /api/agents/deploy now starts the deferred model pull before
the agent is marked ready. If the registry is unavailable, deploy returns
409 with a message naming the deferred download, never a 200 with a
memory-less agent.

Consumer that turns a global default into an agent's memory tier:
- desktop/src/apps/agents/DeployWizard.tsx:111 fetches /api/taosmd/default
  and stores it in memoryDefault; when memoryDeviceId/memoryTierId are
  null the wizard sends memory_config=undefined and the server stores
  None via DeployAgentRequest.memory_config (tinyagentos/routes/agents.py:525)
  and normalize_agent (tinyagentos/config.py:391), causing the runtime to
  fall back to taosmd_default.json.

Changes:
- tinyagentos/routes/agents.py: add _read_taosmd_default helper
- tinyagentos/routes/agents.py: in deploy_agent_endpoint, check
  models_skipped before side effects and return 409 if no registry
- tinyagentos/routes/agents.py: in _background_deploy, wait for the
  deferred setup task and clear models_skipped on success
- desktop/src/apps/agents/DeployWizard.tsx: show "Models deferred" branch
  when models_skipped is true, with a "Download now" action
- tests/test_routes_agents.py: test that deploy returns 409 when deferred
  models cannot be pulled
- tests/test_routes_taosmd.py: test that GET /api/taosmd/default exposes
  models_skipped
- changelog.d/tsk-awxkei-installer-transparency.md: extend with self-heal

```text
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_deploy_deferred_models_no_registry_returns_409
E       assert 200 == 409
E        +  where 200 = <Response [200 OK]>.status_code
============================== short test summary info ==========================
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_deploy_deferred_models_no_registry_returns_409
1 failed in 4.94s
```

```text
.                                                                        [ 100%]
1 passed in 2.90s
```

Docs-Reviewed: self-heal logic is internal to the deploy path; no new
user-facing API surface beyond what the existing taOSmd setup wizard
already documents.

Files:
 changelog.d/tsk-awxkei-installer-transparency.md |   3 +
 desktop/src/apps/agents/DeployWizard.tsx         |  75 +++++++++---
 tests/test_routes_agents.py                      |  43 +++++++
 tests/test_routes_taosmd.py                      | 142 +++++++++++++++++++++++
 tinyagentos/routes/agents.py                     | 120 ++++++++++++++++++-
 tinyagentos/routes/setup.py                      |  11 +-
 tinyagentos/routes/taosmd.py                     |  60 +++++++++-
 7 files changed, 437 insertions(+), 17 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to defer taOSmd model downloads during memory setup.
  * Setup progress now shows estimated model download sizes.
  * Deployment can automatically download deferred models before marking an agent ready.
  * Added recovery actions to download deferred models or skip memory setup.
* **Bug Fixes**
  * Deployments now report a clear conflict when deferred models cannot be downloaded.
  * Failed or timed-out model downloads are surfaced as deployment failures instead of leaving agents ready prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->