### PR TITLE
[lib-audit] R2-8 summary/category calls POST to endpoints no backend serves

### DIFF
--- a/changelog.d/tsk-mlqx77-llm-chat-completions-routing.md
+++ b/changelog.d/tsk-mlqx77-llm-chat-completions-routing.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `knowledge_ingest._summarise` and `knowledge_categories._llm_categorise` now POST to the OpenAI-compatible `/v1/chat/completions` endpoint instead of the unserved `/generate` and bare base-URL paths. LLM failures surface the item status as `partial` with the error stored in metadata rather than silently marking it `ready`.

--- a/tests/test_knowledge_categories.py
+++ b/tests/test_knowledge_categories.py
@@ -100,3 +100,38 @@ async def test_llm_fallback_skipped_when_rules_match(engine):
         metadata={"subreddit": "LocalLLaMA"},
     )
     engine._llm_categorise.assert_not_awaited()
+
+
+# ------------------------------------------------------------------
+# R2-8: LLM category calls must route through /v1/chat/completions
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_llm_categorise_uses_chat_completions_endpoint(store):
+    """R2-8: _llm_categorise must POST to /v1/chat/completions."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    llm_response = MagicMock()
+    llm_response.status_code = 200
+    llm_response.json = MagicMock(return_value={
+        "choices": [{"message": {"content": '["Hardware"]'}}]
+    })
+    llm_response.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=llm_response)
+
+    engine = CategoryEngine(store, http_client=mock_http, llm_url="http://localhost:8080")
+
+    categories = await engine.categorise(
+        source_type="article",
+        source_url="https://unknownsite.com/post",
+        title="Some obscure post",
+        summary="About hardware.",
+        metadata={},
+    )
+
+    mock_http.post.assert_called_once()
+    call_url = mock_http.post.call_args[0][0]
+    assert "/v1/chat/completions" in call_url, f"Expected /v1/chat/completions, got {call_url}"
+    assert "Hardware" in categories

--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -213,19 +213,12 @@ async def test_summarise_called_when_llm_url_set(store):
 
     llm_response = AsyncMock()
     llm_response.status_code = 200
-    llm_response.json = MagicMock(return_value={"text": "This is a generated summary."})
+    llm_response.json = MagicMock(return_value={
+        "choices": [{"message": {"content": "This is a generated summary."}}]
+    })
     llm_response.raise_for_status = MagicMock()
 
-    article_response = AsyncMock()
-    article_response.status_code = 200
-    article_response.is_redirect = False
-    article_response.headers = {}
-    article_response.text = "<html><body><p>Long enough article body text content here for testing purposes.</p></body></html>"
-    article_response.raise_for_status = MagicMock()
-
     mock_http = AsyncMock()
-    # First call is article fetch, second call is LLM summarise
-    mock_http.get = AsyncMock(return_value=article_response)
     mock_http.post = AsyncMock(return_value=llm_response)
 
     notif = AsyncMock()
@@ -246,7 +239,7 @@ async def test_summarise_called_when_llm_url_set(store):
     item_id = await pipeline.submit(
         url="https://example.com/summarise-test",
         title="",
-        text="",
+        text="Long enough content to trigger summarisation pipeline call here.",
         categories=[],
         source="test",
     )
@@ -254,6 +247,146 @@ async def test_summarise_called_when_llm_url_set(store):
 
     item = await store.get_item(item_id)
     assert item["summary"] == "This is a generated summary."
+
+
+# ------------------------------------------------------------------
+# R2-8: LLM summary/category calls must route through /v1/chat/completions
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_summarise_uses_chat_completions_endpoint(store):
+    """R2-8: when llm_base_url is set, _summarise must POST to /v1/chat/completions
+    and the summary text must land on the item."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+
+    llm_response = MagicMock()
+    llm_response.status_code = 200
+    llm_response.json = MagicMock(return_value={
+        "choices": [{"message": {"content": "Generated summary from chat completions."}}]
+    })
+    llm_response.raise_for_status = MagicMock()
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=llm_response)
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+
+    pipeline = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        fetch_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        qmd_base_url="",
+        llm_base_url="http://localhost:8080",
+    )
+
+    item_id = await pipeline.submit(
+        url="https://example.com/summarise-test",
+        title="",
+        text="Long enough content to trigger summarisation pipeline call here.",
+        categories=[],
+        source="test",
+    )
+    await pipeline.run(item_id)
+
+    post_calls = [str(call) for call in mock_http.post.call_args_list]
+    assert any("/v1/chat/completions" in c for c in post_calls), (
+        f"Expected POST to /v1/chat/completions, got: {post_calls}"
+    )
+
+    item = await store.get_item(item_id)
+    assert item["summary"] == "Generated summary from chat completions."
+
+
+@pytest.mark.asyncio
+async def test_summarise_failure_sets_partial_status(store):
+    """R2-8: when the LLM proxy returns 500, the item must not be marked ready."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+
+    llm_response = MagicMock()
+    llm_response.status_code = 500
+    llm_response.raise_for_status = MagicMock(side_effect=Exception("LLM 500"))
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=llm_response)
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = AsyncMock()
+    cat_engine.categorise = AsyncMock(return_value=[])
+
+    pipeline = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        fetch_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        qmd_base_url="",
+        llm_base_url="http://localhost:8080",
+    )
+
+    item_id = await pipeline.submit(
+        url="https://example.com/summarise-fail",
+        title="",
+        text="Long enough content to trigger summarisation pipeline call here.",
+        categories=[],
+        source="test",
+    )
+    await pipeline.run(item_id)
+
+    item = await store.get_item(item_id)
+    assert item["status"] != "ready"
+    assert item["status"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_category_llm_failure_sets_partial_status(store):
+    """R2-8: when the LLM proxy returns 500 during categorisation, the item
+    must not be marked ready."""
+    from tinyagentos.knowledge_ingest import IngestPipeline
+    from tinyagentos.knowledge_categories import CategoryEngine
+
+    llm_response = MagicMock()
+    llm_response.status_code = 500
+    llm_response.raise_for_status = MagicMock(side_effect=Exception("LLM 500"))
+
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=llm_response)
+
+    notif = AsyncMock()
+    notif.emit_event = AsyncMock()
+    cat_engine = CategoryEngine(
+        store=store,
+        http_client=mock_http,
+        llm_url="http://localhost:8080",
+    )
+
+    pipeline = IngestPipeline(
+        store=store,
+        http_client=mock_http,
+        fetch_client=mock_http,
+        notifications=notif,
+        category_engine=cat_engine,
+        qmd_base_url="",
+        llm_base_url="http://localhost:8080",
+    )
+
+    item_id = await pipeline.submit(
+        url="https://example.com/category-fail",
+        title="",
+        text="Long enough content to trigger summarisation pipeline call here.",
+        categories=[],
+        source="test",
+    )
+    await pipeline.run(item_id)
+
+    item = await store.get_item(item_id)
+    assert item["status"] != "ready"
+    assert item["status"] == "partial"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/knowledge_categories.py
+++ b/tinyagentos/knowledge_categories.py
@@ -65,15 +65,12 @@ class CategoryEngine:
                     matched.append(rule["category"])
 
         if not matched:
-            try:
-                matched = await self._llm_categorise(
-                    source_type=source_type,
-                    source_url=source_url,
-                    title=title,
-                    summary=summary,
-                )
-            except Exception as exc:
-                logger.warning("LLM category fallback failed: %s", exc)
+            matched = await self._llm_categorise(
+                source_type=source_type,
+                source_url=source_url,
+                title=title,
+                summary=summary,
+            )
 
         return matched
 
@@ -111,13 +108,21 @@ class CategoryEngine:
         )
 
         resp = await self._http_client.post(
-            self._llm_url,
-            json={"prompt": prompt, "max_tokens": 60},
+            f"{self._llm_url}/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 60,
+            },
             timeout=30,
         )
         resp.raise_for_status()
         data = resp.json()
-        raw = data.get("text", data.get("content", "[]"))
+        choices = data.get("choices", [])
+        if choices:
+            raw = choices[0].get("message", {}).get("content", "[]")
+        else:
+            raw = "[]"
 
         import json
         try:

--- a/tinyagentos/knowledge_ingest.py
+++ b/tinyagentos/knowledge_ingest.py
@@ -260,22 +260,39 @@ class IngestPipeline:
 
             # Step 2: categorise
             categories = item["categories"] or []
+            category_error = None
             if not categories:
-                categories = await self._category_engine.categorise(
-                    source_type=item["source_type"],
-                    source_url=item["source_url"],
-                    title=title or item["source_url"],
-                    summary="",
-                    metadata=metadata,
-                )
+                try:
+                    categories = await self._category_engine.categorise(
+                        source_type=item["source_type"],
+                        source_url=item["source_url"],
+                        title=title or item["source_url"],
+                        summary="",
+                        metadata=metadata,
+                    )
+                except Exception as exc:
+                    category_error = str(exc)
+                    logger.warning("Category LLM call failed for %s: %s", item_id, exc)
+                    categories = []
 
             # Step 3: summarise via LLM (best-effort, non-fatal)
-            summary = await self._summarise(title, content)
+            summary = ""
+            llm_error = None
+            try:
+                summary = await self._summarise(title, content)
+            except Exception as exc:
+                llm_error = str(exc)
+                logger.warning("Summarise LLM call failed for %s: %s", item_id, exc)
 
             # Step 4: embed via QMD (best-effort, non-fatal)
             embed_failures = await self._embed(item_id, title, content)
 
             # Step 5: write final data
+            if llm_error:
+                metadata["llm_summarise_error"] = llm_error
+            if category_error:
+                metadata["llm_category_error"] = category_error
+
             await self._store.update_item(
                 item_id,
                 title=title or item["source_url"],
@@ -285,7 +302,7 @@ class IngestPipeline:
                 categories=categories,
                 metadata=metadata,
             )
-            if embed_failures:
+            if embed_failures or llm_error or category_error:
                 await self._store.update_status(item_id, "partial")
             else:
                 await self._store.update_status(item_id, "ready")
@@ -448,18 +465,21 @@ class IngestPipeline:
             f"Be specific about what the content covers and who it is useful for.\n\n"
             f"Title: {title}\n\nContent:\n{truncated}"
         )
-        try:
-            resp = await self._http_client.post(
-                f"{self._llm_base_url}/generate",
-                json={"prompt": prompt, "max_tokens": 150},
-                timeout=60,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return data.get("text", data.get("content", "")).strip()
-        except Exception as exc:
-            logger.warning("Summarise LLM call failed: %s", exc)
-            return ""
+        resp = await self._http_client.post(
+            f"{self._llm_base_url}/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 150,
+            },
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        choices = data.get("choices", [])
+        if choices:
+            return choices[0].get("message", {}).get("content", "").strip()
+        return ""
 
     # ------------------------------------------------------------------
     # Embed step


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-8 summary/category calls POST to endpoints no backend serves

Autonomous build of board card tsk-mlqx77.

R2-8: _summarise POSTed to {base}/generate and _llm_categorise POSTed the
bare base URL. Neither path is served by any backend. Both failures were
swallowed, so items were marked ready with empty summaries and no categories.

Route both through the OpenAI-compatible /v1/chat/completions endpoint via
the existing http_client. Surface LLM failures as item status partial with
the error stored in metadata rather than silently marking ready.

Tests added:
- test_summarise_uses_chat_completions_endpoint
- test_summarise_failure_sets_partial_status
- test_category_llm_failure_sets_partial_status
- test_llm_categorise_uses_chat_completions_endpoint

RED-FIRST proof:
```
FAILED tests/test_knowledge_ingest.py::test_summarise_uses_chat_completions_endpoint - AssertionError
FAILED tests/test_knowledge_ingest.py::test_summarise_failure_sets_partial_status - AssertionError
FAILED tests/test_knowledge_ingest.py::test_category_llm_failure_sets_partial_status - AssertionError
FAILED tests/test_knowledge_categories.py::test_llm_categorise_uses_chat_completions_endpoint - AssertionError
============================== 4 failed in 0.59s ==============================
```

GREEN after fix:
```
42 passed in 1.25s
```

Files:
 .../tsk-mlqx77-llm-chat-completions-routing.md     |   3 +
 tests/test_knowledge_categories.py                 |  35 +++++
 tests/test_knowledge_ingest.py                     | 155 +++++++++++++++++++--
 tinyagentos/knowledge_categories.py                |  29 ++--
 tinyagentos/knowledge_ingest.py                    |  62 ++++++---
 5 files changed, 240 insertions(+), 44 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - LLM-powered summarization and categorization now use the OpenAI-compatible chat completions endpoint.
  - Items affected by summarization or categorization failures are marked as **partial** instead of **ready**.
  - LLM processing errors are recorded in item metadata for improved visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->