### PR TITLE
Account model slice 6 (per design doc)

### DIFF
--- a/changelog.d/tsk-u7i6il-webstudio-subdomain-picker.md
+++ b/changelog.d/tsk-u7i6il-webstudio-subdomain-picker.md
@@ -1,0 +1,3 @@
+### Added
+
+- Web Studio Share view now includes a Publish to taos.my action with a subdomain picker fed by the account's active claims, an optional label, and copy-link and unpublish controls after publish. Empty states guide the user through sign-in, taOSgo subscription, subdomain claiming, and mesh join in order.

--- a/desktop/src/apps/webstudio/ShareView.test.tsx
+++ b/desktop/src/apps/webstudio/ShareView.test.tsx
@@ -15,12 +15,30 @@ function makeFetchMock(opts?: {
   installStatus?: number;
   installBody?: unknown;
   findings?: unknown[];
+  accountStatus?: number;
+  accountBody?: unknown;
+  meshJoined?: boolean;
 }) {
   const installCalls: FormData[] = [];
   const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = (init?.method ?? "GET").toUpperCase();
 
+    if (url === "/api/account/me") {
+      const status = opts?.accountStatus ?? 401;
+      const body = opts?.accountBody ?? {};
+      return Promise.resolve({
+        ok: status < 400,
+        status,
+        json: () => Promise.resolve(body),
+      } as Response);
+    }
+    if (url === "/api/account/mesh/status") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ joined: opts?.meshJoined ?? false }),
+      } as Response);
+    }
     if (url === "/api/web/sites/share-site" && method === "GET") {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(SITE) } as Response);
     }
@@ -45,6 +63,16 @@ function makeFetchMock(opts?: {
           ),
       } as Response);
     }
+    if (url === "/api/web/sites/share-site/publish" && method === "POST") {
+      const body = (init?.body ? JSON.parse(init.body as string) : {}) as { subdomain?: string; label?: string };
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ fqdn: `${body.subdomain}.taos.my` }),
+      } as Response);
+    }
+    if (url === "/api/web/sites/share-site/publish" && method === "DELETE") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    }
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
   });
   return { fetchMock, installCalls };
@@ -56,7 +84,17 @@ describe("ShareView", () => {
   });
 
   it("shows an empty state with no active site", () => {
-    vi.stubGlobal("fetch", vi.fn() as unknown as typeof fetch);
+    const emptyFetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/account/me") {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (url === "/api/account/mesh/status") {
+        return Promise.resolve(new Response(JSON.stringify({ joined: false }), { headers: { "Content-Type": "application/json" } }));
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    vi.stubGlobal("fetch", emptyFetch as unknown as typeof fetch);
     render(<ShareView siteId={null} provenance="user-uploaded" />);
     expect(screen.getByText(/Save a site in the Edit view first/)).toBeDefined();
   });
