### PR TITLE
Dispatcher S1: in-product assignment engine (#2141)

### DIFF
--- a/changelog.d/tsk-rpxqsj-dispatcher.md
+++ b/changelog.d/tsk-rpxqsj-dispatcher.md
@@ -1,0 +1,2 @@
+### Added
+- Dispatcher service for auto-assigning claimable project tasks to eligible shared agents across boards, with per-user config CRUD and selection policy (priority desc, created asc, pooled across enabled boards, blocked-on skip, per-agent concurrency cap).

--- a/tests/projects/test_dispatcher.py
+++ b/tests/projects/test_dispatcher.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import json
+import secrets
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.agent_grants_store import AgentGrantsStore
+from tinyagentos.projects.dispatcher import DispatcherService, DispatcherStore
+from tinyagentos.projects.project_store import ProjectStore
+from tinyagentos.projects.task_store import ProjectTaskStore
+
+
+def _make_app_state(tmp_path):
+    class _AppState:
+        pass
+
+    state = _AppState()
+    state.data_dir = tmp_path
+    state.config = type("Config", (), {"agents": []})()
+    return state
+
+
+def _make_config(tmp_path) -> dict:
+    return {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+
+
+@pytest_asyncio.fixture
+async def dispatcher_store(tmp_path):
+    s = DispatcherStore(tmp_path / "dispatcher.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def project_store(tmp_path):
+    s = ProjectStore(tmp_path / "projects.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def task_store(tmp_path, project_store):
+    s = ProjectTaskStore(tmp_path / "tasks.db", project_store=project_store)
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def grants_store(tmp_path):
+    s = AgentGrantsStore(tmp_path / "grants.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+def app_state(tmp_path, dispatcher_store, project_store, task_store, grants_store):
+    state = _make_app_state(tmp_path)
+    state.dispatcher_store = dispatcher_store
+    state.project_store = project_store
+    state.project_task_store = task_store
+    state.agent_grants = grants_store
+    state.bridge_sessions = None
+    state.chat_channels = None
+    state.chat_messages = None
+    state.config.agents = [
+        {"id": "agent-1", "name": "Agent 1", "canonical_id": "agent-1"},
+        {"id": "agent-2", "name": "Agent 2", "canonical_id": "agent-2"},
+    ]
+    return state
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default(dispatcher_store):
+    cfg = await dispatcher_store.get_config("user-1")
+    assert cfg["enabled"] is False
+    assert cfg["boards"] == []
+    assert cfg["eligible_agents"] == []
+    assert cfg["max_concurrent_per_agent"] == 1
+    assert cfg["poll_seconds"] == 30
+
+
+@pytest.mark.asyncio
+async def test_config_crud_persists(dispatcher_store):
+    await dispatcher_store.set_config("user-1", {"enabled": True, "boards": ["b1"]})
+    cfg = await dispatcher_store.get_config("user-1")
+    assert cfg["enabled"] is True
+    assert cfg["boards"] == ["b1"]
+    assert cfg["eligible_agents"] == []
+    assert cfg["max_concurrent_per_agent"] == 1
+    assert cfg["poll_seconds"] == 30
+
+
+@pytest.mark.asyncio
+async def test_config_merge_does_not_wipe_other_fields(dispatcher_store):
+    await dispatcher_store.set_config(
+        "user-1", {"enabled": True, "boards": ["b1"], "eligible_agents": ["a1"]}
+    )
+    await dispatcher_store.set_config("user-1", {"max_concurrent_per_agent": 2})
+    cfg = await dispatcher_store.get_config("user-1")
+    assert cfg["enabled"] is True
+    assert cfg["boards"] == ["b1"]
+    assert cfg["eligible_agents"] == ["a1"]
+    assert cfg["max_concurrent_per_agent"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_all_configs(app_state):
+    await app_state.dispatcher_store.set_config("u1", {"enabled": True})
+    await app_state.dispatcher_store.set_config("u2", {"enabled": False})
+    configs = await app_state.dispatcher_store.get_all_configs()
+    assert len(configs) == 2
+    assert {c["user_id"] for c in configs} == {"u1", "u2"}
+
+
+@pytest.mark.asyncio
+async def test_priority_then_oldest_assignment(app_state, task_store, grants_store):
+    prj_a = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+    prj_b = await app_state.project_store.create_project(
+        name="B", slug="proj-b", created_by="user-1", user_id="user-1"
+    )
+
+    t1 = await task_store.create_task(
+        project_id=prj_a["id"], title="Low priority old", created_by="user-1", priority=1
+    )
+    t2 = await task_store.create_task(
+        project_id=prj_a["id"], title="High priority new", created_by="user-1", priority=10
+    )
+    t3 = await task_store.create_task(
+        project_id=prj_b["id"], title="High priority old", created_by="user-1", priority=10
+    )
+
+    for t in [t1, t2, t3]:
+        await task_store.update_task(t["id"], labels=["claimable"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj_a["id"]
+    )
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj_b["id"]
+    )
+    await grants_store.add_grant(
+        canonical_id="agent-2", scope="project_tasks", project_id=prj_a["id"]
+    )
+    await grants_store.add_grant(
+        canonical_id="agent-2", scope="project_tasks", project_id=prj_b["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj_a["id"], prj_b["id"]],
+            "eligible_agents": ["agent-1", "agent-2"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    tasks = {t["id"]: await task_store.get_task(t["id"]) for t in [t1, t2, t3]}
+    assigned = {tid: t["assignee_id"] for tid, t in tasks.items() if t["assignee_id"]}
+
+    assert len(assigned) == 2
+    assert tasks[t2["id"]]["assignee_id"] is not None
+    assert tasks[t3["id"]]["assignee_id"] is not None
+    assert tasks[t1["id"]]["assignee_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_per_agent_concurrency_cap(app_state, task_store, grants_store):
+    prj = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+
+    t1 = await task_store.create_task(
+        project_id=prj["id"], title="T1", created_by="user-1", priority=10
+    )
+    t2 = await task_store.create_task(
+        project_id=prj["id"], title="T2", created_by="user-1", priority=9
+    )
+    t3 = await task_store.create_task(
+        project_id=prj["id"], title="T3", created_by="user-1", priority=8
+    )
+
+    for t in [t1, t2, t3]:
+        await task_store.update_task(t["id"], labels=["claimable"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj["id"]],
+            "eligible_agents": ["agent-1"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    tasks = {t["id"]: await task_store.get_task(t["id"]) for t in [t1, t2, t3]}
+    assigned = [t for t in tasks.values() if t["assignee_id"]]
+    assert len(assigned) == 1
+    assert assigned[0]["assignee_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_blocked_on_skip(app_state, task_store, grants_store):
+    prj = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+
+    blocker = await task_store.create_task(
+        project_id=prj["id"], title="Blocker", created_by="user-1"
+    )
+    blocked = await task_store.create_task(
+        project_id=prj["id"], title="Blocked", created_by="user-1", priority=10
+    )
+    free = await task_store.create_task(
+        project_id=prj["id"], title="Free", created_by="user-1", priority=5
+    )
+
+    await task_store.update_task(blocked["id"], labels=["claimable", f"blocked-on:{blocker['id']}"])
+    await task_store.update_task(free["id"], labels=["claimable"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj["id"]],
+            "eligible_agents": ["agent-1"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    blocked_task = await task_store.get_task(blocked["id"])
+    free_task = await task_store.get_task(free["id"])
+    assert blocked_task["assignee_id"] is None
+    assert free_task["assignee_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_closing_blocker_releases_card(app_state, task_store, grants_store):
+    prj = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+
+    blocker = await task_store.create_task(
+        project_id=prj["id"], title="Blocker", created_by="user-1"
+    )
+    blocked = await task_store.create_task(
+        project_id=prj["id"], title="Blocked", created_by="user-1", priority=10
+    )
+
+    await task_store.update_task(blocked["id"], labels=["claimable", f"blocked-on:{blocker['id']}"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj["id"]],
+            "eligible_agents": ["agent-1"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    blocked_task = await task_store.get_task(blocked["id"])
+    assert blocked_task["assignee_id"] is None
+
+    await task_store.close_task(blocker["id"], closed_by="user-1")
+
+    await service.dispatch_once()
+    blocked_task = await task_store.get_task(blocked["id"])
+    assert blocked_task["assignee_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_agent_without_grant_never_gets_cards(app_state, task_store, grants_store):
+    prj_a = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+    prj_b = await app_state.project_store.create_project(
+        name="B", slug="proj-b", created_by="user-1", user_id="user-1"
+    )
+
+    t_a = await task_store.create_task(
+        project_id=prj_a["id"], title="A task", created_by="user-1"
+    )
+    t_b = await task_store.create_task(
+        project_id=prj_b["id"], title="B task", created_by="user-1"
+    )
+
+    for t in [t_a, t_b]:
+        await task_store.update_task(t["id"], labels=["claimable"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj_a["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj_a["id"], prj_b["id"]],
+            "eligible_agents": ["agent-1"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    t_a_row = await task_store.get_task(t_a["id"])
+    t_b_row = await task_store.get_task(t_b["id"])
+    assert t_a_row["assignee_id"] == "agent-1"
+    assert t_b_row["assignee_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_manual_claim_unaffected(app_state, task_store, grants_store):
+    prj = await app_state.project_store.create_project(
+        name="A", slug="proj-a", created_by="user-1", user_id="user-1"
+    )
+
+    t = await task_store.create_task(
+        project_id=prj["id"], title="Claimable", created_by="user-1"
+    )
+    await task_store.update_task(t["id"], labels=["claimable"])
+
+    await grants_store.add_grant(
+        canonical_id="agent-1", scope="project_tasks", project_id=prj["id"]
+    )
+
+    await app_state.dispatcher_store.set_config(
+        "user-1",
+        {
+            "enabled": True,
+            "boards": [prj["id"]],
+            "eligible_agents": ["agent-1"],
+            "max_concurrent_per_agent": 1,
+        },
+    )
+
+    service = DispatcherService(app_state)
+    await service.dispatch_once()
+
+    task = await task_store.get_task(t["id"])
+    assert task["assignee_id"] == "agent-1"
+
+    manual_ok = await task_store.claim_task(t["id"], claimer_id="manual-user")
+    assert manual_ok is True
+
+    task = await task_store.get_task(t["id"])
+    assert task["claimed_by"] == "manual-user"
+
+
+# ---------------------------------------------------------------------------
+# Route-level integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path):
+    config = _make_config(tmp_path)
+    (tmp_path / "config.yaml").write_text(json.dumps(config))
+    (tmp_path / ".setup_complete").touch()
+
+    app = create_app(data_dir=tmp_path)
+
+    dispatcher_store = DispatcherStore(tmp_path / "dispatcher.db")
+    await dispatcher_store.init()
+    app.state.dispatcher_store = dispatcher_store
+
+    app.state.auth.setup_user("admin", "Admin", "", "adminpass")
+    record = app.state.auth.find_user("admin")
+    token = app.state.auth.create_session(user_id=record["id"], long_lived=True)
+    app.state._startup_complete = True
+
+    csrf_token = secrets.token_hex(32)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token, "csrf_token": csrf_token},
+        headers={"X-CSRF-Token": csrf_token},
+    ) as c:
+        yield c
+
+    await dispatcher_store.close()
+
+
+@pytest.mark.asyncio
+async def test_route_get_default_config(client):
+    store = client._transport.app.state.dispatcher_store
+    assert store._db is not None
+    resp = await client.get("/api/dispatcher/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config"]["enabled"] is False
+    assert data["config"]["max_concurrent_per_agent"] == 1
+    assert data["config"]["poll_seconds"] == 30
+
+
+@pytest.mark.asyncio
+async def test_route_put_and_get_config(client):
+    resp = await client.put(
+        "/api/dispatcher/config",
+        json={
+            "enabled": True,
+            "boards": ["board-1"],
+            "eligible_agents": ["agent-x"],
+            "max_concurrent_per_agent": 2,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config"]["enabled"] is True
+    assert data["config"]["boards"] == ["board-1"]
+    assert data["config"]["eligible_agents"] == ["agent-x"]
+    assert data["config"]["max_concurrent_per_agent"] == 2
+
+    resp = await client.get("/api/dispatcher/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config"]["enabled"] is True
+    assert data["config"]["boards"] == ["board-1"]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -430,6 +430,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     receipt_store = ReceiptStore(data_dir / "receipts.db")
     from tinyagentos.projects.strike_store import StrikeStore
     strike_store = StrikeStore(data_dir / "task_strikes.db")
+    from tinyagentos.projects.dispatcher import DispatcherStore
+    dispatcher_store = DispatcherStore(data_dir / "dispatcher.db")
     project_task_store = ProjectTaskStore(
         data_dir / "projects.db",
         broker=project_event_broker,
@@ -645,6 +647,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await board_audit_store.init()
         await receipt_store.init()
         await strike_store.init()
+        await dispatcher_store.init()
         await project_task_store.init()
         await project_element_store.init()
         await routine_store.init()
@@ -1332,6 +1335,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         from tinyagentos.agent_heartbeat import agent_heartbeat_loop
         _create_supervised_task(agent_heartbeat_loop(app.state), app.state._background_tasks)
 
+        from tinyagentos.projects.dispatcher import DispatcherService
+        dispatcher_service = DispatcherService(app.state)
+        app.state.dispatcher_service = dispatcher_service
+        _create_supervised_task(
+            dispatcher_service.dispatcher_loop(), app.state._background_tasks
+        )
+
         try:
             canvas_snapshotter = CanvasSnapshotter(
                 project_store=project_store,
@@ -1761,6 +1771,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.board_audit = board_audit_store
     app.state.receipt_store = receipt_store
     app.state.task_strikes = strike_store
+    app.state.dispatcher_store = dispatcher_store
     app.state.project_task_store = project_task_store
     app.state.project_element_store = project_element_store
     app.state.routine_store = routine_store

--- a/tinyagentos/projects/dispatcher.py
+++ b/tinyagentos/projects/dispatcher.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+
+from tinyagentos.projects.tx import ProjectsDBStore
+from tinyagentos.projects.task_store import _row_to_task
+from tinyagentos.wake_budget import can_wake, record_scheduled_wake
+
+logger = logging.getLogger(__name__)
+
+DISPATCHER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS dispatcher_config (
+    user_id TEXT NOT NULL,
+    config TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (user_id)
+);
+"""
+
+_DEFAULT_CONFIG = {
+    "enabled": False,
+    "boards": [],
+    "eligible_agents": [],
+    "max_concurrent_per_agent": 1,
+    "poll_seconds": 30,
+}
+
+
+class DispatcherStore(ProjectsDBStore):
+    SCHEMA = DISPATCHER_SCHEMA
+
+    async def get_config(self, user_id: str) -> dict:
+        async with self._read(
+            "SELECT config FROM dispatcher_config WHERE user_id = ?", (user_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return dict(_DEFAULT_CONFIG)
+            try:
+                cfg = json.loads(row[0])
+            except json.JSONDecodeError:
+                cfg = {}
+            return {**_DEFAULT_CONFIG, **cfg}
+
+    async def set_config(self, user_id: str, config: dict) -> None:
+        current = await self.get_config(user_id)
+        current.update(config)
+        async with self._tx():
+            await self._db.execute(
+                """INSERT INTO dispatcher_config (user_id, config)
+                   VALUES (?, ?)
+                   ON CONFLICT(user_id) DO UPDATE SET config = excluded.config""",
+                (user_id, json.dumps(current)),
+            )
+
+    async def get_all_configs(self) -> list[dict]:
+        async with self._read("SELECT user_id, config FROM dispatcher_config") as cur:
+            rows = await cur.fetchall()
+            result = []
+            for row in rows:
+                try:
+                    cfg = json.loads(row[1])
+                except json.JSONDecodeError:
+                    cfg = {}
+                result.append({"user_id": row[0], "config": {**_DEFAULT_CONFIG, **cfg}})
+            return result
+
+
+class DispatcherService:
+    def __init__(self, app_state) -> None:
+        self._app_state = app_state
+
+    async def dispatch_once(self) -> None:
+        store = getattr(self._app_state, "dispatcher_store", None)
+        if store is None:
+            return
+
+        project_task_store = getattr(self._app_state, "project_task_store", None)
+        agent_grants_store = getattr(self._app_state, "agent_grants", None)
+        project_store = getattr(self._app_state, "project_store", None)
+
+        if not all([project_task_store, agent_grants_store, project_store]):
+            return
+
+        try:
+            configs = await store.get_all_configs()
+        except Exception:
+            return
+
+        for entry in configs:
+            user_id = entry["user_id"]
+            cfg = entry.get("config", {})
+            if not cfg.get("enabled", False):
+                continue
+
+            try:
+                await self._dispatch_for_user(user_id, cfg)
+            except Exception:
+                logger.exception("dispatcher: dispatch failed for user %s", user_id)
+
+    async def _dispatch_for_user(self, user_id: str, cfg: dict) -> None:
+        project_task_store = self._app_state.project_task_store
+        agent_grants_store = self._app_state.agent_grants
+        project_store = self._app_state.project_store
+        config = getattr(self._app_state, "config", None)
+        data_dir = getattr(self._app_state, "data_dir", None)
+
+        boards = cfg.get("boards") or []
+        eligible_agents = cfg.get("eligible_agents") or []
+        max_concurrent = cfg.get("max_concurrent_per_agent", 1)
+
+        if not boards:
+            projects = await project_store.list_for_user(user_id)
+            boards = [p["id"] for p in projects]
+
+        if not boards or not eligible_agents:
+            return
+
+        candidates: list[dict] = []
+        for board_id in boards:
+            board_tasks = await self._get_candidates(project_task_store, board_id)
+            candidates.extend(board_tasks)
+
+        candidates.sort(
+            key=lambda t: (-(t.get("priority") or 0), t.get("created_at") or 0)
+        )
+
+        assigned_tasks: set[str] = set()
+
+        for agent_id in eligible_agents:
+            claimed_count = await self._count_claimed_tasks(
+                project_task_store, agent_id
+            )
+            if claimed_count >= max_concurrent:
+                continue
+
+            for task in candidates:
+                if task["id"] in assigned_tasks:
+                    continue
+
+                if not await self._agent_has_grant(
+                    agent_grants_store, agent_id, task["project_id"]
+                ):
+                    continue
+
+                if await self._is_blocked(project_task_store, task):
+                    continue
+
+                await self._dispatch_task(task, agent_id, data_dir, config)
+                assigned_tasks.add(task["id"])
+                break
+
+    async def _get_candidates(self, project_task_store, board_id: str) -> list[dict]:
+        statuses = ("open", "todo", "ready", "backlog")
+        placeholders = ",".join("?" * len(statuses))
+
+        async with project_task_store._read(
+            f"""SELECT * FROM project_tasks
+               WHERE project_id = ?
+                 AND status IN ({placeholders})
+                 AND claimed_by IS NULL
+                 AND (
+                     assignee_id IS NULL
+                     OR assignee_id = ''
+                     OR assignee_id = '@any'
+                 )
+               ORDER BY priority DESC, created_at ASC""",
+            [board_id, *statuses],
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+            tasks = [_row_to_task(r, desc) for r in rows]
+
+        return [
+            t
+            for t in tasks
+            if any(l in ("claimable", "fleet:claimable") for l in (t.get("labels") or []))
+        ]
+
+    async def _is_blocked(self, project_task_store, task: dict) -> bool:
+        task_id = task["id"]
+        project_id = task["project_id"]
+
+        labels = task.get("labels") or []
+        for label in labels:
+            if label.startswith("blocked-on:"):
+                dep_id = label[len("blocked-on:") :]
+                dep = await project_task_store.get_task(dep_id)
+                if dep is None:
+                    continue
+                if dep["project_id"] != project_id:
+                    continue
+                if dep["status"] not in ("closed", "cancelled"):
+                    return True
+
+        rels = await project_task_store.list_relationships(task_id, direction="from")
+        for rel in rels:
+            if rel["kind"] == "blocks":
+                blocker = await project_task_store.get_task(rel["to_task_id"])
+                if blocker is None:
+                    continue
+                if blocker["project_id"] != project_id:
+                    continue
+                if blocker["status"] not in ("closed", "cancelled"):
+                    return True
+
+        return False
+
+    async def _agent_has_grant(
+        self, agent_grants_store, agent_id: str, project_id: str
+    ) -> bool:
+        grants = await agent_grants_store.list_grants(agent_id)
+        for g in grants:
+            if g["scope"] == "project_tasks" and g["project_id"] == project_id:
+                return True
+        return False
+
+    async def _count_claimed_tasks(self, project_task_store, agent_id: str) -> int:
+        async with project_task_store._read(
+            "SELECT COUNT(*) FROM project_tasks WHERE claimed_by = ? AND status = 'claimed'",
+            (agent_id,),
+        ) as cur:
+            row = await cur.fetchone()
+            return row[0] if row else 0
+
+    async def _dispatch_task(self, task: dict, agent_id: str, data_dir, config) -> None:
+        project_task_store = self._app_state.project_task_store
+        config_obj = getattr(self._app_state, "config", None)
+
+        agent = None
+        for a in getattr(config_obj, "agents", None) or []:
+            if a.get("id") == agent_id or a.get("canonical_id") == agent_id:
+                agent = a
+                break
+
+        await project_task_store.update_task(task["id"], assignee_id=agent_id)
+
+        if agent is None:
+            return
+
+        if not can_wake(
+            data_dir, agent_id, agent.get("name", agent_id), task["project_id"], config_obj
+        ):
+            return
+
+        from tinyagentos.agent_heartbeat import _wake_agent_with_task
+
+        if await _wake_agent_with_task(self._app_state, agent, task):
+            record_scheduled_wake(data_dir, agent_id, task["project_id"])
+
+
+async def dispatcher_loop(app_state, interval: float = 30.0) -> None:
+    service = DispatcherService(app_state)
+    while True:
+        try:
+            await service.dispatch_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("dispatcher: sweep iteration crashed")
+        await asyncio.sleep(interval)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -75,6 +75,9 @@ def register_all_routers(app):
     from tinyagentos.routes import projects as projects_routes
     app.include_router(projects_routes.router, dependencies=_csrf)
 
+    from tinyagentos.routes.dispatcher import router as dispatcher_router
+    app.include_router(dispatcher_router, dependencies=_csrf)
+
     from tinyagentos.routes.community import router as community_router
     app.include_router(community_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/dispatcher.py
+++ b/tinyagentos/routes/dispatcher.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class DispatcherConfigIn(BaseModel):
+    enabled: bool | None = None
+    boards: list[str] | None = None
+    eligible_agents: list[str] | None = None
+    max_concurrent_per_agent: int | None = None
+    poll_seconds: int | None = None
+
+
+@router.get("/api/dispatcher/config")
+async def get_dispatcher_config(
+    request: Request, user: CurrentUser = Depends(current_user)
+):
+    store = getattr(request.app.state, "dispatcher_store", None)
+    if store is None:
+        return JSONResponse({"error": "dispatcher not configured"}, status_code=503)
+    cfg = await store.get_config(user.user_id)
+    return {"config": cfg}
+
+
+@router.put("/api/dispatcher/config")
+async def update_dispatcher_config(
+    request: Request,
+    body: DispatcherConfigIn,
+    user: CurrentUser = Depends(current_user),
+):
+    store = getattr(request.app.state, "dispatcher_store", None)
+    if store is None:
+        return JSONResponse({"error": "dispatcher not configured"}, status_code=503)
+
+    current = await store.get_config(user.user_id)
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        return {"config": current}
+
+    merged = {**current, **updates}
+    await store.set_config(user.user_id, merged)
+    return {"config": merged}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Dispatcher S1: in-product assignment engine (#2141)

Autonomous build of board card tsk-rpxqsj.

Config CRUD, selection policy, dispatch via update_task + wake, per-user
config persisted in dispatcher.db, background poll loop, routes registered.

Docs-Reviewed: dispatcher routes are self-contained and do not change
existing project/task/claim behaviour

Files:
 changelog.d/tsk-rpxqsj-dispatcher.md |   2 +
 tests/projects/test_dispatcher.py    | 463 +++++++++++++++++++++++++++++++++++
 tinyagentos/app.py                   |  11 +
 tinyagentos/projects/dispatcher.py   | 263 ++++++++++++++++++++
 tinyagentos/routes/__init__.py       |   3 +
 tinyagentos/routes/dispatcher.py     |  51 ++++
 6 files changed, 793 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic assignment of eligible, claimable project tasks to shared agents.
  * Tasks are prioritized by priority and age, while blocked tasks, unavailable agents, and concurrency limits are respected.
  * Added dispatcher configuration controls for enablement, boards, eligible agents, concurrency limits, and polling frequency.
  * Added configuration access through the dispatcher API, with settings preserved between sessions.
  * Dispatcher runs automatically in the background when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->