### PR TITLE
fix-forward #2948 (tsk-qk7fiw, R2-12): page through ALL ready items in get_due_items - RED-FIRST, red re-measured by the lead

### DIFF
--- a/changelog.d/tsk-54kexu-knowledge-monitor-fixes.md
+++ b/changelog.d/tsk-54kexu-knowledge-monitor-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Restored LIMIT/OFFSET pagination in KnowledgeStore.list_items so callers no longer load the entire knowledge table into memory
+- MonitorService.poll_item now refreshes item content with extracted text via the ingest readability extractor instead of skipping updates or storing raw HTML
+- Implemented stop_after_days: items whose created_at exceeds the monitor's stop_after_days are no longer polled and are marked with status=stopped

--- a/changelog.d/tsk-qk7fiw-page-through-all-items.md
+++ b/changelog.d/tsk-qk7fiw-page-through-all-items.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- MonitorService.get_due_items now paginates through ALL ready items instead of reading only the first page of 100

--- a/changelog.d/tsk-xiinm2-knowledge-monitor-fixes.md
+++ b/changelog.d/tsk-xiinm2-knowledge-monitor-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- MonitorService no longer skips knowledge items beyond the 50-item limit when finding items to poll
+- Monitor no longer overwrites extracted text with raw HTML during polling
+- Monitor no longer updates baseline hash when a fetch fails

--- a/tests/test_knowledge_monitor.py
+++ b/tests/test_knowledge_monitor.py
@@ -286,3 +286,151 @@ async def test_fetch_article_rejects_non_text_content_type(store):
     assert new_content == ""
     assert changed is False
     assert resp.bytes_read == 0, "Non-text response should not be buffered at all"
+
+
+# ------------------------------------------------------------------
+# R2-12: FIRST POLL BUGS: polling limit, raw HTML overwrite, baseline on fail, stop_after_days
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_monitor_polls_all_ready_items(store):
+    """R2-12 first bug: MonitorService.get_due_items uses limit=50, missing items beyond 50.
+
+    list_items(status="ready") defaults to limit=50, so items 51+ never polled.
+    """
+    # Create 60 items with identical monitor configs so all become due at once
+    item_count = 60
+    item_ids = []
+    now = time.time()
+    for i in range(item_count):
+        item_id = await store.add_item(
+            source_type="article",
+            source_url=f"https://example.com/article{i}",
+            title=f"Article {i}",
+            author="",
+            content=f"Original content {i}",
+            summary="summary",
+            categories=[],
+            tags=[],
+            metadata={},
+            status="ready",
+            monitor={
+                "frequency": 3600,
+                "decay_rate": 1.5,
+                "stop_after_days": 14,
+                "pinned": False,
+                "last_poll": 0,
+                "current_interval": 3600,
+                "last_hash": "",
+            },
+        )
+        item_ids.append(item_id)
+
+    svc = MonitorService(store=store, http_client=AsyncMock())
+    due = await svc.get_due_items()
+
+    # With bug: due contains at most 50 items (list_items default limit)
+    # After fix: due should contain all 60 items
+    assert len(due) == item_count, f"Expected {item_count} due items, got {len(due)}"
+
+
+@pytest.mark.asyncio
+async def test_monitor_does_not_overwrite_text_with_raw_html(store):
+    """R2-12 second bug: First poll stores raw HTML over extracted text.
+
+    _fetch_article returns (new_content, changed), but line 139-140 writes new_content
+    (raw HTML) into item content, not the extracted text from the ingest extractor.
+    """
+    item_id = await store.add_item(
+        source_type="article",
+        source_url="https://example.com/article",
+        title="Test Article",
+        author="",
+        content="original content",
+        summary="summary",
+        categories=[],
+        tags=[],
+        metadata={},
+        status="ready",
+        monitor={
+            "frequency": 86400,
+            "decay_rate": 2.0,
+            "stop_after_days": 14,
+            "pinned": False,
+            "last_poll": 0,
+            "current_interval": 86400,
+            "last_hash": "",
+        },
+    )
+    # Mock the HTTP client to return raw HTML that differs from original
+    raw_html = "<html><body>Raw HTML content</body></html>"
+    
+    response = AsyncMock()
+    response.status_code = 200
+    response.headers = {"content-type": "text/html"}
+    response.encoding = "utf-8"
+    
+    async def mock_aiter_bytes(chunk_size=8192):
+        yield raw_html.encode("utf-8")
+    
+    response.aiter_bytes = mock_aiter_bytes
+    response.raise_for_status = lambda: None
+    
+    mock_http = AsyncMock()
+    mock_http.get = AsyncMock(return_value=response)
+
+    svc = MonitorService(store=store, http_client=mock_http)
+
+    # First poll: _fetch_article returns raw HTML
+    await svc.poll_item(item_id)
+
+    item = await store.get_item(item_id)
+    # Bug: content becomes raw HTML
+    # After fix: content should remain "original content" (not overwritten with raw HTML)
+    # The fix ensures content stays as the original (not overwritten with raw HTML)
+    assert item["content"] == "original content", f"Content should not be overwritten with raw HTML, got: {item['content']}"
+    assert item["content"] != raw_html, "Content should not be raw HTML"
+
+
+@pytest.mark.asyncio
+async def test_monitor_does_not_update_baseline_on_failed_fetch(store):
+    """R2-12 third bug: Failed fetch sets baseline hash to sha256(\"").
+
+    _fetch_article returns ("", False) on failure. This results in
+    content_hash = sha256("") being stored at line 128 and line 153.
+    """
+    item_id = await store.add_item(
+        source_type="article",
+        source_url="https://example.com/article",
+        title="Test Article",
+        author="",
+        content="original content",
+        summary="summary",
+        categories=[],
+        tags=[],
+        metadata={},
+        status="ready",
+        monitor={
+            "frequency": 86400,
+            "decay_rate": 2.0,
+            "stop_after_days": 14,
+            "pinned": False,
+            "last_poll": 0,
+            "current_interval": 86400,
+            "last_hash": "a" * 64,  # sha256 of "a" * 64
+        },
+    )
+    # Mock a failed fetch
+    response = AsyncMock()
+    response.raise_for_status = AsyncMock(side_effect=Exception("Network error"))
+    mock_http = AsyncMock()
+    mock_http.get = AsyncMock(return_value=response)
+
+    svc = MonitorService(store=store, http_client=mock_http)
+    await svc.poll_item(item_id)
+
+    item = await store.get_item(item_id)
+    # Bug: last_hash becomes sha256("")
+    # After fix: last_hash should remain unchanged (skip baseline update)
+    assert item["monitor"]["last_hash"] == "a" * 64, "Baseline hash should not change on failure"

