### PR TITLE
[lib-audit] Browser proxy never rewrites @import or text/css

### DIFF
--- a/changelog.d/tsk-fgs3yp-css-proxy-rewrite.md
+++ b/changelog.d/tsk-fgs3yp-css-proxy-rewrite.md
@@ -1,0 +1,2 @@
+### Fixed
+- Browser proxy now rewrites `@import` preludes and `text/css` response bodies through the proxy, closing isolation leaks where CSS URLs bypassed cookie isolation and the SSRF choke point. Data-URI `url()` values with nested parentheses are also preserved correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ dependencies = [
     # relicence or CVE reached users without tripping any gate. Declared here so
     # it goes through the lockfile like everything else.
     "yt-dlp>=2025.1.15",
+    # CSS tokenizer for the browser proxy — rewrites url() and @import in
+    # proxied stylesheets (tsk-fgs3yp). BSD-3-Clause, pure py3-none-any,
+    # one dep (webencodings, also BSD).
+    "tinycss2>=1.5.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/routes/desktop_browser/test_css_rewrite.py
+++ b/tests/routes/desktop_browser/test_css_rewrite.py
@@ -1,0 +1,75 @@
+"""Tests for CSS URL rewriting in the browser proxy.
+
+Red-first: these tests reproduce three isolation leaks described in
+tsk-fgs3yp and must fail against the current regex-based rewriter.
+"""
+from __future__ import annotations
+
+import respx
+import pytest
+
+
+def _proxy(url: str) -> str:
+    from urllib.parse import quote
+    return f"/api/desktop/browser/proxy?profile_id=p&url={quote(url, safe='')}"
+
+
+class TestCssRewrite:
+    def test_rewrites_import_in_inline_style_block(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            b'<html><head><style>'
+            b'@import "https://evil.example/x.css";'
+            b'</style></head><body></body></html>'
+        )
+        out = rewrite_html(html, base_url="https://example.com/", proxy=_proxy)
+
+        assert b"/api/desktop/browser/proxy" in out
+        assert b"https://evil.example/x.css" not in out
+
+    def test_rewrites_quoted_url_with_parentheses(self):
+        from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+
+        html = (
+            b"<html><body><div style='background: "
+            b'url("http://example.com/img(rgb).png)\'>'
+            b"</div></body></html>"
+        )
+        out = rewrite_html(html, base_url="http://example.com/", proxy=_proxy)
+
+        assert b"/api/desktop/browser/proxy" in out
+        assert b"img%28rgb%29.png" in out
+
+
+@pytest.mark.asyncio
+class TestProxyCssRewrite:
+    @respx.mock
+    async def test_rewrites_text_css_response_body(self, client):
+        from httpx import Response
+        from unittest.mock import patch
+
+        css_body = (
+            b'@import "https://evil.example/x.css";\n'
+            b'body { background: url(/bg.png); }'
+        )
+        respx.get("http://example.com/style.css").mock(
+            return_value=Response(
+                200,
+                content=css_body,
+                headers={"content-type": "text/css"},
+            )
+        )
+
+        with patch(
+            "tinyagentos.routes.desktop_browser.ssrf.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        ):
+            resp = await client.get(
+                "/api/desktop/browser/proxy",
+                params={"profile_id": "personal", "url": "http://example.com/style.css"},
+            )
+
+        assert resp.status_code == 200
+        assert b"/api/desktop/browser/proxy" in resp.content
+        assert b"https://evil.example/x.css" not in resp.content

--- a/tinyagentos/routes/desktop_browser/proxy.py
+++ b/tinyagentos/routes/desktop_browser/proxy.py
@@ -51,7 +51,7 @@ from tinyagentos.routes.desktop_browser.profile import (
     ensure_default_profiles,
     get_profile_or_404,
 )
-from tinyagentos.routes.desktop_browser.rewriter import rewrite_html
+from tinyagentos.routes.desktop_browser.rewriter import rewrite_css, rewrite_html
 from tinyagentos.routes.desktop_browser.ssrf import (
     SsrfBlockedError,
     guarded_async_client,
@@ -480,6 +480,38 @@ async def proxy_get(
             status_code=response.status_code,
             headers=out_headers,
             media_type="text/html; charset=utf-8",
+        )
+
+    if "text/css" in content_type:
+        proxy_prefix = (
+            f"/api/desktop/browser/proxy?profile_id={quote(profile_id, safe='')}"
+            f"&url="
+        )
+
+        def _proxy_url(absolute: str) -> str:
+            return f"{proxy_prefix}{quote(absolute, safe='')}"
+
+        rewritten = rewrite_css(
+            response.content.decode("utf-8", errors="replace"),
+            base_url=str(response.url),
+            proxy=_proxy_url,
+        )
+        rewritten_bytes = rewritten.encode("utf-8")
+
+        if len(rewritten_bytes) > _MAX_RESPONSE_BYTES:
+            _logger.info(
+                "browser proxy rewritten CSS too large: bytes=%d limit=%d",
+                len(rewritten_bytes), _MAX_RESPONSE_BYTES,
+            )
+            return JSONResponse(
+                {"error": "response too large"}, status_code=502,
+            )
+
+        return Response(
+            content=rewritten_bytes,
+            status_code=response.status_code,
+            headers=out_headers,
+            media_type="text/css; charset=utf-8",
         )
 
     # Non-HTML — pass through bytes verbatim

--- a/tinyagentos/routes/desktop_browser/rewriter.py
+++ b/tinyagentos/routes/desktop_browser/rewriter.py
@@ -32,19 +32,13 @@ import re
 from typing import Callable
 from urllib.parse import urljoin
 
+import tinycss2
 from lxml import html as lxml_html
 
 
 # Schemes we never rewrite — these aren't HTTP fetches the proxy can serve.
 _SKIP_PREFIXES = (
     "data:", "javascript:", "mailto:", "tel:", "blob:", "about:", "#",
-)
-
-
-# CSS url() rewriter — captures url(), url(""), url('').
-_CSS_URL_RE = re.compile(
-    r"""url\(\s*(['"]?)([^)'"]+)\1\s*\)""",
-    re.IGNORECASE,
 )
 
 
@@ -218,16 +212,154 @@ def _rewrite_srcset(
         el.set("srcset", ", ".join(parts))
 
 
+def _quote_string(original_representation: str, new_value: str) -> str:
+    """Preserve the quote style from the original StringToken representation."""
+    if original_representation.startswith("'"):
+        return f"'{new_value}'"
+    if original_representation.startswith('"'):
+        return f'"{new_value}"'
+    return new_value
+
+
+def _rewrite_css_token(token, *, base_url: str, proxy: Callable[[str], str]):
+    """Rewrite a single tinycss2 token if it carries a rewriteable URL.
+
+    Returns the (possibly new) token.  Block tokens are recursed into so
+    that url() inside a CurlyBracketsBlock is also rewritten.
+    """
+    if isinstance(token, tinycss2.ast.URLToken):
+        url = token.value
+        if _should_rewrite(url):
+            new_url = _rewrite_one(url, base_url=base_url, proxy=proxy)
+            return tinycss2.ast.URLToken(
+                token.source_line, token.source_column, new_url, f"url({new_url})",
+            )
+        return token
+
+    if (
+        isinstance(token, tinycss2.ast.FunctionBlock)
+        and token.name.lower() == "url"
+    ):
+        new_args = []
+        modified = False
+        for arg in token.arguments:
+            if isinstance(arg, tinycss2.ast.StringToken):
+                url = arg.value
+                if _should_rewrite(url):
+                    new_url = _rewrite_one(url, base_url=base_url, proxy=proxy)
+                    new_args.append(
+                        tinycss2.ast.StringToken(
+                            arg.source_line, arg.source_column, new_url,
+                            _quote_string(arg.representation, new_url),
+                        )
+                    )
+                    modified = True
+                    continue
+            new_args.append(arg)
+        if modified:
+            return tinycss2.ast.FunctionBlock(
+                token.source_line, token.source_column, token.name, new_args,
+            )
+        return token
+
+    if hasattr(token, "content"):
+        new_content = _rewrite_css_tokens(
+            list(token.content), base_url=base_url, proxy=proxy,
+        )
+        if new_content != token.content:
+            new_token = token.__class__.__new__(token.__class__)
+            for attr in ("source_line", "source_column"):
+                if hasattr(token, attr):
+                    setattr(new_token, attr, getattr(token, attr))
+            new_token.content = new_content
+            return new_token
+    return token
+
+
+def _rewrite_css_tokens(
+    tokens: list, *, base_url: str, proxy: Callable[[str], str],
+) -> list:
+    """Walk a flat list of tinycss2 tokens, rewriting url() and @import URLs."""
+    out = []
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+
+        if isinstance(token, tinycss2.ast.AtKeywordToken) and token.value == "import":
+            out.append(token)
+            i += 1
+            while i < len(tokens) and isinstance(tokens[i], tinycss2.ast.WhitespaceToken):
+                out.append(tokens[i])
+                i += 1
+            if i < len(tokens):
+                url_token = tokens[i]
+                if isinstance(url_token, tinycss2.ast.StringToken):
+                    url = url_token.value
+                    if _should_rewrite(url):
+                        new_url = _rewrite_one(url, base_url=base_url, proxy=proxy)
+                        out.append(
+                            tinycss2.ast.StringToken(
+                                url_token.source_line, url_token.source_column, new_url,
+                                _quote_string(url_token.representation, new_url),
+                            )
+                        )
+                        i += 1
+                        continue
+                elif (
+                    isinstance(url_token, tinycss2.ast.FunctionBlock)
+                    and url_token.name.lower() == "url"
+                ):
+                    new_args = []
+                    modified = False
+                    for arg in url_token.arguments:
+                        if isinstance(arg, tinycss2.ast.StringToken):
+                            url = arg.value
+                            if _should_rewrite(url):
+                                new_url = _rewrite_one(url, base_url=base_url, proxy=proxy)
+                                new_args.append(
+                                    tinycss2.ast.StringToken(
+                                        arg.source_line, arg.source_column, new_url,
+                                        _quote_string(arg.representation, new_url),
+                                    )
+                                )
+                                modified = True
+                                continue
+                        new_args.append(arg)
+                    if modified:
+                        out.append(
+                            tinycss2.ast.FunctionBlock(
+                                url_token.source_line, url_token.source_column,
+                                url_token.name, new_args,
+                            )
+                        )
+                        i += 1
+                        continue
+            out.append(url_token)
+            i += 1
+            continue
+
+        out.append(_rewrite_css_token(token, base_url=base_url, proxy=proxy))
+        i += 1
+    return out
+
+
+def rewrite_css(
+    css_text: str, *, base_url: str, proxy: Callable[[str], str],
+) -> str:
+    """Rewrite url() and @import URLs in a CSS text string.
+
+    Used by the proxy for text/css responses as well as by the HTML
+    rewriter for inline styles and <style> tags.
+    """
+    return _rewrite_css_text(css_text, base_url=base_url, proxy=proxy)
+
+
 def _rewrite_css_text(
     text: str, *, base_url: str, proxy: Callable[[str], str],
 ) -> str:
-    def replace(match: re.Match) -> str:
-        quote = match.group(1)
-        url = match.group(2).strip()
-        new_url = _rewrite_one(url, base_url=base_url, proxy=proxy)
-        return f"url({quote}{new_url}{quote})"
-
-    return _CSS_URL_RE.sub(replace, text)
+    tokens = tinycss2.parse_component_value_list(text)
+    rewritten = _rewrite_css_tokens(tokens, base_url=base_url, proxy=proxy)
+    return tinycss2.serialize(rewritten)
 
 
 def _rewrite_inline_styles(
@@ -235,7 +367,7 @@ def _rewrite_inline_styles(
 ) -> None:
     for el in tree.iter():
         style = el.get("style")
-        if not style or "url(" not in style.lower():
+        if not style or ("url(" not in style.lower() and "@import" not in style.lower()):
             continue
         el.set("style", _rewrite_css_text(style, base_url=base_url, proxy=proxy))
 
@@ -244,10 +376,11 @@ def _rewrite_style_tags(
     tree, *, base_url: str, proxy: Callable[[str], str],
 ) -> None:
     for style_el in tree.iter("style"):
-        if style_el.text is None or "url(" not in style_el.text.lower():
+        text = style_el.text
+        if text is None or ("url(" not in text.lower() and "@import" not in text.lower()):
             continue
         style_el.text = _rewrite_css_text(
-            style_el.text, base_url=base_url, proxy=proxy
+            text, base_url=base_url, proxy=proxy
         )
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] Browser proxy never rewrites @import or text/css

Autonomous build of board card tsk-fgs3yp.

The browser proxy's CSS rewriter used a regex that could not match
@import preludes or quoted url() values containing parentheses, and
the proxy only rewrote text/html responses, leaving text/css as a
byte pass-through isolation leak.

Changes:
- Add tinycss2>=1.5.1 (BSD-3-Clause) to pyproject.toml
- Replace _CSS_URL_RE regex in rewriter.py with tinycss2 token
  parsing that rewrites both url() and @import URLs
- Add text/css branch in proxy.py that rewrites CSS through
  rewrite_css() and checks rewritten size post-serialization
- Update style-tag and inline-style guards to also process @import
- Add tests in test_css_rewrite.py covering @import, quoted url()
  with parentheses, and text/css response rewriting

Docs-Reviewed: CSS proxy rewrite is internal routing logic, no
agent-coordination doc change needed

RED-FIRST proof:
```
FAILED tests/routes/desktop_browser/test_css_rewrite.py::TestCssRewrite::test_rewrites_import_in_inline_style_block
FAILED tests/routes/desktop_browser/test_css_rewrite.py::TestCssRewrite::test_rewrites_quoted_url_with_parentheses
FAILED tests/routes/desktop_browser/test_css_rewrite.py::TestProxyCssRewrite::test_rewrites_text_css_response_body
3 failed, 2 warnings
```

GREEN:
```
3 passed, 2 warnings
```

Files:
 changelog.d/tsk-fgs3yp-css-proxy-rewrite.md      |   2 +
 pyproject.toml                                   |   4 +
 tests/routes/desktop_browser/test_css_rewrite.py |  75 ++++++++++
 tinyagentos/routes/desktop_browser/proxy.py      |  34 ++++-
 tinyagentos/routes/desktop_browser/rewriter.py   | 167 ++++++++++++++++++++---
 5 files changed, 264 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser proxy handling for CSS stylesheets, including `@import` rules and resource URLs.
  * Fixed rewriting of CSS resources while preserving cookie isolation and secure request routing.
  * Corrected handling of data-URI `url()` values containing nested parentheses.
  * Inline styles and embedded `<style>` blocks now consistently rewrite CSS imports and URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->