@@ -132,5 +170,175 @@ describe("ShareView", () => {
     render(<ShareView siteId="draft-site" provenance="user-uploaded" />);
     await waitFor(() => expect(screen.getByText(/hasn't been saved with rendered content/)).toBeDefined());
     expect(screen.queryByRole("button", { name: /Install on this taOS/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a sign-in prompt when the user is not authenticated", async () => {
+    const { fetchMock } = makeFetchMock({ accountStatus: 401 });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    await waitFor(() => expect(screen.getByText(/Sign in to your taOS account to publish/)).toBeDefined());
+  });
+
+  it("shows a taOSgo prompt when the account is signed in but not subscribed", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: { user_id: "u1", email: "jay@example.com", taosgo: { status: "none" } },
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    await waitFor(() => expect(screen.getByText(/taOSgo subscription required to publish/)).toBeDefined());
+  });
+
+  it("shows a no-subdomains prompt with a Settings link when subscribed but no claims yet", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: { user_id: "u1", email: "jay@example.com", taosgo: { status: "active" }, subdomains: [] },
+      meshJoined: true,
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    await waitFor(() => expect(screen.getByText(/No claimed subdomains/)).toBeDefined());
+    expect(screen.getByText(/Claim one in Settings to publish/)).toBeDefined();
+  });
+
+  it("shows a mesh-join prompt when subscribed with claims but the host is not on the mesh", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: {
+        user_id: "u1",
+        email: "jay@example.com",
+        taosgo: { status: "active" },
+        subdomains: [{ id: "c1", account_id: "u1", name: "mybiz", status: "active" }],
+      },
+      meshJoined: false,
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    await waitFor(() => expect(screen.getByText(/Connect your taOS account to the mesh first/)).toBeDefined());
+  });
+
+  it("renders the subdomain picker and sends the chosen subdomain on publish", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: {
+        user_id: "u1",
+        email: "jay@example.com",
+        taosgo: { status: "active" },
+        subdomains: [
+          { id: "c1", account_id: "u1", name: "mybiz", status: "active" },
+          { id: "c2", account_id: "u1", name: "personal", status: "active" },
+        ],
+      },
+      meshJoined: true,
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    const select = await screen.findByRole("combobox");
+    expect(select).toBeDefined();
+
+    fireEvent.change(select, { target: { value: "personal" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+
+    await waitFor(() => expect(screen.getByText("Published to personal.taos.my")).toBeDefined());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/web/sites/share-site/publish",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ subdomain: "personal" }),
+      }),
+    );
+  });
+
+  it("sends an optional label along with the subdomain on publish", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: {
+        user_id: "u1",
+        email: "jay@example.com",
+        taosgo: { status: "active" },
+        subdomains: [{ id: "c1", account_id: "u1", name: "mybiz", status: "active" }],
+      },
+      meshJoined: true,
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    const select = await screen.findByRole("combobox");
+    fireEvent.change(select, { target: { value: "mybiz" } });
+
+    const labelInput = screen.getByPlaceholderText("Label (optional)");
+    fireEvent.change(labelInput, { target: { value: "blog" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+
+    await waitFor(() => expect(screen.getByText("Published to mybiz.taos.my")).toBeDefined());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/web/sites/share-site/publish",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ subdomain: "mybiz", label: "blog" }),
+      }),
+    );
+  });
+
+  it("shows an unpublish button and calls DELETE when clicked", async () => {
+    const { fetchMock } = makeFetchMock({
+      accountStatus: 200,
+      accountBody: {
+        user_id: "u1",
+        email: "jay@example.com",
+        taosgo: { status: "active" },
+        subdomains: [{ id: "c1", account_id: "u1", name: "mybiz", status: "active" }],
+      },
+      meshJoined: true,
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    const select = await screen.findByRole("combobox");
+    fireEvent.change(select, { target: { value: "mybiz" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+
+    await waitFor(() => expect(screen.getByText("Published to mybiz.taos.my")).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: /Unpublish/ }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/web/sites/share-site/publish",
+      expect.objectContaining({ method: "DELETE" }),
+    ));
+  });
+
+  it("surfaces a publish error instead of faking success", async () => {
+    const errorMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/account/me") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ user_id: "u1", email: "jay@example.com", taosgo: { status: "active" }, subdomains: [{ id: "c1", account_id: "u1", name: "mybiz", status: "active" }] }) } as Response);
+      }
+      if (url === "/api/account/mesh/status") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ joined: true }) } as Response);
+      }
+      if (url === "/api/web/sites/share-site" && (init?.method ?? "GET").toUpperCase() === "GET") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(SITE) } as Response);
+      }
+      if (url === "/api/userspace-apps/analyze" && (init?.method ?? "GET").toUpperCase() === "POST") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ findings: [], blocked: false }) } as Response);
+      }
+      if (url === "/api/web/sites/share-site/publish" && (init?.method ?? "GET").toUpperCase() === "POST") {
+        return Promise.resolve({ ok: false, status: 403, json: () => Promise.resolve({ error: "subdomain_not_active" }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    });
+    vi.stubGlobal("fetch", errorMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    const select = await screen.findByRole("combobox");
+    fireEvent.change(select, { target: { value: "mybiz" } });
+    fireEvent.click(screen.getByRole("button", { name: /Publish/ }));
+
+    await waitFor(() => expect(screen.getByText("subdomain_not_active")).toBeDefined());
   });
 });