--- a/tests/test_knowledge_monitor.py
+++ b/tests/test_knowledge_monitor.py
@@ -295,12 +295,12 @@ async def test_fetch_article_rejects_non_text_content_type(store):
 
 @pytest.mark.asyncio
 async def test_monitor_polls_all_ready_items(store):
-    """R2-12 first bug: MonitorService.get_due_items uses limit=50, missing items beyond 50.
+    """R2-12 first bug: MonitorService.get_due_items uses limit=100, missing items beyond 100.
 
-    list_items(status="ready") defaults to limit=50, so items 51+ never polled.
+    list_items(status="ready", limit=100, offset=0) returns only the first page.
     """
-    # Create 60 items with identical monitor configs so all become due at once
-    item_count = 60
+    # Create 250 items with identical monitor configs so all become due at once
+    item_count = 250
     item_ids = []
     now = time.time()
     for i in range(item_count):
@@ -330,9 +330,11 @@ async def test_monitor_polls_all_ready_items(store):
     svc = MonitorService(store=store, http_client=AsyncMock())
     due = await svc.get_due_items()
 
-    # With bug: due contains at most 50 items (list_items default limit)
-    # After fix: due should contain all 60 items
+    # With bug: due contains at most 100 items (single page of list_items)
+    # After fix: due should contain all 250 items, and every created id must be in due
     assert len(due) == item_count, f"Expected {item_count} due items, got {len(due)}"
+    for item_id in item_ids:
+        assert any(d["id"] == item_id for d in due), f"Item {item_id} not in due list"
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_monitor.py
+++ b/tests/test_knowledge_monitor.py
@@ -386,16 +386,16 @@ async def test_monitor_does_not_overwrite_text_with_raw_html(store):
     await svc.poll_item(item_id)
 
     item = await store.get_item(item_id)
-    # Bug: content becomes raw HTML
-    # After fix: content should remain "original content" (not overwritten with raw HTML)
-    # The fix ensures content stays as the original (not overwritten with raw HTML)
-    assert item["content"] == "original content", f"Content should not be overwritten with raw HTML, got: {item['content']}"
-    assert item["content"] != raw_html, "Content should not be raw HTML"
+    # After fix: content is updated with extracted text, never raw HTML
+    assert item["content"] != raw_html, "Content must not be raw HTML"
+    assert "Raw HTML content" in item["content"], (
+        f"Content should contain extracted text, got: {item['content']}"
+    )
 
 
 @pytest.mark.asyncio
 async def test_monitor_does_not_update_baseline_on_failed_fetch(store):
-    """R2-12 third bug: Failed fetch sets baseline hash to sha256(\"").
+    """R2-12 third bug: Failed fetch sets baseline hash to sha256("").
 
     _fetch_article returns ("", False) on failure. This results in
     content_hash = sha256("") being stored at line 128 and line 153.
@@ -434,3 +434,148 @@ async def test_monitor_does_not_update_baseline_on_failed_fetch(store):
     # Bug: last_hash becomes sha256("")
     # After fix: last_hash should remain unchanged (skip baseline update)
     assert item["monitor"]["last_hash"] == "a" * 64, "Baseline hash should not change on failure"
+
+
+# ------------------------------------------------------------------
+# RED-FIRST: R2-12 follow-up tests for the three remaining bugs
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_items_uses_limit_offset_in_sql(store):
+    """R2-12 fix-forward: list_items must push LIMIT/OFFSET into SQL.
+
+    The branch removed LIMIT/OFFSET from the SQL and slices in Python,
+    so every caller loads the whole knowledge table.
+    """
+    # Populate with enough rows that Python-slicing would be expensive
+    for i in range(60):
+        await store.add_item(
+            source_type="article",
+            source_url=f"https://example.com/article{i}",
+            title=f"Article {i}",
+            author="",
+            content=f"content {i}",
+            summary="summary",
+            categories=[],
+            tags=[],
+            metadata={},
+            status="ready",
+            monitor={"frequency": 86400, "decay_rate": 2.0, "stop_after_days": 14,
+                     "pinned": False, "last_poll": 0, "current_interval": 86400},
+        )
+
+    executed_sqls = []
+    original_execute = store._db.execute
+
+    async def spy_execute(sql, params=None):
+        executed_sqls.append(sql)
+        return await original_execute(sql, params)
+
+    store._db.execute = spy_execute
+
+    try:
+        result = await store.list_items(status="ready", limit=100, offset=0)
+    finally:
+        store._db.execute = original_execute
+
+    list_sql_calls = [s for s in executed_sqls if "FROM knowledge_items" in s]
+    assert list_sql_calls, "No SELECT from knowledge_items was executed"
+    sql = list_sql_calls[-1]
+    assert "LIMIT ?" in sql, f"SQL must contain LIMIT ?, got: {sql}"
+    assert "OFFSET ?" in sql, f"SQL must contain OFFSET ?, got: {sql}"
+
+
+@pytest.mark.asyncio
+async def test_monitor_refreshes_content_with_extracted_text(store):
+    """R2-12 fix-forward: poll must store extracted text, not raw HTML.
+
+    _fetch_article returns raw HTML text bytes. The fix must run the same
+    extractor the Library ingest path uses and store only the extracted text.
+    """
+    raw_html = "<html><head><title>X</title></head><body><p>Extracted text content here</p></body></html>"
+
+    response = AsyncMock()
+    response.status_code = 200
+    response.headers = {"content-type": "text/html"}
+    response.encoding = "utf-8"
+
+    async def mock_aiter_bytes(chunk_size=8192):
+        yield raw_html.encode("utf-8")
+
+    response.aiter_bytes = mock_aiter_bytes
+    response.raise_for_status = lambda: None
+
+    mock_http = AsyncMock()
+    mock_http.get = AsyncMock(return_value=response)
+
+    item_id = await store.add_item(
+        source_type="article",
+        source_url="https://example.com/article",
+        title="Test Article",
+        author="",
+        content="old",
+        summary="summary",
+        categories=[],
+        tags=[],
+        metadata={},
+        status="ready",
+        monitor={
+            "frequency": 86400,
+            "decay_rate": 2.0,
+            "stop_after_days": 14,
+            "pinned": False,
+            "last_poll": 0,
+            "current_interval": 86400,
+            "last_hash": "",
+        },
+    )
+    svc = MonitorService(store=store, http_client=mock_http)
+    await svc.poll_item(item_id)
+
+    item = await store.get_item(item_id)
+    assert item["content"] != raw_html, "Content must not be raw HTML"
+    assert item["content"] != "old", "Content must be refreshed from the fetched HTML"
+    assert "Extracted text content here" in item["content"], (
+        f"Content should contain extracted text, got: {item['content']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_after_days_prevents_polling_old_items(store):
+    """R2-12 fix-forward: items older than stop_after_days must not be polled and must be marked stopped."""
+    old_ts = time.time() - (31 * 86400)  # 31 days ago
+    item_id = await store.add_item(
+        source_type="article",
+        source_url="https://example.com/article",
+        title="Old Article",
+        author="",
+        content="old content",
+        summary="summary",
+        categories=[],
+        tags=[],
+        metadata={},
+        status="ready",
+        monitor={
+            "frequency": 86400,
+            "decay_rate": 2.0,
+            "stop_after_days": 30,
+            "pinned": False,
+            "last_poll": 0,
+            "current_interval": 86400,
+            "last_hash": "",
+        },
+    )
+    # Override created_at to make the item old
+    await store._db.execute(
+        "UPDATE knowledge_items SET created_at = ? WHERE id = ?",
+        (old_ts, item_id),
+    )
+    await store._db.commit()
+
+    svc = MonitorService(store=store, http_client=AsyncMock())
+    due = await svc.get_due_items()
+    assert not any(d["id"] == item_id for d in due), "Old item should not be due for polling"
+
+    item = await store.get_item(item_id)
+    assert item["status"] == "stopped", f"Old item should be marked stopped, got {item['status']}"

--- a/tinyagentos/knowledge_monitor.py
+++ b/tinyagentos/knowledge_monitor.py
@@ -101,9 +101,22 @@ class MonitorService:
         Items whose monitor config is missing or empty are excluded.
         """
         now = time.time()
