### PR TITLE
StrikeStore residue: wire record_strike/quarantine triggers + board surfacing (re-cut of tsk-7g6ltb, #2333 has merged)

### DIFF
--- a/changelog.d/tsk-mw2pvn-quarantine-on-third-strike.md
+++ b/changelog.d/tsk-mw2pvn-quarantine-on-third-strike.md
@@ -1,0 +1,2 @@
+### Fixed
+- release_task now quarantines a card on the third cumulative strike instead of parking it, so the lead can review and un-quarantine failed tasks

--- a/tests/projects/test_strike_wiring.py
+++ b/tests/projects/test_strike_wiring.py
@@ -137,10 +137,10 @@ async def test_unquarantine_route_lead_success_and_noauth_failure(app):
 @pytest.mark.asyncio
 async def test_release_parks_after_threshold_strikes(app):
     """Releasing a claimed task records a strike; after STRIKE_THRESHOLD
-    cumulative releases the task is permanently parked."""
+    cumulative releases the task is quarantined."""
     async with app.router.lifespan_context(app):
         async with _auth_client(app) as c:
-            _, task_id = await _make_project_and_task(c, "strike-park")
+            _, task_id = await _make_project_and_task(c, "strike-quarantine")
 
             task_store = app.state.project_task_store
             strikes = app.state.task_strikes
@@ -154,19 +154,19 @@ async def test_release_parks_after_threshold_strikes(app):
                     assert count == i + 1
 
             fetched = await task_store.get_task(task_id)
-            assert fetched["status"] == "parked"
+            assert fetched["status"] == "quarantined"
             assert await strikes.count_strikes(task_id) == strikes.STRIKE_THRESHOLD
 
 
 @pytest.mark.asyncio
 async def test_concurrent_claim_during_release(app):
     """During release_task, if another worker claims the task, the strike
-    recording and parking must not leave the task in an invalid state with a
-    stale claimed_by held in parked status.
+    recording and quarantine must not leave the task in an invalid state with a
+    stale claimed_by held in quarantined status.
 
-    The release must record the *threshold* strike for the parking path to run
-    at all, so seed STRIKE_THRESHOLD - 1 strikes first; with fewer the release
-    never reaches park_task and the test proves nothing."""
+    The release must record the *threshold* strike for the quarantine path to
+    run at all, so seed STRIKE_THRESHOLD - 1 strikes first; with fewer the
+    release never reaches quarantine_task and the test proves nothing."""
     async with app.router.lifespan_context(app):
         async with _auth_client(app) as c:
             _, task_id = await _make_project_and_task(c, "strike-concurrent")
@@ -178,13 +178,13 @@ async def test_concurrent_claim_during_release(app):
             await task_store.claim_task(task_id, "worker-1")
 
             # Seed up to one below the threshold so the strike recorded by
-            # release_task below is the one that trips parking.
+            # release_task below is the one that trips quarantine.
             for _ in range(strikes.STRIKE_THRESHOLD - 1):
                 await strikes.record_strike(task_id, "dispatch_failed", actor="worker-1")
             assert await strikes.count_strikes(task_id) == strikes.STRIKE_THRESHOLD - 1
 
             # Now race: release the task (which records the threshold strike and
-            # attempts to park) while another worker tries to claim it.
+            # attempts to quarantine) while another worker tries to claim it.
             released = asyncio.create_task(
                 task_store.release_task(task_id, "worker-1")
             )
@@ -195,18 +195,47 @@ async def test_concurrent_claim_during_release(app):
 
             fetched = await task_store.get_task(task_id)
             status = fetched["status"]
-            assert status in ("open", "claimed", "parked")
-            # Parking may never swallow a live claim, and a parked card may
-            # never carry an owner that can no longer release it.
-            if status == "parked":
-                assert fetched.get("claimed_by") is None, "Task parked with stale claimed_by"
-                assert fetched.get("claimed_at") is None, "Task parked with stale claimed_at"
+            assert status in ("open", "claimed", "quarantined")
+            # Quarantine may never swallow a live claim, and a quarantined card
+            # may never carry an owner that can no longer release it.
+            if status == "quarantined":
+                assert fetched.get("claimed_by") is None, "Task quarantined with stale claimed_by"
+                assert fetched.get("claimed_at") is None, "Task quarantined with stale claimed_at"
             if claim_ok:
                 # worker-2 won the claim, so the release path must have left it
-                # alone rather than parking someone else's active card.
+                # alone rather than quarantining someone else's active card.
                 assert status == "claimed", f"concurrent claim was overridden ({status})"
                 assert fetched.get("claimed_by") == "worker-2"
             # The threshold strike from the release is recorded regardless of
-            # whether parking was skipped.
+            # whether quarantine was skipped.
             count = await strikes.count_strikes(task_id)
             assert count == strikes.STRIKE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_three_releases_quarantine_via_http(app):
+    """Three cumulative dispatch_failed strikes through the release HTTP route
+    must quarantine the card.  This is the end-to-end proof that the trigger
+    wiring is live: if record_strike is dropped or quarantine_task is not
+    called on the threshold, the task remains open instead of quarantined."""
+    from tinyagentos.projects.strike_store import StrikeStore
+
+    async with app.router.lifespan_context(app):
+        async with _auth_client(app) as c:
+            project_id, task_id = await _make_project_and_task(c, "strike-e2e")
+
+            for _ in range(StrikeStore.STRIKE_THRESHOLD):
+                r = await c.post(
+                    f"/api/projects/{project_id}/tasks/{task_id}/claim",
+                    json={"claimer_id": "worker-1"},
+                )
+                assert r.status_code == 200, r.text
+                r = await c.post(
+                    f"/api/projects/{project_id}/tasks/{task_id}/release",
+                    json={"releaser_id": "worker-1"},
+                )
+                assert r.status_code == 200, r.text
+
+            r = await c.get(f"/api/projects/{project_id}/tasks/{task_id}")
+            assert r.status_code == 200, r.text
+            assert r.json()["status"] == "quarantined"

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -921,12 +921,13 @@ async def test_update_refused_by_the_parked_guard_publishes_nothing(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_release_parking_does_not_steal_a_concurrent_claim(tmp_path):
-    """Parking on release must not swallow a claim made after the pre-check.
+async def test_release_quarantine_does_not_steal_a_concurrent_claim(tmp_path):
+    """Quarantine on release must not swallow a claim made after the pre-check.
 
-    The release path records the threshold strike and then parks.  If it
+    The release path records the threshold strike and then quarantines.  If it
     decides on a separate read, another worker can claim the task in the gap
-    between that read and the park, and the park lands on a live claim.
+    between that read and the quarantine, and the quarantine would then
+    swallow that worker's live claim.
     """
     from tinyagentos.projects.strike_store import StrikeStore
 
@@ -941,8 +942,8 @@ async def test_release_parking_does_not_steal_a_concurrent_claim(tmp_path):
         await s.claim_task(task["id"], "worker-1")
 
         # Drive the interleaving deterministically: worker-2 claims the task in
-        # the last moment before the parking UPDATE runs -- exactly the window a
-        # separate pre-read leaves open.  Both the pre-read design and the
+        # the last moment before the quarantine UPDATE runs -- exactly the window
+        # a separate pre-read leaves open.  Both the pre-read design and the
         # conditional-update design reach this point, so the hook is fair to
         # either implementation.
         real_execute = s._db.execute
@@ -951,12 +952,12 @@ async def test_release_parking_does_not_steal_a_concurrent_claim(tmp_path):
         def racing_execute(sql, *args, **kwargs):
             # Stay a plain function so non-matching statements hand back
             # aiosqlite's cursor object unchanged (callers use it both with
-            # `await` and with `async with`). Parking statements are only ever
-            # awaited, so returning a coroutine for those is safe.
+            # `await` and with `async with`). Quarantine statements are only
+            # ever awaited, so returning a coroutine for those is safe.
             if (
                 not state["raced"]
                 and sql.lstrip().upper().startswith("UPDATE")
-                and "'parked'" in sql
+                and "'quarantined'" in sql
             ):
                 state["raced"] = True
 
@@ -996,7 +997,7 @@ async def test_release_records_strike_and_parks_after_threshold(tmp_path):
             ok = await s.release_task(task["id"], "worker-1")
             assert ok is True
         fetched = await s.get_task(task["id"])
-        assert fetched["status"] == "parked"
+        assert fetched["status"] == "quarantined"
         assert await strikes.count_strikes(task["id"]) == StrikeStore.STRIKE_THRESHOLD
     finally:
         await s.close()

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -497,13 +497,13 @@ class ProjectTaskStore(ProjectsDBStore):
                         task_id, "dispatch_failed", actor=releaser_id
                     )
                     if count >= StrikeStore.STRIKE_THRESHOLD:
-                        # The conditional UPDATE inside park_task is itself the
-                        # decision: it only fires while the task is still open
-                        # and unclaimed.  A separate pre-read here would leave a
-                        # window in which another worker claims the task between
-                        # the check and the park, and the park would then
-                        # swallow that worker's live claim.
-                        await self.park_task(
+                        # The conditional UPDATE inside quarantine_task is itself
+                        # the decision: it only fires while the task is still
+                        # open and unclaimed.  A separate pre-read here would
+                        # leave a window in which another worker claims the task
+                        # between the check and the quarantine, and the
+                        # quarantine would then swallow that worker's live claim.
+                        await self.quarantine_task(
                             task_id, "system", only_if_unclaimed=True
                         )
                 except Exception:
@@ -656,20 +656,32 @@ class ProjectTaskStore(ProjectsDBStore):
             )
         return changed
 
-    async def quarantine_task(self, task_id: str, actor: str) -> bool:
+    async def quarantine_task(
+        self, task_id: str, actor: str, *, only_if_unclaimed: bool = False
+    ) -> bool:
         """Move a task into the ``quarantined`` status.
 
         A quarantined card is visible on the board (distinct column) but is
         removed from the ready pool -- the fleet will not pick it up until a
         lead explicitly un-quarantines it.  Only acts on a task that is not
         already closed/cancelled; returns False otherwise.
+
+        ``only_if_unclaimed`` narrows the guard to a task that is still ``open``
+        with no claimer, so a caller that must not steal another worker's live
+        claim can use this update's row count as the quarantine decision instead
+        of a separate (racy) pre-read.
         """
         now = time.time()
+        guard = (
+            "status = 'open' AND claimed_by IS NULL"
+            if only_if_unclaimed
+            else "status NOT IN ('closed', 'cancelled', 'quarantined')"
+        )
         async with self._tx():
             cursor = await self._db.execute(
-                """UPDATE project_tasks
-                   SET status = 'quarantined', updated_at = ?
-                   WHERE id = ? AND status NOT IN ('closed', 'cancelled', 'quarantined')""",
+                f"""UPDATE project_tasks
+                    SET status = 'quarantined', updated_at = ?
+                    WHERE id = ? AND {guard}""",
                 (now, task_id),
             )
             changed = cursor.rowcount == 1


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): StrikeStore residue: wire record_strike/quarantine triggers + board surfacing (re-cut of tsk-7g6ltb, #2333 has merged)

Autonomous build of board card tsk-mw2pvn.

release_task now calls quarantine_task(only_if_unclaimed=True) on the
third cumulative dispatch_failed strike, so the lead can review and
un-quarantine failed cards rather than parking them permanently.

quarantine_task accepts only_if_unclaimed to keep the same race-free
guard park_task used, preventing a concurrent claim from being stolen
by the quarantine UPDATE.

Updated existing tests that asserted 'parked' to assert 'quarantined',
and added an end-to-end HTTP test that proves 3 strikes -> quarantine.

Docs-Reviewed: no route changes, quarantine status already surfaced on board frontend

RED-GREEN proof:

```
FAILED tests/projects/test_strike_wiring.py::test_three_releases_quarantine_via_http
1 failed in 6.37s
```

After fix:

```
1 passed in 6.99s
```

Files:
 .../tsk-mw2pvn-quarantine-on-third-strike.md       |  2 +
 tests/projects/test_strike_wiring.py               | 65 ++++++++++++++++------
 tests/test_task_store.py                           | 21 +++----
 tinyagentos/projects/task_store.py                 | 34 +++++++----
 4 files changed, 83 insertions(+), 39 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tasks are now quarantined after the third cumulative release failure, rather than parked.
  - Quarantined tasks can be reviewed and restored by authorized leads.
  - Active claims are protected from being overwritten during concurrent release or quarantine operations.
  - Verified the updated behavior through task-store and end-to-end HTTP workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Removes-Intentionally: tests/test_task_store.py:test_release_parking_does_not_steal_a_concurrent_claim, tests/test_task_store.py:test_release_parking_does_not_steal_a_concurrent_claim.racing_execute, tests/test_task_store.py:test_release_parking_does_not_steal_a_concurrent_claim.racing_execute._claim_then_execute

Waiver rationale (lead): pure rename, not a coverage loss. The test is
`test_release_quarantine_does_not_steal_a_concurrent_claim` at HEAD
(tests/test_task_store.py:924, with racing_execute:952 and
_claim_then_execute:964) and it keeps the same race assertions, with the
interleaving hook correctly re-pointed from `'parked'` to `'quarantined'`
so it still fires on the UPDATE this PR introduces.
