### PR TITLE
fix-forward #2964 (tsk-t5bup2): half-finished store->pstore rename NameErrors six projects write endpoints, and the unbounded->bounded queue change deadlocks the whole project event broker

### DIFF
--- a/changelog.d/tsk-ob2mpd-fix-project-routes-broker-deadlock.md
+++ b/changelog.d/tsk-ob2mpd-fix-project-routes-broker-deadlock.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Projects router: Fixed half-finished store->pstore rename in six write handlers (update_project, archive_project, delete_project, add_member, set_project_lead, remove_member) that raised NameError at request time
+- Projects events: Fixed ProjectEventBroker deadlock by releasing the lock before putting to subscriber queues and evicting oldest items on full queues instead of blocking
+- Projects events: Preserved replay history on last-unsubscribe so reconnecting SSE clients can catch up on missed events

--- a/changelog.d/tsk-t5bup2-fix-routing-validation-events.md
+++ b/changelog.d/tsk-t5bup2-fix-routing-validation-events.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Projects router: Changed `require_owner_or_admin` to `_get_owned_project` for 6 routes to provide consistent 404 behavior for non-owners
+- Projects router: Updated `delete_element` mode parameter to use `Literal["strict", "untag"]` for type safety
+- Projects router: Consolidated `_SLUG_RE` regex definition from 3 locations to 1 in `element_store.py`
+- Projects router: Added `_TaskRequestModelMixin` to `CreateChecklistItemIn` model
+- Projects router: Fixed `project_events` stream to include `id` field in emitted events
+- Projects events: Added `maxsize` parameter to prevent unbounded queue growth
+- Projects events: Clean up empty subscriber keys to prevent memory leaks
+- Element store: Updated import to use centralized `_SLUG_RE` from `element_store.py`
+- Fixed imports in projects.py: removed unused `re` import, added `Literal` and `_SLUG_RE` imports

--- a/changelog.d/tsk-whwh5n-sparkle-release-tests.md
+++ b/changelog.d/tsk-whwh5n-sparkle-release-tests.md
@@ -1,0 +1,6 @@
+### Added
+
+- Added `assemble_bundle.sh` release-build smoke test verifying Sparkle.framework is bundled on success and missing-framework fails non-zero
+- Added domain audit test ensuring no `taos.app` feed or download references remain under `mac/`
+
+S2-23: Mac updater is a no-op: Sparkle never fetched; feed host is not the project domain

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,25 @@
+fix-forward #2964 (tsk-ob2mpd): repair half-finished store->pstore rename, fix ProjectEventBroker deadlock, preserve replay on unsubscribe
+
+RED:
+```
+FAILED tests/test_routes_projects.py::test_update_project_returns_200 - NameError: name 'store' is not defined
+FAILED tests/test_routes_projects.py::test_archive_project_returns_200 - NameError: name 'store' is not defined
+FAILED tests/test_project_events.py::test_publish_does_not_deadlock_when_a_subscriber_queue_is_full
+FAILED tests/test_project_events.py::test_unsubscribe_preserves_replay_history
+============================== 4 failed in 7.60s ==============================
+```
+
+GREEN:
+```
+4 passed in 5.92s
+```
+
+Also verified: 86 passed across tests/projects/test_routes_a2a.py, tests/test_project_events.py, tests/test_routes_projects.py.
+
+Defect 1 - six project write handlers (update_project, archive_project, delete_project, add_member, set_project_lead, remove_member) had pstore = request.app.state.project_store but the rest of each body still referenced bare store, raising NameError at request time. Fixed every reference to pstore.
+
+Defect 2 - ProjectEventBroker.publish() held self._lock while doing await q.put(event) on a bounded queue. A stalled consumer whose queue filled would block publish forever holding the lock, making subscribe/unsubscribe impossible and stalling every project. Fixed by releasing the lock before putting, with a backpressure policy that evicts the oldest item from a full subscriber queue and retries.
+
+Defect 3 - unsubscribe() popped self._replay when the last subscriber left, destroying the replay buffer exactly when a reconnecting client needed it. Kept _replay; the bounded deque holds memory fixed.
+
+Docs-Reviewed: bug fix to existing routes and event broker, no route surface change.

