### PR TITLE
[lib-audit] MessagesApp leaks a zombie WebSocket after unmount

### DIFF
--- a/changelog.d/tsk-qg7evy-messages-ws-reconnect.md
+++ b/changelog.d/tsk-qg7evy-messages-ws-reconnect.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- MessagesApp no longer leaks a zombie WebSocket after unmount; reconnect timers are cancelled on cleanup, delays are jittered to prevent lockstep reconnects, and reconnection stops after 20 failed attempts.

--- a/desktop/src/apps/MessagesApp/index.tsx
+++ b/desktop/src/apps/MessagesApp/index.tsx
@@ -983,6 +983,8 @@ export function MessagesApp({
   const lastTypingSentRef = useRef(0);
   const autoScrollRef = useRef(true);
   const reconnectDelayRef = useRef(1000);
+  const reconnectAttemptsRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevChannelRef = useRef<string | null>(null);
 
   /* ---- fetch channels + unread ---- */
@@ -1254,10 +1256,17 @@ export function MessagesApp({
     ws.onclose = () => {
       setWsStatus("disconnected");
       wsRef.current = null;
-      // reconnect with backoff
-      const delay = reconnectDelayRef.current;
-      reconnectDelayRef.current = Math.min(delay * 2, 30000);
-      setTimeout(connectWs, delay);
+      if (reconnectAttemptsRef.current >= 20) return;
+      reconnectAttemptsRef.current += 1;
+      const base = reconnectDelayRef.current;
+      const jitter = Math.floor(Math.random() * base);
+      const delay = base + jitter;
+      reconnectDelayRef.current = Math.min(base * 2, 30000);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        connectWs();
+      }, delay);
     };
 
     ws.onerror = () => {
@@ -1295,10 +1304,14 @@ export function MessagesApp({
     fetchAgentLists();
     connectWs();
     return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = null;
       if (wsRef.current) {
         wsRef.current.onclose = null;
         wsRef.current.close();
       }
+      wsRef.current = null;
+      reconnectAttemptsRef.current = 0;
     };
   }, [fetchChannels, fetchArchivedChannels, fetchAgentLists, connectWs]);
 

--- a/desktop/src/apps/__tests__/MessagesApp.ws.test.tsx
+++ b/desktop/src/apps/__tests__/MessagesApp.ws.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import React from "react";
+
+// ─── WebSocket mock ──────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    this.readyState = MockWebSocket.CONNECTING;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(_data: unknown) {}
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+// ─── Lightweight stubs for heavy deps ────────────────────────────────────────
+
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: vi.fn() }));
+vi.mock("@/hooks/use-visual-viewport", () => ({
+  useVisualViewport: () => ({ height: 800, keyboardInset: 0 }),
+}));
+vi.mock("@/hooks/use-chat-notifications", () => ({
+  useChatNotifications: () => ({ notify: vi.fn() }),
+}));
+vi.mock("@/hooks/use-thread-panel", () => ({
+  useThreadPanel: () => ({
+    openThread: null,
+    openThreadFor: vi.fn(),
+    closeThread: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/use-bus-channels", () => ({
+  useBusChannels: () => ({ channels: [], loading: false }),
+}));
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+vi.mock("@/hooks/use-drop-target", () => ({
+  useDropTarget: () => ({
+    isOver: false,
+    isValidTarget: false,
+    dropHandlers: {
+      onDragEnter: vi.fn(),
+      onDragOver: vi.fn(),
+      onDragLeave: vi.fn(),
+      onDrop: vi.fn(),
+    },
+  }),
+}));
+vi.mock("@/registry/app-registry", () => ({
+  getApp: () => undefined,
+}));
+vi.mock("@/components/mobile/MobileSplitView", () => ({
+  MobileSplitView: ({ listTitle, list, detail }: {
+    listTitle?: string;
+    list?: React.ReactNode;
+    detail?: React.ReactNode;
+  }) => (
+    <div data-testid="mobile-split-view" data-list-title={listTitle}>
+      <div data-testid="msv-list">{list}</div>
+      <div data-testid="msv-detail">{detail}</div>
+    </div>
+  ),
+}));
+vi.mock("@/lib/api", () => ({
+  attachmentFromPath: vi.fn(),
+  uploadDiskFile: vi.fn(),
+  uploadFileAttachment: vi.fn(),
+}));
+vi.mock("../MessagesApp.stallWatch", () => ({
+  useStallWatch: () => ({ stallInfo: null }),
+  computeStallInfo: () => null,
+}));
+vi.mock("../MessagesApp.a2aSelection", () => ({
+  selectInitialBusChannel: vi.fn(),
+  selectFirstBoundChannel: vi.fn(),
+}));
+vi.mock("../chat/ChannelSidebar", () => ({
+  ChannelSidebar: () => <div data-testid="channel-sidebar" />,
+}));
+vi.mock("../chat/MessageList", () => ({
+  MessageList: () => <div data-testid="message-list" />,
+}));
+vi.mock("../chat/MessageInput", () => ({
+  MessageInput: () => <div data-testid="message-input" />,
+}));
+vi.mock("../chat/A2aBusPanel", () => ({
+  A2aBusMessageView: () => <div data-testid="a2a-bus-view" />,
+  useBusChannels: () => ({ channels: [], loading: false }),
+}));
+
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { MessagesApp } from "../MessagesApp";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function reset() {
+  MockWebSocket.instances = [];
+  vi.clearAllTimers();
+  vi.clearAllMocks();
+  (useIsMobile as ReturnType<typeof vi.fn>).mockReturnValue(false);
+}
+
+async function openFirstSocket() {
+  const ws = MockWebSocket.instances[0];
+  ws.readyState = MockWebSocket.OPEN;
+  ws.onopen?.();
+  await act(async () => {});
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MessagesApp WebSocket reconnect (tsk-qg7evy)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    reset();
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  it("unmounting cancels the pending reconnect", async () => {
+    render(<MessagesApp windowId="test" />);
+    await openFirstSocket();
+
+    // Simulate backend restart: socket closes and arms reconnect timer.
+    MockWebSocket.instances[0].close();
+    await act(async () => {});
+
+    // Unmount before the timer fires.
+    cleanup();
+
+    // Fast-forward past the default 1s reconnect window.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("reconnect delay is jittered across instances", async () => {
+    const delays: number[] = [];
+
+    const originalSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: TimerHandler, ms: number) => {
+      delays.push(ms);
+      return originalSetTimeout(fn, ms);
+    });
+
+    render(<MessagesApp windowId="test" />);
+    await openFirstSocket();
+    MockWebSocket.instances[0].close();
+    await act(async () => {});
+
+    render(<MessagesApp windowId="test-2" />);
+    await openFirstSocket();
+    MockWebSocket.instances[1].close();
+    await act(async () => {});
+
+    // Both instances should not reconnect with the exact same delay.
+    const unique = new Set(delays.filter((d) => d > 0));
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it("a remount after a zombie opens a fresh socket", async () => {
+    render(<MessagesApp windowId="test" />);
+    await openFirstSocket();
+
+    // Backend restart: onclose arms the reconnect timer.
+    MockWebSocket.instances[0].close();
+    await act(async () => {});
+
+    // Unmount without cancelling the timer (current bug).
+    cleanup();
+
+    // Let the timer fire: a zombie socket opens for the unmounted component.
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    // Remount: after the fix, no zombie should have been created, so a fresh
+    // socket is the only additional one (total = 2: initial + remount).
+    render(<MessagesApp windowId="test" />);
+    await act(async () => {});
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(MockWebSocket.instances[1].url).toContain("/ws/chat");
+  });
+});


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] MessagesApp leaks a zombie WebSocket after unmount

