### PR TITLE
[bus-3964] deployed agent with llm_key=None 409-loops forever and nothing re-mints the key -- re-cut of tsk-luyrm3 on current dev (supersedes #2956)

### DIFF
--- a/changelog.d/tsk-luyrm3-fix-perma-409.md
+++ b/changelog.d/tsk-luyrm3-fix-perma-409.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `/api/openclaw/bootstrap` now re-mints a missing `llm_key` for a deployed agent instead of returning 409 forever, and the agents model/permitted-models routes re-mint before giving up on a missing key.

--- a/tests/test_openclaw_re_mint_key.py
+++ b/tests/test_openclaw_re_mint_key.py
@@ -1,0 +1,120 @@
+"""Red-first test: deployed agent with llm_key=None must get a key on bootstrap."""
+from __future__ import annotations
+
+import asyncio
+import yaml
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.bridge_session import BridgeSessionRegistry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def re_mint_data_dir(tmp_path):
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [
+            {"name": "test-backend", "type": "rkllama", "url": "http://localhost:8080", "priority": 1}
+        ],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [
+            {
+                "name": "mybot",
+                "host": "192.168.1.10",
+                "color": "#aabbcc",
+                "model": "qwen2.5:7b",
+                "fallback_models": ["kilo-auto/free", "gpt-4o"],
+                "chat_channel_id": "ch_mybot",
+            }
+        ],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return tmp_path
+
+
+@pytest.fixture
+def re_mint_app(re_mint_data_dir):
+    return create_app(data_dir=re_mint_data_dir)
+
+
+@pytest_asyncio.fixture
+async def re_mint_client(re_mint_app):
+    app = re_mint_app
+    for attr in ("metrics", "notifications", "secrets", "scheduler", "channels",
+                 "relationships", "conversion", "training", "agent_messages",
+                 "shared_folders", "streaming_sessions", "expert_agents",
+                 "chat_messages", "chat_channels", "canvas_store"):
+        store = getattr(app.state, attr)
+        if getattr(store, "_db", None) is not None:
+            await store.close()
+        await store.init()
+    await app.state.qmd_client.init()
+    app.state.bridge_sessions = BridgeSessionRegistry(
+        chat_messages=app.state.chat_messages,
+        chat_channels=app.state.chat_channels,
+        chat_hub=app.state.chat_hub,
+    )
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    token = app.state.auth.get_local_token()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as c:
+        yield c, app
+    for attr in ("canvas_store", "chat_channels", "chat_messages", "expert_agents",
+                 "streaming_sessions", "shared_folders", "agent_messages",
+                 "conversion", "training", "relationships", "channels",
+                 "scheduler", "secrets", "notifications", "metrics"):
+        store = getattr(app.state, attr)
+        try:
+            await store.close()
+        except Exception:
+            pass
+    try:
+        await app.state.qmd_client.close()
+    except Exception:
+        pass
+    try:
+        await app.state.http_client.aclose()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bootstrap_re_mints_missing_llm_key(re_mint_client):
+    """An agent with llm_key=None must get a key minted on bootstrap."""
+    client, app = re_mint_client
+    for a in app.state.config.agents:
+        if a.get("name") == "mybot":
+            a.pop("llm_key", None)
+
+    mock_proxy = MagicMock()
+    mock_proxy.is_running.return_value = True
+    mock_key = "sk-taos-re-minted-test"
+    mock_proxy.create_agent_key = AsyncMock(return_value=mock_key)
+    app.state.llm_proxy = mock_proxy
+
+    resp1 = await client.get("/api/openclaw/bootstrap?agent=mybot")
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    assert data1["agent_name"] == "mybot"
+    assert app.state.config.agents[0].get("llm_key") == mock_key
+
+    resp2 = await client.get("/api/openclaw/bootstrap?agent=mybot")
+    assert resp2.status_code == 200

--- a/tinyagentos/agent_keys.py
+++ b/tinyagentos/agent_keys.py
@@ -1,0 +1,34 @@
+"""Agent LLM key lifecycle helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+from tinyagentos.config import save_config_locked
+
+
+async def re_mint_agent_key(
+    agent_name: str,
+    agent: dict[str, Any],
+    proxy: Any,
+    config: Any,
+    config_path: str,
+    models: list[str] | None = None,
+) -> str | None:
+    """Re-mint a missing per-agent LiteLLM key and persist it.
+
+    Returns the new plaintext key on success, or None if the proxy is
+    unavailable or the mint failed.
+    """
+    if proxy is None or not proxy.is_running():
+        return None
+    if models is None:
+        models = [m for m in [agent.get("model"), *(agent.get("fallback_models") or [])] if m]
+    try:
+        new_key = await proxy.create_agent_key(agent_name, models=models or None)
+    except Exception:
+        return None
+    if not new_key:
+        return None
+    agent["llm_key"] = new_key
+    await save_config_locked(config, config_path)
+    return new_key

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1615,11 +1615,18 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     proxy = getattr(request.app.state, "llm_proxy", None)
     llm_key = agent.get("llm_key")
     key_rescoped = False
-    if proxy is not None and llm_key:
-        try:
-            key_rescoped = await proxy.update_agent_key(llm_key, permitted)
-        except Exception:
-            logger.exception("update_agent_model: re-scoping key for %s failed", name)
+    if proxy is not None:
+        if not llm_key:
+            from tinyagentos.agent_keys import re_mint_agent_key
+
+            llm_key = await re_mint_agent_key(
+                name, agent, proxy, config, config.config_path, models=permitted
+            )
+        if llm_key:
+            try:
+                key_rescoped = await proxy.update_agent_key(llm_key, permitted)
+            except Exception:
+                logger.exception("update_agent_model: re-scoping key for %s failed", name)
         if not key_rescoped:
             # Key re-scope failed (e.g. provider type mismatch after model
             # change).  Discard the stale per-agent key so the deployer
@@ -1726,11 +1733,18 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
     proxy = getattr(request.app.state, "llm_proxy", None)
     llm_key = agent.get("llm_key")
     key_rescoped = False
-    if proxy is not None and llm_key:
-        try:
-            key_rescoped = await proxy.update_agent_key(llm_key, permitted)
-        except Exception:
-            logger.exception("set_permitted_models: re-scoping key for %s failed", name)
+    if proxy is not None:
+        if not llm_key:
+            from tinyagentos.agent_keys import re_mint_agent_key
+
+            llm_key = await re_mint_agent_key(
+                name, agent, proxy, config, config.config_path, models=permitted
+            )
+        if llm_key:
+            try:
+                key_rescoped = await proxy.update_agent_key(llm_key, permitted)
+            except Exception:
+                logger.exception("set_permitted_models: re-scoping key for %s failed", name)
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):

--- a/tinyagentos/routes/openclaw.py
+++ b/tinyagentos/routes/openclaw.py
@@ -89,15 +89,22 @@ async def bootstrap(request: Request, agent: str | None = None):
 
     llm_key = agent_dict.get("llm_key")
     if not llm_key:
-        return JSONResponse(
-            {
-                "error": (
-                    "agent llm_key not yet minted; deployer must call "
-                    f"/api/agents/{agent}/start after key generation"
-                )
-            },
-            status_code=409,
+        from tinyagentos.agent_keys import re_mint_agent_key
+
+        proxy = getattr(request.app.state, "llm_proxy", None)
+        llm_key = await re_mint_agent_key(
+            agent, agent_dict, proxy, config, config.config_path
         )
+        if not llm_key:
+            return JSONResponse(
+                {
+                    "error": (
+                        "agent llm_key not yet minted; deployer must call "
+                        f"/api/agents/{agent}/start after key generation"
+                    )
+                },
+                status_code=409,
+            )
 
     agent_dict["bootstrap_last_seen_at"] = int(time.time())
     await save_config_locked(config, config.config_path)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [bus-3964] deployed agent with llm_key=None 409-loops forever and nothing re-mints the key -- re-cut of tsk-luyrm3 on current dev (supersedes #2956)

Autonomous build of board card tsk-uszboh.

A deployed agent whose llm_key is None gets stuck in a 409 loop on
/api/openclaw/bootstrap because nothing ever mints a replacement key.
Add a re-mint path in tinyagentos/agent_keys.py and call it from the
bootstrap endpoint and the agents model/permitted-models routes so a
missing key is regenerated and persisted automatically.

Docs-Reviewed: bootstrap re-mint path is internal key repair, no new user-facing surface or route change

```text
FAILED tests/test_openclaw_re_mint_key.py::test_bootstrap_re_mints_missing_llm_key - AssertionError
1 failed in 3.12s
```

```text
1 passed in 3.07s
```

Files:
 changelog.d/tsk-luyrm3-fix-perma-409.md |   3 +
 tests/test_openclaw_re_mint_key.py      | 120 ++++++++++++++++++++++++++++++++
 tinyagentos/agent_keys.py               |  34 +++++++++
 tinyagentos/routes/agents.py            |  34 ++++++---
 tinyagentos/routes/openclaw.py          |  23 +++---
 5 files changed, 196 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Agent bootstrap now restores a missing LLM key automatically when the configured proxy is available, preventing repeated 409 errors.
  - Updating an agent’s model or permitted models now also restores missing LLM access keys before applying changes.
  - Bootstrap continues to provide deployment guidance when key restoration cannot be completed.
- **Tests**
  - Added coverage confirming repeated bootstrap requests succeed after an agent’s missing LLM key is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->