-        items = await self._store.list_items(status="ready")
+        
+        # Page through all items with status="ready" to avoid the limit 50 bug
+        all_items = []
+        limit = 100  # Use a reasonable page size
+        offset = 0
+        while True:
+            page = await self._store.list_items(status="ready", limit=limit, offset=offset)
+            if not page:
+                break
+            all_items.extend(page)
+            if len(page) < limit:
+                break
+            offset += limit
+        
         due = []
-        for item in items:
+        for item in all_items:
             m = item.get("monitor") or {}
             current_interval = m.get("current_interval", 0)
             last_poll = m.get("last_poll", 0)
@@ -135,9 +148,14 @@ class MonitorService:
             metadata_json={},
         )
 
-        # Update content if changed
+        # Bug fix: Never overwrite stored text with raw HTML
+        # Only update item content when we have extracted text (not raw HTML)
+        # For now, there's no extractor, so we skip updating content
         if changed and new_content:
-            await self._store.update_item(item_id, content=new_content)
+            # For now, we don't have an extractor, so we keep the original content
+            # The fix ensures we don't overwrite with raw HTML
+            # await self._store.update_item(item_id, content=new_content)
+            pass
 
         # Compute next interval
         next_interval = compute_next_interval(
@@ -150,7 +168,9 @@ class MonitorService:
         )
 
         monitor["last_poll"] = time.time()
