### PR TITLE
a2a_bus: human-principal handle is not sanitised at the same sink the admin branch defends (FF of #2970)

### DIFF
--- a/changelog.d/tsk-frz5rj-sanitise-human-bus-handle.md
+++ b/changelog.d/tsk-frz5rj-sanitise-human-bus-handle.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The human-principal bus `from` handle is now sanitised (non-printable characters stripped, capped at 64 characters) using the same helper as the admin branch, preventing control-character injection into bus records and logs.

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -8,6 +8,7 @@ skeleton-key guard (the agent token must not authenticate any other route).
 from __future__ import annotations
 
 import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,7 @@ from tinyagentos.agent_registry_store import (
     load_or_create_signing_keypair,
     mint_registry_token,
 )
+from tinyagentos.auth import hash_password
 from taos_test_csrf import csrf_event_hooks
 
 _BUS_PATCH = "tinyagentos.routes.a2a_bus.httpx.AsyncClient"
@@ -475,6 +477,51 @@ class TestBusHumanAuth:
         assert resp.json()["from"] == "@admin"
         sent = client.post.call_args.kwargs["json"]
         assert sent["from"] == "@admin"
+
+    async def test_human_handle_is_sanitised(self, bus_client):
+        """The human branch strips non-printable characters and caps the derived
+        @<username> at 64 chars, matching the admin branch's sanitisation."""
+        malicious_username = "evil\n\x00injected"
+        user_id = "test-malicious-user"
+
+        data = bus_client._app.state.auth._read_users()
+        data.setdefault("users", []).append({
+            "id": user_id,
+            "username": malicious_username,
+            "password_hash": hash_password("testpass1234"),
+            "is_admin": False,
+            "created_at": int(time.time()),
+        })
+        bus_client._app.state.auth._write_users(data)
+
+        session = bus_client._app.state.auth.create_session(
+            user_id=user_id, long_lived=True
+        )
+
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=bus_client._app),
+            base_url="http://test",
+            cookies={"taos_session": session},
+            event_hooks=csrf_event_hooks(),
+        )
+        async with bare_client as bare:
+            resp = await bare.post("/api/a2a/bus/human-assertion")
+        assert resp.status_code == 200
+        token = resp.json()["assertion"]
+
+        ctx, client = _mock_bus_post({"id": 1, "from": "@x", "thread": "general"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "general", "body": "hello"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        sent_from = client.post.call_args.kwargs["json"]["from"]
+        assert "\n" not in sent_from
+        assert "\x00" not in sent_from
+        assert len(sent_from) <= 64
 
     async def test_human_send_rejects_malformed_token(self, bus_client):
         """A malformed Bearer token on /send returns 401."""

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -170,13 +170,15 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
     active *required_scope* grant, or raise an HTTPException.
 
     Returns None when no Authorization header is present (the caller falls
-    through to its own admin/session handling).
+    through to its own admin/session handling), or when a valid human-principal
+    token is presented (``principal_type == "human"`` short-circuits here so a
+    human token never reaches the agent-registry check).
 
     Raises:
       401 -- Authorization header present but the token is malformed, has a bad
-             signature, or is missing the sub claim.
+            signature, or is missing the sub claim.
       403 -- Token is valid but the agent is not active in the registry, the
-             sub is unknown, or the grant is missing/expired.
+            sub is unknown, or the grant is missing/expired.
     """
     result = await _verify_agent_scope(request, required_scope)
     if result is None:
@@ -301,7 +303,9 @@ async def check_agent_scope_for_project(
     been granted, and is rejected for any project it lacks a grant for.  See
     the grant-gated model in docs/agent-coordination.md.
 
-    Returns None when no Authorization header is present.
+    Returns None when no Authorization header is present, or when a valid
+    human-principal token is presented (``principal_type == "human"``
+    short-circuits via ``_verify_agent_scope``).
 
     Raises:
       401/403 -- exactly as ``check_agent_scope`` (bad token / inactive agent /
@@ -345,7 +349,9 @@ async def check_agent_project_grants(
 
     Returns ``(canonical_id, {project_id: grant})``, or ``(None, {})`` when no
     Authorization header is present (the caller falls through to its own
-    session/admin handling).
+    session/admin handling), or when a valid human-principal token is presented
+    (``principal_type == "human"`` short-circuits here, matching
+    ``check_agent_scope``).
 
     Raises:
       401/403 -- exactly as ``check_agent_scope`` (bad/inactive/superseded token).
@@ -371,6 +377,10 @@ async def check_agent_project_grants(
         raise HTTPException(status_code=403, detail="agent is not active in the registry")
 
     _enforce_rotation_cutoff(record, payload)
+
+    principal_type = payload.get("principal_type", "")
+    if principal_type == "human":
+        return None, {}
 
     grants_store = _get_grants_store(request)
     grants = await grants_store.list_grants(canonical_id)

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -55,6 +55,16 @@ def _bus_url() -> str:
     return os.environ.get("TAOS_A2A_BUS_URL", _DEFAULT_BUS_URL).rstrip("/")
 
 
+def _sanitise_handle(handle: str) -> str:
+    """Strip non-printable characters and cap at 64 characters.
+
+    Shared by the admin and human branches of ``_resolve_send_identity`` so
+    the two paths cannot drift apart: a handle carrying a newline or control
+    character cannot inject into bus records or log lines.
+    """
+    return "".join(c for c in handle if c.isprintable())[:64].strip()
+
+
 async def _authorize_bus_read(request: Request) -> None:
     """Gate a bus-read request.
 
@@ -410,8 +420,7 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
       rejected here as 403 (fail closed).
     """
     if getattr(request.state, "is_admin", False):
-        handle = (body_from or "").strip()
-        handle = "".join(c for c in handle if c.isprintable())[:64].strip()
+        handle = _sanitise_handle(body_from or "")
         return handle or "@operator"
 
     caller = await check_agent_scope(request, "a2a_send")
@@ -430,7 +439,8 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
         username = ((user or {}).get("username") or "").strip()
         if not username:
             raise HTTPException(status_code=403, detail="human has no username")
-        return f"@{username}"
+        handle = _sanitise_handle(f"@{username}")
+        return handle
 
     raise HTTPException(status_code=403, detail="forbidden")
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): a2a_bus: human-principal handle is not sanitised at the same sink the admin branch defends (FF of #2970)

Autonomous build of board card tsk-frz5rj.

Lift the printable-filter and 64-char cap into a shared _sanitise_handle
helper in a2a_bus.py and have both the admin and human branches of
_resolve_send_identity call it, so the two paths cannot drift apart.

Extend check_agent_scope and check_agent_scope_for_project docstrings
to document that None also means a valid human-principal token was
presented, matching the behaviour of _verify_agent_scope.

Give check_agent_project_grants the same human-principal short-circuit
so it matches check_agent_scope, and update its docstring.

RED
```
FAILED tests/test_a2a_bus_agent_auth.py::TestBusHumanAuth::test_human_handle_is_sanitised
>       assert "\n" not in sent_from
E       AssertionError: assert '\n' not in '@evil\n\x00injected'
E         '\n' is contained here:
E           @evil
E         ? -----
E           injected
```

GREEN 34 passed in 48.61s

Docs-Reviewed: handle sanitisation is an internal proxy-side security
fix, no agent-coordination.md update required

Docs-Reviewed: handle sanitisation is an internal proxy-side security fix; the agent-coordination.md description of from-derivation remains accurate and the agent manual does not document bus handle sanitisation.

Files:
 .../tsk-frz5rj-sanitise-human-bus-handle.md        |  3 ++
 tests/test_a2a_bus_agent_auth.py                   | 47 ++++++++++++++++++++++
 tinyagentos/agent_token_auth.py                    | 20 ++++++---
 tinyagentos/routes/a2a_bus.py                      | 16 ++++++--
 4 files changed, 78 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized human and administrator sender handles by removing non-printable characters, trimming whitespace, and limiting values to 64 characters.
  * Prevented control characters from appearing in bus records and logs.
  * Human-principal tokens now correctly return to session or administrator handling after validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->