### PR TITLE
S4c-server: enrich the agent + app-permissions Decision notification sites (they push as plain alerts today) + thread-id, interruption-level, url, option cap

### DIFF
--- a/changelog.d/tsk-nrlqte-decision-notification-enrichment.md
+++ b/changelog.d/tsk-nrlqte-decision-notification-enrichment.md
@@ -1,0 +1,5 @@
+### Fixed
+- Enrich the agent tool and app-permissions decision notification sites with `data` (kind, url, priority, from_agent, options), matching the existing REST route
+- Cap notification option lists to the first 4 options with labels truncated to 40 characters
+- Set `aps.thread-id` on APNs decision pushes so repeat notifications coalesce into a single thread
+- Set `aps.interruption-level` to `time-sensitive` only for blocking-priority decisions

--- a/tests/push/test_apns.py
+++ b/tests/push/test_apns.py
@@ -446,3 +446,29 @@ def test_build_payload_data_cannot_replace_aps():
         title="Hi", body="there", data={"aps": {"alert": "hijacked"}},
     )
     assert payload["aps"]["alert"] == {"title": "Hi", "body": "there"}
+
+
+def test_build_payload_sets_thread_id_for_decision():
+    payload = build_apns_payload(
+        title="Decide", body="deploy?", category="DECISION_APPROVE_DENY",
+        data={"decision_id": "dec-123"},
+        thread_id="dec-123",
+    )
+    assert payload["aps"]["thread-id"] == "dec-123"
+
+
+def test_build_payload_omits_thread_id_when_none():
+    payload = build_apns_payload(title="Hi", body="there")
+    assert "thread-id" not in payload["aps"]
+
+
+def test_build_payload_sets_interruption_level_for_blocking():
+    payload = build_apns_payload(
+        title="Block", body="now", interruption_level="time-sensitive",
+    )
+    assert payload["aps"]["interruption-level"] == "time-sensitive"
+
+
+def test_build_payload_omits_interruption_level_when_none():
+    payload = build_apns_payload(title="Hi", body="there")
+    assert "interruption-level" not in payload["aps"]

--- a/tests/test_decision_tools.py
+++ b/tests/test_decision_tools.py
@@ -8,19 +8,28 @@ from tinyagentos.decisions.decision_store import DecisionStore
 from tinyagentos.tools.decision_tools import execute_request_decision, _normalize_options
 
 
+class FakeNotifications:
+    def __init__(self):
+        self.added = []
+
+    async def add(self, **kwargs):
+        self.added.append(kwargs)
+
+
 @pytest_asyncio.fixture
 async def app_request(tmp_path):
     store = DecisionStore(tmp_path / "decisions.db")
     await store.init()
-    app = types.SimpleNamespace(state=types.SimpleNamespace(decision_store=store, notifications=None))
+    notifs = FakeNotifications()
+    app = types.SimpleNamespace(state=types.SimpleNamespace(decision_store=store, notifications=notifs))
     req = types.SimpleNamespace(app=app, state=types.SimpleNamespace(user_id="user-1", is_admin=False))
-    yield req, store
+    yield req, store, notifs
     await store.close()
 
 
 @pytest.mark.asyncio
 async def test_creates_pending_decision(app_request):
-    req, store = app_request
+    req, store, _ = app_request
     res = await execute_request_decision(
         {"question": "Pick a colour", "type": "single_select", "options": ["Red", "Blue"]}, req
     )
@@ -37,7 +46,7 @@ async def test_creates_pending_decision(app_request):
 
 @pytest.mark.asyncio
 async def test_from_agent_is_carried(app_request):
-    req, store = app_request
+    req, store, _ = app_request
     res = await execute_request_decision(
         {"question": "Ship it?", "type": "approve_deny", "from_agent": "@builder"}, req
     )
@@ -47,28 +56,28 @@ async def test_from_agent_is_carried(app_request):
 
 @pytest.mark.asyncio
 async def test_select_type_requires_options(app_request):
-    req, _ = app_request
+    req, _, _ = app_request
     res = await execute_request_decision({"question": "Which?", "type": "multi_select"}, req)
     assert "error" in res and "options" in res["error"]
 
 
 @pytest.mark.asyncio
 async def test_rejects_unknown_type(app_request):
-    req, _ = app_request
+    req, _, _ = app_request
     res = await execute_request_decision({"question": "Q", "type": "rank"}, req)
     assert "error" in res
 
 
 @pytest.mark.asyncio
 async def test_requires_question(app_request):
-    req, _ = app_request
+    req, _, _ = app_request
     res = await execute_request_decision({"type": "free_text"}, req)
     assert "error" in res
 
 
 @pytest.mark.asyncio
 async def test_free_text_needs_no_options(app_request):
