### PR TITLE
Every restart ends in SIGKILL: 3 of 4 controller units ExecStart uvicorn directly and never load tinyagentos/__main__.py, so the bounded graceful shutdown never runs (supersedes tsk-fl2kkq)

### DIFF
--- a/changelog.d/tsk-mpco4a-controller-unit-entrypoint.md
+++ b/changelog.d/tsk-mpco4a-controller-unit-entrypoint.md
@@ -1,0 +1,2 @@
+### Fixed
+- Controller units now start via `python -m tinyagentos` instead of invoking uvicorn directly, so the bounded graceful-shutdown handler in `__main__.py` runs on every restart and SIGKILL no longer occurs on low-end ARM hardware.

--- a/os-build/userpatches/overlay/etc/systemd/system/tinyagentos.service
+++ b/os-build/userpatches/overlay/etc/systemd/system/tinyagentos.service
@@ -8,7 +8,7 @@ Type=simple
 User=taos
 Group=taos
 WorkingDirectory=/opt/tinyagentos
-ExecStart=/opt/tinyagentos/venv/bin/python -m uvicorn tinyagentos.app:create_app --factory --host 0.0.0.0 --port 6969
+ExecStart=/opt/tinyagentos/venv/bin/python -m tinyagentos
 Restart=on-failure
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1

--- a/systemd/tinyagentos.service
+++ b/systemd/tinyagentos.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=%h/tinyagentos
-ExecStart=%h/tinyagentos/.venv/bin/python -m uvicorn tinyagentos.app:create_app --factory --host 0.0.0.0 --port 6969
+ExecStart=%h/tinyagentos/.venv/bin/python -m tinyagentos
 ExecStop=/usr/local/bin/taos-graceful-stop
 Restart=on-failure
 RestartSec=5

--- a/tests/test_controller_unit_entrypoint.py
+++ b/tests/test_controller_unit_entrypoint.py
@@ -1,0 +1,62 @@
+"""Controller systemd units must start via the module entrypoint, not uvicorn directly.
+
+Every restart on a Pi 4 ended in SIGKILL because three of four units bypassed
+``tinyagentos/__main__.py``, so the bounded graceful-shutdown handler never ran.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _service_files() -> list[Path]:
+    return sorted(REPO_ROOT.rglob("*.service"))
+
+
+def _exec_start_values(unit_text: str) -> list[str]:
+    values: list[str] = []
+    in_service = False
+    pending: str | None = None
+    for raw_line in unit_text.splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_service = stripped == "[Service]"
+            if pending is not None:
+                values.append(pending)
+                pending = None
+            continue
+        if in_service and stripped.startswith("ExecStart="):
+            value = stripped.split("=", 1)[1].strip()
+            if value.endswith("\\"):
+                pending = value[:-1].strip()
+                continue
+            if pending is not None:
+                value = pending + " " + value
+                pending = None
+            values.append(value)
+    if pending is not None:
+        values.append(pending)
+    return values
+
+
+def test_units_start_via_module_entry() -> None:
+    bad: list[tuple[Path, str]] = []
+    for unit_path in _service_files():
+        text = unit_path.read_text()
+        for value in _exec_start_values(text):
+            if "tinyagentos.app" in value or "-m tinyagentos" in value:
+                if "-m tinyagentos" not in value or "-m uvicorn" in value:
+                    bad.append((unit_path, value))
+
+    assert not bad, (
+        "The following controller unit(s) must use ``-m tinyagentos`` "
+        "instead of ``-m uvicorn``:\n"
+        + "\n".join(
+            f"  {path.relative_to(REPO_ROOT)}: {value!r}"
+            for path, value in bad
+        )
+    )

--- a/tinyagentos.service
+++ b/tinyagentos.service
@@ -17,7 +17,7 @@ ExecStartPre=+/bin/sh -c '\
   chmod o+r /sys/kernel/debug/rkrga/load 2>/dev/null || true; \
   chmod o+rx /sys/kernel/debug/mali0 2>/dev/null || true; \
   chmod o+r /sys/kernel/debug/mali0/dvfs_utilization 2>/dev/null || true'
-ExecStart=/home/jay/tinyagentos/.venv/bin/python -m uvicorn tinyagentos.app:create_app --factory --host 0.0.0.0 --port 6969
+ExecStart=/home/jay/tinyagentos/.venv/bin/python -m tinyagentos
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=3


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Every restart ends in SIGKILL: 3 of 4 controller units ExecStart uvicorn directly and never load tinyagentos/__main__.py, so the bounded graceful shutdown never runs (supersedes tsk-fl2kkq)

Autonomous build of board card tsk-mpco4a.

Three of four systemd units invoked uvicorn directly, bypassing
tinyagentos/__main__.py and its bounded graceful-shutdown handler. Every
restart on a Pi 4 ended in SIGKILL at TimeoutStopSec=45 because uvicorn
waited indefinitely for open SSE streams and cluster heartbeats.

RED-FIRST proof:

```
FAILED tests/test_controller_unit_entrypoint.py::test_units_start_via_module_entry
1 failed
```

GREEN after fix:

```
tests/test_controller_unit_entrypoint.py .                      [100%]
1 passed in 0.22s
```

Closes tsk-fl2kkq

Files:
 .../tsk-mpco4a-controller-unit-entrypoint.md       |  2 +
 .../overlay/etc/systemd/system/tinyagentos.service |  2 +-
 systemd/tinyagentos.service                        |  2 +-
 tests/test_controller_unit_entrypoint.py           | 62 ++++++++++++++++++++++
 tinyagentos.service                                |  2 +-
 5 files changed, 67 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controller startup and restart behavior by ensuring the application’s graceful-shutdown handling runs consistently.
  - Prevented unexpected forced termination during restarts on low-end ARM hardware.

- **Reliability**
  - Standardized service startup across supported deployments for more consistent controller operation.

- **Tests**
  - Added validation to ensure service configurations use the supported controller startup method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->