### PR TITLE
fix-forward #2949 (tsk-xh7xhc / tsk-mhhgvn): restore scripts/check_schema_migrations.py:_split_columns deleted by the #2885 rewrite - deleted-symbols-gate RED, one splitting test, RED-FIRST

### DIFF
--- a/changelog.d/tsk-mhhgvn-migration-guard-fixes.md
+++ b/changelog.d/tsk-mhhgvn-migration-guard-fixes.md
@@ -1,0 +1,5 @@
+### Fixed
+- Expression indexes are now properly parsed using sqlglot instead of regex
+- Quoted identifiers in ALTER TABLE statements are now detected
+- Unterminated CREATE TABLE statements are now caught as violations
+- Both schema-migration and retrofit-migration guards use a real SQL parser for robust parsing

--- a/changelog.d/tsk-snomeq-restore-split-columns.md
+++ b/changelog.d/tsk-snomeq-restore-split-columns.md
@@ -1,0 +1,2 @@
+### Fixed
+- Restore `_split_columns` helper in `scripts/check_schema_migrations.py` that was dropped by the #2885 rewrite; the regex fallback path once again correctly splits multi-column CREATE TABLE bodies, including quoted column identifiers.

--- a/scripts/check_retrofit_migrations.py
+++ b/scripts/check_retrofit_migrations.py
@@ -51,19 +51,19 @@ STORES_ROOT = REPO_ROOT / "tinyagentos"
 
 # ALTER TABLE <table> ADD [COLUMN] <col> ...
 _ADD_COLUMN_RE = re.compile(
-    r"ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)",
+    r'ALTER\s+TABLE\s+(["\w]+)\s+ADD\s+(?:COLUMN\s+)?(["\w]+)',
     re.IGNORECASE,
 )
 
 # CREATE [UNIQUE] INDEX [IF NOT EXISTS] <name> ON <table> (col, col, ...)
 _CREATE_INDEX_RE = re.compile(
-    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)",
+    r'CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(["\w]+)',
     re.IGNORECASE,
 )
 
 # CREATE TABLE [IF NOT EXISTS] <table> ( ... )
 _CREATE_TABLE_RE = re.compile(
-    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(",
+    r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(["\w]+)\s*\(',
     re.IGNORECASE,
 )
 
@@ -121,7 +121,7 @@ def _normalize(sql: str) -> str:
 
 def _extract_schema_tables(schema_sql: str) -> set[str]:
     """Return the set of table names declared in CREATE TABLE statements."""
-    return {m.group(1) for m in _CREATE_TABLE_RE.finditer(schema_sql)}
+    return {m.group(1).strip('"\'') for m in _CREATE_TABLE_RE.finditer(schema_sql)}
 
 
 def _check_migration_sql(
@@ -143,7 +143,7 @@ def _check_migration_sql(
 
     # ALTER TABLE <schema_table> ADD COLUMN <col> -> retrofit
     for m in _ADD_COLUMN_RE.finditer(sql):
-        table = m.group(1)
+        table = m.group(1).strip('"\'')
         if table in schema_tables:
             violations.append(Violation(
                 path=path,
@@ -156,7 +156,7 @@ def _check_migration_sql(
 
     # CREATE INDEX ... ON <schema_table> -> retrofit (baseline skips it)
     for m in _CREATE_INDEX_RE.finditer(sql):
-        table = m.group(1)
+        table = m.group(1).strip('"\'')
         if table in schema_tables:
             violations.append(Violation(
                 path=path,

--- a/scripts/check_schema_migrations.py
+++ b/scripts/check_schema_migrations.py
@@ -107,12 +107,12 @@ def _extract_table_columns(sql: str) -> dict[str, set[str]]:
     
     # Fallback to regex-based extraction for compatibility
     _CREATE_TABLE_RE = re.compile(
-        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w]+)\s*\((.*?)\)\s*;",
+        r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(["\w]+)\s*\((.*?)\)\s*;',
         re.IGNORECASE | re.DOTALL,
     )
-    
+
     for tm in _CREATE_TABLE_RE.finditer(sql):
-        table = tm.group(1)
+        table = tm.group(1).strip('"\'')
         cols_part = tm.group(2)
         
         # Simple column extraction for fallback
@@ -188,19 +188,30 @@ def _extract_index_column_refs(sql: str) -> list[tuple[str, str]]:
     
     # Fallback to regex-based extraction for compatibility
     _CREATE_INDEX_RE = re.compile(
-        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)\s*\(([^)]*)\)",
+        r'CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(["\w]+)\s*\((.+)\)',
         re.IGNORECASE,
     )
-    
+
     for im in _CREATE_INDEX_RE.finditer(sql):
-        table = im.group(1)
+        table = im.group(1).strip('"\'')
         cols_part = im.group(2)
         indexed = [c.strip() for c in cols_part.split(",") if c.strip()]
         for col in indexed:
-            col_name = col.split()[0] if col.split() else col
-            col_name = col_name.strip("`\"[]")
-            if col_name:
-                index_refs.append((table, col_name))
+            col = col.strip()
+            func_match = re.match(r"(?i)^\s*(\w+)\s*\(([^)]*)\)\s*$", col)
+            if func_match:
+                inner = func_match.group(2)
+                for inner_col in inner.split(","):
+                    inner_col = inner_col.strip()
+                    if inner_col:
+                        name = inner_col.split()[0].strip("`\"[]")
+                        if name:
+                            index_refs.append((table, name))
+            else:
+                col_name = col.split()[0] if col.split() else col
+                col_name = col_name.strip("`\"[]")
+                if col_name:
+                    index_refs.append((table, col_name))
     
     return index_refs
 
@@ -281,7 +292,7 @@ def find_violations(path: Path) -> list[Violation]:
                     # Find the original index statement for reporting
                     # Use regex to reconstruct the index statement
                     _CREATE_INDEX_RE = re.compile(
-                        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+\w+\s*\(([^)]*)\)",
+                        r'CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(["\w]+)\s*\(([^)]*)\)',
                         re.IGNORECASE,
                     )
                     match = _CREATE_INDEX_RE.search(schema)
@@ -320,7 +331,8 @@ def find_all_violations(root: Path = STORES_ROOT) -> list[Violation]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    violations = find_all_violations()
+    root = Path(argv[0]) if argv else STORES_ROOT
+    violations = find_all_violations(root)
     if not violations:
         print("schema-migration-guard: clean")
         return 0

--- a/scripts/check_schema_migrations.py
+++ b/scripts/check_schema_migrations.py
@@ -23,7 +23,9 @@ Usage:
 Prints ``schema-migration-guard: clean`` and exits 0 when no violations, or
 prints each violation and exits 1.
 
-Dependency-light: stdlib only (ast + re + pathlib).
+Dependency-light: sqlglot is a CI/dev-only dependency — it never lands on a Pi
+(ARM64) because its Rust/C accelerators are opt-in extras. The pure-Python
+version (30.18.0) has zero required runtime deps.
 """
 from __future__ import annotations
 
@@ -33,48 +35,20 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# sqlglot is a CI/dev-only dependency — it never lands on a Pi (ARM64) because
+# its Rust/C accelerators are opt-in extras. The pure-Python version (30.18.0)
+# has zero required runtime deps.
+try:
+    import sqlglot
+    from sqlglot import exp
+    SQLGLOT_AVAILABLE = True
+except ImportError:
+    SQLGLOT_AVAILABLE = False
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # A store is any Python file under tinyagentos/ that assigns SCHEMA (a string).
 STORES_ROOT = REPO_ROOT / "tinyagentos"
-
-# CREATE [UNIQUE] INDEX [IF NOT EXISTS] <name> ON <table> (col, col, ...)
-_CREATE_INDEX_RE = re.compile(
-    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)\s*\(([^)]*)\)",
-    re.IGNORECASE,
-)
-
-# CREATE TABLE [IF NOT EXISTS] <table> ( ... )
-_CREATE_TABLE_RE = re.compile(
-    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\((.*?)\)\s*;",
-    re.IGNORECASE | re.DOTALL,
-)
-
-# A single column definition line/segment inside a CREATE TABLE body.
-# We match leading column names that are NOT constraint keywords.
-_COLUMN_NAME_RE = re.compile(r"^\s*(\w+)\s+", re.IGNORECASE)
-
-# Inline UNIQUE/PKEY/CHECK/FK/... constraints inside a CREATE TABLE body that
-# reference columns but do NOT add a new column (so the column is "safe").
-_INLINE_CONSTRAINT_RE = re.compile(
-    r"^\s*(?:CONSTRAINT\s+\w+\s+)?(?:PRIMARY\s+KEY|UNIQUE|CHECK|FOREIGN\s+KEY|REFERENCES)\b",
-    re.IGNORECASE,
-)
-
-# ALTER TABLE <table> ADD COLUMN <col> ...
-_ADD_COLUMN_RE = re.compile(
-    r"ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)",
-    re.IGNORECASE,
-)
-
-# Keyword names that may appear where a column name would in a column def;
-# these are not candidate column names.
-_NON_COLUMN_KEYWORDS = {
-    "create", "table", "primary", "key", "unique", "check", "foreign",
-    "references", "constraint", "default", "not", "null", "integer", "text",
-    "real", "blob", "numeric", "autoincrement", "if", "exists", "select",
-    "on", "and", "or", "as", "collate", "generated", "always",
-}
 
 
 @dataclass
@@ -97,43 +71,156 @@ class Violation:
         )
 
 
-def _split_columns(body: str) -> set[str]:
-    """Extract declared column names from a CREATE TABLE body.
+def _parse_with_sqlglot(sql: str):
+    """Parse SQL using sqlglot, returns a list of expressions."""
+    if not SQLGLOT_AVAILABLE:
+        return None
+    try:
+        parsed = sqlglot.parse(sql, dialect="sqlite")
+        return parsed if isinstance(parsed, list) else [parsed]
+    except Exception:
+        return None
 
-    Splits on commas that are not inside parentheses (so function/default
-    expressions and inline CHECK(...) are handled), then keeps the first
-    whitespace-delimited token of each segment as the column name (unless that
-    segment is an inline table-level constraint, which does not add a column).
-    """
-    columns: set[str] = set()
-    depth = 0
-    segments: list[str] = []
-    current: list[str] = []
-    for ch in body:
-        if ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-        if ch == "," and depth == 0:
-            segments.append("".join(current))
-            current = []
-        else:
-            current.append(ch)
-    segments.append("".join(current))
 
-    for seg in segments:
-        if _INLINE_CONSTRAINT_RE.match(seg):
-            # Might be `UNIQUE (a, b)` -- those columns are safe (declared in
-            # CREATE TABLE), but it does not *add* a column. Skip as a column.
-            continue
-        m = _COLUMN_NAME_RE.match(seg)
-        if not m:
-            continue
-        name = m.group(1)
-        if name.lower() in _NON_COLUMN_KEYWORDS:
-            continue
-        columns.add(name)
-    return columns
+def _extract_table_columns(sql: str) -> dict[str, set[str]]:
+    """Extract table names and their columns from CREATE TABLE statements."""
+    tables = {}
+    
+    # Try sqlglot first for robust parsing (handles quoted identifiers)
+    parsed = _parse_with_sqlglot(sql)
+    if parsed is not None:
+        for stmt in parsed:
+            if isinstance(stmt, exp.Create) and isinstance(stmt.this, exp.Table):
+                table_name = stmt.this.name
+                columns = set()
+                
+                # Extract column names from ColumnDef expressions
+                if hasattr(stmt, 'expressions'):
+                    for col_def in stmt.expressions:
+                        if isinstance(col_def, exp.ColumnDef):
+                            columns.add(col_def.name)
+                
+                tables[table_name] = columns
+        # If we successfully parsed with sqlglot, return now
+        if tables:
+            return tables
+    
+    # Fallback to regex-based extraction for compatibility
+    _CREATE_TABLE_RE = re.compile(
+        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w]+)\s*\((.*?)\)\s*;",
+        re.IGNORECASE | re.DOTALL,
+    )
+    
+    for tm in _CREATE_TABLE_RE.finditer(sql):
+        table = tm.group(1)
+        cols_part = tm.group(2)
+        
+        # Simple column extraction for fallback
+        columns = set()
+        # Split by commas not inside parentheses
+        depth = 0
+        current = []
+        for ch in cols_part:
+            if ch == '(':
+                depth += 1
+            elif ch == ')':
+                depth -= 1
+            elif ch == ',' and depth == 0:
+                segment = ''.join(current).strip()
+                # Extract first word (column name)
+                match = re.match(r'^(\w+)', segment, re.IGNORECASE)
+                if match:
+                    col_name = match.group(1).lower()
+                    # Skip constraint keywords
+                    if col_name not in {'primary', 'key', 'unique', 'check', 'foreign', 'references', 'constraint'}:
+                        columns.add(col_name)
+                current = []
+            else:
+                current.append(ch)
+        
+        if current:
+            segment = ''.join(current).strip()
+            match = re.match(r'^(\w+)', segment, re.IGNORECASE)
+            if match:
+                col_name = match.group(1).lower()
+                if col_name not in {'primary', 'key', 'unique', 'check', 'foreign', 'references', 'constraint'}:
+                    columns.add(col_name)
+        
+        tables[table] = columns
+    
+    return tables
+
+
+def _extract_index_column_refs(sql: str) -> list[tuple[str, str]]:
+    """Extract table and column references from CREATE INDEX statements."""
+    index_refs = []
+    
+    # Try sqlglot first for robust parsing (handles expression indexes)
+    parsed = _parse_with_sqlglot(sql)
+    if parsed is not None:
+        for stmt in parsed:
+            if isinstance(stmt, exp.Create) and isinstance(stmt.this, exp.Index):
+                # Find the table and columns in the Index expression
+                table = None
+                columns = []
+                
+                # Walk through the Index expression tree to find Table and Column nodes
+                def walk_and_extract(node):
+                    nonlocal table
+                    
+                    if isinstance(node, exp.Table):
+                        table = node.name
+                    
+                    if isinstance(node, exp.Column):
+                        columns.append(node.name)
+                    
+                    for child in node.iter_expressions():
+                        walk_and_extract(child)
+                
+                walk_and_extract(stmt.this)
+                
+                if table and columns:
+                    for col in columns:
+                        index_refs.append((table, col))
+        # If we successfully parsed with sqlglot, return now
+        if index_refs:
+            return index_refs
+    
+    # Fallback to regex-based extraction for compatibility
+    _CREATE_INDEX_RE = re.compile(
+        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)\s*\(([^)]*)\)",
+        re.IGNORECASE,
+    )
+    
+    for im in _CREATE_INDEX_RE.finditer(sql):
+        table = im.group(1)
+        cols_part = im.group(2)
+        indexed = [c.strip() for c in cols_part.split(",") if c.strip()]
+        for col in indexed:
+            col_name = col.split()[0] if col.split() else col
+            col_name = col_name.strip("`\"[]")
+            if col_name:
+                index_refs.append((table, col_name))
+    
+    return index_refs
+
+
+def _extract_add_column_statements(source: str) -> set[tuple[str, str]]:
+    """Extract ALTER TABLE ... ADD COLUMN statements from Python source."""
+    added_columns: set[tuple[str, str]] = set()
+    
+    # Use regex to find ADD COLUMN statements (handles quoted identifiers)
+    _ADD_COLUMN_RE = re.compile(
+        r'ALTER\s+TABLE\s+(["\w]+)\s+ADD\s+(?:COLUMN\s+)?(["\w]+)',
+        re.IGNORECASE,
+    )
+    
+    for m in _ADD_COLUMN_RE.finditer(source):
+        table = m.group(1).strip('"\'')
+        column = m.group(2).strip('"\'')
+        added_columns.add((table, column))
+    
+    return added_columns
 
 
 def find_violations(path: Path) -> list[Violation]:
@@ -170,40 +257,55 @@ def find_violations(path: Path) -> list[Violation]:
     if not schema_strings:
         return []
 
-    # ADD COLUMN migrations anywhere in the file (they run after SCHEMA).
-    added_columns: set[tuple[str, str]] = set()
-    for m in _ADD_COLUMN_RE.finditer(source):
-        added_columns.add((m.group(1), m.group(2)))
+    # Get all ALTER TABLE ADD COLUMN statements in the file
+    added_columns = _extract_add_column_statements(source)
 
     violations: list[Violation] = []
     for schema in schema_strings:
-        # Tables declared in CREATE TABLE are safe (column already exists).
-        safe_columns: set[tuple[str, str]] = set()
-        for tm in _CREATE_TABLE_RE.finditer(schema):
-            table = tm.group(1)
-            for col in _split_columns(tm.group(2)):
-                safe_columns.add((table, col))
+        # Extract tables and columns from CREATE TABLE statements
+        tables = _extract_table_columns(schema)
 
-        # Every index INSIDE the SCHEMA string.
-        for im in _CREATE_INDEX_RE.finditer(schema):
-            table = im.group(1)
-            cols_part = im.group(2)
-            indexed = [c.strip() for c in cols_part.split(",") if c.strip()]
-            for col in indexed:
-                # Strip a trailing direction/collation qualifier (e.g. "DESC").
-                col_name = col.split()[0] if col.split() else col
-                col_name = col_name.strip("`\"[]")
-                if not col_name:
-                    continue
-                if (table, col_name) in added_columns and (table, col_name) not in safe_columns:
+        # Extract index references
+        index_refs = _extract_index_column_refs(schema)
+
+        # Check each index reference
+        for table, col in index_refs:
+            # Check if this column was added by an ALTER TABLE statement
+            if (table, col) in added_columns:
+                # Check if the column is already defined in the table
+                safe = False
+                if table in tables:
+                    safe = col.lower() in tables[table]
+
+                if not safe:
+                    # Find the original index statement for reporting
+                    # Use regex to reconstruct the index statement
+                    _CREATE_INDEX_RE = re.compile(
+                        r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+\w+\s*\(([^)]*)\)",
+                        re.IGNORECASE,
+                    )
+                    match = _CREATE_INDEX_RE.search(schema)
+                    if match:
+                        cols_part = match.group(1)
+                        # Find the full index statement
+                        for im in _CREATE_INDEX_RE.finditer(schema):
+                            if im.group(1) == table:
+                                index_stmt = im.group(0).strip()
+                                break
+                        else:
+                            index_stmt = f"CREATE INDEX ON {table}({col})"
+                    else:
+                        index_stmt = f"CREATE INDEX ON {table}({col})"
+
                     violations.append(
                         Violation(
                             path=path,
                             table=table,
-                            column=col_name,
-                            index_stmt=im.group(0).strip(),
+                            column=col,
+                            index_stmt=index_stmt,
                         )
                     )
+
     return violations
 
 

--- a/scripts/check_schema_migrations.py
+++ b/scripts/check_schema_migrations.py
@@ -115,40 +115,69 @@ def _extract_table_columns(sql: str) -> dict[str, set[str]]:
         table = tm.group(1).strip('"\'')
         cols_part = tm.group(2)
         
-        # Simple column extraction for fallback
-        columns = set()
-        # Split by commas not inside parentheses
-        depth = 0
-        current = []
-        for ch in cols_part:
-            if ch == '(':
-                depth += 1
-            elif ch == ')':
-                depth -= 1
-            elif ch == ',' and depth == 0:
-                segment = ''.join(current).strip()
-                # Extract first word (column name)
-                match = re.match(r'^(\w+)', segment, re.IGNORECASE)
-                if match:
-                    col_name = match.group(1).lower()
-                    # Skip constraint keywords
-                    if col_name not in {'primary', 'key', 'unique', 'check', 'foreign', 'references', 'constraint'}:
-                        columns.add(col_name)
-                current = []
-            else:
-                current.append(ch)
-        
-        if current:
-            segment = ''.join(current).strip()
-            match = re.match(r'^(\w+)', segment, re.IGNORECASE)
-            if match:
-                col_name = match.group(1).lower()
-                if col_name not in {'primary', 'key', 'unique', 'check', 'foreign', 'references', 'constraint'}:
-                    columns.add(col_name)
+        columns = _split_columns(cols_part)
         
         tables[table] = columns
     
     return tables
+
+
+# A single column definition line/segment inside a CREATE TABLE body.
+# We match leading column names that are NOT constraint keywords.
+_COLUMN_NAME_RE = re.compile(r'^\s*[`"\[]?(\w+)[`"\]]?\s+', re.IGNORECASE)
+
+# Inline UNIQUE/PKEY/CHECK/FK/... constraints inside a CREATE TABLE body that
+# reference columns but do NOT add a new column (so the column is "safe").
+_INLINE_CONSTRAINT_RE = re.compile(
+    r"^\s*(?:CONSTRAINT\s+\w+\s+)?(?:PRIMARY\s+KEY|UNIQUE|CHECK|FOREIGN\s+KEY|REFERENCES)\b",
+    re.IGNORECASE,
+)
+
+# Keyword names that may appear where a column name would in a column def;
+# these are not candidate column names.
+_NON_COLUMN_KEYWORDS = {
+    "create", "table", "primary", "key", "unique", "check", "foreign",
+    "references", "constraint", "default", "not", "null", "integer", "text",
+    "real", "blob", "numeric", "autoincrement", "if", "exists", "select",
+    "on", "and", "or", "as", "collate", "generated", "always",
+}
+
+
+def _split_columns(body: str) -> set[str]:
+    """Extract declared column names from a CREATE TABLE body.
+
+    Splits on commas that are not inside parentheses (so function/default
+    expressions and inline CHECK(...) are handled), then keeps the first
+    whitespace-delimited token of each segment as the column name (unless that
+    segment is an inline table-level constraint, which does not add a column).
+    """
+    columns: set[str] = set()
+    depth = 0
+    segments: list[str] = []
+    current: list[str] = []
+    for ch in body:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == "," and depth == 0:
+            segments.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    segments.append("".join(current))
+
+    for seg in segments:
+        if _INLINE_CONSTRAINT_RE.match(seg):
+            continue
+        m = _COLUMN_NAME_RE.match(seg)
+        if not m:
+            continue
+        name = m.group(1).strip("`\"[]")
+        if name.lower() in _NON_COLUMN_KEYWORDS:
+            continue
+        columns.add(name.lower())
+    return columns
 
 
 def _extract_index_column_refs(sql: str) -> list[tuple[str, str]]:

--- a/tests/scripts/test_check_retrofit_migrations_false_negatives.py
+++ b/tests/scripts/test_check_retrofit_migrations_false_negatives.py
@@ -1,0 +1,132 @@
+"""False-negative fixtures for check_retrofit_migrations (taOS #2188 / tsk-mhhgvn).
+
+Each test exercises one defect class that the regex-only checker (origin/dev)
+missed when scanning MIGRATIONS against a SCHEMA table:
+  1. expression index  CREATE INDEX ... ON t (lower(name))
+  2. quoted identifiers  ALTER TABLE "t" ADD COLUMN "name"
+  3. unterminated CREATE TABLE in SCHEMA (regex requires trailing semicolon,
+      so the table is dropped from schema_tables and retrofits on it are
+      silently skipped)
+
+The test asserts the fixed checker reports a violation.  On the unfixed
+origin/dev checker these tests FAIL because the bad stores pass clean.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "check_retrofit_migrations.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_retrofit_migrations", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+crm = _load_module()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _write_tmp_store(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "synthetic_store.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. Expression index in MIGRATIONS
+# ---------------------------------------------------------------------------
+
+def test_expression_index_retrofit(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE t (id INTEGER);
+        """
+
+        MIGRATIONS = [
+            (1, "CREATE INDEX ix ON t (lower(name))"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) >= 1, "expression CREATE INDEX on SCHEMA table must be flagged"
+    assert any(v.table == "t" and v.kind == "CREATE INDEX" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# 2. Quoted identifiers in MIGRATIONS ALTER TABLE
+# ---------------------------------------------------------------------------
+
+def test_quoted_identifier_retrofit_alter(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE "t" (id INTEGER);
+        """
+
+        MIGRATIONS = [
+            (1, 'ALTER TABLE "t" ADD COLUMN "name" TEXT'),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) >= 1, "quoted-identifier ALTER on SCHEMA table must be flagged"
+    assert any(v.table == "t" and v.kind == "ALTER TABLE ADD COLUMN" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# 3. Unterminated CREATE TABLE in SCHEMA drops table from schema_tables
+# ---------------------------------------------------------------------------
+
+def test_unterminated_create_table_drops_schema_table(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE t (id INTEGER)
+        """
+
+        MIGRATIONS = [
+            (1, "ALTER TABLE t ADD COLUMN name TEXT"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) >= 1, (
+        "ALTER on a table from an unterminated CREATE TABLE must still be flagged"
+    )
+    assert any(v.table == "t" and v.kind == "ALTER TABLE ADD COLUMN" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# main() exit-code integration
+# ---------------------------------------------------------------------------
+
+def test_main_exits_nonzero_on_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE t (id INTEGER);
+        """
+
+        MIGRATIONS = [
+            (1, "CREATE INDEX ix ON t (lower(name))"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    monkeypatch.setattr(crm, "STORES_ROOT", tmp_path)
+    rc = crm.main([])
+    assert rc == 1, "main() must exit 1 when violations exist"

--- a/tests/scripts/test_check_schema_migrations_false_negatives.py
+++ b/tests/scripts/test_check_schema_migrations_false_negatives.py
@@ -118,6 +118,16 @@ def test_unterminated_create_table(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Multi-column CREATE TABLE body: every column must be seen
+# ---------------------------------------------------------------------------
+
+def test_multi_column_body_all_columns_seen() -> None:
+    body = 'id INTEGER, "name" TEXT, ts REAL'
+    columns = csm._split_columns(body)
+    assert columns == {"id", "name", "ts"}, "every column in a multi-column body must be extracted"
+
+
+# ---------------------------------------------------------------------------
 # main() exit-code integration
 # ---------------------------------------------------------------------------
 

--- a/tests/scripts/test_check_schema_migrations_false_negatives.py
+++ b/tests/scripts/test_check_schema_migrations_false_negatives.py
@@ -1,0 +1,142 @@
+"""False-negative fixtures for check_schema_migrations (taOS #1865 / tsk-mhhgvn).
+
+Each test exercises one defect class that the regex-only checker (origin/dev)
+missed:
+  1. expression index  CREATE INDEX ... ON t (lower(name))
+  2. quoted identifiers  CREATE TABLE "t" ... ALTER TABLE "t" ADD COLUMN "name"
+  3. unterminated CREATE TABLE (missing closing paren / semicolon)
+
+The test asserts the fixed checker reports a violation.  On the unfixed
+origin/dev checker these tests FAIL because the bad stores pass clean.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "check_schema_migrations.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_schema_migrations", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+csm = _load_module()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _write_tmp_store(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "synthetic_store.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. Expression index  CREATE INDEX ix ON t (lower(name))
+# ---------------------------------------------------------------------------
+
+def test_expression_index_boot_brick(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        from tinyagentos.base_store import BaseStore
+
+        class ExprIdxStore(BaseStore):
+            SCHEMA = """
+            CREATE TABLE t (id INTEGER);
+            CREATE INDEX ix ON t (lower(name));
+            """
+
+            async def _post_init(self):
+                await self._db.execute("ALTER TABLE t ADD COLUMN name TEXT")
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = csm.find_violations(path)
+    assert len(violations) >= 1, "expression index on ALTER-added column must be flagged"
+    assert any(v.table == "t" and v.column == "name" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# 2. Quoted identifiers in CREATE TABLE / CREATE INDEX / ALTER TABLE
+# ---------------------------------------------------------------------------
+
+def test_quoted_identifier_alter(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        from tinyagentos.base_store import BaseStore
+
+        class QuotedStore(BaseStore):
+            SCHEMA = """
+            CREATE TABLE "t" (id INTEGER);
+            CREATE INDEX ix ON "t" (name);
+            """
+
+            async def _post_init(self):
+                await self._db.execute('ALTER TABLE "t" ADD COLUMN "name" TEXT')
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = csm.find_violations(path)
+    assert len(violations) >= 1, "quoted-identifier ALTER on indexed column must be flagged"
+    assert any(v.table == "t" and v.column == "name" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# 3. Unterminated CREATE TABLE (missing closing paren / semicolon)
+# ---------------------------------------------------------------------------
+
+def test_unterminated_create_table(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        from tinyagentos.base_store import BaseStore
+
+        class UnterminatedStore(BaseStore):
+            SCHEMA = """
+            CREATE TABLE t (id INTEGER
+            CREATE INDEX ix ON t (name);
+            """
+
+            async def _post_init(self):
+                await self._db.execute("ALTER TABLE t ADD COLUMN name TEXT")
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = csm.find_violations(path)
+    assert len(violations) >= 1, (
+        "index on ALTER-added column after unterminated CREATE TABLE must be flagged"
+    )
+    assert any(v.table == "t" and v.column == "name" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# main() exit-code integration
+# ---------------------------------------------------------------------------
+
+def test_main_exits_nonzero_on_fixture(tmp_path: Path) -> None:
+    body = textwrap.dedent(
+        '''
+        from tinyagentos.base_store import BaseStore
+
+        class ExprIdxStore(BaseStore):
+            SCHEMA = """
+            CREATE TABLE t (id INTEGER);
+            CREATE INDEX ix ON t (lower(name));
+            """
+
+            async def _post_init(self):
+                await self._db.execute("ALTER TABLE t ADD COLUMN name TEXT")
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = csm.find_all_violations(tmp_path)
+    assert len(violations) >= 1
+    assert csm.main([str(tmp_path)]) == 1, "main() must exit 1 when violations exist"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2949 (tsk-xh7xhc / tsk-mhhgvn): restore scripts/check_schema_migrations.py:_split_columns deleted by the #2885 rewrite - deleted-symbols-gate RED, one splitting test, RED-FIRST

Autonomous build of board card tsk-snomeq.

REVISION: built on `exec/tsk-xh7xhc` (cut at `4de36113fa8583e6eed8619ae6f046c210278987`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

The #2885 rewrite of scripts/check_schema_migrations.py dropped the
_split_columns helper and its call site. Restore it as the parsing helper
the rewritten code calls in the regex fallback, adapted to handle quoted
column identifiers consistent with the rest of the checker.

RED on BASE (exec/tsk-xh7xhc):

```
FAILED tests/scripts/test_check_schema_migrations_false_negatives.py::test_multi_column_body_all_columns_seen
1 failed, 4 passed in 0.33s
```

Green on branch:

```
5 passed in 0.21s
```

Carries the fragment from BASE (do not duplicate).

Files:
 changelog.d/tsk-mhhgvn-migration-guard-fixes.md    |   5 +
 changelog.d/tsk-snomeq-restore-split-columns.md    |   2 +
 scripts/check_retrofit_migrations.py               |  12 +-
 scripts/check_schema_migrations.py                 | 279 ++++++++++++++++-----
 ...st_check_retrofit_migrations_false_negatives.py | 132 ++++++++++
 ...test_check_schema_migrations_false_negatives.py | 152 +++++++++++
 6 files changed, 508 insertions(+), 74 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved migration validation for quoted table and column names.
  - Added detection for expression-based indexes.
  - Improved handling of incomplete `CREATE TABLE` statements.
  - Migration checks now more reliably identify indexes and columns added through schema changes.
  - Retrofit and schema migration validation now use SQL-aware parsing for more accurate results.

- **Tests**
  - Added coverage for previously missed migration violations and multi-column table definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->