### PR TITLE
projects: return the invite kind in GET /api/projects/{id}/invites (prerequisite for #2067, not the UI)

### DIFF
--- a/changelog.d/tsk-mj5blg-invite-kind.md
+++ b/changelog.d/tsk-mj5blg-invite-kind.md
@@ -1,0 +1,3 @@
+### Added
+
+- `GET /api/projects/{id}/invites` now returns each invite's `kind` (`agent` or `collab`), so the Members and Agents screens can badge pending invites by type

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -737,6 +737,7 @@ async def list_invites(
             "status": i["status"],
             "expires_ts": i["expires_ts"],
             "redeemed_by": i.get("redeemed_by"),
+            "kind": i.get("kind", "agent"),
         }
         for i in items
     ]


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Surface pending invites in Members screen + Agents app (issue #2067)

Autonomous build of board card tsk-mj5blg.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

Docs-Reviewed: executor rescue commit -- the model left these edits uncommitted and wrote no commit message, so doc drift was NOT assessed by the model; the lead reviews docs at PR time.

Files:
 tinyagentos/routes/project_invites.py | 1 +
 1 file changed, 1 insertion(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project invite listings now include the invite type for each record.
  - Invites without a stored type are identified as agent invites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->