### PR TITLE
fix(a2a): keep the registry credential off cleartext transports (FF of #2981)

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -323,11 +323,12 @@ Two details of the agent path are load-bearing, so do not "tidy" either one:
 
 Humans obtain an assertion via `POST /api/a2a/bus/human-assertion` (requires a
 valid session). The assertion is a compact EdDSA JWT verified through the same
-chain as agent tokens; the bus derives `from` from the credential, so a human
-cannot post as anyone else. The assertion is verified by the CONTROLLER and is
-not forwarded to the bus today: a human assertion's `sub` is the user_id while
-its bus `from` is `@<username>`, and how the bus resolves a human principal's
-spelling is still open (taosmd `a2a-bus-auth-transition`, open question 1).
+chain as agent tokens; the CONTROLLER derives `from` from the credential
+(`@<username>`), so a human cannot post as anyone else. The assertion is
+verified by the controller and is not forwarded to the bus today: a human
+assertion's `sub` is the user_id while its bus `from` is `@<username>`, and how
+the bus resolves a human principal's spelling is still open (taosmd
+`a2a-bus-auth-transition`, open question 1).
 
 ## Reading the bus
 Read through the controller with your own registry token, not the raw bus port:

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -334,6 +334,7 @@ class TestBusAgentSend:
         # it, byte-for-byte (the bus verifies the signature over these bytes).
         headers = client.post.call_args.kwargs["headers"]
         assert headers == {"Authorization": f"Bearer {token}"}
+        assert resp.json()["credential_forwarded"] is True
 
     async def test_agent_without_send_scope_forbidden(self, bus_client):
         # Only a2a_receive -> cannot send.
@@ -540,6 +541,83 @@ class TestBusSendAuthGate:
         )
         assert resp.status_code == 403
         assert not client.post.called
+
+
+class TestCredentialTransportRule:
+    """A registry JWT is an unexpiring bearer credential: it is only ever sent
+    over a transport that keeps it off the wire in the clear."""
+
+    def test_loopback_http_is_allowed(self):
+        from tinyagentos.routes.a2a_bus import _credential_transport_is_private
+
+        assert _credential_transport_is_private("http://127.0.0.1:7900") is True
+        assert _credential_transport_is_private("http://localhost:7900") is True
+        assert _credential_transport_is_private("http://[::1]:7900") is True
+
+    def test_https_anywhere_is_allowed(self):
+        from tinyagentos.routes.a2a_bus import _credential_transport_is_private
+
+        assert _credential_transport_is_private("https://bus.example:7900") is True
+
+    def test_remote_cleartext_is_refused(self):
+        from tinyagentos.routes.a2a_bus import _credential_transport_is_private
+
+        # A LAN address is remote, however close it looks: only loopback is
+        # private, and "it is on my network" is not a transport guarantee.
+        assert _credential_transport_is_private("http://192.168.1.50:7900") is False
+        assert _credential_transport_is_private("http://bus.example:7900") is False
+        assert _credential_transport_is_private("http://localhost.evil:7900") is False
+
+    def test_unknown_scheme_is_refused(self):
+        from tinyagentos.routes.a2a_bus import _credential_transport_is_private
+
+        assert _credential_transport_is_private("ftp://bus.example") is False
+        assert _credential_transport_is_private("") is False
+
+
+@pytest.mark.asyncio
+class TestBusCredentialTransport:
+    """End-to-end: the message always goes, the credential only where it is safe."""
+
+    async def test_credential_withheld_from_a_remote_cleartext_bus(
+        self, bus_client, monkeypatch
+    ):
+        monkeypatch.setenv("TAOS_A2A_BUS_URL", "http://bus.example:7900")
+        cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 3, "from": cid, "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        # The message is not dropped -- a degraded attribution must not become a
+        # dead bus -- but the secret stays here...
+        assert resp.status_code == 200
+        assert client.post.call_args.kwargs["headers"] is None
+        assert client.post.call_args.kwargs["json"]["from"] == cid
+        # ...and the caller is told, because the 200 looks identical either way.
+        assert resp.json()["credential_forwarded"] is False
+
+    async def test_credential_forwarded_over_https_to_a_remote_bus(
+        self, bus_client, monkeypatch
+    ):
+        monkeypatch.setenv("TAOS_A2A_BUS_URL", "https://bus.example:7900")
+        cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 4, "from": cid, "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert client.post.call_args.kwargs["headers"] == {
+            "Authorization": f"Bearer {token}"
+        }
+        assert resp.json()["credential_forwarded"] is True
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -37,6 +37,7 @@ import logging
 import math
 import os
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import httpx
 import asyncio
