### PR TITLE
[lib-audit] R2-6 IdempotencyCache.release() leaves result=None -> retries get 503 for an hour

### DIFF
--- a/changelog.d/tsk-xx7vqa-idempotency-cache-release-fix.md
+++ b/changelog.d/tsk-xx7vqa-idempotency-cache-release-fix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **IdempotencyCache:** `release()` now removes the key when the handler raised instead of leaving `None` cached, so a retry with the same `Idempotency-Key` executes the handler again instead of receiving 503 for the TTL duration. `set()` now stores `(status_code, body)` tuples so cached error responses replay with their original status code instead of being returned as 200.

--- a/tests/test_agent_idempotency.py
+++ b/tests/test_agent_idempotency.py
@@ -34,10 +34,10 @@ class TestIdempotencyCache:
         _, waiter_event = cache.try_reserve("req-1")
         assert not event.is_set()
 
-        cache.set("req-1", {"status": "created"})
+        cache.set("req-1", 200, {"status": "created"})
         assert event.is_set()
         # The waiter can now get() the result
-        assert cache.get("req-1") == {"status": "created"}
+        assert cache.get("req-1") == (200, {"status": "created"})
 
     async def test_retry_after_completion_finds_cached_result(self):
         """After set() stores a result, a new try_reserve on the
@@ -45,7 +45,7 @@ class TestIdempotencyCache:
         get() returns the cached result."""
         cache = IdempotencyCache()
         cache.try_reserve("req-1")
-        cache.set("req-1", {"status": "created", "name": "agent-x"})
+        cache.set("req-1", 200, {"status": "created", "name": "agent-x"})
 
         # "Retry" — another request with the same Idempotency-Key
         mode, event = cache.try_reserve("req-1")
@@ -53,7 +53,7 @@ class TestIdempotencyCache:
         assert event.is_set()  # Already resolved — no need to actually await
 
         result = cache.get("req-1")
-        assert result == {"status": "created", "name": "agent-x"}
+        assert result == (200, {"status": "created", "name": "agent-x"})
 
     async def test_different_keys_do_not_interfere(self):
         """Each idempotency key is independently tracked."""
@@ -64,10 +64,10 @@ class TestIdempotencyCache:
         assert mode_b == "proceed"
         assert event_a is not event_b
 
-        cache.set("key-a", {"result": "a"})
+        cache.set("key-a", 200, {"result": "a"})
         assert event_a.is_set()
         assert not event_b.is_set()
-        assert cache.get("key-a") == {"result": "a"}
+        assert cache.get("key-a") == (200, {"result": "a"})
         assert cache.get("key-b") is None
 
     async def test_get_returns_none_for_unknown_key(self):
@@ -79,8 +79,8 @@ class TestIdempotencyCache:
         """Calling set() without a prior try_reserve() still
         stores the result for get()."""
         cache = IdempotencyCache()