Autonomous build of board card tsk-qg7evy.

- track reconnect timer and cancel it on unmount
- add jitter to reconnect delay
- cap reconnection at 20 attempts
- null out wsRef in cleanup so remount is not blocked

RED-FIRST proof:

```
FAIL  desktop/src/apps/__tests__/MessagesApp.ws.test.tsx
  > unmounting cancels the pending reconnect
    AssertionError: expected [ MockWebSocket{ …(6) }, …(1) ] to have a length of 1 but got 2
  > reconnect delay is jittered across instances
    AssertionError: expected 1 to be greater than 1
  > a remount after a zombie opens a fresh socket
    AssertionError: expected [ MockWebSocket{ …(6) }, …(2) ] to have a length of 2 but got 3
  3 failed, 0 passed
```

Green after fix:

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Files:
 changelog.d/tsk-qg7evy-messages-ws-reconnect.md    |   3 +
 desktop/src/apps/MessagesApp/index.tsx             |  21 +-
 desktop/src/apps/__tests__/MessagesApp.ws.test.tsx | 212 +++++++++++++++++++++
 3 files changed, 232 insertions(+), 4 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Messages could leave behind an active WebSocket after the app was closed or remounted.
  * Improved reconnection behavior by cancelling pending retries, varying retry delays, and stopping after repeated failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->