### PR TITLE
[lib-audit] R2-11 lsof -ti :port also returns clients -- proxy restart kills the incus forkproxy

### DIFF
--- a/changelog.d/tsk-7z2gni-proxy-port-listener-only.md
+++ b/changelog.d/tsk-7z2gni-proxy-port-listener-only.md
@@ -1,0 +1,5 @@
+### Fixed
+- `_pids_listening_on` now uses `lsof -ti -a -iTCP:{port} -sTCP:LISTEN` so
+  client sockets on the same port are no longer returned. Proxy restart
+  therefore no longer kills the incus forkproxy that holds a client
+  connection. Spawn PID is also preferred over any port-scan result.

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -9,6 +9,7 @@ import pytest
 from tinyagentos.llm_proxy import (
     EMBEDDING_ALIAS,
     _is_embedding_model,
+    _pids_listening_on,
     generate_litellm_config,
     LLMProxy,
 )
@@ -382,6 +383,7 @@ class TestTraceUrlPropagation:
         captured = {}
 
         class _FakePopen:
+            pid = 12345
             def __init__(self, *args, **kwargs):
                 captured["env"] = kwargs.get("env") or {}
             # R2-29 readiness loop calls proc.poll(); None = still running.
@@ -419,6 +421,7 @@ class TestTraceUrlPropagation:
         monkeypatch.setattr(shutil, "which", lambda _: "/fake/litellm")
 
         class _FakePopen:
+            pid = 12346
             def __init__(self, *a, **kw):
                 pass
             # R2-29 readiness loop calls proc.poll(); None = still running.
@@ -994,6 +997,7 @@ class TestStderrLogHandling:
         monkeypatch.setattr(mod.LLMProxy, "_resolve_litellm_cmd", lambda self: "/fake/litellm")
 
         class _FakePopen:
+            pid = 12347
             def __init__(self, *a, **kw):
                 pass
             def poll(self):
@@ -1173,6 +1177,66 @@ class TestConfigDirPermissions:
                 await proxy.write_config([])
         assert not (proxy.config_dir / "litellm_config.yaml").exists()
         assert not (proxy.config_dir / "taos_callback.py").exists()
+
+
+class TestPidsListeningOn:
+    """R2-11: _pids_listening_on must return only LISTEN sockets, not clients."""
+
+    def test_only_listener_returned_when_client_connected(self):
+        """A client socket held by a child process must NOT appear in the
+        result — only the actual listener PID should be returned."""
+        import os
+        import socket
+        import subprocess
+        import sys
+        import time
+
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        client_script = (
+            "import socket, time\n"
+            f"s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            f"s.connect(('127.0.0.1', {port}))\n"
+            "time.sleep(30)\n"
+        )
+        client_proc = subprocess.Popen(
+            [sys.executable, "-c", client_script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            accepted = False
+            for _ in range(50):
+                try:
+                    listener.settimeout(0.1)
+                    conn, _ = listener.accept()
+                    conn.close()
+                    accepted = True
+                    break
+                except socket.timeout:
+                    pass
+            if not accepted:
+                listener.close()
+                client_proc.kill()
+                client_proc.wait()
+                pytest.fail("client did not connect in time")
+
+            pids = _pids_listening_on(port)
+            listener_pid = os.getpid()
+
+            assert listener_pid in pids, (
+                f"listener PID {listener_pid} should be in {pids}"
+            )
+            assert client_proc.pid not in pids, (
+                f"client PID {client_proc.pid} must NOT be in {pids}"
+            )
+        finally:
+            listener.close()
+            client_proc.kill()
+            client_proc.wait()
 
 
 class TestSystemdUnitPermissions:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -47,13 +47,13 @@ def _pid_alive(pid: int) -> bool:
 def _pids_listening_on(port: int) -> list[int]:
     """Best-effort lookup of PIDs holding a TCP listen on ``port``.
 
-    Uses ``lsof -ti:<port>`` which is available on macOS, most Linux
+    Uses ``lsof -ti -a -iTCP:{port} -sTCP:LISTEN`` which is available on macOS, most Linux
     distros, and the Fedora LXC we ship on the Pi. Returns ``[]`` when
     ``lsof`` is missing, errors, or reports nothing.
     """
     try:
         out = subprocess.check_output(
-            ["lsof", "-ti", f":{port}"], text=True, stderr=subprocess.DEVNULL
+            ["lsof", "-ti", "-a", f"-iTCP:{port}", "-sTCP:LISTEN"], text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return []
@@ -139,6 +139,7 @@ class LLMProxy:
         # When None, an in-memory key is used (acceptable in tests / routing-only mode).
         self._data_dir = data_dir
         self._process: subprocess.Popen | None = None
+        self._last_spawn_pid: int | None = None
         self._keystore_cache = None
         self._budget_store_cache = None
         # One-shot guard: if litellm is missing at start() (e.g. a pre-fix
@@ -443,6 +444,8 @@ class LLMProxy:
 
         if port_in_use:
             pids = _pids_listening_on(self.port)
+            if self._last_spawn_pid and self._last_spawn_pid in pids:
+                pids = [p for p in pids if p != self._last_spawn_pid]
             if pids:
                 logger.info(
                     "LiteLLM on port %d owned by foreign PID(s) %r — "
@@ -566,6 +569,7 @@ class LLMProxy:
                 stderr=stderr_handle,
                 env=env,
             )
+            self._last_spawn_pid = self._process.pid
         except FileNotFoundError:
             logger.warning("LiteLLM not installed — proxy disabled. Install with: pip install litellm[proxy]")
             return False


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-11 lsof -ti :port also returns clients -- proxy restart kills the incus forkproxy

Autonomous build of board card tsk-7z2gni.

Filter lsof output to TCP LISTEN sockets so client PIDs are no longer
returned. On proxy restart this prevents killing the incus forkproxy
that holds a client connection. The spawn PID is also preferred over
any stale port-scan result.

RED test (before fix):

```
tests/test_llm_proxy.py::TestPidsListeningOn::test_only_listener_returned_when_client_connected FAILED [100%]
...
E           AssertionError: client PID 933095 must NOT be in [933075, 933095]
...
=========================== short test summary info ============================
FAILED tests/test_llm_proxy.py::TestPidsListeningOn::test_only_listener_returned_when_client_connected - AssertionError
============================== 1 failed in 0.64s
```

GREEN (after fix):

```
tests/test_llm_proxy.py::TestPidsListeningOn::test_only_listener_returned_when_client_connected PASSED [100%]
...
63 passed in 4.88s
```

Files:
 changelog.d/tsk-7z2gni-proxy-port-listener-only.md |  5 ++
 tests/test_llm_proxy.py                            | 64 ++++++++++++++++++++++
 tinyagentos/llm_proxy.py                           |  8 ++-
 3 files changed, 75 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy restart handling to identify only processes actively listening on the configured port.
  - Prevented connected client processes from being terminated during proxy restarts.
  - Prevented the proxy from terminating its own healthy process when resolving port conflicts.

- **Tests**
  - Added coverage for distinguishing listening processes from connected clients and preserving the active proxy process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->