--- a/tests/sparkle_tests.bats
+++ b/tests/sparkle_tests.bats
@@ -135,3 +135,46 @@ PEM
     run grep -q 'dependencies: \["Sparkle"\]' "$pkg_swift"
     [ "$status" -eq 0 ]
 }
+
+@test "assemble_bundle.sh bundles Sparkle.framework in a successful release build" {
+    local fake_root="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake_root/mac/build" "$fake_root/mac/appcast" \
+             "$fake_root/mac/launcher/Sources/taOSLauncher/Resources"
+    cp "$REPO_ROOT/mac/build/assemble_bundle.sh" "$fake_root/mac/build/assemble_bundle.sh"
+    cp "$REPO_ROOT/mac/launcher/Sources/taOSLauncher/Resources/Info.plist.in" \
+       "$fake_root/mac/launcher/Sources/taOSLauncher/Resources/Info.plist.in"
+    for path in tinyagentos static data app-catalog pyproject.toml; do
+        [ -e "$REPO_ROOT/$path" ] && ln -s "$REPO_ROOT/$path" "$fake_root/$path"
+    done
+    cat > "$fake_root/mac/appcast/ed_public.pem" <<'PEM'
+-----BEGIN PUBLIC KEY-----
+testkey
+-----END PUBLIC KEY-----
+PEM
+
+    local staging_dir="$BATS_TEST_TMPDIR/staging"
+    mkdir -p "$staging_dir/frontend/desktop" "$staging_dir/python" "$staging_dir/bin"
+    touch "$staging_dir/frontend/desktop/index.html"
+    touch "$staging_dir/bin/container"
+    mkdir -p "$staging_dir/Sparkle.framework/Versions/A"
+    touch "$staging_dir/Sparkle.framework/Versions/A/Sparkle"
+
+    local binary="$BATS_TEST_TMPDIR/launcher"
+    touch "$binary"
+    chmod +x "$binary"
+
+    run timeout 30 "$fake_root/mac/build/assemble_bundle.sh" \
+        --release \
+        --version "1.2.3" \
+        --staging "$staging_dir" \
+        --launcher-binary "$binary" \
+        --output "$BATS_TEST_TMPDIR/output"
+
+    [ "$status" -eq 0 ]
+    [ -d "$BATS_TEST_TMPDIR/output/taOS.app/Contents/Frameworks/Sparkle.framework" ]
+}
+
+@test "no taos.app feed or download domain references under mac/" {
+    run grep -rE "(https?://taos\.app|taos\.app/(appcast|releases))" "$REPO_ROOT/mac"
+    [ "$status" -ne 0 ]
+}

--- a/tests/test_project_events.py
+++ b/tests/test_project_events.py
@@ -101,3 +101,47 @@ async def test_unsubscribe_missing_queue_is_noop():
     await broker.publish("zeta", ProjectEvent(kind="ok", payload={}))
     ev = await asyncio.wait_for(queue.get(), timeout=0.5)
     assert ev.kind == "ok"
