### PR TITLE
import upload dir polish after #2895: restore the GHSA docstring, log each refusal, refuse a dangling symlink explicitly

### DIFF
--- a/changelog.d/tsk-johato-import-upload-dir-polish.md
+++ b/changelog.d/tsk-johato-import-upload-dir-polish.md
@@ -1,0 +1,4 @@
+### Fixed
+- Restore the `_upload_path` docstring and `embed_files` traversal comment (GHSA-rwrp-hfc4-qg2w rationale) lost in #2895.
+- Log each upload-dir refusal in `_ensure_upload_dir` so operators see symlink, not-a-directory, and wrong-owner 500s in the journal.
+- Refuse dangling upload-dir symlinks explicitly by using `os.lstat` instead of `Path.exists()`.

--- a/tests/test_import_upload_traversal.py
+++ b/tests/test_import_upload_traversal.py
@@ -6,6 +6,7 @@ name must resolve INSIDE UPLOAD_DIR or be refused with a 400 before the
 filesystem is touched."""
 
 import io
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -133,3 +134,46 @@ class TestUploadDirSecurity:
             files={"file": ("x.json", io.BytesIO(b'{}'), "application/json")},
         )
         assert resp.status_code == 500, resp.text
+
+    @pytest.mark.asyncio
+    async def test_dangling_symlink_upload_dir_is_refused(self, client, tmp_path, app):
+        upload_dir = Path(app.state.data_dir) / "imports" / "uploads"
+        upload_dir.parent.mkdir(parents=True, exist_ok=True)
+        if upload_dir.exists():
+            if upload_dir.is_dir() and not upload_dir.is_symlink():
+                import shutil
+                shutil.rmtree(upload_dir)
+            else:
+                upload_dir.unlink()
+        target = tmp_path / "nonexistent"
+        upload_dir.symlink_to(target)
+
+        resp = await client.post(
+            "/api/import/upload",
+            files={"file": ("x.json", io.BytesIO(b'{}'), "application/json")},
+        )
+        assert resp.status_code == 500, resp.text
+        assert resp.json()["detail"] == "Upload directory is a symlink"
+
+    @pytest.mark.asyncio
+    async def test_refusal_is_logged(self, client, app, caplog):
+        upload_dir = Path(app.state.data_dir) / "imports" / "uploads"
+        upload_dir.parent.mkdir(parents=True, exist_ok=True)
+        if upload_dir.exists():
+            if upload_dir.is_dir() and not upload_dir.is_symlink():
+                import shutil
+                shutil.rmtree(upload_dir)
+            else:
+                upload_dir.unlink()
+        upload_dir.write_text("not a directory")
+
+        with caplog.at_level(logging.ERROR):
+            resp = await client.post(
+                "/api/import/upload",
+                files={"file": ("x.json", io.BytesIO(b'{}'), "application/json")},
+            )
+        assert resp.status_code == 500, resp.text
+        assert any(
+            str(upload_dir) in record.getMessage()
+            for record in caplog.records
+        )

--- a/tinyagentos/routes/import_data.py
+++ b/tinyagentos/routes/import_data.py
@@ -24,21 +24,25 @@ def _get_upload_dir(data_dir: Path) -> Path:
 
 
 def _ensure_upload_dir(upload_dir: Path) -> None:
-    if not upload_dir.exists():
+    try:
+        st = os.lstat(upload_dir)
+    except FileNotFoundError:
         upload_dir.mkdir(parents=True, mode=0o700)
         return
-    st = os.lstat(upload_dir)
     if stat.S_ISLNK(st.st_mode):
+        logger.error("import upload dir %s refused: symlink", upload_dir)
         raise HTTPException(
             status_code=500,
             detail="Upload directory is a symlink",
         )
     if not stat.S_ISDIR(st.st_mode):
+        logger.error("import upload dir %s refused: not a directory", upload_dir)
         raise HTTPException(
             status_code=500,
             detail="Upload directory is not a directory",
         )
     if st.st_uid != os.getuid():
+        logger.error("import upload dir %s refused: wrong owner", upload_dir)
         raise HTTPException(
             status_code=500,
             detail="Upload directory is not owned by the service",
@@ -48,6 +52,14 @@ def _ensure_upload_dir(upload_dir: Path) -> None:
 
 
 def _upload_path(filename: str, upload_dir: Path) -> Path | None:
+    """Map a client-supplied filename to a path INSIDE ``upload_dir``.
+
+    ``Path("a") / "/etc/x"`` silently discards the left operand, so an
+    absolute or ``..`` filename would let any authenticated user write
+    (upload) or read (embed) any file the server process can reach
+    (GHSA-rwrp-hfc4-qg2w). Browsers only ever send a bare basename, so
+    anything with a separator, a NUL, or a leading dot is rejected outright.
+    """
     if not filename or "/" in filename or "\\" in filename or "\x00" in filename:
         return None
     if filename in {".", ".."} or filename.startswith("."):
@@ -110,6 +122,8 @@ async def embed_files(request: Request):
     upload_dir = _get_upload_dir(data_dir)
     _ensure_upload_dir(upload_dir)
 
+    # Resolve every name INSIDE the upload dir before touching the filesystem;
+    # a traversal name is a 400, not a read of whatever it points at.
     resolved: dict[str, Path] = {}
     for f in filenames:
         p = _upload_path(f, upload_dir) if isinstance(f, str) else None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): import upload dir polish after #2895: restore the GHSA docstring, log each refusal, refuse a dangling symlink explicitly

Autonomous build of board card tsk-johato.

Restore _upload_path docstring and embed_files traversal comment
(GHSA-rwrp-hfc4-qg2w rationale) lost in #2895.

In _ensure_upload_dir, replace exists() with os.lstat() so dangling
symlinks are refused explicitly instead of falling into an unhandled
FileExistsError from mkdir.

Add logger.error before each HTTPException(500) so operators can see
symlink, not-a-directory, and wrong-owner refusals in the journal.

RED proof (both new tests against origin/dev):

```
FF
FAILED tests/test_import_upload_traversal.py::TestUploadDirSecurity::test_dangling_symlink_upload_dir_is_refused - FileExistsError
FAILED tests/test_import_upload_traversal.py::TestUploadDirSecurity::test_refusal_is_logged - AssertionError
2 failed in 6.40s
```

After fix:

```
10 passed
```

Docs-Reviewed: no doc change needed, internal security hardening only

Files:
 changelog.d/tsk-johato-import-upload-dir-polish.md |  4 ++
 tests/test_import_upload_traversal.py              | 44 ++++++++++++++++++++++
 tinyagentos/routes/import_data.py                  | 18 ++++++++-
 3 files changed, 64 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Upload directories that are dangling symlinks are now rejected consistently.
  - Invalid upload directories continue to return clear error responses, with refusals recorded in error logs.
  - File upload path validation now more reliably blocks traversal attempts before accessing the filesystem.

- **Documentation**
  - Added documentation and comments clarifying upload-directory validation and secure filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->