### PR TITLE
docs(mkdocs): native exclude_docs + a non-vacuous exclusion guard (tsk-mwskmg, supersedes #2862/#2953)

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -232,7 +232,12 @@ time, so patching the module attribute AFTER `create_app` does nothing.
 - Uses `uv sync --frozen` and `pytest -n auto`
 - Also required: `spa-build` (npm build + tsc + **vitest** - a desktop type error or failing
   component test fails CI), a "Verify app starts" `create_app` import smoke, `lint`
-  (`compileall`), and `cla`. The doc-gate, store-wiring gate, bot-review gate,
+  (`compileall`), `docs-build`, and `cla`. `docs-build` is the only job with the mkdocs
+  toolchain installed (mkdocs is NOT a project dependency, so `uv sync` does not provide
+  it): it runs `tests/test_mkdocs_exclude.py` with `TAOS_DOCS_BUILD_TESTS=1`, which turns
+  off the `importorskip` the ordinary shards rely on — put any test that has to build the
+  docs site there, or the shards will silently skip it. The doc-gate, store-wiring gate,
+  bot-review gate,
   distrust-green gate, and evil-merge gate (`.github/workflows/evil-merge-gate.yml`,
   implementation in `scripts/check_evil_merge.py` — fails a PR whose merge resolution
   invents test-file content differing from the `git merge-tree` baseline; the workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,41 @@ jobs:
             exit 1
           fi
 
+  docs-build:
+    # mkdocs is not in the project dependencies, so the ordinary shards skip
+    # tests/test_mkdocs_exclude.py. This job is where that guard actually runs:
+    # it installs the docs toolchain and sets TAOS_DOCS_BUILD_TESTS=1, which
+    # turns the skip off - a missing mkdocs fails here instead of passing by
+    # default. A guard no job executes is a no-op.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --python 3.12
+
+      - name: Install the docs toolchain
+        run: |
+          uv pip install "mkdocs==1.6.1" "mkdocs-material==9.7.7" \
+            "pymdown-extensions==11.0.2"
+
+      - name: Docs exclusion guard (must run, not skip)
+        env:
+          TAOS_DOCS_BUILD_TESTS: "1"
+        run: |
+          uv run --no-sync python -m pytest tests/test_mkdocs_exclude.py \
+            -q --no-header -rs
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/changelog.d/tsk-mwskmg-native-exclude-docs.md
+++ b/changelog.d/tsk-mwskmg-native-exclude-docs.md
@@ -1,0 +1,2 @@
+### Fixed
+- Replaced the unmaintained `mkdocs-exclude` plugin (last release 2019) with the native MkDocs `exclude_docs:` key in `site/docs/mkdocs.yml`. The excluded pages are still absent from the built site.

--- a/site/docs/mkdocs.yml
+++ b/site/docs/mkdocs.yml
@@ -91,16 +91,14 @@ markdown_extensions:
 plugins:
   - search:
       lang: en
-  - exclude:
-      # Exclude private/internal paths that must not appear in public docs.
-      # These patterns match relative to docs_dir.
-      glob:
-        - "strategy/**"
-        - "business/**"
-        - "internal/**"
-        - "private/**"
-        - "*.private.md"
-        - "deploy/platform-lxc-internal*"
+
+exclude_docs: |
+  strategy/**
+  business/**
+  internal/**
+  private/**
+  *.private.md
+  deploy/platform-lxc-internal*
 
 nav:
   - Home: getting-started.md

--- a/tests/test_mkdocs_exclude.py
+++ b/tests/test_mkdocs_exclude.py
@@ -1,0 +1,126 @@
+"""RED test for R2-33: replace mkdocs-exclude plugin with native exclude_docs.
+
+The mkdocs-exclude plugin (1.0.2, last release 2019) is referenced in
+site/docs/mkdocs.yml but is not installed in the test environment.
+Before the fix, building the docs site fails because mkdocs cannot find
+the ``exclude`` plugin. After the fix, the config uses the native
+``exclude_docs`` key (available since MkDocs 1.5) and the build succeeds
+without any third-party exclude plugin.
+
+The test reads the project's mkdocs.yml, massages it into a form that
+mkdocs can load in the test environment (rewriting the docs_dir, stripping
+python/name tags, and removing the pymdownx.emoji extension that needs
+callables), and then runs ``mkdocs build``. It asserts:
+
+* the build exits successfully,
+* pages matching the exclude patterns are absent from the built site.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SITE_DOCS_DIR = REPO_ROOT / "site" / "docs"
+MKdocs_YML = SITE_DOCS_DIR / "mkdocs.yml"
+
+
+def _massage_config_for_test(raw: str, docs_dir: str) -> str:
+    """Rewrite mkdocs.yml so it can build in an isolated temp dir.
+
+    * Replace ``docs_dir`` with the given local path.
+    * Replace ``!!python/name:...`` tags with plain strings.
+    * Drop the ``pymdownx.emoji`` extension (needs callables unavailable here).
+    """
+    raw = re.sub(r"!!python/name:([^\n]+)", r"\1", raw)
+    raw = re.sub(r"^docs_dir:.*$", f"docs_dir: {docs_dir}", raw, flags=re.MULTILINE)
+
+    lines = raw.splitlines()
+    cleaned = []
+    skip_emoji_block = False
+    for line in lines:
+        if "pymdownx.emoji" in line:
+            skip_emoji_block = True
+            continue
+        if skip_emoji_block:
+            if line.startswith("  ") or line.startswith("\t"):
+                continue
+            skip_emoji_block = False
+        cleaned.append(line)
+    return "\n".join(cleaned)
+
+
+def _write_minimal_docs(root: Path) -> None:
+    (root / "getting-started.md").write_text("# Getting started\n")
+    (root / "design").mkdir()
+    (root / "design" / "abstraction-layers.md").write_text("# Design\n")
+    (root / "strategy").mkdir()
+    (root / "strategy" / "secret.md").write_text("# Strategy (should be excluded)\n")
+    (root / "business").mkdir()
+    (root / "business" / "secret.md").write_text("# Business (should be excluded)\n")
+    (root / "internal").mkdir()
+    (root / "internal" / "secret.md").write_text("# Internal (should be excluded)\n")
+    (root / "private").mkdir()
+    (root / "private" / "secret.md").write_text("# Private (should be excluded)\n")
+    (root / "draft.private.md").write_text("# Private draft (should be excluded)\n")
+    (root / "deploy").mkdir()
+    (root / "deploy" / "platform-lxc-internal.md").write_text(
+        "# Internal deploy (should be excluded)\n"
+    )
+
+
+class TestMkdocsExcludeReplacement:
+    def test_build_succeeds_without_mkdocs_exclude_plugin(self):
+        raw = MKdocs_YML.read_text()
+        config = _massage_config_for_test(raw, docs_dir="docs")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            docs_root = tmp_path / "docs"
+            docs_root.mkdir()
+            _write_minimal_docs(docs_root)
+
+            config_path = tmp_path / "mkdocs.yml"
+            config_path.write_text(config)
+
+            site_dir = tmp_path / "site"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "mkdocs",
+                    "build",
+                    "--config-file",
+                    str(config_path),
+                    "--site-dir",
+                    str(site_dir),
+                ],
+                cwd=tmp_path,
+                capture_output=True,
+                text=True,
+            )
+
+            assert result.returncode == 0, (
+                f"mkdocs build failed:\n{result.stdout}\n{result.stderr}"
+            )
+
+            # Assert on the path relative to the site root, not the file name:
+            # mkdocs builds with use_directory_urls, so every page lands as
+            # index.html and the *name* never carries the excluded segment.
+            built = sorted(
+                p.relative_to(site_dir).as_posix() for p in site_dir.rglob("*.html")
+            )
+
+            for forbidden in [
+                "secret",
+                "platform-lxc-internal",
+                "draft.private",
+            ]:
+                assert not any(forbidden in path for path in built), (
+                    f"Excluded page '{forbidden}' found in built site: {built}"
+                )

--- a/tests/test_mkdocs_exclude.py
+++ b/tests/test_mkdocs_exclude.py
@@ -17,6 +17,7 @@ callables), and then runs ``mkdocs build``. It asserts:
 """
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -24,6 +25,17 @@ import tempfile
 from pathlib import Path
 
 import pytest
+
+# mkdocs is not a project dependency: `uv sync` does not install it, so the
+# ordinary test shards cannot build a site and would fail on the environment
+# rather than on the defect. The dedicated `docs-build` CI job installs the
+# docs toolchain and sets TAOS_DOCS_BUILD_TESTS=1; there this test MUST run,
+# and a missing mkdocs is a hard failure instead of a silent skip.
+if os.environ.get("TAOS_DOCS_BUILD_TESTS") != "1":
+    pytest.importorskip(
+        "mkdocs",
+        reason="mkdocs not installed; the docs-build CI job runs this guard",
+    )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SITE_DOCS_DIR = REPO_ROOT / "site" / "docs"


### PR DESCRIPTION
docs(mkdocs): replace the unavailable exclude plugin with native exclude_docs (tsk-mwskmg)

Carries the mkdocs.yml change, fragment and test from #2862 / #2953 (both closed
after three lane attempts) and fixes the one defect that blocked them: the
"excluded page is not published" assertion was vacuous.

mkdocs builds with use_directory_urls, so every page is written as index.html and
the file *name* never contains "secret", "platform-lxc-internal" or "draft.private"
whatever is published. The assertion now compares the path relative to the site
root, so it can actually fail.

RED on origin/dev (mkdocs.yml unchanged, this test file only) - the `exclude`
plugin is not installed, so the build exits non-zero:

```
$ /usr/bin/python3 -m pytest tests/test_mkdocs_exclude.py -q
FAILED tests/test_mkdocs_exclude.py::TestMkdocsExcludeReplacement::test_build_succeeds_without_mkdocs_exclude_plugin
1 failed, 2 warnings in 0.60s
```

GREEN on this branch:

```
$ /usr/bin/python3 -m pytest tests/test_mkdocs_exclude.py -q
1 passed, 2 warnings in 3.32s
```

MUTATION PROOF that the exclusion half of the test is no longer vacuous - the same
run at this head with `exclude_docs:` deleted from site/docs/mkdocs.yml (i.e. nothing
excluded at all). Under the old name-based assertion this went green; it now fails,
naming the private pages that got published:

```
$ /usr/bin/python3 -m pytest tests/test_mkdocs_exclude.py -q
E   AssertionError: Excluded page 'secret' found in built site: ['404.html',
    'business/secret/index.html', 'deploy/platform-lxc-internal/index.html',
    'design/abstraction-layers/index.html', 'draft.private/index.html',
    'getting-started/index.html', 'internal/secret/index.html',
    'private/secret/index.html', 'strategy/secret/index.html']
FAILED tests/test_mkdocs_exclude.py::TestMkdocsExcludeReplacement::test_build_succeeds_without_mkdocs_exclude_plugin
1 failed, 2 warnings in 1.05s
```

Supersedes #2862 (tsk-mwskmg) and #2953 (tsk-mrsk2p).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated site documentation builds to use MkDocs’ built-in exclusion support.
  - Preserved exclusion of strategy, business, internal, private, and deployment-specific pages from the generated site.

- **Tests**
  - Added coverage confirming excluded pages do not appear in successful documentation builds.

- **Chores**
  - Added a dedicated documentation build check to continuously validate site generation and exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up commit: the guard needed a job that has mkdocs

The first push of this branch went red on shards (3.13, 3):

```
FAILED tests/test_mkdocs_exclude.py::TestMkdocsExcludeReplacement::test_build_succeeds_without_mkdocs_exclude_plugin - AssertionError: mkdocs build failed:
  /home/runner/work/taOS/taOS/.venv/bin/python: No module named mkdocs
1 failed, 3434 passed, 18 skipped, 6 xfailed, 42 warnings in 820.18s
```

mkdocs is declared nowhere in the project dependencies, so `uv sync` never
installs it and the shard failed on its environment, not on the defect.

Skipping the test in the shards is only half an answer -- a guard no job runs
is a no-op, which is the failure mode this whole card exists to fix. So:

- the shards skip it (`pytest.importorskip("mkdocs")`), and
- a new `docs-build` job installs the pinned docs toolchain and runs it with
  `TAOS_DOCS_BUILD_TESTS=1`, which turns the skip OFF. In that job a missing
  mkdocs is a hard failure rather than a silent skip.

Measured locally, three ways:

```
$ .venv/bin/python -m pytest tests/test_mkdocs_exclude.py -q -rs   # shard-like: no mkdocs
SKIPPED [1] tests/test_mkdocs_exclude.py:35: mkdocs not installed; the docs-build CI job runs this guard
1 skipped in 0.20s

$ TAOS_DOCS_BUILD_TESTS=1 .venv/bin/python -m pytest tests/test_mkdocs_exclude.py -q   # docs job, mkdocs MISSING
FAILED tests/test_mkdocs_exclude.py::TestMkdocsExcludeReplacement::test_build_succeeds_without_mkdocs_exclude_plugin
1 failed in 0.28s

$ TAOS_DOCS_BUILD_TESTS=1 /usr/bin/python3 -m pytest tests/test_mkdocs_exclude.py -q   # docs job, mkdocs present
1 passed, 2 warnings in 2.70s
```

The second run is the one that matters: the docs job cannot go green by
skipping.


---

Gate acknowledgements (both gates are correct here, so they are answered rather than worked around):

- `gate-integrity-allow`: this PR edits `.github/workflows/ci.yml` (it adds the `docs-build` job). Reviewed and labelled by the lead.
- The skip in the ordinary shards is exactly what `check-all-skip` is built to catch, and it would be manufacturing coverage if `docs-build` did not exist. It does: that job installs the docs toolchain and sets `TAOS_DOCS_BUILD_TESTS=1`, which turns the skip off, so a missing mkdocs fails there instead of passing by default. `docs-build` is green on this head.

Tests-Skipped-Intentionally: test_mkdocs_exclude.py, mkdocs is not a project dependency so the shards cannot build a docs site; the new docs-build job installs the toolchain and runs this test with TAOS_DOCS_BUILD_TESTS=1, which disables the skip and makes a missing mkdocs a hard failure.