+
+
+@pytest.mark.asyncio
+async def test_publish_does_not_deadlock_when_a_subscriber_queue_is_full():
+    broker = ProjectEventBroker(replay_size=32)
+    q_slow = await broker.subscribe("proj-x")
+    q_fast = await broker.subscribe("proj-x")
+    for i in range(32):
+        q_slow.put_nowait(ProjectEvent(kind="fill", payload={"i": i}))
+
+    async def do_publish():
+        await asyncio.wait_for(
+            broker.publish("proj-x", ProjectEvent(kind="live", payload={})),
+            timeout=0.5,
+        )
+
+    async def do_unsubscribe():
+        await asyncio.wait_for(
+            broker.unsubscribe("proj-x", q_slow),
+            timeout=0.5,
+        )
+
+    await asyncio.gather(do_publish(), do_unsubscribe())
+    ev = await asyncio.wait_for(q_fast.get(), timeout=0.5)
+    assert ev.kind == "live"
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_preserves_replay_history():
+    broker = ProjectEventBroker(replay_size=8)
+    await broker.publish("proj-y", ProjectEvent(kind="a", payload={"n": 1}))
+    await broker.publish("proj-y", ProjectEvent(kind="b", payload={"n": 2}))
+
+    q1 = await broker.subscribe("proj-y")
+    await asyncio.wait_for(q1.get(), timeout=0.5)
+    await asyncio.wait_for(q1.get(), timeout=0.5)
+
+    await broker.unsubscribe("proj-y", q1)
+
+    q2 = await broker.subscribe("proj-y")
+    first = await asyncio.wait_for(q2.get(), timeout=0.5)
+    second = await asyncio.wait_for(q2.get(), timeout=0.5)
+    assert first.kind == "a"
+    assert second.kind == "b"

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -1074,6 +1074,24 @@ async def test_ready_limit_clamp_500_enforced_with_501_tasks(client):
 
 
 @pytest.mark.asyncio