--- a/desktop/src/apps/webstudio/ShareView.tsx
+++ b/desktop/src/apps/webstudio/ShareView.tsx
@@ -1,27 +1,31 @@
 import { useCallback, useEffect, useState } from "react";
-import { Share2, Download, Loader2, CheckCircle2, AlertCircle, Globe2 } from "lucide-react";
+import { Share2, Download, Loader2, CheckCircle2, AlertCircle, Globe2, Link2, Unplug } from "lucide-react";
 import { analyzeAppSource, type Finding } from "../appstudio/analyze-source";
 import { FindingsPanel } from "../appstudio/FindingsPanel";
 import { installUserspaceApp, USERSPACE_APPS_CHANGED } from "@/lib/userspace-apps";
 import { emitAppEvent } from "@/lib/app-event-bus";
-import { fetchSitePackage, getSiteRow } from "./web-sites-api";
+import { fetchAccount, type AccountState, type SubdomainClaim } from "@/lib/account-client";
+import { fetchSitePackage, getSiteRow, publishSite, unpublishSite } from "./web-sites-api";
 import type { SiteRow } from "./web-sites-api";
 
 /* ------------------------------------------------------------------ */
-/*  ShareView -- install locally or export a .taosapp package           */
+/*  ShareView -- install locally, export a .taosapp package, or publish */
 /*                                                                     */
-/*  Both actions build the SAME package: GET /api/web/sites/{id}/package */
-/*  returns a real .taosapp zip (manifest.yaml + the site's rendered      */
-/*  index.html) built by the backend's build_package() -- the exact same  */
-/*  pipeline Game Studio's ShareView uses. "Install" POSTs that file to    */
-/*  the existing, unmodified /api/userspace-apps/install endpoint tagged   */
-/*  provenance "ai-generated"; the static security analyzer runs on         */
-/*  install same as any other userspace app, and its findings are shown     */
-/*  honestly here too (previewed via the same analyze endpoint App Studio   */
-/*  and Game Studio use). "Export" downloads the identical package.         */
+/*  Both install and export build the SAME package: GET                */
+/*  /api/web/sites/{id}/package returns a real .taosapp zip built by   */
+/*  the backend's build_package() -- the exact same pipeline Game       */
+/*  Studio's ShareView uses. "Install" POSTs that file to the existing, */
+/*  unmodified /api/userspace-apps/install endpoint tagged provenance   */
+/*  "ai-generated"; the static security analyzer runs on install same   */
+/*  as any other userspace app, and its findings are shown honestly     */
+/*  here too (previewed via the same analyze endpoint App Studio and    */
+/*  Game Studio use). "Export" downloads the identical package.         */
 /*                                                                          */
 /*  A site must be saved at least once (it needs a rendered index_html)     */
 /*  before it can be shared -- there is no unsaved-site install path.       */