@@ -437,6 +438,28 @@ def _bearer_token(request: Request) -> str | None:
     return auth_header[7:].strip() or None
 
 
+def _credential_transport_is_private(bus_url: str) -> bool:
+    """True when *bus_url* can carry a registry JWT without exposing it.
+
+    A registry JWT is a bearer credential with no expiry that authorises its
+    holder as the agent until it is revoked, so it is only ever sent over a
+    transport that keeps it off the wire in the clear: HTTPS, or plain HTTP to a
+    loopback address (a local co-located bus, which is the default deployment).
+    A remote ``http://`` bus is refused as a credential destination -- the
+    message still goes (unverified, as it does today), but the secret does not.
+
+    Note the asymmetry, and that it is deliberate: an unverifiable post is a
+    degraded state, a leaked registry JWT is a compromised identity.
+    """
+    parts = urlsplit(bus_url)
+    if parts.scheme == "https":
+        return True
+    if parts.scheme != "http":
+        return False
+    host = (parts.hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "::1"} or host.startswith("127.")
+
+
 async def _resolve_send_identity(
     request: Request, body_from: str | None
 ) -> _BusIdentity:
@@ -515,6 +538,12 @@ async def bus_send(request: Request, body: BusSendBody):
     credential under a different spelling would be presenting a proof that
     cannot match its own claim.
 