-    req, store = app_request
+    req, store, _ = app_request
     res = await execute_request_decision({"question": "Name it", "type": "free_text"}, req)
     assert res["ok"] is True
 
@@ -82,6 +91,28 @@ async def test_no_user_refuses(tmp_path):
     res = await execute_request_decision({"question": "Q", "type": "free_text"}, req)
     assert res["error"] == "no authenticated user to ask"
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_notification_enriches_data(app_request):
+    req, store, notifs = app_request
+    options = [f"Option {i}" for i in range(10)]
+    res = await execute_request_decision(
+        {"question": "Pick one", "type": "single_select", "options": options, "from_agent": "@builder"},
+        req,
+    )
+    assert res["ok"] is True
+    assert len(notifs.added) == 1
+    data = notifs.added[0]["data"]
+    assert data["decision_id"] == res["decision_id"]
+    assert data["decision_type"] == "single_select"
+    assert data["url"] == f"/decisions/{res['decision_id']}"
+    assert data["priority"] == "normal"
+    assert data["from_agent"] == "@builder"
+    assert data["kind"] == "decision"
+    assert len(data["options"]) == 4
+    for o in data["options"]:
+        assert len(o["label"]) <= 40
 
 
 def test_normalize_options_dedupes_colliding_labels():

--- a/tests/test_notifications_push.py
+++ b/tests/test_notifications_push.py
@@ -13,7 +13,12 @@ import requests
 from pywebpush import WebPushException
 
 from tinyagentos.notifications import NotificationStore
-from tinyagentos.notifications_push import NotificationPushStore, send_web_push, send_device_push
+from tinyagentos.notifications_push import (
+    NotificationPushStore,
+    _build_device_push_payload,
+    send_web_push,
+    send_device_push,
+)
 from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
 from taos_test_csrf import csrf_event_hooks
 
@@ -973,3 +978,59 @@ class TestSendDevicePush:
         ]
         assert body["data"]["image"] == "https://cdn.example.com/run/42.png"
         assert body["data"]["actions"] == body["actions"]
+
+
+def test_build_device_push_payload_caps_options_at_4_and_truncates_labels():
+    row = {
+        "title": "Pick",
+        "message": "pick one",
+        "source": "decisions",
+        "data": {
+            "decision_type": "single_select",
+            "options": [
+                {"label": "A" * 50, "value": "a"},
+                {"label": "B" * 50, "value": "b"},
+                {"label": "C" * 50, "value": "c"},
+                {"label": "D" * 50, "value": "d"},
+                {"label": "E" * 50, "value": "e"},
+            ],
+            "decision_id": "dec-1",
+            "priority": "normal",
+        },
+    }
+    payload, actions = _build_device_push_payload(row)
+    assert len(actions) == 4
+    assert len(payload["data"]["options"]) == 4
+    for o in payload["data"]["options"]:
+        assert len(o["label"]) <= 40
+    assert payload["thread_id"] == "dec-1"
+    assert "interruption_level" not in payload
+
+
+def test_build_device_push_payload_sets_interruption_level_for_blocking():
+    row = {
+        "title": "Block",
+        "message": "now",
+        "source": "decisions",
+        "data": {
+            "decision_type": "approve_deny",
+            "options": [],
+            "decision_id": "dec-2",
+            "priority": "blocking",
+        },
+    }
+    payload, _ = _build_device_push_payload(row)
+    assert payload["interruption_level"] == "time-sensitive"
+    assert payload["category"] == "DECISION_APPROVE_DENY"
+
+
+def test_build_device_push_payload_non_decision_has_no_category_or_thread():
+    row = {
+        "title": "Hi",
+        "message": "there",
+        "source": "system",
+        "data": {},
+    }
+    payload, _ = _build_device_push_payload(row)
+    assert "category" not in payload
+    assert "thread_id" not in payload

--- a/tests/test_routes_app_permissions.py
+++ b/tests/test_routes_app_permissions.py
@@ -194,3 +194,26 @@ async def test_request_consent_skips_caps_with_pending_decision(client):
     await client.post(f"/api/decisions/{dec_id}/answer", json={"value": ["app.net"]})
     r3 = await client.post("/api/apps/lazy-app/request-consent", json={"capabilities": ["app.memory"]})
     assert r3.json()["pending"] == ["app.memory"]
