### PR TITLE
Unified chat: human-principal assertion issuance (controller-signed)

### DIFF
--- a/changelog.d/tsk-ao7x7w-human-bus-assertion.md
+++ b/changelog.d/tsk-ao7x7w-human-bus-assertion.md
@@ -1,0 +1,3 @@
+### Added
+
+- Human users can now post to the A2A bus via `POST /api/a2a/bus/human-assertion`, which issues a controller-signed EdDSA assertion verified through the same chain as agent registry JWTs. The bus derives `from` from the credential (`@<username>`), so a human cannot spoof another identity.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -299,12 +299,19 @@ The raw bus above is unauthenticated on the LAN and trusts the `from` field, so
 reaching it means either the owner's account or an SSH hop. A registered agent
 should instead post through the controller's authenticated proxy, which forces
 `from` to the agent's own registry handle (no spoofing), so it posts as itself,
-not the owner:
+not the owner. A human user can post through the same proxy with a
+controller-issued signed assertion, which forces `from` to `@<username>` (also
+no spoofing):
 
 ```
 POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope a2a_send>)
 {"thread": "build", "body": "...", "reply_to": <id>?}
 ```
+
+Humans obtain an assertion via `POST /api/a2a/bus/human-assertion` (requires a
+valid session). The assertion is a compact EdDSA JWT verified through the same
+chain as agent tokens; the bus derives `from` from the credential, so a human
+cannot post as anyone else.
 
 ## Reading the bus
 Read through the controller with your own registry token, not the raw bus port:

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -12,11 +12,13 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import json
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.agent_registry_store import (
+    _b64url_encode,
     load_or_create_signing_keypair,
     mint_registry_token,
 )
@@ -406,3 +408,96 @@ class TestBusAgentSend:
                     headers={"Authorization": f"Bearer {token}"},
                 )
         assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+class TestBusHumanAuth:
+    """Human-principal bus auth: controller-issued assertions verified through
+    the same Ed25519 chain as agent JWTs, with ``from`` derived from the
+    credential so a human cannot post as anyone else."""
+
+    async def test_issue_human_assertion(self, bus_client):
+        """POST /api/a2a/bus/human-assertion returns a signed JWT for the
+        currently authenticated human user."""
+        resp = await bus_client.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "assertion" in data
+        token = data["assertion"]
+        assert isinstance(token, str)
+        assert len(token.split(".")) == 3
+
+    async def test_human_assertion_verifies_via_existing_chain(self, bus_client):
+        """The issued human assertion passes verify_registry_token (same chain)."""
+        from tinyagentos.agent_registry_store import verify_registry_token
+
+        resp = await bus_client.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 200
+        token = resp.json()["assertion"]
+        _priv, pub = bus_client._app.state.agent_registry_keypair
+        payload = verify_registry_token(token, pub)
+        assert payload["principal_type"] == "human"
+        assert payload["sub"] == bus_client._test_admin_uid
+
+    async def test_tampered_human_assertion_rejected(self, bus_client):
+        """A tampered human assertion fails verification."""
+        from tinyagentos.agent_registry_store import verify_registry_token
+
+        resp = await bus_client.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 200
+        token = resp.json()["assertion"]
+        _priv, pub = bus_client._app.state.agent_registry_keypair
+        parts = token.split(".")
+        tampered_payload = _b64url_encode(
+            json.dumps({"sub": "other-user", "principal_type": "human"}).encode()
+        )
+        tampered = f"{parts[0]}.{tampered_payload}.{parts[2]}"
+        with pytest.raises(ValueError):
+            verify_registry_token(tampered, pub)
+
+    async def test_human_send_derives_from_from_credential(self, bus_client):
+        """A human Bearer token posts as @<username>, ignoring any client-supplied from."""
+        resp = await bus_client.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 200
+        token = resp.json()["assertion"]
+
+        ctx, client = _mock_bus_post(
+            {"id": 1, "from": "@admin", "thread": "general"}
+        )
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "general", "body": "hello", "from": "@impostor"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["from"] == "@admin"
+        sent = client.post.call_args.kwargs["json"]
+        assert sent["from"] == "@admin"
+
+    async def test_human_send_rejects_malformed_token(self, bus_client):
+        """A malformed Bearer token on /send returns 401."""
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "general", "body": "hi"},
+                headers={"Authorization": "Bearer not-a-valid-token"},
+            )
+        assert resp.status_code == 401
+
+    async def test_agent_token_not_accepted_as_human(self, bus_client):
+        """An agent-principal token cannot obtain a human assertion."""
+        _cid, agent_token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/human-assertion",
+                headers={"Authorization": f"Bearer {agent_token}"},
+            )
+        assert resp.status_code == 401
+
+    async def test_human_assertion_requires_auth(self, bus_client):
+        """Unauthenticated callers cannot issue a human assertion."""
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 401

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -327,6 +327,7 @@ def mint_registry_token(
     user_id: str = "",
     framework: str = "",
     project_id: Optional[str] = None,
+    principal_type: str = "agent",
 ) -> str:
     """Return a signed compact EdDSA JWT: <header>.<payload>.<signature> (base64url).
 
@@ -335,13 +336,17 @@ def mint_registry_token(
     can verify it without importing tinyagentos code.
 
     Claims:
-      sub        - canonical_id (immutable agent identity)
-      iss        - "taos-registry"
-      iat        - unix timestamp of issuance
-      user_id    - owning user_id at registration time
-      framework  - agent framework at registration time
-      project_id - project binding, present only when non-empty; absent means
-                   the token is global (not bound to any project)
+      sub           - canonical_id for agents, user_id for humans (the principal
+                      identifier)
+      iss           - "taos-registry"
+      iat           - unix timestamp of issuance
+      jti           - unique token id
+      principal_type- "agent" (default) or "human" — the two principal types
+                      verified through the same Ed25519 chain
+      user_id       - owning user_id at registration time (agent tokens only)
+      framework     - agent framework at registration time (agent tokens only)
+      project_id    - project binding, present only when non-empty; absent means
+                      the token is global (not bound to any project)
 
     Signed with Ed25519 over the UTF-8 bytes of ``<header_b64url>.<payload_b64url>``.
     """