+    The credential is only forwarded over a transport that keeps it private --
+    HTTPS, or loopback HTTP (the default co-located bus). A remote cleartext
+    ``http://`` bus still receives the message, but without the credential; the
+    response reports that in ``credential_forwarded`` rather than letting a 200
+    read as "the bus could verify this".
+
     Unlike the read endpoints, a bus failure surfaces as 502: a caller must know
     when its message did not land.
     """
@@ -540,14 +569,28 @@ async def bus_send(request: Request, body: BusSendBody):
     if body.reply_to is not None:
         payload["reply_to"] = body.reply_to
 
-    headers: dict[str, str] = {}
-    if identity.credential:
-        # Only ever sent to the OPERATOR-configured bus URL (`TAOS_A2A_BUS_URL`,
-        # default loopback): the credential is the caller's own, and the bus is
-        # the one service that must see it to verify the sender.
-        headers["Authorization"] = f"Bearer {identity.credential}"
-
     bus = _bus_url()
+
+    headers: dict[str, str] = {}
+    credential_forwarded = False
+    if identity.credential:
+        # The credential is the caller's own, and the bus is the one service
+        # that must see it to verify the sender -- but only over a transport
+        # that keeps it private (HTTPS, or loopback HTTP). See
+        # _credential_transport_is_private: a leaked registry JWT is a
+        # compromised identity, while an unverifiable post is merely the state
+        # every proxy send is in today.
+        if _credential_transport_is_private(bus):
+            headers["Authorization"] = f"Bearer {identity.credential}"
+            credential_forwarded = True
+        else:
+            logger.warning(
+                "A2A bus send: NOT forwarding the registry credential to %s "
+                "(cleartext http to a non-loopback host would expose it in "
+                "transit); the message will reach the bus unverified",
+                bus,
+            )
+
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.post(
@@ -559,7 +602,15 @@ async def bus_send(request: Request, body: BusSendBody):
         logger.warning("A2A bus send failed (%s): %s", bus, exc)
         raise HTTPException(status_code=502, detail="a2a bus unavailable")
 
-    return {"ok": True, "from": identity.from_handle, "message": data}
+    # Report the attribution state rather than leaving the caller to assume it:
+    # a send whose credential was withheld lands exactly like an authenticated
+    # one, and "it returned 200" is not evidence that the bus could verify it.
+    return {
+        "ok": True,
+        "from": identity.from_handle,
+        "credential_forwarded": credential_forwarded,
+        "message": data,
+    }
 
 
 @router.post("/api/a2a/bus/human-assertion")


### PR DESCRIPTION
Kanban task: t_d174ff4e. Fix-forward of #2981 (merged as 1a2990a2). Part of #2112.

## Why a second PR

#2981 was merged at 19:27Z; the CodeRabbit round on it landed at 19:23Z and this fix was pushed at 19:42Z, so the merge took the pre-fix revision. This carries the fix onto dev. The reasoning is already written up on the merged PR: https://github.com/jaylfc/taOS/pull/2981#issuecomment-5639764644

## The finding

**`tinyagentos/routes/a2a_bus.py` — Sensitive Data Exposure, CWE-319 (🟠 Major).** `bus_send` forwarded the caller's registry JWT in the `Authorization` header to whatever `TAOS_A2A_BUS_URL` names, including a remote cleartext `http://` bus — putting an unexpiring bearer credential for the agent's scopes on the wire in the clear.

Fixed by `_credential_transport_is_private()`: the credential is forwarded only over HTTPS or loopback HTTP (the default co-located bus).

**Deliberate deviation from the suggested shape**, stated plainly because it is a judgement call: the credential is *withheld*, not the send rejected. The bus is explicitly allowed to be LAN-reachable, so hard-rejecting every remote `http://` URL would take the coordination bus down for those installs — a confidentiality control turned into an availability outage, and a bigger change than this fix. Withholding is the safe side of the asymmetry: an unverifiable post is the state every proxy send is in today, while a leaked registry JWT is a compromised agent identity (the tokens carry no `exp`, so revocation is the only control plane). The omission is logged, and the response now carries `credential_forwarded` so a 200 cannot be read as "the bus verified this". One line in the same helper flips it to a hard failure if that is preferred.

**`docs/agent-coordination.md` (🟡 Minor).** The human-assertion paragraph said "the bus derives `from`"; the CONTROLLER derives `@<username>` and the bus is never given that credential.

Not actioned: the CodeRabbit **Docstring Coverage** warning (60% < 80%). The functions without docstrings are test methods, including pre-existing ones this PR amends, and the repo does not gate on the threshold.

## Red / green

RED (source reverted to the pre-fix revision, new tests present):

```
FAILED tests/test_a2a_bus_agent_auth.py::TestBusCredentialTransport::test_credential_withheld_from_a_remote_cleartext_bus
FAILED tests/test_a2a_bus_agent_auth.py::TestBusCredentialTransport::test_credential_forwarded_over_https_to_a_remote_bus
E       KeyError: 'credential_forwarded'
2 failed, 44 deselected in 26.95s
```

GREEN: `tests/test_a2a_bus_agent_auth.py` → `46 passed in 348.29s`.

Neighbour modules, serial (project invites, doc gate, auth middleware, agent token auth): `271 passed in 1531.22s`.

The three files this PR touches are byte-identical to the revision that was already green across the full CI matrix (3.12 and 3.13 shards) on the merged PR, re-based onto dev's current head.

Docs-Reviewed: `docs/agent-coordination.md` corrected in the same commit (controller, not bus, derives the human `from`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Registry credentials are now forwarded only over HTTPS or loopback HTTP connections.
  - For remote unencrypted connections, messages continue to be sent without forwarding credentials, with a warning recorded.

- **New Features**
  - Bus send responses now indicate whether credentials were forwarded.

- **Documentation**
  - Clarified how sender identity is derived from human assertion credentials and how assertions are verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->