-        cache.set("direct-set", {"status": "ok"})
-        assert cache.get("direct-set") == {"status": "ok"}
+        cache.set("direct-set", 200, {"status": "ok"})
+        assert cache.get("direct-set") == (200, {"status": "ok"})
 
     async def test_multiple_waiters_all_see_same_result(self):
         """When multiple callers reserve the same key, set()
@@ -90,10 +90,53 @@ class TestIdempotencyCache:
         cache.try_reserve("req-1")       # second — wait
         cache.try_reserve("req-1")       # third — wait
 
-        cache.set("req-1", {"status": "deployed"})
+        cache.set("req-1", 200, {"status": "deployed"})
         # All subsequent retrievals return the same result
-        assert cache.get("req-1") == {"status": "deployed"}
-        assert cache.get("req-1") == {"status": "deployed"}
+        assert cache.get("req-1") == (200, {"status": "deployed"})
+        assert cache.get("req-1") == (200, {"status": "deployed"})
+
+    async def test_release_after_handler_raise_deletes_key(self):
+        """When release() is called without a preceding set() (handler raised),
+        the key is removed so a retry actually executes the handler again
+        instead of receiving 503 for the TTL duration."""
+        cache = IdempotencyCache()
+        mode, event = cache.try_reserve("req-1")
+        assert mode == "proceed"
+        cache.release("req-1")
+
+        # After release without set, the key should be gone.
+        assert cache.get("req-1") is None
+
+        # A retry must get 'proceed' so the handler runs again.
+        mode2, event2 = cache.try_reserve("req-1")
+        assert mode2 == "proceed"
+
+    async def test_error_response_replays_with_status_code(self):
+        """A cached error response must replay with its original status code."""
+        cache = IdempotencyCache()
+        cache.try_reserve("req-1")
+        cache.set("req-1", 400, {"error": "bad request"})
+
+        mode, event = cache.try_reserve("req-1")
+        assert mode == "wait"
+        assert event.is_set()
+
+        status, body = cache.get("req-1")
+        assert status == 400
+        assert body == {"error": "bad request"}
+
+    async def test_success_response_replays_with_status_code(self):
+        """A cached success response must replay with status 200."""
+        cache = IdempotencyCache()
+        cache.try_reserve("req-1")
+        cache.set("req-1", 200, {"status": "created", "name": "agent-x"})
+
+        mode, event = cache.try_reserve("req-1")
+        assert mode == "wait"
+
+        status, body = cache.get("req-1")
+        assert status == 200
+        assert body == {"status": "created", "name": "agent-x"}
 
 
 class TestIdempotencyCacheEviction:
@@ -110,18 +153,18 @@ class TestIdempotencyCacheEviction:
         for i in range(5):
             key = f"key-{i}"
             cache.try_reserve(key)
-            cache.set(key, {"n": i})
+            cache.set(key, 200, {"n": i})
 
         # All 5 are present.
         assert len(cache._entries) == 5
 
         # Adding a 6th triggers eviction of the oldest (key-0).
         cache.try_reserve("key-new")
-        cache.set("key-new", {"n": 99})
+        cache.set("key-new", 200, {"n": 99})
 
         assert len(cache._entries) == 5
         assert cache.get("key-0") is None          # evicted
-        assert cache.get("key-new") == {"n": 99}   # newest present
+        assert cache.get("key-new") == (200, {"n": 99})   # newest present
 
     def test_lru_does_not_evict_in_flight_entries(self):
         """In-flight entries (event not yet set) must not be evicted even
@@ -144,7 +187,7 @@ class TestIdempotencyCacheEviction:
         """get() returns None and removes the entry once TTL has elapsed."""
         cache = IdempotencyCache()
         cache.try_reserve("old-key")
-        cache.set("old-key", {"status": "created"})
+        cache.set("old-key", 200, {"status": "created"})
 
         # Back-date the insertion timestamp to simulate TTL expiry.
         ev, res, _ts = cache._entries["old-key"]
@@ -158,7 +201,7 @@ class TestIdempotencyCacheEviction:
         new event, allowing the request to be processed again."""
         cache = IdempotencyCache()
         cache.try_reserve("stale")
-        cache.set("stale", {"status": "created"})
+        cache.set("stale", 200, {"status": "created"})
 
         # Expire the entry.
         ev, res, _ts = cache._entries["stale"]
@@ -172,10 +215,10 @@ class TestIdempotencyCacheEviction:
         """Fresh entries survive TTL checks and remain accessible."""
         cache = IdempotencyCache()
         cache.try_reserve("fresh")
-        cache.set("fresh", {"status": "ok"})
+        cache.set("fresh", 200, {"status": "ok"})
 
         # Should still be present immediately after set().
-        assert cache.get("fresh") == {"status": "ok"}
+        assert cache.get("fresh") == (200, {"status": "ok"})
 
     def test_max_size_constant_is_sensible(self):
         """Sanity-check: default _MAX_SIZE is 1000 and _TTL_SECONDS is 3600."""

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -55,7 +55,7 @@ class IdempotencyCache:
     already handling this key — the caller should ``await event.wait()``
     and then call ``get(key)`` for the cached result.
 
-    ``set(key, result)`` stores the result and fires the event so all
+    ``set(key, status_code, result)`` stores the response and fires the event so all
     waiters can proceed.
 
     This closes the race in the naive get-then-set pattern where
@@ -67,8 +67,8 @@ class IdempotencyCache:
     _MAX_SIZE: int = 1000         # LRU cap; oldest completed entry evicted first
 
     def __init__(self) -> None:
-        # Values: (event, result_or_None, inserted_at)
-        self._entries: OrderedDict[str, tuple[asyncio.Event, dict | None, float]] = OrderedDict()
+        # Values: (event, (status_code, body) | None, inserted_at)
+        self._entries: OrderedDict[str, tuple[asyncio.Event, tuple[int, dict] | None, float]] = OrderedDict()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -123,22 +123,22 @@ class IdempotencyCache:
         self._entries[key] = (event, None, time.monotonic())
         return ("proceed", event)
 
-    def set(self, key: str, result: dict) -> None:
-        """Store *result* and wake all waiters on *key*."""
+    def set(self, key: str, status_code: int, result: dict) -> None:
+        """Store *result* with *status_code* and wake all waiters on *key*."""
         entry = self._entries.get(key)
         if entry is None:
             self._evict_if_needed()
             event = asyncio.Event()
             event.set()
-            self._entries[key] = (event, result, time.monotonic())
+            self._entries[key] = (event, (status_code, result), time.monotonic())
             return
         event, _, inserted_at = entry
-        self._entries[key] = (event, result, inserted_at)
+        self._entries[key] = (event, (status_code, result), inserted_at)
         self._entries.move_to_end(key)
         event.set()
 
-    def get(self, key: str) -> dict | None:
-        """Return the cached result for *key*, or ``None``.
+    def get(self, key: str) -> tuple[int, dict] | None:
+        """Return the cached ``(status_code, body)`` for *key*, or ``None``.
 
         Returns ``None`` for unknown or TTL-expired keys.
         """
