### PR TITLE
CI: detect evil merges in test files (a conflict resolution that matches neither parent)

### DIFF
--- a/changelog.d/tsk-hlnd2t-evil-merge-parent-match.md
+++ b/changelog.d/tsk-hlnd2t-evil-merge-parent-match.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `scripts/check_evil_merge.py` now allows a merge conflict resolution that matches one parent wholesale to pass the guard. Previously the guard compared the merge result only against the `git merge-tree` conflict-marker baseline, which incorrectly flagged legitimate conflict resolutions that took one side entirely.
+- Updated the CLI failure output to say `matches neither parent` and to show only the merge and parent hashes, matching the documented gate contract.
+
+### Added
+
+- Added `tests/test_check_evil_merge.py::TestEvilMergeGuard::test_conflict_resolved_by_taking_one_side_wholesale_stays_green` covering the conflict-resolution control case.

--- a/scripts/check_evil_merge.py
+++ b/scripts/check_evil_merge.py
@@ -252,9 +252,12 @@ def check_evil_merge(
                     Violation(path, merge_sha, parent1, parent2, merge_tree_sha)
                 )
         elif head_blob != expected:
-            violations.append(
-                Violation(path, merge_sha, parent1, parent2, merge_tree_sha)
-            )
+            p1_blob = p1_blobs.get(path)
+            p2_blob = p2_blobs.get(path)
+            if head_blob != p1_blob and head_blob != p2_blob:
+                violations.append(
+                    Violation(path, merge_sha, parent1, parent2, merge_tree_sha)
+                )
 
     return violations
 
@@ -294,11 +297,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     v = violations[0]
-    print(f"EVIL-MERGE FAIL: {v.path} differs from merge-tree baseline")
-    print(f"  merge         M  {v.merge_hash[:8]}")
-    print(f"  merge-tree    T  {v.merge_tree_hash[:8]}")
-    print(f"  parent1      P1  {v.parent1_hash[:8]}")
-    print(f"  parent2      P2  {v.parent2_hash[:8]}")
+    print(f"EVIL-MERGE FAIL: {v.path} matches neither parent")
+    print(f"  merge   M  {v.merge_hash[:8]}")
+    print(f"  parent1 P1 {v.parent1_hash[:8]}")
+    print(f"  parent2 P2 {v.parent2_hash[:8]}")
     return 1
 
 

--- a/tests/test_check_evil_merge.py
+++ b/tests/test_check_evil_merge.py
@@ -141,10 +141,10 @@ class TestEvilMergeGuard:
         assert v.merge_hash != v.parent2_hash
 
     def test_merge_taking_one_side_wholesale_stays_green(self, tmp_path: Path):
-        """CONTROL A: both branches touch different, non-overlapping parts of
-        the same test file, producing a clean auto-merge.  Resolving by
-        keeping side-a's content wholesale matches what git would produce,
-        so the guard passes."""
+        """CONTROL A (clean auto-merge variant): both branches touch different,
+        non-overlapping parts of the same test file, producing a clean
+        auto-merge.  Resolving by keeping side-a's content wholesale matches
+        what git would produce, so the guard passes."""
         repo = tmp_path / "repo"
         _init_repo(repo)
 
@@ -174,6 +174,50 @@ class TestEvilMergeGuard:
         _checkout(repo, "main")
         _git_merge(repo, "side-a")
         _git_merge(repo, "side-b")
+
+        violations = cem.check_evil_merge(repo)
+        assert violations == []
+
+    def test_conflict_resolved_by_taking_one_side_wholesale_stays_green(self, tmp_path: Path):
+        """CONTROL A (conflict variant): the same contradictory branches as the
+        RED case, but the merge conflict is resolved by taking one parent's
+        content wholesale.  The guard must stay green because the blob at
+        head matches a parent exactly."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    pass\n",
+            "test: add test_principal",
+        )
+
+        _branch(repo, "side-a")
+        _checkout(repo, "side-a")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+            "feat: assert accepted",
+        )
+
+        _checkout(repo, "main")
+        _branch(repo, "side-b")
+        _checkout(repo, "side-b")
+        _commit_file(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_rejected()\n",
+            "feat: assert rejected",
+        )
+
+        _checkout(repo, "main")
+        _git_merge(repo, "side-a")
+        _git_merge(repo, "side-b")
+
+        # Resolve the conflict by taking side-a's content wholesale.
+        _resolve_and_commit(
+            repo, "tests/test_widget.py",
+            "def test_principal():\n    assert principal_is_accepted()\n",
+        )
 
         violations = cem.check_evil_merge(repo)
         assert violations == []


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): CI: detect evil merges in test files (a conflict resolution that matches neither parent)

Autonomous build of board card tsk-hlnd2t.

The guard previously compared the merge result only against the
git merge-tree conflict-marker baseline.  That incorrectly flagged
legitimate conflict resolutions that took one side entirely, because
the conflict-marker blob never matches a clean parent blob.

The fix adds a second check: when head differs from merge-tree,
verify that it also differs from both parents before declaring a
violation.  If head matches either parent exactly, the resolution
is a clean wholesale take and the guard stays green.

Updated CLI output to match the documented gate contract:
EVIL-MERGE FAIL: <path> matches neither parent
  merge   M  <hash>
  parent1 P1 <hash>
  parent2 P2 <hash>

Added control test for the conflict-resolution-by-taking-one-side
case, which was the untested false positive that motivated the fix.

RED-FIRST proof:

```
FAILED tests/test_check_evil_merge.py::TestEvilMergeGuard::test_conflict_resolved_by_taking_one_side_wholesale_stays_green - AssertionError
```

Green after fix:

```
tests/test_check_evil_merge.py tests/test_check_gate_integrity.py tests/test_check_doc_gate.py -q
120 passed in 4.12s
```

Files:
 changelog.d/tsk-hlnd2t-evil-merge-parent-match.md |  8 ++++
 scripts/check_evil_merge.py                       | 18 ++++----
 tests/test_check_evil_merge.py                    | 52 +++++++++++++++++++++--
 3 files changed, 66 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed merge validation to allow conflict resolutions that correctly match one parent’s content.
  - Updated failure messages to clearly identify cases that match neither parent, including the merge and parent hashes.
- **Tests**
  - Added regression coverage for conflict resolutions that take one parent’s content wholesale.
- **Documentation**
  - Added a changelog entry describing the merge validation fix and updated CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->