### PR TITLE
fix-forward #2938 (tsk-5ggef6): the models_skipped-clear block is dead code behind a return (re-indent regression), and the stall guard clears the dedup pointer while the real pull is still running

### DIFF
--- a/changelog.d/tsk-5ggef6-selfheal-wait.md
+++ b/changelog.d/tsk-5ggef6-selfheal-wait.md
@@ -1,0 +1,2 @@
+### Fixed
+- Deploy-time self-heal for deferred taOSmd models no longer times out after a fixed 300 s wall-clock cap; wait now polls until the pull task reaches a terminal state and only fails if progress/message stalls for 10 minutes. Concurrent deploys against the same deferred default attach to a single in-flight pull instead of starting duplicate downloads.

--- a/changelog.d/tsk-aikmem-fix-forward.md
+++ b/changelog.d/tsk-aikmem-fix-forward.md
@@ -1,0 +1,2 @@
+### Fixed
+- The deferred-model self-heal deploy path now correctly clears `models_skipped` on success and preserves `taosmd_selfheal_task_id` when a stall guard triggers, preventing both duplicate multi-GB pulls and lost in-flight task pointers.

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -2262,3 +2262,124 @@ class TestDeployDeferredModelsSelfHeal:
                 assert setup_task.get("progress_pct", 0) > 0
                 assert len(sleep_calls) > 300
                 assert len(sleep_calls) > 300
