### PR TITLE
deploy self-heal for deferred taOSmd models: 300 s wall-clock cap fails multi-GB pulls and concurrent deploys start duplicate pulls (follow-up #2937)

### DIFF
--- a/changelog.d/tsk-5ggef6-selfheal-wait.md
+++ b/changelog.d/tsk-5ggef6-selfheal-wait.md
@@ -1,0 +1,2 @@
+### Fixed
+- Deploy-time self-heal for deferred taOSmd models no longer times out after a fixed 300 s wall-clock cap; wait now polls until the pull task reaches a terminal state and only fails if progress/message stalls for 10 minutes. Concurrent deploys against the same deferred default attach to a single in-flight pull instead of starting duplicate downloads.

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -2102,3 +2102,163 @@ class TestDeployDeferredModelsSelfHeal:
         assert resp.status_code == 409
         data = resp.json()
         assert "deferred" in data["error"].lower() or "download" in data["error"].lower()
+
+    async def test_concurrent_deploys_share_single_run_setup(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """Two concurrent deploys against a deferred default must attach to
+        the same in-flight _run_setup task and never start a duplicate pull."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        setup_call_count = 0
+        setup_event = asyncio.Event()
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            nonlocal setup_call_count
+            setup_call_count += 1
+            tasks[task_id] = {
+                "state": "downloading",
+                "progress_pct": 0,
+                "message": "Downloading…",
+                "error": None,
+            }
+            await setup_event.wait()
+            tasks[task_id] = {
+                "state": "done",
+                "progress_pct": 100,
+                "message": "Memory layer ready.",
+                "error": None,
+            }
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            resp_a = await client.post("/api/agents/deploy", json={
+                "name": "concurrent-a",
+                "framework": "none",
+                "model": "test-model",
+                "memory_plugin": "taosmd",
+                "memory_config": None,
+            })
+            resp_b = await client.post("/api/agents/deploy", json={
+                "name": "concurrent-b",
+                "framework": "none",
+                "model": "test-model",
+                "memory_plugin": "taosmd",
+                "memory_config": None,
+            })
+            assert resp_a.status_code == 200
+            assert resp_b.status_code == 200
+            assert setup_call_count == 1
+
+            setup_event.set()
+            await asyncio.sleep(1.0)
+
+            for name in ("concurrent-a", "concurrent-b"):
+                detail = await client.get(f"/api/agents/{name}")
+                assert detail.status_code == 200
+                assert detail.json().get("status") == "running"
+
+    async def test_advancing_progress_avoids_timeout(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """A pull that keeps advancing progress_pct past 300 simulated seconds
+        must not mark the deploy failed."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        _original_sleep = asyncio.sleep
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            await _original_sleep(0)
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            for i in range(600):
+                if i % 50 == 0:
+                    tasks[task_id] = {
+                        "state": "downloading",
+                        "progress_pct": min(99, i // 6),
+                        "message": f"Downloading model {min(99, i // 6)}%",
+                        "error": None,
+                    }
+                await _original_sleep(0)
+            tasks[task_id] = {
+                "state": "done",
+                "progress_pct": 100,
+                "message": "Memory layer ready.",
+                "error": None,
+            }
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            with patch("asyncio.sleep", fake_sleep):
+                resp = await client.post("/api/agents/deploy", json={
+                    "name": "advancing-progress",
+                    "framework": "none",
+                    "model": "test-model",
+                    "memory_plugin": "taosmd",
+                    "memory_config": None,
+                })
+                assert resp.status_code == 200
+
+                for _ in range(300):
+                    await asyncio.sleep(1.0)
+
+                detail = await client.get("/api/agents/advancing-progress")
+                assert detail.status_code == 200
+                assert detail.json().get("status") != "failed"
+                deploy_status = app.state.deploy_tasks.get("advancing-progress", {}).get("status")
+                assert deploy_status != "failed"
+                setup_task = app.state.taosmd_setup_tasks.get(
+                    next(iter(app.state.taosmd_setup_tasks))
+                )
+                assert setup_task is not None
+                assert setup_task.get("progress_pct", 0) > 0
+                assert len(sleep_calls) > 300
+                assert len(sleep_calls) > 300

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -6,6 +6,7 @@ import logging
 import math
 import secrets
 import time
+import uuid
 from collections import OrderedDict
 
 from fastapi import APIRouter, Request
@@ -691,29 +692,62 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     from tinyagentos.routes.taosmd import MEMORY_TIERS, _run_setup, _tasks
                     tier_cfg = MEMORY_TIERS.get(tier_id)
                     if tier_cfg is not None:
-                        task_id = str(uuid.uuid4())
                         tasks = _tasks(request)
-                        tasks[task_id] = {
-                            "state": "pending",
-                            "progress_pct": 0,
-                            "message": "Queued…",
-                            "error": None,
-                        }
-                        asyncio.create_task(
-                            _run_setup(
-                                tasks,
-                                task_id,
-                                default_data.get("device_id", "local"),
-                                tier_id,
-                                tier_cfg,
-                                registry=registry,
-                                hardware_profile=getattr(request.app.state, "hardware_profile", None),
-                                backends=list(getattr(config, "backends", []) or []) if config else [],
-                                skip_models=False,
-                                data_dir=data_dir,
+                        existing_task_id = getattr(request.app.state, "taosmd_selfheal_task_id", None)
+                        if existing_task_id is not None:
+                            existing_task = tasks.get(existing_task_id)
+                            if existing_task is not None and existing_task.get("state") not in {"done", "failed"}:
+                                task_id = existing_task_id
+                                self_heal_setup_task_id = task_id
+                            else:
+                                request.app.state.taosmd_selfheal_task_id = None
+                                task_id = str(uuid.uuid4())
+                                tasks[task_id] = {
+                                    "state": "pending",
+                                    "progress_pct": 0,
+                                    "message": "Queued…",
+                                    "error": None,
+                                }
+                                asyncio.create_task(
+                                    _run_setup(
+                                        tasks,
+                                        task_id,
+                                        default_data.get("device_id", "local"),
+                                        tier_id,
+                                        tier_cfg,
+                                        registry=registry,
+                                        hardware_profile=getattr(request.app.state, "hardware_profile", None),
+                                        backends=list(getattr(config, "backends", []) or []) if config else [],
+                                        skip_models=False,
+                                        data_dir=data_dir,
+                                    )
+                                )
+                                request.app.state.taosmd_selfheal_task_id = task_id
+                                self_heal_setup_task_id = task_id
+                        else:
+                            task_id = str(uuid.uuid4())
+                            tasks[task_id] = {
+                                "state": "pending",
+                                "progress_pct": 0,
+                                "message": "Queued…",
+                                "error": None,
+                            }
+                            asyncio.create_task(
+                                _run_setup(
+                                    tasks,
+                                    task_id,
+                                    default_data.get("device_id", "local"),
+                                    tier_id,
+                                    tier_cfg,
+                                    registry=registry,
+                                    hardware_profile=getattr(request.app.state, "hardware_profile", None),
+                                    backends=list(getattr(config, "backends", []) or []) if config else [],
+                                    skip_models=False,
+                                    data_dir=data_dir,
+                                )
                             )
-                        )
-                        self_heal_setup_task_id = task_id
+                            request.app.state.taosmd_selfheal_task_id = task_id
+                            self_heal_setup_task_id = task_id
 
         # Register the agent with taOSmd BEFORE mutating config so a failure
         # here aborts cleanly with no half-state. Skipped for memory_mode='framework'
@@ -823,37 +857,53 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     if setup_task is not None:
                         terminal = {"done", "failed"}
                         if setup_task.get("state") not in terminal:
-                            for _ in range(300):
+                            last_progress = setup_task.get("progress_pct")
+                            last_message = setup_task.get("message")
+                            stall_seconds = 0
+                            max_stall_seconds = 600
+                            while True:
                                 await asyncio.sleep(1)
                                 setup_task = setup_tasks.get(self_heal_setup_task_id)
                                 if setup_task is None or setup_task.get("state") in terminal:
                                     break
-                            else:
-                                setup_task = {
-                                    "state": "failed",
-                                    "message": "timed out waiting for model download",
-                                }
+                                pct = setup_task.get("progress_pct")
+                                msg = setup_task.get("message")
+                                if pct == last_progress and msg == last_message:
+                                    stall_seconds += 1
+                                    if stall_seconds >= max_stall_seconds:
+                                        setup_task = {
+                                            "state": "failed",
+                                            "message": "model download stalled — no progress for 10 minutes",
+                                        }
+                                        break
+                                else:
+                                    stall_seconds = 0
+                                    last_progress = pct
+                                    last_message = msg
 
-                        if not setup_task or setup_task.get("state") != "done":
-                            agent = find_agent(config, body.name)
-                            if agent is not None:
-                                agent["status"] = "failed"
-                            err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
-                            deploy_tasks[body.name] = {
-                                "status": "failed",
-                                "name": body.name,
-                                "error": err_msg,
-                            }
-                            notif = getattr(request.app.state, "notifications", None)
-                            if notif:
-                                await notif.add(
-                                    title=f"Deploy failed: {body.name}",
-                                    message=f"Deploy failed for {body.name}: {err_msg}",
-                                    level="error",
-                                    source="agents.deploy",
-                                )
-                            await save_config_locked(config, config.config_path)
-                            return
+                    if setup_task is not None and setup_task.get("state") in terminal:
+                        request.app.state.taosmd_selfheal_task_id = None
+
+                    if not setup_task or setup_task.get("state") != "done":
+                        agent = find_agent(config, body.name)
+                        if agent is not None:
+                            agent["status"] = "failed"
+                        err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
+                        deploy_tasks[body.name] = {
+                            "status": "failed",
+                            "name": body.name,
+                            "error": err_msg,
+                        }
+                        notif = getattr(request.app.state, "notifications", None)
+                        if notif:
+                            await notif.add(
+                                title=f"Deploy failed: {body.name}",
+                                message=f"Deploy failed for {body.name}: {err_msg}",
+                                level="error",
+                                source="agents.deploy",
+                            )
+                        await save_config_locked(config, config.config_path)
+                        return
 
                         # Setup succeeded: clear models_skipped so future deploys
                         # don't re-trigger the pull.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): deploy self-heal for deferred taOSmd models: 300 s wall-clock cap fails multi-GB pulls and concurrent deploys start duplicate pulls (follow-up #2937)

Autonomous build of board card tsk-5ggef6.

Record the in-flight self-heal task id on app.state.taosmd_selfheal_task_id when
started; a second deploy that finds a non-terminal in-flight task must ATTACH to
it (wait on the same task id), never start another. Clear the pointer on terminal
state.

Replace the fixed 300-iteration cap with a wait bounded by the task itself: poll
until state in {done, failed}; add a liveness guard instead of a wall-clock cap
(fail only if progress_pct/message has not changed for 10 minutes). Keep the 1 s
poll.

RED-FIRST proof:

```text
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_concurrent_deploys_share_single_run_setup
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_advancing_progress_avoids_timeout
========================= 2 failed in 4.32s ==========================
```

Green on head:

```text
============================== 3 passed in 7.61s ===============================
```

Docs-Reviewed: no agent-coordination doc change needed, self-heal wait behavior is internal to the deploy endpoint.

Files:
 changelog.d/tsk-5ggef6-selfheal-wait.md |   2 +
 tests/test_routes_agents.py             | 160 ++++++++++++++++++++++++++++++++
 tinyagentos/routes/agents.py            | 146 +++++++++++++++++++----------
 3 files changed, 260 insertions(+), 48 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deferred model deployment recovery by waiting for download progress instead of using a fixed timeout.
  * Prevented concurrent deployments from starting duplicate downloads by sharing the active setup task.
  * Deployments now fail after 10 minutes without progress, with failure status and notifications recorded appropriately.

* **Tests**
  * Added coverage for concurrent deferred deployments and downloads that continue beyond the previous timeout window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->