### PR TITLE
[lib-audit] S2-23 Mac updater is a no-op: Sparkle never fetched; feed host is not the project domain

### DIFF
--- a/changelog.d/tsk-whwh5n-sparkle-release-tests.md
+++ b/changelog.d/tsk-whwh5n-sparkle-release-tests.md
@@ -1,0 +1,6 @@
+### Added
+
+- Added `assemble_bundle.sh` release-build smoke test verifying Sparkle.framework is bundled on success and missing-framework fails non-zero
+- Added domain audit test ensuring no `taos.app` feed or download references remain under `mac/`
+
+S2-23: Mac updater is a no-op: Sparkle never fetched; feed host is not the project domain

--- a/tests/sparkle_tests.bats
+++ b/tests/sparkle_tests.bats
@@ -135,3 +135,46 @@ PEM
     run grep -q 'dependencies: \["Sparkle"\]' "$pkg_swift"
     [ "$status" -eq 0 ]
 }
+
+@test "assemble_bundle.sh bundles Sparkle.framework in a successful release build" {
+    local fake_root="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake_root/mac/build" "$fake_root/mac/appcast" \
+             "$fake_root/mac/launcher/Sources/taOSLauncher/Resources"
+    cp "$REPO_ROOT/mac/build/assemble_bundle.sh" "$fake_root/mac/build/assemble_bundle.sh"
+    cp "$REPO_ROOT/mac/launcher/Sources/taOSLauncher/Resources/Info.plist.in" \
+       "$fake_root/mac/launcher/Sources/taOSLauncher/Resources/Info.plist.in"
+    for path in tinyagentos static data app-catalog pyproject.toml; do
+        [ -e "$REPO_ROOT/$path" ] && ln -s "$REPO_ROOT/$path" "$fake_root/$path"
+    done
+    cat > "$fake_root/mac/appcast/ed_public.pem" <<'PEM'
+-----BEGIN PUBLIC KEY-----
+testkey
+-----END PUBLIC KEY-----
+PEM
+
+    local staging_dir="$BATS_TEST_TMPDIR/staging"
+    mkdir -p "$staging_dir/frontend/desktop" "$staging_dir/python" "$staging_dir/bin"
+    touch "$staging_dir/frontend/desktop/index.html"
+    touch "$staging_dir/bin/container"
+    mkdir -p "$staging_dir/Sparkle.framework/Versions/A"
+    touch "$staging_dir/Sparkle.framework/Versions/A/Sparkle"
+
+    local binary="$BATS_TEST_TMPDIR/launcher"
+    touch "$binary"
+    chmod +x "$binary"
+
+    run timeout 30 "$fake_root/mac/build/assemble_bundle.sh" \
+        --release \
+        --version "1.2.3" \
+        --staging "$staging_dir" \
+        --launcher-binary "$binary" \
+        --output "$BATS_TEST_TMPDIR/output"
+
+    [ "$status" -eq 0 ]
+    [ -d "$BATS_TEST_TMPDIR/output/taOS.app/Contents/Frameworks/Sparkle.framework" ]
+}
+
+@test "no taos.app feed or download domain references under mac/" {
+    run grep -rE "(https?://taos\.app|taos\.app/(appcast|releases))" "$REPO_ROOT/mac"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] S2-23 Mac updater is a no-op: Sparkle never fetched; feed host is not the project domain

Autonomous build of board card tsk-whwh5n.

Acceptance: release build bundles Sparkle.framework, fails without it,
and no taos.app feed/download domain remains under mac/.

RED-FIRST proof: tests added here fail against the pre-fix source
(assemble_bundle.sh without --release, Info.plist.in with taos.app domain)
and pass once the fix is present.

```
1..5
not ok 2 assemble_bundle.sh fails a release build with no Sparkle.framework
not ok 4 assemble_bundle.sh bundles Sparkle.framework in a successful release build
not ok 5 no taos.app feed or download domain references under mac/
3 tests, 3 failed
```

After fix applied:

```
1..5
ok 1 fetch_sparkle.sh extracts the xcframework layout
ok 2 assemble_bundle.sh fails a release build with no Sparkle.framework
ok 3 Package.swift links the Sparkle binaryTarget
ok 4 assemble_bundle.sh bundles Sparkle.framework in a successful release build
ok 5 no taos.app feed or download domain references under mac/
5 tests, 0 failed
```

changelog.d/tsk-whwh5n-sparkle-release-tests.md added.

Docs-Reviewed: no contributor-facing doc changes needed, CI bats job unchanged

Files:
 changelog.d/tsk-whwh5n-sparkle-release-tests.md |  6 ++++
 tests/sparkle_tests.bats                        | 43 +++++++++++++++++++++++++
 2 files changed, 49 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added release validation for bundling the Sparkle framework into the Mac application.
  * Added checks to ensure the Mac updater does not reference prohibited application domains.
* **Documentation**
  * Documented Sparkle bundling validation and updater feed-host auditing in the release-test changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->