+
+    async def test_deploy_clears_models_skipped_on_success(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """When _run_setup marks the deferred task done, the deploy must clear
+        models_skipped in taosmd_default.json so future deploys don't start
+        another pull."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            tasks[task_id] = {
+                "state": "done",
+                "progress_pct": 100,
+                "message": "Memory layer ready.",
+                "error": None,
+            }
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            resp = await client.post("/api/agents/deploy", json={
+                "name": "models-skipped-cleared",
+                "framework": "none",
+                "model": "test-model",
+                "memory_plugin": "taosmd",
+                "memory_config": None,
+            })
+            assert resp.status_code == 200
+            await asyncio.sleep(0.2)
+
+        default_after = json.loads((tmp_data_dir / "taosmd_default.json").read_text())
+        assert default_after.get("models_skipped") is False
+
+    async def test_stall_guard_preserves_selfheal_task_id(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """When progress stalls for 600 simulated seconds and the deploy fails,
+        taosmd_selfheal_task_id must remain the original task id so a retry
+        re-attaches instead of starting a duplicate pull."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        captured_task_id = None
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            nonlocal captured_task_id
+            captured_task_id = task_id
+            tasks[task_id] = {
+                "state": "running",
+                "progress_pct": 0,
+                "message": "Starting…",
+                "error": None,
+            }
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        _original_sleep = asyncio.sleep
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            await _original_sleep(0)
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            with patch("asyncio.sleep", fake_sleep):
+                resp = await client.post("/api/agents/deploy", json={
+                    "name": "stall-guard",
+                    "framework": "none",
+                    "model": "test-model",
+                    "memory_plugin": "taosmd",
+                    "memory_config": None,
+                })
+                assert resp.status_code == 200
+                for _ in range(600):
+                    await asyncio.sleep(1.0)
+
+        assert captured_task_id is not None
+        assert app.state.taosmd_selfheal_task_id == captured_task_id

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -2102,3 +2102,163 @@ class TestDeployDeferredModelsSelfHeal:
         assert resp.status_code == 409
         data = resp.json()
         assert "deferred" in data["error"].lower() or "download" in data["error"].lower()
+
+    async def test_concurrent_deploys_share_single_run_setup(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """Two concurrent deploys against a deferred default must attach to
+        the same in-flight _run_setup task and never start a duplicate pull."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        setup_call_count = 0
+        setup_event = asyncio.Event()
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            nonlocal setup_call_count
+            setup_call_count += 1
+            tasks[task_id] = {
+                "state": "downloading",
+                "progress_pct": 0,
+                "message": "Downloading…",
+                "error": None,
+            }
+            await setup_event.wait()
+            tasks[task_id] = {
+                "state": "done",
+                "progress_pct": 100,
+                "message": "Memory layer ready.",
+                "error": None,
+            }
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            resp_a = await client.post("/api/agents/deploy", json={
+                "name": "concurrent-a",
+                "framework": "none",
+                "model": "test-model",
+                "memory_plugin": "taosmd",
+                "memory_config": None,
+            })
+            resp_b = await client.post("/api/agents/deploy", json={
+                "name": "concurrent-b",
+                "framework": "none",
+                "model": "test-model",
+                "memory_plugin": "taosmd",
+                "memory_config": None,
+            })
+            assert resp_a.status_code == 200
+            assert resp_b.status_code == 200
+            assert setup_call_count == 1
+
+            setup_event.set()
+            await asyncio.sleep(1.0)
+
+            for name in ("concurrent-a", "concurrent-b"):
+                detail = await client.get(f"/api/agents/{name}")
+                assert detail.status_code == 200
+                assert detail.json().get("status") == "running"
+
+    async def test_advancing_progress_avoids_timeout(
+        self, client, app, tmp_data_dir, monkeypatch
+    ):
+        """A pull that keeps advancing progress_pct past 300 simulated seconds
+        must not mark the deploy failed."""
+        import asyncio
+        import json
+        from unittest.mock import patch
+
+        default_data = {
+            "device_id": "local",
+            "tier_id": "standard",
+            "tier_name": "Standard",
+            "models_skipped": True,
+        }
+        (tmp_data_dir / "taosmd_default.json").write_text(json.dumps(default_data))
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        _original_sleep = asyncio.sleep
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            await _original_sleep(0)
+
+        async def fake_run_setup(tasks, task_id, *args, **kwargs):
+            for i in range(600):
+                if i % 50 == 0:
+                    tasks[task_id] = {
+                        "state": "downloading",
+                        "progress_pct": min(99, i // 6),
+                        "message": f"Downloading model {min(99, i // 6)}%",
+                        "error": None,
+                    }
+                await _original_sleep(0)
+            tasks[task_id] = {
+                "state": "done",
+                "progress_pct": 100,
+                "message": "Memory layer ready.",
+                "error": None,
+            }
+
+        with patch("tinyagentos.routes.taosmd._run_setup", fake_run_setup):
+            with patch("asyncio.sleep", fake_sleep):
+                resp = await client.post("/api/agents/deploy", json={
+                    "name": "advancing-progress",
+                    "framework": "none",
+                    "model": "test-model",
+                    "memory_plugin": "taosmd",
+                    "memory_config": None,
+                })
+                assert resp.status_code == 200
+
+                for _ in range(300):
+                    await asyncio.sleep(1.0)
+
+                detail = await client.get("/api/agents/advancing-progress")
+                assert detail.status_code == 200
+                assert detail.json().get("status") != "failed"
+                deploy_status = app.state.deploy_tasks.get("advancing-progress", {}).get("status")
+                assert deploy_status != "failed"
+                setup_task = app.state.taosmd_setup_tasks.get(
+                    next(iter(app.state.taosmd_setup_tasks))
+                )
+                assert setup_task is not None
+                assert setup_task.get("progress_pct", 0) > 0
+                assert len(sleep_calls) > 300
+                assert len(sleep_calls) > 300

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -6,6 +6,7 @@ import logging
 import math
 import secrets
 import time
+import uuid
 from collections import OrderedDict
 
 from fastapi import APIRouter, Request
@@ -691,29 +692,62 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     from tinyagentos.routes.taosmd import MEMORY_TIERS, _run_setup, _tasks
                     tier_cfg = MEMORY_TIERS.get(tier_id)
                     if tier_cfg is not None:
-                        task_id = str(uuid.uuid4())
                         tasks = _tasks(request)
-                        tasks[task_id] = {
-                            "state": "pending",
-                            "progress_pct": 0,
-                            "message": "Queued…",
-                            "error": None,
-                        }
-                        asyncio.create_task(
-                            _run_setup(
-                                tasks,
-                                task_id,
-                                default_data.get("device_id", "local"),
-                                tier_id,
-                                tier_cfg,
-                                registry=registry,
-                                hardware_profile=getattr(request.app.state, "hardware_profile", None),
-                                backends=list(getattr(config, "backends", []) or []) if config else [],
-                                skip_models=False,
-                                data_dir=data_dir,
+                        existing_task_id = getattr(request.app.state, "taosmd_selfheal_task_id", None)
+                        if existing_task_id is not None:
+                            existing_task = tasks.get(existing_task_id)
+                            if existing_task is not None and existing_task.get("state") not in {"done", "failed"}:
+                                task_id = existing_task_id
+                                self_heal_setup_task_id = task_id
+                            else:
+                                request.app.state.taosmd_selfheal_task_id = None
+                                task_id = str(uuid.uuid4())
+                                tasks[task_id] = {
+                                    "state": "pending",
+                                    "progress_pct": 0,
+                                    "message": "Queued…",
+                                    "error": None,
+                                }
+                                asyncio.create_task(
+                                    _run_setup(
+                                        tasks,
+                                        task_id,
+                                        default_data.get("device_id", "local"),
+                                        tier_id,
+                                        tier_cfg,
+                                        registry=registry,
+                                        hardware_profile=getattr(request.app.state, "hardware_profile", None),
+                                        backends=list(getattr(config, "backends", []) or []) if config else [],
+                                        skip_models=False,
+                                        data_dir=data_dir,
+                                    )
+                                )
+                                request.app.state.taosmd_selfheal_task_id = task_id
+                                self_heal_setup_task_id = task_id
+                        else:
+                            task_id = str(uuid.uuid4())
+                            tasks[task_id] = {
+                                "state": "pending",
+                                "progress_pct": 0,
+                                "message": "Queued…",
+                                "error": None,
+                            }
+                            asyncio.create_task(
+                                _run_setup(
+                                    tasks,
+                                    task_id,
+                                    default_data.get("device_id", "local"),
+                                    tier_id,
+                                    tier_cfg,
+                                    registry=registry,
+                                    hardware_profile=getattr(request.app.state, "hardware_profile", None),
+                                    backends=list(getattr(config, "backends", []) or []) if config else [],
+                                    skip_models=False,
+                                    data_dir=data_dir,
+                                )
                             )
-                        )
-                        self_heal_setup_task_id = task_id
+                            request.app.state.taosmd_selfheal_task_id = task_id
+                            self_heal_setup_task_id = task_id
 
         # Register the agent with taOSmd BEFORE mutating config so a failure
         # here aborts cleanly with no half-state. Skipped for memory_mode='framework'
@@ -823,37 +857,53 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     if setup_task is not None:
                         terminal = {"done", "failed"}
                         if setup_task.get("state") not in terminal:
-                            for _ in range(300):
+                            last_progress = setup_task.get("progress_pct")
+                            last_message = setup_task.get("message")
+                            stall_seconds = 0
+                            max_stall_seconds = 600
+                            while True:
                                 await asyncio.sleep(1)
                                 setup_task = setup_tasks.get(self_heal_setup_task_id)
                                 if setup_task is None or setup_task.get("state") in terminal:
                                     break
-                            else:
-                                setup_task = {
-                                    "state": "failed",
-                                    "message": "timed out waiting for model download",
-                                }
+                                pct = setup_task.get("progress_pct")
+                                msg = setup_task.get("message")
+                                if pct == last_progress and msg == last_message:
+                                    stall_seconds += 1
+                                    if stall_seconds >= max_stall_seconds:
+                                        setup_task = {
+                                            "state": "failed",
+                                            "message": "model download stalled — no progress for 10 minutes",
+                                        }
+                                        break
+                                else:
+                                    stall_seconds = 0
+                                    last_progress = pct
+                                    last_message = msg
 
-                        if not setup_task or setup_task.get("state") != "done":
-                            agent = find_agent(config, body.name)
-                            if agent is not None:
-                                agent["status"] = "failed"
-                            err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
-                            deploy_tasks[body.name] = {
-                                "status": "failed",
-                                "name": body.name,
-                                "error": err_msg,
-                            }
-                            notif = getattr(request.app.state, "notifications", None)
-                            if notif:
-                                await notif.add(
-                                    title=f"Deploy failed: {body.name}",
-                                    message=f"Deploy failed for {body.name}: {err_msg}",
-                                    level="error",
-                                    source="agents.deploy",
-                                )
-                            await save_config_locked(config, config.config_path)
-                            return
+                    if setup_task is not None and setup_task.get("state") in terminal:
+                        request.app.state.taosmd_selfheal_task_id = None
+
+                    if not setup_task or setup_task.get("state") != "done":
+                        agent = find_agent(config, body.name)
+                        if agent is not None:
+                            agent["status"] = "failed"
+                        err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
+                        deploy_tasks[body.name] = {
+                            "status": "failed",
+                            "name": body.name,
+                            "error": err_msg,
+                        }
+                        notif = getattr(request.app.state, "notifications", None)
+                        if notif:
+                            await notif.add(
+                                title=f"Deploy failed: {body.name}",
+                                message=f"Deploy failed for {body.name}: {err_msg}",
+                                level="error",
+                                source="agents.deploy",
+                            )
+                        await save_config_locked(config, config.config_path)
+                        return
 
                         # Setup succeeded: clear models_skipped so future deploys
                         # don't re-trigger the pull.

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -694,37 +694,16 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                     if tier_cfg is not None:
                         tasks = _tasks(request)
                         existing_task_id = getattr(request.app.state, "taosmd_selfheal_task_id", None)
+                        reuse = False
                         if existing_task_id is not None:
                             existing_task = tasks.get(existing_task_id)
                             if existing_task is not None and existing_task.get("state") not in {"done", "failed"}:
                                 task_id = existing_task_id
                                 self_heal_setup_task_id = task_id
-                            else:
-                                request.app.state.taosmd_selfheal_task_id = None
-                                task_id = str(uuid.uuid4())
-                                tasks[task_id] = {
-                                    "state": "pending",
-                                    "progress_pct": 0,
-                                    "message": "Queued…",
-                                    "error": None,
-                                }
-                                asyncio.create_task(
-                                    _run_setup(
-                                        tasks,
-                                        task_id,
-                                        default_data.get("device_id", "local"),
-                                        tier_id,
-                                        tier_cfg,
-                                        registry=registry,
-                                        hardware_profile=getattr(request.app.state, "hardware_profile", None),
-                                        backends=list(getattr(config, "backends", []) or []) if config else [],
-                                        skip_models=False,
-                                        data_dir=data_dir,
-                                    )
-                                )
-                                request.app.state.taosmd_selfheal_task_id = task_id
-                                self_heal_setup_task_id = task_id
-                        else:
+                                reuse = True
+
+                        if not reuse:
+                            request.app.state.taosmd_selfheal_task_id = None
                             task_id = str(uuid.uuid4())
                             tasks[task_id] = {
                                 "state": "pending",
@@ -881,29 +860,30 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                                     last_progress = pct
                                     last_message = msg
 
-                    if setup_task is not None and setup_task.get("state") in terminal:
-                        request.app.state.taosmd_selfheal_task_id = None
+                        real_entry = setup_tasks.get(self_heal_setup_task_id)
+                        if real_entry is not None and real_entry.get("state") in terminal:
+                            request.app.state.taosmd_selfheal_task_id = None
 
-                    if not setup_task or setup_task.get("state") != "done":
-                        agent = find_agent(config, body.name)
-                        if agent is not None:
-                            agent["status"] = "failed"
-                        err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
-                        deploy_tasks[body.name] = {
-                            "status": "failed",
-                            "name": body.name,
-                            "error": err_msg,
-                        }
-                        notif = getattr(request.app.state, "notifications", None)
-                        if notif:
-                            await notif.add(
-                                title=f"Deploy failed: {body.name}",
-                                message=f"Deploy failed for {body.name}: {err_msg}",
-                                level="error",
-                                source="agents.deploy",
-                            )
-                        await save_config_locked(config, config.config_path)
-                        return
+                        if setup_task.get("state") != "done":
+                            agent = find_agent(config, body.name)
+                            if agent is not None:
+                                agent["status"] = "failed"
+                            err_msg = (setup_task or {}).get("error") or (setup_task or {}).get("message") or "Setup failed"
+                            deploy_tasks[body.name] = {
+                                "status": "failed",
+                                "name": body.name,
+                                "error": err_msg,
+                            }
+                            notif = getattr(request.app.state, "notifications", None)
+                            if notif:
+                                await notif.add(
+                                    title=f"Deploy failed: {body.name}",
+                                    message=f"Deploy failed for {body.name}: {err_msg}",
+                                    level="error",
+                                    source="agents.deploy",
+                                )
+                            await save_config_locked(config, config.config_path)
+                            return
 
                         # Setup succeeded: clear models_skipped so future deploys
                         # don't re-trigger the pull.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): fix-forward #2938 (tsk-5ggef6): the models_skipped-clear block is dead code behind a return (re-indent regression), and the stall guard clears the dedup pointer while the real pull is still running

Autonomous build of board card tsk-aikmem.

REVISION: built on `exec/tsk-5ggef6` (cut at `97e4e76659f6e194c5a0809655b140c26b26285d`), not on `dev`. That branch's
commits are ancestors of this one. Verified by `git merge-base --is-ancestor`
before the PR was opened.

Defect 1: the failure block in _background_deploy was dedented one level,
putting the '# Setup succeeded: clear models_skipped' block inside the
failure path AFTER the return. It was dead code. Re-indent so the failure
block sits inside `if setup_task is not None:` and the success block is
reachable exactly when state == 'done'.

Defect 2: on a stall the loop replaces local setup_task with a synthetic
{"state": "failed", ...} dict and breaks. The next pointer-clear check
saw that synthetic dict and cleared taosmd_selfheal_task_id while the
real entry in taosmd_setup_tasks was still running. A retry deploy then
started a duplicate pull. Derive the pointer-clear from the real entry
(setup_tasks.get(self_heal_setup_task_id)) instead.

Refactor: collapse the two byte-identical _run_setup launch blocks in
deploy_agent_endpoint into a single create path keyed on `reuse`.

Tests added (red-first on BASE):

```
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_deploy_clears_models_skipped_on_success
FAILED tests/test_routes_agents.py::TestDeployDeferredModelsSelfHeal::test_stall_guard_preserves_selfheal_task_id
2 failed, 3 passed, 2 warnings in 10.99s
```

Green on head:

```
5 passed, 2 warnings in 10.79s
```

Docs-Reviewed: no doc change needed, the fix is in internal deploy retry logic

Files:
 changelog.d/tsk-5ggef6-selfheal-wait.md |   2 +
 changelog.d/tsk-aikmem-fix-forward.md   |   2 +
 tests/test_routes_agents.py             | 281 ++++++++++++++++++++++++++++++++
 tinyagentos/routes/agents.py            |  86 ++++++----
 4 files changed, 343 insertions(+), 28 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred model self-healing now continues while downloads make progress, avoiding premature timeouts.
  * Stalled downloads are detected after 10 minutes without progress, while preserving task information for retries.
  * Concurrent deployments now share one active model download instead of starting duplicates.
  * Successful self-healing clears the skipped-model status, allowing deployment to complete correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->