@@ -157,14 +157,16 @@ class IdempotencyCache:
 
         Call this in a ``finally`` block so that an unexpected exception
         never leaves the event unset and waiters hanging indefinitely.
-        Waiters that resume will receive ``None`` from ``get()``.
-        No-op when the event is already set (i.e. ``set()`` already called).
+        When ``set()`` was never called, the key is removed so a retry
+        can execute the handler again instead of receiving 503 for the
+        TTL duration.  No-op when the event is already set.
         """
         entry = self._entries.get(key)
         if entry is not None:
             ev, _res, _ts = entry
             if not ev.is_set():
                 ev.set()
+                del self._entries[key]
 
 
 @router.get("/api/agents")
@@ -358,7 +360,8 @@ async def add_agent(request: Request, body: AgentCreate):
             cached = idempotency_cache.get(scoped_key)
             if cached is None:
                 return JSONResponse({"error": "concurrent request failed"}, status_code=503)
-            return cached
+            status, body = cached
+            return JSONResponse(body, status_code=status)
 
     # Wrap so any unexpected exception still unblocks idempotency waiters.
     try:
@@ -368,7 +371,7 @@ async def add_agent(request: Request, body: AgentCreate):
         if name_error:
             err = {"error": name_error}
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, err)
+                idempotency_cache.set(scoped_key, 400, err)
             return JSONResponse(err, status_code=400)
 
         try:
@@ -376,7 +379,7 @@ async def add_agent(request: Request, body: AgentCreate):
         except ValueError as e:
             err = {"error": str(e)}
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, err)
+                idempotency_cache.set(scoped_key, 400, err)
             return JSONResponse(err, status_code=400)
 
         agent = body.model_dump()
@@ -386,7 +389,7 @@ async def add_agent(request: Request, body: AgentCreate):
         await save_config_locked(config, config.config_path)
         result = {"status": "created", "name": unique_slug, "display_name": display_name}
         if scoped_key and idempotency_cache is not None:
-            idempotency_cache.set(scoped_key, result)
+            idempotency_cache.set(scoped_key, 200, result)
         return result
     finally:
         # No-op when set() already fired; unblocks waiters on unexpected exceptions.
@@ -610,7 +613,8 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
             cached = idempotency_cache.get(scoped_key)
             if cached is None:
                 return JSONResponse({"error": "concurrent request failed"}, status_code=503)
-            return cached
+            status, body = cached
+            return JSONResponse(body, status_code=status)
 
     # Wrap so any unexpected exception still unblocks idempotency waiters.
     try:
@@ -619,7 +623,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         name_error = validate_agent_name(display_name)
         if name_error:
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, {"error": name_error})
+                idempotency_cache.set(scoped_key, 400, {"error": name_error})
             return JSONResponse({"error": name_error}, status_code=400)
         # Derive a container-safe slug and ensure uniqueness
         try:
@@ -627,7 +631,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         except ValueError as e:
             err = {"error": str(e)}
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, err)
+                idempotency_cache.set(scoped_key, 400, err)
             return JSONResponse(err, status_code=400)
         # Rewrite body.name to the unique slug; the original user-entered name
         # is preserved as display_name for the UI.
@@ -636,7 +640,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         fw_err = agent_deploy.validate_framework_and_ram(request, body)
         if fw_err is not None:
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, json.loads(fw_err.body))
+                idempotency_cache.set(scoped_key, fw_err.status_code, json.loads(fw_err.body))
             return fw_err
 
         # ------------------------------------------------------------------
@@ -645,7 +649,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         routed = agent_deploy.resolve_deploy_routing(request, body)
         if routed is not None:
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, json.loads(routed.body))
+                idempotency_cache.set(scoped_key, routed.status_code, json.loads(routed.body))
             return routed
 
         # Explicit target_worker pin: create the agent container ON that
@@ -654,7 +658,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         deploy_remote, deploy_taos_host, remote_err = await agent_deploy.configure_remote_deploy(request, body)
         if remote_err is not None:
             if scoped_key and idempotency_cache is not None:
-                idempotency_cache.set(scoped_key, json.loads(remote_err.body))
+                idempotency_cache.set(scoped_key, remote_err.status_code, json.loads(remote_err.body))
             return remote_err
 
         data_dir = request.app.state.data_dir
@@ -684,7 +688,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                             )
                         }
                         if scoped_key and idempotency_cache is not None:
-                            idempotency_cache.set(scoped_key, err_body)
+                            idempotency_cache.set(scoped_key, 409, err_body)
                         return JSONResponse(err_body, status_code=409)
 
                     tier_id = default_data.get("tier_id", "standard")
@@ -727,7 +731,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 logger.exception("register_agent(%s) failed", unique_slug)
                 err_body = {"error": f"Could not register agent with taosmd: {e}"}
                 if scoped_key and idempotency_cache is not None:
-                    idempotency_cache.set(scoped_key, err_body)
+                    idempotency_cache.set(scoped_key, 500, err_body)
                 return JSONResponse(err_body, status_code=500)
 
         # Register the agent in the agent registry, minting a canonical_id.
@@ -749,13 +753,13 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 # Reserved-prefix names are a user error, not a server fault.
                 err_body = {"error": str(e)}
                 if scoped_key and idempotency_cache is not None:
-                    idempotency_cache.set(scoped_key, err_body)
+                    idempotency_cache.set(scoped_key, 400, err_body)
                 return JSONResponse(err_body, status_code=400)
             except Exception as e:
                 logger.exception("agent_registry.register(%s) failed", unique_slug)
                 err_body = {"error": f"Could not register agent in registry: {e}"}
                 if scoped_key and idempotency_cache is not None:
-                    idempotency_cache.set(scoped_key, err_body)
+                    idempotency_cache.set(scoped_key, 500, err_body)
                 return JSONResponse(err_body, status_code=500)
 
         # Add agent entry immediately with deploying status. qmd_url has
@@ -997,7 +1001,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         result = {"status": "deploying", "name": body.name, "archive_smoke_ok": smoke_ok}
 
         if scoped_key and idempotency_cache is not None:
-            idempotency_cache.set(scoped_key, result)
+            idempotency_cache.set(scoped_key, 200, result)
 
         return result
     finally:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-6 IdempotencyCache.release() leaves result=None -> retries get 503 for an hour

Autonomous build of board card tsk-xx7vqa.

release() now removes the key when the handler raised instead of leaving
None cached, so a retry with the same Idempotency-Key executes the
handler again instead of receiving 503 for the TTL duration. set() now
stores (status_code, body) tuples so cached error responses replay with
their original status code instead of being returned as 200.

Proof: before the fix the three new RED tests failed.

```
FAILED tests/test_agent_idempotency.py::TestIdempotencyCache::test_release_after_handler_raise_deletes_key - AssertionError: assert 'wait' == 'proceed'
FAILED tests/test_agent_idempotency.py::TestIdempotencyCache::test_error_response_replays_with_status_code - TypeError: IdempotencyCache.set() takes 3 positional arguments but 4 were given
FAILED tests/test_agent_idempotency.py::TestIdempotencyCache::test_success_response_replays_with_status_code - TypeError: IdempotencyCache.set() takes 3 positional arguments but 4 were given
```

After the fix all 95 tests in tests/test_agent_idempotency.py and
tests/test_routes_agents.py pass.

Docs-Reviewed: IdempotencyCache is internal implementation detail, not user-facing agent coordination

Files:
 .../tsk-xx7vqa-idempotency-cache-release-fix.md    |  3 +
 tests/test_agent_idempotency.py                    | 79 +++++++++++++++++-----
 tinyagentos/routes/agents.py                       | 56 ++++++++-------
 3 files changed, 94 insertions(+), 44 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed retries using the same idempotency key after a failed request, allowing the request to run again instead of returning a stale temporary error.
  - Cached responses now preserve and replay their original HTTP status codes, including validation, routing, registration, success, and error responses.
  - Improved consistency for repeated agent creation and deployment requests using idempotency keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->