-        monitor["last_hash"] = content_hash
+        # Bug fix: Skip baseline update on failed fetch
+        if new_content:
+            monitor["last_hash"] = content_hash
         monitor["current_interval"] = next_interval
 
         await self._store.update_item(item_id, monitor=monitor)
@@ -178,10 +198,14 @@ class MonitorService:
             resp.raise_for_status()
             from tinyagentos.web_fetch import stream_text_response
             _, _, text_bytes = await stream_text_response(resp)
+            # BUG FIX: Use the ingest extractor to get extracted text, not raw HTML
+            # The extract() function would parse the HTML and return the extracted text
+            # For now, we just keep the raw text from stream_text_response
             new_content = text_bytes.decode("utf-8", errors="replace")
             old_content = item.get("content", "")
             changed = new_content.strip() != old_content.strip()
             return new_content, changed
         except Exception as exc:
             logger.warning("Article re-fetch failed for %s: %s", item["source_url"], exc)
+            # BUG FIX: Return empty content on failure to avoid updating baseline
             return "", False

--- a/tinyagentos/knowledge_monitor.py
+++ b/tinyagentos/knowledge_monitor.py
@@ -99,28 +99,22 @@ class MonitorService:
         An item is due when ``last_poll + current_interval <= now``.
         Items with ``current_interval == 0`` (files, manual) are excluded.
         Items whose monitor config is missing or empty are excluded.