+
+
+@pytest.mark.asyncio
+async def test_request_consent_notification_enriches_data(client):
+    app = client._transport.app
+    notifs = app.state.notifications
+    await notifs.list()  # clear any stale rows
+    resp = await client.post(
+        "/api/apps/stream-chat/request-consent",
+        json={"capabilities": ["app.net", "app.memory"]},
+    )
+    assert resp.status_code == 200
+    items = await notifs.list()
+    assert len(items) == 1
+    data = items[0]["data"]
+    assert data["decision_type"] == "multi_select"
+    assert data["kind"] == "decision"
+    assert data["priority"] == "blocking"
+    assert data["from_agent"] == "@taos-app-install"
+    assert data["url"].startswith("/decisions/")
+    assert len(data["options"]) <= 4
+    for o in data["options"]:
+        assert len(o["label"]) <= 40

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -1106,3 +1106,27 @@ async def test_dec_sfdooy_wake_budget_decision_created_and_closed(client, app):
     if isinstance(answer_value, str):
         answer_value = json.loads(answer_value)
     assert answer_value["value"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_create_decision_notification_enriches_data(client, app):
+    notifs = app.state.notifications
+    await notifs.close()
+    await notifs.init()
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@taOS-dev",
+        "question": "Pick engine",
+        "type": "single_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    assert resp.status_code == 200
+    items = await notifs.list()
+    assert len(items) == 1
+    data = items[0]["data"]
+    assert data["decision_type"] == "single_select"
+    assert data["decision_id"] == resp.json()["id"]
+    assert data["url"] == f"/decisions/{resp.json()['id']}"
+    assert data["priority"] == "normal"
+    assert data["from_agent"] == "@taOS-dev"
+    assert data["kind"] == "decision"
+    assert len(data["options"]) <= 4

--- a/tinyagentos/notifications_push.py
+++ b/tinyagentos/notifications_push.py
@@ -355,9 +355,6 @@ def _build_device_push_payload(row: dict) -> tuple[dict, list[dict] | None]:
     category: str | None = None
     decision_type = data.get("decision_type")
     if decision_type == "approve_deny":
-        # The native shell maps a category id to a registered UNNotificationCategory;
-        # tsk-cf7wzc pins the button set to approve / reject / add-note on both
-        # iPhone and Apple Watch.
         category = "DECISION_APPROVE_DENY"
         actions = [
             {"id": "approve", "label": "Approve"},
@@ -367,11 +364,21 @@ def _build_device_push_payload(row: dict) -> tuple[dict, list[dict] | None]:
     elif decision_type in ("single_select", "multi_select"):
         category = "DECISION_OPTIONS"
         opts = data.get("options") or []
-        actions = [{"id": o.get("value", o.get("label", "")), "label": o.get("label", "")} for o in opts]
+        capped = [
+            {"label": o.get("label", "")[:40], "value": o.get("value", o.get("label", ""))}
+            for o in opts[:4]
+        ]
+        actions = [{"id": o.get("value", o.get("label", "")), "label": o.get("label", "")} for o in capped]
     elif decision_type == "free_text":
         category = "DECISION_FREE_TEXT"
         actions = [{"id": "quick_reply", "label": "Reply"}]
     payload_data = dict(data)
+    if decision_type in ("single_select", "multi_select"):
+        opts = data.get("options") or []
+        payload_data["options"] = [
+            {"label": o.get("label", "")[:40], "value": o.get("value", o.get("label", ""))}
+            for o in opts[:4]
+        ]
     image = data.get("image")
     if isinstance(image, str) and image:
         payload_data["image"] = image
@@ -380,6 +387,12 @@ def _build_device_push_payload(row: dict) -> tuple[dict, list[dict] | None]:
     payload: dict = {"title": title, "body": body, "data": payload_data}
     if category:
         payload["category"] = category
+    decision_id = data.get("decision_id")
+    if decision_id:
+        payload["thread_id"] = decision_id
+    priority = data.get("priority")
+    if priority == "blocking":
+        payload["interruption_level"] = "time-sensitive"
     if isinstance(image, str) and image:
         payload["image"] = image
     return payload, actions
@@ -423,6 +436,8 @@ async def _send_one_device(
             category=base_payload.get("category"),
             actions=actions,
             image=base_payload.get("image"),
+            thread_id=base_payload.get("thread_id"),
+            interruption_level=base_payload.get("interruption_level"),
         )
     elif platform == "android":
         from tinyagentos.push.unifiedpush import build_unifiedpush_payload

--- a/tinyagentos/push/apns.py
+++ b/tinyagentos/push/apns.py
@@ -87,6 +87,8 @@ def build_apns_payload(
     category: str | None = None,
     actions: list[dict] | None = None,
     image: str | None = None,
+    thread_id: str | None = None,
+    interruption_level: str | None = None,
 ) -> dict:
     """Build an APNs payload, letting explicit keyword args win over `data`.
 
@@ -127,6 +129,10 @@ def build_apns_payload(
     # controller's Decisions answer route.
     if category:
         aps["category"] = category
+    if thread_id:
+        aps["thread-id"] = thread_id
+    if interruption_level:
+        aps["interruption-level"] = interruption_level
     # Any rich attachment (image) or action set requires the notification service
     # extension to mutate the payload before display: download the image, attach
     # UNNotificationAttachment, and surface the action buttons. APNs only allows

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -214,11 +214,28 @@ async def request_app_consent(
     if notifs is not None:
         # Best effort: a notification failure must not fail the queued decision.
         try:
+            raw_options = [
+                {"label": str(o.get("label", o.get("value", ""))), "value": str(o.get("value", o.get("label", "")))}
+                for o in (decision.get("options") or [])
+            ]
+            capped = [
+                {"label": o["label"][:40], "value": o["value"]}
+                for o in raw_options[:4]
+            ]
             await notifs.add(
                 title="Permission needed",
                 message=f"{app_id} is requesting permissions",
                 level="warning",
                 source="decisions",
+                data={
+                    "decision_type": "multi_select",
+                    "options": capped,
+                    "decision_id": decision["id"],
+                    "kind": "decision",
+                    "url": f"/decisions/{decision['id']}",
+                    "priority": "blocking",
+                    "from_agent": decision.get("from_agent", "@taos-app-install"),
+                },
             )
         except Exception:
             pass

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -312,6 +312,11 @@ async def create_decision(
     if notifs is not None:
         # Best effort: a notification failure must not fail the queued decision.
         try:
+            raw_options = [o.model_dump() for o in body.options]
+            capped = [
+                {"label": o.get("label", "")[:40], "value": o.get("value", o.get("label", ""))}
+                for o in raw_options[:4]
+            ]
             await notifs.add(
                 title="Decision needed",
                 message=f"{from_agent} needs a decision: {body.question[:120]}",
@@ -319,8 +324,12 @@ async def create_decision(
                 source="decisions",
                 data={
                     "decision_type": body.type,
-                    "options": [o.model_dump() for o in body.options],
+                    "options": capped,
                     "decision_id": decision["id"],
+                    "kind": "decision",
+                    "url": f"/decisions/{decision['id']}",
+                    "priority": body.priority,
+                    "from_agent": from_agent,
                 },
             )
         except Exception:

--- a/tinyagentos/tools/decision_tools.py
+++ b/tinyagentos/tools/decision_tools.py
@@ -118,11 +118,24 @@ async def execute_request_decision(args: dict, request: Request) -> dict:
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
         try:
+            capped = [
+                {"label": o.get("label", "")[:40], "value": o.get("value", o.get("label", ""))}
+                for o in options[:4]
+            ]
             await notifs.add(
                 title="Decision needed",
                 message=f"{from_agent} needs a decision: {question[:120]}",
                 level="warning" if priority == "blocking" else "info",
                 source="decisions",
+                data={
+                    "decision_type": dtype,
+                    "options": capped,
+                    "decision_id": decision["id"],
+                    "kind": "decision",
+                    "url": f"/decisions/{decision['id']}",
+                    "priority": priority,
+                    "from_agent": from_agent,
+                },
             )
         except Exception:
             pass


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): S4c-server: enrich the agent + app-permissions Decision notification sites (they push as plain alerts today) + thread-id, interruption-level, url, option cap

Autonomous build of board card tsk-nrlqte.

Hook the agent tool and app-permissions notifs.add() sites into the same
enriched data the REST route already sends (decision_id, decision_type,
options, kind, url, priority, from_agent), and cap options to the first 4
with labels truncated to 40 characters.

In _build_device_push_payload, derive thread_id from data.decision_id and
interruption_level from data.priority == blocking, then pass both to
build_apns_payload so aps.thread-id and aps.interruption-level appear on
decision pushes. The per-type category taxonomy (DECISION_APPROVE_DENY,
DECISION_OPTIONS, DECISION_FREE_TEXT) is preserved deliberately: a single
flat category id cannot render approve/deny and an option list differently.

Docs-Reviewed: no agent-facing API surface changed; only notification data
and APNs payload keys were added to existing routes

Files:
 tests/test_routes_app_permissions.py               | 23 ++++++++
 tests/test_routes_decisions.py                     | 24 +++++++++
 tinyagentos/notifications_push.py                  | 23 ++++++--
 tinyagentos/push/apns.py                           |  6 +++
 tinyagentos/routes/app_permissions.py              | 17 ++++++
 tinyagentos/routes/decisions.py                    | 11 +++-
 tinyagentos/tools/decision_tools.py                | 13 +++++
 11 files changed, 244 insertions(+), 14 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Decision notifications now include richer details, including decision type, priority, source, and a direct link.
  * Notification options are limited to four, with labels shortened to 40 characters for clearer display.
  * Apple notifications now group repeated decision alerts into a single thread.
  * Blocking-priority decisions are marked as time-sensitive on Apple devices.
  * App-permission consent notifications now provide the same enriched decision information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->