+/*                                                                          */
+/*  Publish sends the chosen subdomain to the controller, which then      */
+/*  registers the route with taos.my on the account's behalf.              */
 /* ------------------------------------------------------------------ */
 
 export interface ShareViewProps {
@@ -48,6 +52,35 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
 
+  const [accountState, setAccountState] = useState<AccountState>({ kind: "loading" });
+  const [meshStatus, setMeshStatus] = useState<{ joined: boolean; detail?: string }>({ joined: false });
+
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState<{ fqdn: string } | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
+  const [selectedSubdomain, setSelectedSubdomain] = useState<string>("");
+  const [label, setLabel] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const account = await fetchAccount();
+      if (!cancelled) setAccountState(account);
+      try {
+        const res = await fetch("/api/account/mesh/status", { credentials: "include" });
+        if (res.ok) {
+          const data = await res.json();
+          if (!cancelled) setMeshStatus({ joined: Boolean(data?.joined), detail: data?.detail });
+        }
+      } catch {
+        // mesh status unavailable; stays at default joined=false
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     if (!siteId) {
       setLoading(false);
@@ -59,6 +92,10 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
     setInstallResult(null);
     setInstallError(null);
     setExportError(null);
+    setPublishResult(null);
+    setPublishError(null);
+    setSelectedSubdomain("");
+    setLabel("");
     getSiteRow(siteId)
       .then((s) => {
         if (cancelled) return;
@@ -94,6 +131,18 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
   const needsSave = !loading && !loadError && site !== null && !site.index_html;
   const blocked = !scanning && !scanError && findings.some((f) => f.severity === "critical");
   const actionsDisabled = loading || scanning || blocked || !site || needsSave;
+
+  const account = accountState.kind === "signed-in" ? accountState.account : null;
+  const taosgo = account?.taosgo;
+  const activeSubdomains = account?.subdomains?.filter((s: SubdomainClaim) => s.status === "active") ?? [];
+
+  const publishEmptyMessage = (() => {
+    if (accountState.kind !== "signed-in") return "Sign in to your taOS account to publish.";
+    if (!taosgo || taosgo.status === "none") return "taOSgo subscription required to publish.";
+    if (activeSubdomains.length === 0) return "No claimed subdomains. Claim one in Settings to publish.";
+    if (!meshStatus.joined) return "Connect your taOS account to the mesh first.";
+    return null;
+  })();
 
   const handleInstall = useCallback(async () => {
     if (!site) return;
@@ -133,6 +182,44 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
     }
   }, [site]);
 
+  const handlePublish = useCallback(async () => {
+    if (!siteId || !selectedSubdomain) return;
+    setPublishing(true);
+    setPublishError(null);
+    setPublishResult(null);
+    try {
+      const result = await publishSite(siteId, selectedSubdomain, label || undefined);
+      setPublishResult(result);
+    } catch (e) {
+      setPublishError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPublishing(false);
+    }
+  }, [siteId, selectedSubdomain, label]);
+
+  const handleUnpublish = useCallback(async () => {
+    if (!siteId) return;
+    setPublishing(true);
+    setPublishError(null);
+    try {
+      await unpublishSite(siteId);
+      setPublishResult(null);
+    } catch (e) {
+      setPublishError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPublishing(false);
+    }
+  }, [siteId]);
+
+  const copyFqdn = useCallback(async () => {
+    if (!publishResult) return;
+    try {
+      await navigator.clipboard.writeText(`https://${publishResult.fqdn}`);
+    } catch {
+      // clipboard unavailable; silently ignore
+    }
+  }, [publishResult]);
+
   if (!siteId) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-2 text-shell-text-tertiary">
@@ -169,7 +256,7 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
         <header>
           <h2 className="text-[17px] font-bold tracking-[-0.02em]">Share "{site.title}"</h2>
           <p className="mt-1 text-[12.5px] text-shell-text-secondary">
-            Install it on this taOS or export a .taosapp package to share elsewhere.
+            Install it on this taOS, export a .taosapp package, or publish it to taos.my.
           </p>
         </header>
 
@@ -210,6 +297,86 @@ export function ShareView({ siteId, provenance }: ShareViewProps) {
                 </div>
               </>
             )}
+
+            <div className="mt-1 flex flex-col gap-2.5">
+              <p className="text-[12.5px] font-medium text-shell-text-secondary">Publish to taos.my</p>
+
+              {publishEmptyMessage && (
+                <div className="rounded-xl border border-shell-border bg-shell-surface/50 px-3.5 py-3 text-[12.5px] text-shell-text-secondary">
+                  {publishEmptyMessage}
+                </div>
+              )}
+
+              {!publishEmptyMessage && !publishResult && (
+                <div className="flex flex-wrap items-center gap-2.5">
+                  <select
+                    value={selectedSubdomain}
+                    onChange={(e) => setSelectedSubdomain(e.target.value)}
+                    className="h-[36px] rounded-lg border border-shell-border bg-shell-bg px-3 text-[13px] text-shell-text focus:outline-none focus:ring-2 focus:ring-accent/40"
+                  >
+                    <option value="">Choose a subdomain...</option>
+                    {activeSubdomains.map((s) => (
+                      <option key={s.id} value={s.name}>
+                        {s.name}.taos.my
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="Label (optional)"
+                    className="h-[36px] rounded-lg border border-shell-border bg-shell-bg px-3 text-[13px] text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent/40"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handlePublish()}
+                    disabled={publishing || !selectedSubdomain}
+                    className="flex h-[36px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-4 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {publishing ? <Loader2 size={16} className="animate-spin" /> : <Globe2 size={16} />}
+                    {publishing ? "Publishing..." : "Publish"}
+                  </button>
+                </div>
+              )}
+
+              {publishResult && (
+                <div role="status" className="flex items-start gap-2.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-3">
+                  <CheckCircle2 size={16} className="mt-0.5 flex-none text-emerald-400" />
+                  <div className="flex flex-col gap-2">
+                    <p className="text-[12.5px] leading-relaxed text-emerald-200">
+                      Published to {publishResult.fqdn}
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void copyFqdn()}
+                        className="flex h-[30px] items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 text-[12px] font-medium text-emerald-200 transition-colors hover:bg-emerald-500/20"
+                      >
+                        <Link2 size={14} />
+                        Copy link
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleUnpublish()}
+                        disabled={publishing}
+                        className="flex h-[30px] items-center gap-1.5 rounded-full border border-shell-border bg-shell-surface px-3 text-[12px] font-medium text-shell-text transition-colors hover:bg-shell-bg disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Unplug size={14} />
+                        {publishing ? "Unpublishing..." : "Unpublish"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {publishError && (
+                <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3">
+                  <AlertCircle size={16} className="mt-0.5 flex-none text-red-400" />
+                  <p className="text-[12.5px] leading-relaxed text-red-200">{publishError}</p>
+                </div>
+              )}
+            </div>
 
             {installResult === "ok" && (
               <div role="status" className="flex items-start gap-2.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-3">

--- a/desktop/src/apps/webstudio/web-sites-api.ts
+++ b/desktop/src/apps/webstudio/web-sites-api.ts
@@ -47,3 +47,38 @@ export async function fetchSitePackage(id: string): Promise<File> {
   const blob = await res.blob();
   return new File([blob], `${id}.taosapp`, { type: "application/zip" });
 }
+
+export function sitePublishUrl(id: string): string {
+  return `/api/web/sites/${encodeURIComponent(id)}/publish`;
+}
+
+/** Publish a site to a claimed taOSgo subdomain. The controller fills in the
+ *  host_id + port from its own mesh credentials; the desktop only supplies the
+ *  chosen subdomain and an optional label. */
+export async function publishSite(
+  id: string,
+  subdomain: string,
+  label?: string,
+): Promise<{ fqdn: string }> {
+  const res = await fetch(sitePublishUrl(id), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ subdomain, label }),
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return res.json();
+}
+
+export function siteUnpublishUrl(id: string): string {
+  return `/api/web/sites/${encodeURIComponent(id)}/publish`;
+}
+
+/** Unpublish a previously published site (drops the binding; the claim survives). */
+export async function unpublishSite(id: string): Promise<void> {
+  const res = await fetch(siteUnpublishUrl(id), {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(await readError(res));
+}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Account model slice 6 (per design doc)

Autonomous build of board card tsk-u7i6il.

Add publishSite and unpublishSite helpers to web-sites-api.ts, and extend
ShareView with a Publish to taos.my section that feeds off the signed-in
account's active subdomain claims. Empty states appear in order: not signed
in, no taOSgo, no claimed subdomains (with a claim-one-in-Settings pointer),
and mesh not joined. When all gates pass the user picks a subdomain, can add
an optional label, and sees the resulting FQDN with copy-link and unpublish
actions. Tests cover each empty state, the picker ready state, publish payload
shape including the optional label, and publish error surfacing.

Verification: desktop build passes, 14 ShareView tests pass.

Files:
 .../tsk-u7i6il-webstudio-subdomain-picker.md       |   3 +
 desktop/src/apps/webstudio/ShareView.test.tsx      | 210 ++++++++++++++++++++-
 desktop/src/apps/webstudio/ShareView.tsx           | 193 +++++++++++++++++--
 desktop/src/apps/webstudio/web-sites-api.ts        |  35 ++++
 4 files changed, 427 insertions(+), 14 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Publish to taos.my” option in Web Studio.
  * Choose an available subdomain and optional label when publishing.
  * Copy the published link or unpublish a site from the Share view.
  * Added guided prompts for sign-in, subscription, subdomain claiming, and mesh setup.
  * Publish errors and status updates are now displayed in the Share view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->