+        Items older than ``stop_after_days`` are excluded and marked stopped.
         """
         now = time.time()
         
-        # Page through all items with status="ready" to avoid the limit 50 bug
-        all_items = []
-        limit = 100  # Use a reasonable page size
-        offset = 0
-        while True:
-            page = await self._store.list_items(status="ready", limit=limit, offset=offset)
-            if not page:
-                break
-            all_items.extend(page)
-            if len(page) < limit:
-                break
-            offset += limit
+        page = await self._store.list_items(status="ready", limit=100, offset=0)
         
         due = []
-        for item in all_items:
+        for item in page:
             m = item.get("monitor") or {}
             current_interval = m.get("current_interval", 0)
             last_poll = m.get("last_poll", 0)
             if current_interval <= 0:
+                continue
+            stop_after_days = m.get("stop_after_days", 0)
+            if stop_after_days and (now - item.get("created_at", 0) > stop_after_days * 86400):
+                await self._store.update_item(item["id"], status="stopped")
                 continue
             if last_poll + current_interval <= now:
                 due.append(item)
@@ -148,14 +142,12 @@ class MonitorService:
             metadata_json={},
         )
 
-        # Bug fix: Never overwrite stored text with raw HTML
-        # Only update item content when we have extracted text (not raw HTML)
-        # For now, there's no extractor, so we skip updating content
+        # Bug fix: Never overwrite stored text with raw HTML.
+        # _fetch_article now returns extracted text (not raw HTML), so when the
+        # extracted content differs from the baseline we update the item.
         if changed and new_content:
-            # For now, we don't have an extractor, so we keep the original content
-            # The fix ensures we don't overwrite with raw HTML
-            # await self._store.update_item(item_id, content=new_content)
-            pass
+            if content_hash != old_hash:
+                await self._store.update_item(item_id, content=new_content)
 
         # Compute next interval
         next_interval = compute_next_interval(
@@ -198,14 +190,12 @@ class MonitorService:
             resp.raise_for_status()
             from tinyagentos.web_fetch import stream_text_response
             _, _, text_bytes = await stream_text_response(resp)
-            # BUG FIX: Use the ingest extractor to get extracted text, not raw HTML
-            # The extract() function would parse the HTML and return the extracted text
-            # For now, we just keep the raw text from stream_text_response
-            new_content = text_bytes.decode("utf-8", errors="replace")
+            html = text_bytes.decode("utf-8", errors="replace")
+            from tinyagentos.knowledge_ingest import _extract_text_readability
+            new_content = _extract_text_readability(html)
             old_content = item.get("content", "")
             changed = new_content.strip() != old_content.strip()
             return new_content, changed
         except Exception as exc:
             logger.warning("Article re-fetch failed for %s: %s", item["source_url"], exc)
-            # BUG FIX: Return empty content on failure to avoid updating baseline
             return "", False

--- a/tinyagentos/knowledge_monitor.py
+++ b/tinyagentos/knowledge_monitor.py
@@ -103,21 +103,30 @@ class MonitorService:
         """
         now = time.time()
         
-        page = await self._store.list_items(status="ready", limit=100, offset=0)
-        
         due = []
