### PR TITLE
[lib-audit] R2-21 agent budget store rebuilt per request with DDL; sync sqlite on the loop

### DIFF
--- a/changelog.d/tsk-c7run4-budget-store-lifespan.md
+++ b/changelog.d/tsk-c7run4-budget-store-lifespan.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `AgentBudgetStore` is now constructed once in the app lifespan instead of on every request, eliminating repeated DDL execution.
+- Budget route handlers (`GET/PUT/POST /api/agents/{name}/budget*`) now run sync sqlite3 calls via `asyncio.to_thread` so they no longer block the event loop.

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1818,6 +1818,57 @@ class TestAgentBudgetRoutes:
         resp = await client.post("/api/agents/no-such-agent/budget/reset")
         assert resp.status_code == 404
 
+    async def test_budget_store_constructed_once_per_app(self, client):
+        """Two requests must not trigger the DDL constructor twice."""
+        from unittest.mock import patch
+
+        from tinyagentos.agent_budget_store import AgentBudgetStore
+
+        init_calls = []
+        orig_init = AgentBudgetStore._init
+
+        def spy_init(self):
+            init_calls.append(self.path)
+            return orig_init(self)
+
+        with patch.object(AgentBudgetStore, "_init", spy_init):
+            resp1 = await client.get("/api/agents/test-agent/budget")
+            assert resp1.status_code == 200
+            resp2 = await client.get("/api/agents/test-agent/budget")
+            assert resp2.status_code == 200
+
+        assert len(init_calls) == 1, (
+            f"AgentBudgetStore._init called {len(init_calls)} times, expected 1"
+        )
+
+    async def test_budget_route_does_not_block_event_loop(self, client):
+        """Two concurrent budget reads should not serialize if the store is offloaded."""
+        import asyncio
+        import time
+        from unittest.mock import patch
+
+        from tinyagentos.agent_budget_store import AgentBudgetStore
+
+        call_times = []
+
+        def slow_get(self, agent):
+            call_times.append(time.monotonic())
+            time.sleep(0.07)
+            return None
+
+        with patch.object(AgentBudgetStore, "get", slow_get):
+            task1 = asyncio.create_task(client.get("/api/agents/test-agent/budget"))
+            task2 = asyncio.create_task(client.get("/api/agents/test-agent/budget"))
+            r1 = await task1
+            r2 = await task2
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert len(call_times) == 2, f"expected 2 get() calls, got {len(call_times)}"
+        assert call_times[1] - call_times[0] < 0.03, (
+            f"sync get() calls serialized: gap={call_times[1] - call_times[0]:.3f}s"
+        )
+
 
 @pytest.mark.asyncio
 class TestAgentWakeBudget:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1431,6 +1431,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             )
 
         # All startup init complete — allow requests through.
+        from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
+        app.state.agent_budget_store = AgentBudgetStore(default_budget_path(data_dir))
         app.state._startup_complete = True
         logger.info("startup complete — accepting requests")
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1762,11 +1762,15 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
         "key_rescoped": key_rescoped,
     }
 
-
 def _budget_store_for_request(request: Request):
     from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
-    data_dir = request.app.state.data_dir
-    return AgentBudgetStore(default_budget_path(data_dir))
+
+    store = getattr(request.app.state, "agent_budget_store", None)
+    if store is None:
+        data_dir = request.app.state.data_dir
+        store = AgentBudgetStore(default_budget_path(data_dir))
+        request.app.state.agent_budget_store = store
+    return store
 
 
 def _budget_response(agent_name: str, rec: dict | None) -> dict:
@@ -1783,7 +1787,7 @@ async def get_agent_budget(request: Request, name: str):
     if not agent:
         return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
     store = _budget_store_for_request(request)
-    return _budget_response(name, store.get(name))
+    return _budget_response(name, await asyncio.to_thread(store.get, name))
 
 
 class AgentBudgetUpdate(BaseModel):
@@ -1805,8 +1809,8 @@ async def set_agent_budget(request: Request, name: str, body: AgentBudgetUpdate)
             status_code=400,
         )
     store = _budget_store_for_request(request)
-    store.set_budget(name, body.max_budget_usd)
-    return _budget_response(name, store.get(name))
+    await asyncio.to_thread(store.set_budget, name, body.max_budget_usd)
+    return _budget_response(name, await asyncio.to_thread(store.get, name))
 
 
 @router.post("/api/agents/{name}/budget/reset")
@@ -1817,8 +1821,8 @@ async def reset_agent_budget(request: Request, name: str):
     if not agent:
         return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
     store = _budget_store_for_request(request)
-    store.reset_spend(name)
-    return _budget_response(name, store.get(name))
+    await asyncio.to_thread(store.reset_spend, name)
+    return _budget_response(name, await asyncio.to_thread(store.get, name))
 
 
 @router.get("/api/agents/{name}/wake-budget")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-21 agent budget store rebuilt per request with DDL; sync sqlite on the loop

Autonomous build of board card tsk-c7run4.

AgentBudgetStore was rebuilt on every request, running CREATE TABLE
repeatedly. Sync sqlite3 calls on the route handlers also blocked the
event loop. Construct the store once during app startup and dispatch
all budget route sqlite work to a thread.

Docs-Reviewed: no doc change needed; budget store init is an internal
implementation detail not exposed in agent-coordination.md

RED-FIRST proof:

```
FAILED tests/test_routes_agents.py::TestAgentBudgetRoutes::test_budget_store_constructed_once_per_app - AssertionError
FAILED tests/test_routes_agents.py::TestAgentBudgetRoutes::test_budget_route_does_not_block_event_loop - AssertionError
======================== 2 failed in 6.06s =========================
```

After fix:

```
tests/test_routes_agents.py::TestAgentBudgetRoutes::test_budget_store_constructed_once_per_app PASSED
tests/test_routes_agents.py::TestAgentBudgetRoutes::test_budget_route_does_not_block_event_loop PASSED
======================== 2 passed in 4.81s =========================
```

Files:
 changelog.d/tsk-c7run4-budget-store-lifespan.md |  4 ++
 tests/test_routes_agents.py                     | 51 +++++++++++++++++++++++++
 tinyagentos/app.py                              |  2 +
 tinyagentos/routes/agents.py                    | 20 ++++++----
 4 files changed, 69 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved responsiveness for agent budget operations, especially when multiple budget requests run concurrently.
  - Reduced unnecessary repeated initialization during application operation.

- **Reliability**
  - Budget reads, updates, resets, and follow-up checks now execute without blocking other application activity.

- **Tests**
  - Added coverage for consistent budget-store initialization and non-blocking concurrent budget reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->