+async def test_update_project_returns_200(client):
+    resp = await client.post("/api/projects", json={"name": "Updater", "slug": "updater"})
+    pid = resp.json()["id"]
+    resp = await client.patch(f"/api/projects/{pid}", json={"name": "Updater-v2", "description": "renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Updater-v2"
+
+
+@pytest.mark.asyncio
+async def test_archive_project_returns_200(client):
+    resp = await client.post("/api/projects", json={"name": "ArchiveMe", "slug": "archiveme"})
+    pid = resp.json()["id"]
+    resp = await client.post(f"/api/projects/{pid}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "archived"
+
+
+@pytest.mark.asyncio
 async def test_ready_blocked_on_label_does_not_match_across_projects(client):
     """tsk-cifqsh finding 2: a blocked-on:<id> label must only match same-project tasks.
 

--- a/tinyagentos/projects/events.py
+++ b/tinyagentos/projects/events.py
@@ -17,7 +17,7 @@ class ProjectEventBroker:
     """In-memory pub/sub. One channel per project_id.
 
     Single-worker assumption: all subscribers and publishers share one process.
-    See spec §4 — multi-worker is out of scope.
+    See spec s4 -- multi-worker is out of scope.
     """
 
     def __init__(self, replay_size: int = 32) -> None:
@@ -31,7 +31,10 @@ class ProjectEventBroker:
         async with self._lock:
             self._queues.setdefault(project_id, []).append(queue)
             for ev in self._replay.get(project_id, ()):
-                await queue.put(ev)
+                try:
+                    queue.put_nowait(ev)
+                except asyncio.QueueFull:
+                    break
         return queue
 
     async def unsubscribe(self, project_id: str, queue: asyncio.Queue[ProjectEvent]) -> None:
@@ -41,12 +44,28 @@ class ProjectEventBroker:
                 qs.remove(queue)
             if not qs:
                 self._queues.pop(project_id, None)
-                self._replay.pop(project_id, None)
+                # Keep _replay so a reconnecting subscriber (e.g. a reopened
+                # SSE connection) can catch up on events it missed. The deque
+                # has a fixed maxlen so memory stays bounded.
 
     async def publish(self, project_id: str, event: ProjectEvent) -> None:
         async with self._lock:
             buf = self._replay.setdefault(project_id, deque(maxlen=self._replay_size))
             buf.append(event)
-            # Only iterate over a copy in case unsubscribe is called during iteration
-            for q in list(self._queues.get(project_id, [])):
-                await q.put(event)
+            queues = list(self._queues.get(project_id, []))
+        # Backpressure policy: do not block the broker (and every other
+        # subscriber) on a slow consumer. If a subscriber's bounded queue is
+        # full, evict its oldest item and retry so the consumer stays on the
+        # live stream rather than stalling indefinitely.
+        for q in queues:
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    q.put_nowait(event)
+                except asyncio.QueueFull:
+                    pass

--- a/tinyagentos/projects/events.py
+++ b/tinyagentos/projects/events.py
@@ -27,11 +27,11 @@ class ProjectEventBroker:
         self._lock = asyncio.Lock()
 
     async def subscribe(self, project_id: str) -> asyncio.Queue[ProjectEvent]:
-        queue: asyncio.Queue[ProjectEvent] = asyncio.Queue()
+        queue: asyncio.Queue[ProjectEvent] = asyncio.Queue(maxsize=self._replay_size)
         async with self._lock:
             self._queues.setdefault(project_id, []).append(queue)
             for ev in self._replay.get(project_id, ()):
-                queue.put_nowait(ev)
+                await queue.put(ev)
         return queue
 
     async def unsubscribe(self, project_id: str, queue: asyncio.Queue[ProjectEvent]) -> None:
@@ -39,10 +39,14 @@ class ProjectEventBroker:
             qs = self._queues.get(project_id, [])
             if queue in qs:
                 qs.remove(queue)
+            if not qs:
+                self._queues.pop(project_id, None)
+                self._replay.pop(project_id, None)
 
     async def publish(self, project_id: str, event: ProjectEvent) -> None:
         async with self._lock:
             buf = self._replay.setdefault(project_id, deque(maxlen=self._replay_size))
             buf.append(event)
+            # Only iterate over a copy in case unsubscribe is called during iteration
             for q in list(self._queues.get(project_id, [])):
-                q.put_nowait(event)
+                await q.put(event)

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import time as _time
 import uuid
 
@@ -11,13 +10,15 @@ import json as _json
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing import Literal
 
 from tinyagentos.agent_token_auth import (
     PROJECT_SCOPE_MISMATCH_DETAIL,
     check_agent_project_grants,
     check_agent_scope_for_project,
 )
-from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.projects.element_store import _SLUG_RE
 from tinyagentos.projects.folders import (
     ensure_element_folder,
     ensure_project_layout,
@@ -27,8 +28,6 @@ from tinyagentos.projects.project_store import ProjectConflict
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
-
-_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
 
 # The documented task status enum surfaced by the kanban read endpoints.  The
 # store itself is more permissive internally (it also tracks ``cancelled`` and
@@ -206,11 +205,11 @@ async def update_project(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    store = request.app.state.project_store
-    p = await store.get_project(project_id)
-    if p is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    require_owner_or_admin(user, p["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    p = project_or_err
     try:
         await store.update_project(
             project_id,
@@ -243,11 +242,11 @@ async def archive_project(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    store = request.app.state.project_store
-    p = await store.get_project(project_id)
-    if p is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    require_owner_or_admin(user, p["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    p = project_or_err
     await store.set_status(project_id, "archived")
     p = await store.get_project(project_id)
     await store.log_activity(project_id, user.user_id, "project.archived", {})
@@ -260,11 +259,11 @@ async def delete_project(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    store = request.app.state.project_store
-    project = await store.get_project(project_id)
-    if project is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    require_owner_or_admin(user, project["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    project = project_or_err
 
     await store.set_status(project_id, "deleted")
     await store.log_activity(project_id, user.user_id, "project.deleted", {})
@@ -307,11 +306,11 @@ async def add_member(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    store = request.app.state.project_store
-    project = await store.get_project(project_id)
-    if project is None:
-        return JSONResponse({"error": "project not found"}, status_code=404)
-    require_owner_or_admin(user, project["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    project = project_or_err
 
     if payload.mode == "native":
         if not payload.agent_id:
@@ -397,11 +396,11 @@ async def set_project_lead(
     Session-only (owner or admin, same gate as the members routes). A member id
     not in the project returns 404.
     """
-    store = request.app.state.project_store
-    p = await store.get_project(project_id)
-    if p is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    require_owner_or_admin(user, p["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    p = project_or_err
     try:
         await store.set_lead(project_id, body.member_id)
     except KeyError as e:
@@ -431,11 +430,11 @@ async def remove_member(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    store = request.app.state.project_store
-    project = await store.get_project(project_id)
-    if project is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    require_owner_or_admin(user, project["user_id"])
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    project = project_or_err
     await store.remove_member(project_id, member_id)
     await store.log_activity(project_id, user.user_id, "member.removed", {"member_id": member_id})
     members = await store.list_members(project_id)
@@ -1436,7 +1435,7 @@ class AddCommentIn(_TaskRequestModelMixin, BaseModel):
     replies_to_comment_id: str | None = None
 
 
-class CreateChecklistItemIn(BaseModel):
+class CreateChecklistItemIn(_TaskRequestModelMixin, BaseModel):
     text: str
 
 
@@ -1850,7 +1849,7 @@ async def delete_element(
     project_id: str,
     element_id: str,
     request: Request,
-    mode: str = "strict",
+    mode: Literal["strict", "untag"] = "strict",
     user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -211,16 +211,14 @@ async def update_project(
         return project_or_err
     p = project_or_err
     try:
-        await store.update_project(
+        await pstore.update_project(
             project_id,
             name=payload.name,
             description=payload.description,
             settings=payload.settings,
         )
     except ProjectConflict as e:
-        # Same conflict, same answer as the create path: a rename onto a name
-        # another project already holds is a 409, not a silent duplicate.
-        suggestions = await _free_suggestions(store, e.field, e.taken)
+        suggestions = await _free_suggestions(pstore, e.field, e.taken)
         return JSONResponse(
             {
                 "error": str(e),
@@ -230,8 +228,8 @@ async def update_project(
             },
             status_code=409,
         )
-    p = await store.get_project(project_id)
-    await store.log_activity(project_id, user.user_id, "project.updated", payload.model_dump(exclude_none=True))
+    p = await pstore.get_project(project_id)
+    await pstore.log_activity(project_id, user.user_id, "project.updated", payload.model_dump(exclude_none=True))
     _mirror(request, p)
     return p
 
@@ -247,9 +245,9 @@ async def archive_project(
     if isinstance(project_or_err, JSONResponse):
         return project_or_err
     p = project_or_err
-    await store.set_status(project_id, "archived")
-    p = await store.get_project(project_id)
-    await store.log_activity(project_id, user.user_id, "project.archived", {})
+    await pstore.set_status(project_id, "archived")
+    p = await pstore.get_project(project_id)
+    await pstore.log_activity(project_id, user.user_id, "project.archived", {})
     return p
 
 
@@ -265,8 +263,8 @@ async def delete_project(
         return project_or_err
     project = project_or_err
 
-    await store.set_status(project_id, "deleted")
-    await store.log_activity(project_id, user.user_id, "project.deleted", {})
+    await pstore.set_status(project_id, "deleted")
+    await pstore.log_activity(project_id, user.user_id, "project.deleted", {})
 
     # Archive scoped chat channels
     channels = request.app.state.chat_channels
@@ -287,7 +285,7 @@ async def delete_project(
             "project folder tombstone failed for slug=%s: %s", project.get("slug"), exc
         )
 
-    return await store.get_project(project_id)
+    return await pstore.get_project(project_id)
 
 
 class AddMemberIn(BaseModel):
@@ -336,7 +334,7 @@ async def add_member(
     else:
         return JSONResponse({"error": "mode must be native|clone|human"}, status_code=400)
 
-    await store.add_member(
+    await pstore.add_member(
         project_id=project_id,
         member_id=member_id,
         member_kind=member_kind,
@@ -344,11 +342,11 @@ async def add_member(
         source_agent_id=source_agent_id,
         memory_seed=memory_seed,
     )
-    await store.log_activity(
+    await pstore.log_activity(
         project_id, user.user_id, "member.added",
         {"member_id": member_id, "kind": member_kind, "memory_seed": memory_seed},
     )
-    members = await store.list_members(project_id)
+    members = await pstore.list_members(project_id)
     _mirror(request, {**project, "members": members})
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
@@ -402,19 +400,19 @@ async def set_project_lead(
         return project_or_err
     p = project_or_err
     try:
-        await store.set_lead(project_id, body.member_id)
+        await pstore.set_lead(project_id, body.member_id)
     except KeyError as e:
         return JSONResponse({"error": str(e)}, status_code=404)
-    await store.log_activity(
+    await pstore.log_activity(
         project_id, user.user_id, "project.lead_changed", {"member_id": body.member_id}
     )
-    members = await store.list_members(project_id)
+    members = await pstore.list_members(project_id)
     _mirror(request, {**p, "members": members})
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
         await ensure_a2a_channel(
             request.app.state.chat_channels,
-            store,
+            pstore,
             project_id,
             config=getattr(request.app.state, "config", None),
         )
@@ -435,9 +433,9 @@ async def remove_member(
     if isinstance(project_or_err, JSONResponse):
         return project_or_err
     project = project_or_err
-    await store.remove_member(project_id, member_id)
-    await store.log_activity(project_id, user.user_id, "member.removed", {"member_id": member_id})
-    members = await store.list_members(project_id)
+    await pstore.remove_member(project_id, member_id)
+    await pstore.log_activity(project_id, user.user_id, "member.removed", {"member_id": member_id})
+    members = await pstore.list_members(project_id)
     _mirror(request, {**project, "members": members})
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2964 (tsk-t5bup2): half-finished store->pstore rename NameErrors six projects write endpoints, and the unbounded->bounded queue change deadlocks the whole project event broker

Autonomous build of board card tsk-ob2mpd.

REVISION: built on `exec/tsk-t5bup2` (cut at `168aa90413cecd2446ee0240611a609d080ae8f5`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.


RED:
```
FAILED tests/test_routes_projects.py::test_update_project_returns_200 - NameError: name 'store' is not defined
FAILED tests/test_routes_projects.py::test_archive_project_returns_200 - NameError: name 'store' is not defined
FAILED tests/test_project_events.py::test_publish_does_not_deadlock_when_a_subscriber_queue_is_full
FAILED tests/test_project_events.py::test_unsubscribe_preserves_replay_history
============================== 4 failed in 7.60s ==============================
```

GREEN:
```
4 passed in 5.92s
```

Also verified: 86 passed across tests/projects/test_routes_a2a.py, tests/test_project_events.py, tests/test_routes_projects.py.

Defect 1 - six project write handlers (update_project, archive_project, delete_project, add_member, set_project_lead, remove_member) had pstore = request.app.state.project_store but the rest of each body still referenced bare store, raising NameError at request time. Fixed every reference to pstore.

Defect 2 - ProjectEventBroker.publish() held self._lock while doing await q.put(event) on a bounded queue. A stalled consumer whose queue filled would block publish forever holding the lock, making subscribe/unsubscribe impossible and stalling every project. Fixed by releasing the lock before putting, with a backpressure policy that evicts the oldest item from a full subscriber queue and retries.

Defect 3 - unsubscribe() popped self._replay when the last subscriber left, destroying the replay buffer exactly when a reconnecting client needed it. Kept _replay; the bounded deque holds memory fixed.

Docs-Reviewed: bug fix to existing routes and event broker, no route surface change.

Files:
 changelog.d/tsk-whwh5n-sparkle-release-tests.md    |   6 ++
 commit_msg.txt                                     |  25 +++++
 tests/sparkle_tests.bats                           |  43 ++++++++
 tests/test_project_events.py                       |  46 ++++++++-
 tests/test_routes_projects.py                      |  18 ++++
 tinyagentos/projects/events.py                     |  31 +++++-
 tinyagentos/routes/projects.py                     | 113 ++++++++++-----------
 9 files changed, 235 insertions(+), 63 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed project updates, archiving, deletion, and membership changes that could fail unexpectedly.
  - Standardized project access responses for non-owners to return 404.
  - Improved project event delivery to prevent stalls when subscribers are slow or disconnected.
  - Preserved event history so reconnecting clients can catch up on missed updates.
  - Added event identifiers to project event streams.
  - Added validation for supported element-deletion modes.

- **Tests**
  - Added coverage for project routes, event replay, queue handling, and macOS release packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->