-        for item in page:
-            m = item.get("monitor") or {}
-            current_interval = m.get("current_interval", 0)
-            last_poll = m.get("last_poll", 0)
-            if current_interval <= 0:
-                continue
-            stop_after_days = m.get("stop_after_days", 0)
-            if stop_after_days and (now - item.get("created_at", 0) > stop_after_days * 86400):
-                await self._store.update_item(item["id"], status="stopped")
-                continue
-            if last_poll + current_interval <= now:
-                due.append(item)
+        limit = 100
+        offset = 0
+        
+        while True:
+            page = await self._store.list_items(status="ready", limit=limit, offset=offset)
+            
+            for item in page:
+                m = item.get("monitor") or {}
+                current_interval = m.get("current_interval", 0)
+                last_poll = m.get("last_poll", 0)
+                if current_interval <= 0:
+                    continue
+                stop_after_days = m.get("stop_after_days", 0)
+                if stop_after_days and (now - item.get("created_at", 0) > stop_after_days * 86400):
+                    await self._store.update_item(item["id"], status="stopped")
+                    continue
+                if last_poll + current_interval <= now:
+                    due.append(item)
+            
+            if len(page) < limit:
+                break
+            offset += limit
+        
         return due
 
     async def poll_item(self, item_id: str) -> None:

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -280,11 +280,11 @@ class KnowledgeStore(BaseStore):
                 ")"
             )
             params.append(category)
-        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
-        params.extend([limit, offset])
+        sql += " ORDER BY created_at DESC"
         cursor = await self._db.execute(sql, params)
         rows = await cursor.fetchall()
-        return [_row_to_item(r) for r in rows]
+        all_items = [_row_to_item(r) for r in rows]
+        return all_items[offset:offset + limit] if limit > 0 else []
 
     async def list_for_user(self, user_id: str, **kwargs) -> list[dict]:
         """List items belonging to a specific user. Convenience wrapper around list_items."""

--- a/tinyagentos/knowledge_store.py
+++ b/tinyagentos/knowledge_store.py
@@ -280,11 +280,11 @@ class KnowledgeStore(BaseStore):
                 ")"
             )
             params.append(category)
-        sql += " ORDER BY created_at DESC"
+        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
         cursor = await self._db.execute(sql, params)
         rows = await cursor.fetchall()
-        all_items = [_row_to_item(r) for r in rows]
-        return all_items[offset:offset + limit] if limit > 0 else []
+        return [_row_to_item(r) for r in rows]
 
     async def list_for_user(self, user_id: str, **kwargs) -> list[dict]:
         """List items belonging to a specific user. Convenience wrapper around list_items."""


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2948 (tsk-54kexu / tsk-kl7vty / tsk-xiinm2, R2-12): get_due_items reads ONE page of 100 - loop pages + a >2-page polls-all test

Autonomous build of board card tsk-qk7fiw, opened by the lead after an executor rescue (below).

REVISION: built on `exec/tsk-54kexu` (cut at `6af6c590fc3ac6ec71a629a2b1493ec15337f551`), not on `dev`.
That branch's commits are ancestors of this one, verified with `git merge-base --is-ancestor`.

RED-FIRST proof, re-measured by the lead on BASE `exec/tsk-54kexu` in a scratch worktree with only
this branch's test file copied in:

```
>       assert len(due) == item_count, f"Expected {item_count} due items, got {len(due)}"
E       AssertionError: Expected 250 due items, got 100
FAILED tests/test_knowledge_monitor.py::test_monitor_polls_all_ready_items
1 failed, 17 passed, 4 warnings in 0.68s
```

The fix: `get_due_items` now loops `list_items(status="ready", limit=100, offset=offset)`, extending
`due` per page and stopping on a short page, instead of reading a single page. `test_monitor_polls_all_ready_items`
uses 250 items (more than two pages) and asserts every created id is in the due list.

LEAD RESCUE NOTE: the lane's work commit (`1020ec2ed`) already carried the fenced red above. The
executor then added a second commit containing only a stray `COMMIT_BODY` file, and its RED-FIRST
check reads the message of HEAD alone, so it saw a body with no fenced block and refused to open a
PR three times - card tsk-qk7fiw burned to needs-human on tooling, not on the work. The lead dropped
the body-only commit, leaving the lane's commit and body intact, and re-measured the red before
opening this PR.

Closes the R2-12 chain: on merge the lead closes tsk-qk7fiw, tsk-54kexu, tsk-kl7vty and tsk-xiinm2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Knowledge monitoring now checks all eligible items, including those beyond previous page limits.
  - Polling stores readable extracted content instead of raw HTML.
  - Failed or empty fetches no longer overwrite existing content or tracking information.
  - Expired monitors are marked stopped and excluded from future polling.
  - Pagination now correctly retrieves items across multiple pages.
- **Tests**
  - Added coverage for pagination, content extraction, failed fetches, SQL pagination, and expiration handling.
- **Documentation**
  - Added changelog entries describing the monitoring fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->