@@ -357,9 +362,11 @@ def mint_registry_token(
         "iss": "taos-registry",
         "iat": int(time.time()),
         "jti": uuid.uuid4().hex,
-        "user_id": user_id,
-        "framework": framework,
+        "principal_type": principal_type,
     }
+    if principal_type == "agent":
+        claims["user_id"] = user_id
+        claims["framework"] = framework
     if project_id:
         claims["project_id"] = project_id
     payload = _b64url_encode(

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -130,6 +130,10 @@ async def _verify_agent_scope(
     if not canonical_id:
         raise HTTPException(status_code=401, detail="token missing sub claim")
 
+    principal_type = payload.get("principal_type", "")
+    if principal_type == "human":
+        return None
+
     # Agent must be active in the registry.
     registry = _get_store(request)
     record = await registry.get(canonical_id)
@@ -179,6 +183,53 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
         return None
     canonical_id, _payload = result
     return canonical_id
+
+
+async def check_human_identity(request: Request) -> Optional[str]:
+    """Return the user_id from a valid Bearer registry JWT for a HUMAN principal.
+
+    Uses the SAME Ed25519 verification chain as agent tokens (``verify_registry_token``)
+    but accepts only tokens with ``principal_type == "human"``.  The ``sub`` claim
+    is the user_id; a human cannot post as anyone else because ``from`` is derived
+    from the credential, never self-asserted.
+
+    Returns None when no Authorization header is present (the caller falls
+    through to its own admin/session handling).
+
+    Raises:
+      401 -- Authorization header present but the token is malformed, has a bad
+             signature, is missing the sub claim, or carries the wrong principal_type.
+      403 -- Token is well-formed but the user_id does not resolve to an existing
+             human account.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+
+    raw_token = auth_header[7:].strip()
+
+    _private_pem, public_pem = _get_keypair(request)
+    try:
+        payload = verify_registry_token(raw_token, public_pem)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
+
+    principal_type = payload.get("principal_type", "")
+    if principal_type != "human":
+        raise HTTPException(status_code=401, detail="not a human-principal token")
+
+    user_id: str = payload.get("sub", "")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="token missing sub claim")
+
+    auth = getattr(request.app.state, "auth", None)
+    if auth is None:
+        raise RuntimeError("auth store not on app.state")
+    user = auth.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=403, detail="human principal not found")
+
+    return user_id
 
 
 async def check_agent_identity(request: Request) -> Optional[str]:

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -31,11 +31,13 @@ import os
 import httpx
 import asyncio
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
-from tinyagentos.agent_token_auth import check_agent_scope
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.agent_token_auth import check_agent_scope, check_human_identity
+from tinyagentos.auth_context import CurrentUser, current_user
 
 logger = logging.getLogger(__name__)
 
@@ -400,29 +402,37 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
     - Admin (session cookie or local token): may set an explicit ``from``
       (operator posts as any handle); defaults to ``@operator`` when omitted.
     - Otherwise the caller must present a registry JWT holding an active
-      ``a2a_send`` grant. The ``from`` is DERIVED from that agent's registry
-      handle; a client-supplied ``from`` is ignored, so an agent cannot spoof
-      another agent's identity. ``check_agent_scope`` raises 401/403; a missing
-      Bearer header returns None and is rejected here as 403 (fail closed).
+      ``a2a_send`` grant (agent) or a valid human-principal token. The ``from``
+      is DERIVED from the credential for both principal types; a client-supplied
+      ``from`` is ignored, so neither an agent nor a human can spoof another
+      identity. ``check_agent_scope`` raises 401/403; ``check_human_identity``
+      raises 401/403; a missing Bearer header returns None from both and is
+      rejected here as 403 (fail closed).
     """
     if getattr(request.state, "is_admin", False):
-        # Admin may post as an explicit handle, but keep it a single clean token
-        # so it cannot inject newlines/control chars into the bus record or logs.
         handle = (body_from or "").strip()
         handle = "".join(c for c in handle if c.isprintable())[:64].strip()
         return handle or "@operator"
 
     caller = await check_agent_scope(request, "a2a_send")
-    if caller is None:
-        raise HTTPException(status_code=403, detail="forbidden")
+    if caller is not None:
+        registry = getattr(request.app.state, "agent_registry", None)
+        record = await registry.get(caller) if registry is not None else None
+        handle = ((record or {}).get("handle") or "").strip()
+        if not handle:
+            raise HTTPException(status_code=403, detail="agent has no bus handle")
+        return handle
 
-    registry = getattr(request.app.state, "agent_registry", None)
-    record = await registry.get(caller) if registry is not None else None
-    handle = ((record or {}).get("handle") or "").strip()
-    if not handle:
-        # An active a2a_send grant with no bus handle cannot be safely attributed.
-        raise HTTPException(status_code=403, detail="agent has no bus handle")
-    return handle
+    human_id = await check_human_identity(request)
+    if human_id is not None:
+        auth = getattr(request.app.state, "auth", None)
+        user = auth.get_user_by_id(human_id) if auth else None
+        username = ((user or {}).get("username") or "").strip()
+        if not username:
+            raise HTTPException(status_code=403, detail="human has no username")
+        return f"@{username}"
+
+    raise HTTPException(status_code=403, detail="forbidden")
 
 
 @router.post("/api/a2a/bus/send")
@@ -466,3 +476,35 @@ async def bus_send(request: Request, body: BusSendBody):
         raise HTTPException(status_code=502, detail="a2a bus unavailable")
 
     return {"ok": True, "from": from_handle, "message": data}
+
+
+@router.post("/api/a2a/bus/human-assertion")
+async def issue_human_assertion(
+    request: Request,
+    _user: CurrentUser = Depends(current_user),
+):
+    """Issue a signed assertion for the currently authenticated human user.
+
+    The assertion is a compact EdDSA JWT (the same format and signing key as
+    agent registry tokens) with ``principal_type="human"`` and ``sub`` set to
+    the caller's ``user_id``.  It can be presented as ``Authorization: Bearer
+    <assertion>`` to the bus read/write proxies, where it is verified through
+    the SAME chain as agent JWTs.  The bus derives ``from`` from the credential
+    (``@<username>``), so a human cannot post as anyone else.
+
+    Returns the assertion token once; the caller must store it securely.
+    """
+    auth = getattr(request.app.state, "auth", None)
+    if auth is None:
+        raise RuntimeError("auth store not on app.state")
+    user = auth.get_user_by_id(_user.user_id)
+    if user is None:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    priv, _pub = request.app.state.agent_registry_keypair
+    token = mint_registry_token(
+        _user.user_id,
+        priv,
+        principal_type="human",
+    )
+    return {"assertion": token}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Unified chat: human-principal assertion issuance (controller-signed)

Autonomous build of board card tsk-ao7x7w.

Controller issues signed EdDSA assertions for authenticated human users via
POST /api/a2a/bus/human-assertion. The bus verifies them through the same
Ed25519 chain as agent registry JWTs and derives from the credential
(@<username>), so a human cannot spoof another identity.

- mint_registry_token accepts principal_type=human and omits agent-only claims
- _verify_agent_scope returns None for human tokens, letting _resolve_send_identity fall through to check_human_identity
- check_human_identity verifies human-principal tokens and resolves the user_id
- issue_human_assertion endpoint mints assertions for the current session user
- Tests cover issue, verify, tamper-reject, from-derivation, malformed token, and unauthenticated rejection

Docs-Reviewed: updated agent-coordination.md to document human bus posting

Files:
 changelog.d/tsk-ao7x7w-human-bus-assertion.md |  3 +
 docs/agent-coordination.md                    |  9 ++-
 tests/test_a2a_bus_agent_auth.py              | 95 +++++++++++++++++++++++++++
 tinyagentos/agent_registry_store.py           | 25 ++++---
 tinyagentos/agent_token_auth.py               | 51 ++++++++++++++
 tinyagentos/routes/a2a_bus.py                 | 78 +++++++++++++++++-----
 6 files changed, 233 insertions(+), 28 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human users can now post messages to the A2A coordination bus through an authenticated endpoint.
  * Bus messages automatically use the authenticated user’s identity, preventing identity spoofing.
  * Human authentication assertions are signed and verified through the existing security chain.

* **Documentation**
  * Updated coordination-bus documentation with instructions for human-authenticated posting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->