### PR TITLE
feat(a2a): present the caller's registry credential on bus send

### DIFF
--- a/changelog.d/a2a-bus-send-credential.md
+++ b/changelog.d/a2a-bus-send-credential.md
@@ -1,0 +1,11 @@
+### Changed
+
+- The authenticated A2A bus send proxy (`POST /api/a2a/bus/send`) now presents
+  the caller's registry JWT to the bus and attributes an agent's message to its
+  registry canonical_id (the token's `sub`) instead of its display handle.
+  Both halves are required for bus-side verification: the bus authorises a
+  sender by verifying the token signature against the registry public key and
+  then requiring `token sub == from`, so a handle-spelled `from` could never be
+  verified and a credential the bus never received was indistinguishable from
+  none. Admin and human-assertion sends are unchanged (no credential is
+  forwarded for either).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -298,7 +298,8 @@ POST <bus>/a2a/send
 The raw bus above is unauthenticated on the LAN and trusts the `from` field, so
 reaching it means either the owner's account or an SSH hop. A registered agent
 should instead post through the controller's authenticated proxy, which forces
-`from` to the agent's own registry handle (no spoofing), so it posts as itself,
+`from` to the agent's own **verifiable** registry identity and presents that
+agent's registry JWT to the bus so the bus can check it, so it posts as itself,
 not the owner. A human user can post through the same proxy with a
 controller-issued signed assertion, which forces `from` to `@<username>` (also
 no spoofing):
@@ -308,10 +309,25 @@ POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope
 {"thread": "build", "body": "...", "reply_to": <id>?}
 ```
 
+Two details of the agent path are load-bearing, so do not "tidy" either one:
+
+- The message is attributed to the agent's registry **canonical id** (the
+  `sub` of its token), not to the readable handle. The bus authorises a sender
+  by verifying the token against the registry public key and then requiring
+  `token sub == from`; a handle-spelled `from` can never satisfy that, so the
+  post would land as unverifiable. The readable handle is resolved from the same
+  identity for display (taOS #2156 aliases the two spellings).
+- The proxy forwards the caller's registry JWT to the bus as
+  `Authorization: Bearer ...`. The bus only ever sees the credential the proxy
+  gives it, and a credential that never arrives is indistinguishable from none.
+
 Humans obtain an assertion via `POST /api/a2a/bus/human-assertion` (requires a
 valid session). The assertion is a compact EdDSA JWT verified through the same
 chain as agent tokens; the bus derives `from` from the credential, so a human
-cannot post as anyone else.
+cannot post as anyone else. The assertion is verified by the CONTROLLER and is
+not forwarded to the bus today: a human assertion's `sub` is the user_id while
+its bus `from` is `@<username>`, and how the bus resolves a human principal's
+spelling is still open (taosmd `a2a-bus-auth-transition`, open question 1).
 
 ## Reading the bus
 Read through the controller with your own registry token, not the raw bus port:
@@ -512,7 +528,9 @@ The registry-JWT surface, by scope:
 - **a2a_receive**: the bus READ routes only -- `GET /api/a2a/bus/channels`,
   `GET /api/a2a/bus/messages`, `GET /api/a2a/bus/stream`.
   **a2a_send**: `POST /api/a2a/bus/send` only, which forces `from` to the
-  agent's own handle. These are two separate allowlists in
+  agent's own registry canonical_id and presents that agent's registry JWT to
+  the bus (the bus verifies the signature against the registry public key and
+  requires `token sub == from`). These are two separate allowlists in
   `tinyagentos/auth_middleware.py`: an `a2a_receive` token cannot post, and an
   `a2a_send` token is not thereby a reader. Do not describe them as one scope
   covering four routes.

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -301,10 +301,21 @@ def _mock_bus_post(json_payload: dict, *, raise_on_status: bool = False):
 class TestBusAgentSend:
     """Authenticated write path: agents post as themselves, never spoofing."""
 
-    async def test_agent_send_derives_from_from_registry_handle(self, bus_client):
-        # _make_agent_token registers handle "@bus-reader".
-        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
-        ctx, client = _mock_bus_post({"id": 1, "from": "@bus-reader", "thread": "build"})
+    async def test_agent_send_is_verifiable_identity_plus_credential(self, bus_client):
+        """An agent's post carries BOTH the identity its token proves and the
+        token itself.
+
+        The bus authorises a sender by verifying the signature and then
+        requiring ``token sub == from``, where ``sub`` is the registry
+        ``canonical_id``. So the two halves are one unit: a message attributed
+        to a display handle cannot be verified, and a credential the bus never
+        receives is indistinguishable from no credential at all.
+        """
+        # _make_agent_token registers handle "@bus-reader" and returns the
+        # canonical_id the token's `sub` carries.
+        cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        assert cid != "@bus-reader"
+        ctx, client = _mock_bus_post({"id": 1, "from": cid, "thread": "build"})
         with patch(_BUS_PATCH, return_value=ctx):
             async with _bare(bus_client._app) as bare:
                 resp = await bare.post(
@@ -313,12 +324,16 @@ class TestBusAgentSend:
                     headers={"Authorization": f"Bearer {token}"},
                 )
         assert resp.status_code == 200
-        assert resp.json()["from"] == "@bus-reader"
+        assert resp.json()["from"] == cid
         # Anti-spoof: the body's "from" is ignored; the bus is called with the
-        # agent's own registry handle.
+        # agent's own registry identity.
         sent = client.post.call_args.kwargs["json"]
-        assert sent["from"] == "@bus-reader"
+        assert sent["from"] == cid
         assert sent["thread"] == "build" and sent["body"] == "hi"
+        # ...and the credential that makes that identity checkable travels with
+        # it, byte-for-byte (the bus verifies the signature over these bytes).
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers == {"Authorization": f"Bearer {token}"}
 
     async def test_agent_without_send_scope_forbidden(self, bus_client):
         # Only a2a_receive -> cannot send.
@@ -352,6 +367,10 @@ class TestBusAgentSend:
         assert resp.status_code == 200
         # Admin's explicit from is honored.
         assert client.post.call_args.kwargs["json"]["from"] == "@release-bot"
+        # No credential is forwarded: an admin's credential is a session cookie
+        # or the host local token. The local token is admin-equivalent on this
+        # controller, so it must never be handed to another service.
+        assert client.post.call_args.kwargs["headers"] is None
 
     async def test_missing_thread_or_body_400(self, bus_client):
         _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
@@ -408,6 +427,119 @@ class TestBusAgentSend:
                     headers={"Authorization": f"Bearer {token}"},
                 )
         assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+class TestBusSendAuthGate:
+    """The write path is a GATE, not just a re-attribution.
+
+    Every caller whose registry identity cannot be verified is refused at the
+    proxy, and the refusal happens BEFORE any bus call: a caller that is
+    unregistered, suspended, revoked, or holding no ``a2a_send`` grant must not
+    be able to place an unverified message on the bus either. Asserting only the
+    status code would pass on an implementation that refuses the AUTHOR while
+    still forwarding the POST, so each case also asserts the bus was never
+    called.
+    """
+
+    async def _post(self, app, *, headers, body=None):
+        ctx, client = _mock_bus_post({"id": 1, "from": "unused", "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json=body or {"thread": "build", "body": "hi"},
+                    headers=headers,
+                )
+        return resp, client
+
+    async def test_unregistered_agent_token_is_refused_and_bus_never_called(
+        self, bus_client
+    ):
+        """A token correctly signed by the registry key whose ``sub`` has no
+        registry row proves nothing: the identity is unregistered."""
+        priv, _pub = bus_client._app.state.agent_registry_keypair
+        token = mint_registry_token(
+            "ghost-20260101-000000", priv, user_id="u", framework="taosmd"
+        )
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403
+        assert not client.post.called
+
+    async def test_suspended_agent_is_refused_and_bus_never_called(self, bus_client):
+        cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        await bus_client._app.state.agent_registry.set_status(cid, "suspended")
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403
+        assert not client.post.called
+
+    async def test_revoked_agent_is_refused_and_bus_never_called(self, bus_client):
+        cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        await bus_client._app.state.agent_registry.revoke(cid)
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403
+        assert not client.post.called
+
+    async def test_agent_without_send_scope_is_refused_and_bus_never_called(
+        self, bus_client
+    ):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_receive",))
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403
+        assert not client.post.called
+
+    async def test_foreign_key_signed_token_is_refused_and_bus_never_called(
+        self, bus_client
+    ):
+        """A registered ``sub`` with a signature from another key is a forgery."""
+        registry = bus_client._app.state.agent_registry
+        grants = bus_client._app.state.agent_grants
+        rec = await registry.register(
+            framework="taosmd", display_name="Foreign", handle="@foreign"
+        )
+        cid = rec["canonical_id"]
+        await grants.add_grant(cid, "a2a_send")
+        with tempfile.TemporaryDirectory() as d:
+            foreign_priv, _foreign_pub = load_or_create_signing_keypair(Path(d))
+        token = mint_registry_token(cid, foreign_priv, user_id="u", framework="taosmd")
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 401
+        assert not client.post.called
+
+    async def test_no_credential_is_refused_and_bus_never_called(self, bus_client):
+        """No registry credential at all: the bare API request is refused."""
+        resp, client = await self._post(bus_client._app, headers={})
+        assert resp.status_code == 401
+        assert not client.post.called
+
+    async def test_agent_without_bus_handle_is_refused_and_bus_never_called(
+        self, bus_client
+    ):
+        """A registry record with no handle is not a complete bus identity."""
+        registry = bus_client._app.state.agent_registry
+        grants = bus_client._app.state.agent_grants
+        priv, _pub = bus_client._app.state.agent_registry_keypair
+        rec = await registry.register(
+            framework="taosmd", display_name="No Handle", handle=""
+        )
+        cid = rec["canonical_id"]
+        await grants.add_grant(cid, "a2a_send")
+        token = mint_registry_token(cid, priv, user_id="u", framework="taosmd")
+        resp, client = await self._post(
+            bus_client._app, headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 403
+        assert not client.post.called
 
 
 @pytest.mark.asyncio
@@ -475,6 +607,12 @@ class TestBusHumanAuth:
         assert resp.json()["from"] == "@admin"
         sent = client.post.call_args.kwargs["json"]
         assert sent["from"] == "@admin"
+        # The human assertion is NOT forwarded: its `sub` is the user_id while
+        # its bus `from` is `@<username>`, and the bus's principal-spelling
+        # policy for humans is not settled (taosmd a2a-bus-auth-transition).
+        # Forwarding it would present a credential that cannot match its own
+        # accompanying `from`.
+        assert client.post.call_args.kwargs["headers"] is None
 
     async def test_human_send_rejects_malformed_token(self, bus_client):
         """A malformed Bearer token on /send returns 401."""

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -41,7 +41,8 @@ _A2A_BUS_READ_PATHS = frozenset({
 })
 # Authenticated A2A bus WRITE path: an agent may POST here with its own registry
 # JWT (scope a2a_send, verified by the route, which forces the bus `from` to the
-# agent's own handle so it posts as itself instead of the owner's account).
+# agent's own registry canonical_id -- the identity its token proves -- and
+# forwards that token to the bus so the bus can verify the sender).
 _A2A_BUS_WRITE_PATHS = frozenset({
     "/api/a2a/bus/send",
 })

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -10,9 +10,18 @@ These endpoints proxy the bus: the Messages app can list bus channels and read
 messages (read paths), and a registry-authenticated agent (or an admin) can post
 a message (POST /api/a2a/bus/send). The raw bus is unauthenticated on the LAN and
 trusts its ``from`` field, so the send proxy is the authenticated write path --
-an agent posts as its OWN registry handle (scope ``a2a_send``), never able to
+an agent posts as its OWN registry identity (scope ``a2a_send``), never able to
 spoof another identity or borrow the owner's account. The URL is resolved from
 ``TAOS_A2A_BUS_URL``.
+
+An authenticated agent's post is attributed to its registry ``canonical_id`` and
+carries its registry JWT, forwarded to the bus as ``Authorization: Bearer ...``.
+Both halves are required: the bus authorises a sender by verifying the token
+signature against the registry and then requiring ``token sub == from``, so a
+message attributed to a display handle cannot be verified at all, and a
+credential the bus never receives is indistinguishable from no credential.
+Attribution is therefore the identity the bus can actually check, and the
+readable handle stays a display/alias concern (taOS #2156).
 
 Bus API (verified live):
   GET  {bus}/a2a/channels
@@ -27,6 +36,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from dataclasses import dataclass
 
 import httpx
 import asyncio
@@ -384,8 +394,8 @@ class BusSendBody(BaseModel):
 
     ``from_`` (JSON key ``from``) is honored ONLY for admin callers, so an
     operator can post as any handle. For an agent-token caller it is ignored and
-    the ``from`` is derived from the agent's own registry handle -- one agent can
-    never post as another.
+    the ``from`` is derived from the agent's own registry identity -- one agent
+    can never post as another.
     """
 
     thread: str
@@ -396,11 +406,48 @@ class BusSendBody(BaseModel):
     model_config = {"populate_by_name": True}
 
 
-async def _resolve_send_identity(request: Request, body_from: str | None) -> str:
-    """Return the bus ``from`` handle authorized for this send, or raise.
+@dataclass(frozen=True)
+class _BusIdentity:
+    """Who a bus send is attributed to, and the credential that proves it.
+
+    ``from_handle`` is the value the bus records as the message author.
+    ``credential`` is the caller's OWN registry JWT, forwarded to the bus so the
+    bus can verify the author against the registry instead of trusting the
+    request body. ``None`` means this caller presents no bus-verifiable
+    credential (an admin session, or a human assertion whose spelling the bus
+    does not resolve yet) -- the proxy still authorizes the caller, but the bus
+    has nothing to check, which is the pre-existing state for those callers.
+    """
+
+    from_handle: str
+    credential: str | None = None
+
+
+def _bearer_token(request: Request) -> str | None:
+    """Return the caller's raw Bearer credential, or None when absent.
+
+    Returned VERBATIM: it is forwarded to the bus, which verifies the signature
+    over the exact bytes it was signed with. Normalising it here (trimming
+    interior characters, re-encoding) would invalidate the signature and turn a
+    verifiable send into a rejected one.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+    return auth_header[7:].strip() or None
+
+
+async def _resolve_send_identity(
+    request: Request, body_from: str | None
+) -> _BusIdentity:
+    """Return the identity (and credential) authorized for this send, or raise.
 
     - Admin (session cookie or local token): may set an explicit ``from``
       (operator posts as any handle); defaults to ``@operator`` when omitted.
+      No credential is forwarded: an admin credential is a session cookie or the
+      host local token, neither of which the bus can verify, and the local token
+      is admin-equivalent ON THIS CONTROLLER -- handing it to another service
+      would widen its blast radius for no authentication gain.
     - Otherwise the caller must present a registry JWT holding an active
       ``a2a_send`` grant (agent) or a valid human-principal token. The ``from``
       is DERIVED from the credential for both principal types; a client-supplied
@@ -412,7 +459,7 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
     if getattr(request.state, "is_admin", False):
         handle = (body_from or "").strip()
         handle = "".join(c for c in handle if c.isprintable())[:64].strip()
-        return handle or "@operator"
+        return _BusIdentity(handle or "@operator")
 
     caller = await check_agent_scope(request, "a2a_send")
     if caller is not None:
@@ -420,8 +467,19 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
         record = await registry.get(caller) if registry is not None else None
         handle = ((record or {}).get("handle") or "").strip()
         if not handle:
+            # Kept deliberately: a registry record with no handle is an
+            # incomplete bus identity (the handle is what every reader and the
+            # alias layer resolves, taOS #2156), and relaxing an access
+            # condition is not this change's business.
             raise HTTPException(status_code=403, detail="agent has no bus handle")
-        return handle
+        # Attribute the message to the registry ``canonical_id`` (the token's
+        # ``sub``), not to the display handle. The bus derives identity from the
+        # credential: it verifies the signature and then requires
+        # ``token sub == from``. A handle-spelled ``from`` can never satisfy
+        # that, so an authenticated agent's post would still be recorded as
+        # unverifiable -- the exact gap this closes. The readable handle is
+        # resolved from the same identity for display (taOS #2156).
+        return _BusIdentity(caller, _bearer_token(request))
 
     human_id = await check_human_identity(request)
     if human_id is not None:
@@ -430,7 +488,12 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
         username = ((user or {}).get("username") or "").strip()
         if not username:
             raise HTTPException(status_code=403, detail="human has no username")
-        return f"@{username}"
+        # The assertion is NOT forwarded: a human assertion's ``sub`` is the
+        # user_id while its bus ``from`` is ``@<username>``, and the bus's
+        # principal-spelling policy for humans is not settled yet (taosmd
+        # a2a-bus-auth-transition, open question 1). Forwarding it today would
+        # present a credential whose sub cannot match the from it accompanies.
+        return _BusIdentity(f"@{username}")
 
     raise HTTPException(status_code=403, detail="forbidden")
 
@@ -441,13 +504,21 @@ async def bus_send(request: Request, body: BusSendBody):
 
     Authorized senders: an admin session / host local token (may set ``from``),
     or an active agent registry JWT holding the ``a2a_send`` scope (``from`` is
-    forced to the agent's own handle). This is the authenticated write path so
-    agents post as themselves instead of sharing the owner's account.
+    forced to the agent's own registry identity). This is the authenticated
+    write path so agents post as themselves instead of sharing the owner's
+    account.
+
+    An agent caller's registry JWT is forwarded to the bus, and the ``from`` it
+    accompanies is the SAME identity the token proves (the registry
+    ``canonical_id``). Those two travel together or not at all: the bus checks
+    the signature and then requires ``token sub == from``, so forwarding the
+    credential under a different spelling would be presenting a proof that
+    cannot match its own claim.
 
     Unlike the read endpoints, a bus failure surfaces as 502: a caller must know
     when its message did not land.
     """
-    from_handle = await _resolve_send_identity(request, body.from_)
+    identity = await _resolve_send_identity(request, body.from_)
 
     thread = body.thread.strip()
     text = body.body.strip()
@@ -461,21 +532,34 @@ async def bus_send(request: Request, body: BusSendBody):
             {"error": "reply_to must be a positive message id"}, status_code=400
         )
 
-    payload: dict = {"from": from_handle, "thread": thread, "body": text}
+    payload: dict = {
+        "from": identity.from_handle,
+        "thread": thread,
+        "body": text,
+    }
     if body.reply_to is not None:
         payload["reply_to"] = body.reply_to
+
+    headers: dict[str, str] = {}
+    if identity.credential:
+        # Only ever sent to the OPERATOR-configured bus URL (`TAOS_A2A_BUS_URL`,
+        # default loopback): the credential is the caller's own, and the bus is
+        # the one service that must see it to verify the sender.
+        headers["Authorization"] = f"Bearer {identity.credential}"
 
     bus = _bus_url()
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.post(f"{bus}/a2a/send", json=payload)
+            resp = await client.post(
+                f"{bus}/a2a/send", json=payload, headers=headers or None
+            )
             resp.raise_for_status()
             data = resp.json()
     except Exception as exc:  # noqa: BLE001
         logger.warning("A2A bus send failed (%s): %s", bus, exc)
         raise HTTPException(status_code=502, detail="a2a bus unavailable")
 
-    return {"ok": True, "from": from_handle, "message": data}
+    return {"ok": True, "from": identity.from_handle, "message": data}
 
 
 @router.post("/api/a2a/bus/human-assertion")

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -559,7 +559,8 @@ def _build_guide_markdown(
         lines.append(
             "Reach other agents and the coordinator through the authenticated proxy "
             "`/api/a2a/bus/*` (never the raw :7900 bus). The proxy forces `from` to your "
-            "own handle, so you always post as yourself. Send with "
+            "own registry canonical identity and presents your registry token to the "
+            "bus, so you always post as yourself and the bus can verify it. Send with "
             "`POST /api/a2a/bus/send` using the body `{thread, body}` (and optional "
             "`reply_to`); `channel` is ignored, address threads by name. Read via "
             "`GET /api/a2a/bus/messages?channel={channel}&since={cursor}`."
@@ -626,7 +627,8 @@ def _build_os_guide_markdown(
         lines.append(
             "Reach other agents and the coordinator through the authenticated proxy "
             "`/api/a2a/bus/*` (never the raw :7900 bus). The proxy forces `from` to your "
-            "own handle, so you always post as yourself. Send with "
+            "own registry canonical identity and presents your registry token to the "
+            "bus, so you always post as yourself and the bus can verify it. Send with "
             "`POST /api/a2a/bus/send` using the body `{thread, body}` (and optional "
             "`reply_to`); `channel` is ignored, address threads by name. Read via "
             "`GET /api/a2a/bus/messages?channel={channel}&since={cursor}`."


### PR DESCRIPTION
Kanban task: t_d174ff4e — taOS #2112 (A2A bus auth). Refs #2112 (the issue's taosmd-side items — `registry_url` config on the Pi and the bus's own Stage 2/3 enforcement — are tracked in taosmd; see jaylfc/taosmd#209).

## What this changes

`POST /api/a2a/bus/send` now does two things it did not do before, and they are one unit:

1. The message is attributed to the agent's registry **canonical_id** (the `sub` of its token), not to the display handle.
2. The caller's registry JWT is forwarded to the bus as `Authorization: Bearer ...`.

## Why both, and why together

The bus authorises a sender by verifying the JWT against the registry's Ed25519 public key and then requiring `token sub == from` (`taosmd/registry_auth.py::authorize_sender`; target state item 2 of taosmd's `docs/specs/a2a-bus-auth-transition.md` is "`from` is derived from the token, never read from the body").

The proxy did neither half. The credential stopped at the controller proxy — `client.post(...)` carried no `Authorization` header at all — and the message was attributed to the agent's display handle (`@bus-reader`). Whichever way the bus is configured, that pair can never verify:

- no credential reaches the bus, so a fully migrated agent posting through the *recommended* path (`docs/agent-coordination.md` tells agents to post through this proxy) is indistinguishable from an unauthenticated sender;
- a credential forwarded under a handle-spelled `from` would be a proof that cannot match its own claim, and the bus rejects a mismatched sub/from pair **regardless of the warn/enforce flag** (`_handle_a2a_send`, class-2 failure) — so forwarding is only safe when the identity sent is the identity proven.

taOS's own agent client already works the way this PR makes the proxy work: `docs/agent-join-kit/taos_agent.py` posts `from = TAOS_CANONICAL` (the token `sub`) and sends the token to the bus. This makes the controller proxy consistent with it, and the verifiable identity is the same one the registry's revocation and grants feeds are keyed on (`/api/agents/registry/{revoked,grants}` return `canonical_id`), so the whole check chain lines up.

The readable handle is untouched as a concept — it is resolved from the same registry record for display, which is the alias work in #2156. Nothing here rewrites history or renames existing bus senders.

**Admin and human-assertion sends forward no credential.** An admin credential is a session cookie or the host local token, neither of which the bus can verify, and the local token is admin-equivalent on this controller, so handing it to another service widens its blast radius for no authentication gain. A human assertion's `sub` is the `user_id` while its `from` is `@<username>`, and how the bus resolves a human principal's spelling is still open (taosmd spec, open question 1) — forwarding it today would present a credential that cannot match its accompanying `from`. Both behaviours are pinned by tests rather than left implicit.

## Tests

`tests/test_a2a_bus_agent_auth.py`:

- the positive path asserts BOTH halves against the mocked bus: `from == canonical_id` and `headers == {"Authorization": "Bearer <the caller's own token>"}` (verbatim — the bus verifies the signature over exactly those bytes).
- a new `TestBusSendAuthGate` class asserts the gate is a gate: an **unregistered** (well-signed token, unknown `sub`), suspended, revoked, foreign-key-signed, scope-less, credential-less or handle-less caller is refused **and the bus is never called**. A refusal that still forwards the POST would pass a status-code-only assertion, so each case asserts the mock was never invoked.
- admin and human paths assert no `Authorization` header is forwarded.

RED first (source reverted to `origin/dev`, new tests present):

```
FAILED tests/test_a2a_bus_agent_auth.py::TestBusAgentSend::test_agent_send_is_verifiable_identity_plus_credential
FAILED tests/test_a2a_bus_agent_auth.py::TestBusAgentSend::test_admin_may_send_with_explicit_from
E       KeyError: 'headers'
2 failed, 14 passed, 24 deselected in 59.05s
```

GREEN (same command, change applied):

```
40 passed in 123.23s (0:02:03)
```

Targeted neighbours: `tests/test_a2a_bus_agent_auth.py tests/test_routes_a2a_bus.py tests/test_routes_a2a_bus_stream.py` → `61 passed in 398.25s`.

## Files

- `tinyagentos/routes/a2a_bus.py` — `_BusIdentity(from_handle, credential)`, `_bearer_token()`, `_resolve_send_identity` returns the pair, `bus_send` forwards the credential.
- `tests/test_a2a_bus_agent_auth.py` — assertions above.
- `tinyagentos/auth_middleware.py`, `tinyagentos/routes/project_invites.py`, `docs/agent-coordination.md` — the three places that described `from` as the agent's handle now describe the verifiable identity (project_invites is the text handed to invited agents).
- `changelog.d/a2a-bus-send-credential.md`.

Docs-Reviewed: `docs/agent-coordination.md` (bus posting contract + `a2a_send` scope) and the invited-agent bus instructions in `project_invites.py` updated in the same commit.

## Overlap

`tinyagentos/routes/a2a_bus.py::_resolve_send_identity` is also touched by open PR #2971 (handle sanitisation). The two changes are in different branches of the same function; whoever merges second has a small textual conflict, and the intent of both survives.

Out of scope here, deliberately: forwarding a credential on the bus **read** paths (the bus's read ACLs are taosmd #483/#478), and authenticating taOS's own unauthenticated raw-bus writers (`@taOS-decisions` in `routes/decisions.py`, `system` in `routes/settings.py`) — those need a service identity, not a caller's token.

## Deliberate symbol removal (one, and it is a rename)

`TestBusAgentSend.test_agent_send_derives_from_from_registry_handle` (added by f221bffb, #1768) is **renamed**, not deleted: the assertions live on as `test_agent_send_is_verifiable_identity_plus_credential`, which asserts the same derivation plus the credential. The old name encodes the behaviour this PR changes (attribution to the registry *handle*), so keeping it would leave a test whose name contradicts what it checks. Declared for the deleted-symbols gate rather than left as a silent signal:

Removes-Intentionally: tests/test_a2a_bus_agent_auth.py:TestBusAgentSend.test_agent_send_derives_from_from_registry_handle
