### PR TITLE
bus_send forwards a registry JWT to TAOS_A2A_BUS_URL with no transport condition: a non-loopback http:// bus puts a controller-accepted credential on the wire in cleartext

### DIFF
--- a/changelog.d/tsk-ivt562-a2a-bus-send-transport-guard.md
+++ b/changelog.d/tsk-ivt562-a2a-bus-send-transport-guard.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- The A2A bus send proxy now withholds the caller's registry JWT when the
+  operator-configured bus URL (`TAOS_A2A_BUS_URL`) is a non-loopback `http://`
+  destination. The credential is forwarded only over `https://` or loopback
+  `http://` (`127.0.0.1`, `::1`, `localhost`). Operators with a remote `http://`
+  bus can restore forwarding by setting
+  `TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL` to any truthy value.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -320,14 +320,20 @@ Two details of the agent path are load-bearing, so do not "tidy" either one:
 - The proxy forwards the caller's registry JWT to the bus as
   `Authorization: Bearer ...`. The bus only ever sees the credential the proxy
   gives it, and a credential that never arrives is indistinguishable from none.
+  The proxy only attaches the header when the bus URL is `https://` or a
+  loopback `http://` host (`127.0.0.1`, `::1`, `localhost`); a non-loopback
+  `http://` bus drops the credential to avoid sending it in cleartext across
+  the LAN. Operators with a remote `http://` bus can restore forwarding by
+  setting `TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL`.
 
 Humans obtain an assertion via `POST /api/a2a/bus/human-assertion` (requires a
-valid session). The assertion is a compact EdDSA JWT verified through the same
-chain as agent tokens; the bus derives `from` from the credential, so a human
-cannot post as anyone else. The assertion is verified by the CONTROLLER and is
-not forwarded to the bus today: a human assertion's `sub` is the user_id while
-its bus `from` is `@<username>`, and how the bus resolves a human principal's
-spelling is still open (taosmd `a2a-bus-auth-transition`, open question 1).
+valid session). For a human principal the controller derives the sender from the
+credential: `_resolve_send_identity` resolves the token's `user_id` to
+`@<username>`, and no credential is forwarded to the bus. The assertion is a
+compact EdDSA JWT verified through the same chain as agent tokens, but the bus's
+principal-spelling policy for humans is still open (taosmd
+`a2a-bus-auth-transition`, open question 1), so forwarding it would present a
+credential whose `sub` cannot match the `@<username>` `from` it accompanies.
 
 ## Reading the bus
 Read through the controller with your own registry token, not the raw bus port:

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -7,6 +7,7 @@ skeleton-key guard (the agent token must not authenticate any other route).
 """
 from __future__ import annotations
 
+import os
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -639,3 +640,98 @@ class TestBusHumanAuth:
         async with _bare(bus_client._app) as bare:
             resp = await bare.post("/api/a2a/bus/human-assertion")
         assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestBusSendCredentialTransport:
+    """The credential is only forwarded over secure transports or loopback.
+
+    A non-loopback ``http://`` bus URL drops the credential: forwarding a
+    long-lived registry JWT in cleartext across the LAN hands a replayable
+    credential to a passive observer. The operator may opt in for a specific
+    deployment via ``TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL``.
+    """
+
+    async def _post_with_bus_url(self, app, token, bus_url, *, allow_insecure=None):
+        old_bus_url = os.environ.get("TAOS_A2A_BUS_URL")
+        old_allow = os.environ.get("TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL")
+        os.environ["TAOS_A2A_BUS_URL"] = bus_url
+        if allow_insecure is not None:
+            os.environ["TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL"] = allow_insecure
+        elif "TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL" in os.environ:
+            del os.environ["TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL"]
+        try:
+            ctx, client = _mock_bus_post({"id": 1, "from": "x", "thread": "build"})
+            with patch(_BUS_PATCH, return_value=ctx):
+                async with _bare(app) as bare:
+                    resp = await bare.post(
+                        "/api/a2a/bus/send",
+                        json={"thread": "build", "body": "hi"},
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
+        finally:
+            if old_bus_url is None:
+                os.environ.pop("TAOS_A2A_BUS_URL", None)
+            else:
+                os.environ["TAOS_A2A_BUS_URL"] = old_bus_url
+            if old_allow is None:
+                os.environ.pop("TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL", None)
+            else:
+                os.environ["TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL"] = old_allow
+        return resp, client
+
+    async def test_remote_http_withholds_credential(self, bus_client):
+        """Non-loopback http:// bus URL: no Authorization header is forwarded."""
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        resp, client = await self._post_with_bus_url(
+            bus_client._app, token, "http://bus.example.test:7900"
+        )
+        assert resp.status_code == 200
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers is None
+
+    async def test_loopback_http_forwards_credential(self, bus_client):
+        """Loopback http:// (127.0.0.1) forwards the credential byte-identical."""
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        resp, client = await self._post_with_bus_url(
+            bus_client._app, token, "http://127.0.0.1:7900"
+        )
+        assert resp.status_code == 200
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers == {"Authorization": f"Bearer {token}"}
+
+    async def test_https_forwards_credential(self, bus_client):
+        """Any https:// destination forwards the credential."""
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        resp, client = await self._post_with_bus_url(
+            bus_client._app, token, "https://bus.example.test"
+        )
+        assert resp.status_code == 200
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers == {"Authorization": f"Bearer {token}"}
+
+    async def test_remote_http_with_opt_in_forwards_credential(self, bus_client):
+        """TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL restores forwarding over
+        non-loopback http://."""
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        resp, client = await self._post_with_bus_url(
+            bus_client._app,
+            token,
+            "http://bus.example.test:7900",
+            allow_insecure="1",
+        )
+        assert resp.status_code == 200
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers == {"Authorization": f"Bearer {token}"}
+
+    async def test_substring_loopback_near_miss_withholds_credential(
+        self, bus_client
+    ):
+        """http://127.0.0.1.evil.test is NOT loopback: credential is withheld."""
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        resp, client = await self._post_with_bus_url(
+            bus_client._app, token, "http://127.0.0.1.evil.test:7900"
+        )
+        assert resp.status_code == 200
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers is None

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -33,10 +33,12 @@ Bus API (verified live):
 """
 from __future__ import annotations
 
+import ipaddress
 import logging
 import math
 import os
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import httpx
 import asyncio
@@ -63,6 +65,44 @@ _STREAM_HEARTBEAT_SEC = 25
 def _bus_url() -> str:
     """Resolve the bus base URL from the environment, trailing slash stripped."""
     return os.environ.get("TAOS_A2A_BUS_URL", _DEFAULT_BUS_URL).rstrip("/")
+
+
+def _credential_may_cross(bus_url: str) -> bool:
+    """Return True when the caller's registry credential may be forwarded to *bus_url*.
+
+    The credential is forwarded over:
+
+    - any ``https://`` destination (TLS protects it in transit), or
+    - an ``http://`` destination whose host is a loopback address
+      (``127.0.0.1``, ``::1``, or the literal hostname ``localhost``), because
+      the traffic never leaves the host.
+
+    Non-loopback ``http://`` destinations drop the credential: forwarding a
+    long-lived registry JWT in cleartext across the LAN would hand a replayable
+    credential to a passive observer.
+
+    The operator can opt back in for a specific non-loopback deployment by
+    setting ``TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL`` to any truthy value.
+
+    The host check uses parsed address resolution, not substring matching:
+    ``http://127.0.0.1.evil.test:7900`` does NOT count as loopback.
+    """
+    parsed = urlparse(bus_url)
+    if parsed.scheme != "http":
+        return True
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return False
+    if hostname == "localhost":
+        return True
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        if addr.is_loopback:
+            return True
+    return bool(os.environ.get("TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL"))
 
 
 async def _authorize_bus_read(request: Request) -> None:
@@ -542,10 +582,14 @@ async def bus_send(request: Request, body: BusSendBody):
 
     headers: dict[str, str] = {}
     if identity.credential:
-        # Only ever sent to the OPERATOR-configured bus URL (`TAOS_A2A_BUS_URL`,
-        # default loopback): the credential is the caller's own, and the bus is
-        # the one service that must see it to verify the sender.
-        headers["Authorization"] = f"Bearer {identity.credential}"
+        bus = _bus_url()
+        if _credential_may_cross(bus):
+            headers["Authorization"] = f"Bearer {identity.credential}"
+        else:
+            logger.warning(
+                "A2A bus credential withheld for non-loopback http destination %s",
+                bus,
+            )
 
     bus = _bus_url()
     try:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): bus_send forwards a registry JWT to TAOS_A2A_BUS_URL with no transport condition: a non-loopback http:// bus puts a controller-accepted credential on the wire in cleartext

Autonomous build of board card tsk-ivt562.

Transport guard in bus_send: credential only forwarded over https:// or
loopback http:// (127.0.0.1, ::1, localhost). Non-loopback http:// drops the
credential and logs a warning. Operator opt-in via
TAOS_A2A_BUS_ALLOW_INSECURE_CREDENTIAL restores forwarding for remote http://
fleets. Helper _credential_may_cross lives next to _bus_url for reuse.

Red-first proof (origin/dev, before fix):
```
FAILED tests/test_a2a_bus_agent_auth.py::TestBusSendCredentialTransport::test_remote_http_withholds_credential - AssertionError
FAILED tests/test_a2a_bus_agent_auth.py::TestBusSendCredentialTransport::test_substring_loopback_near_miss_withholds_credential - AssertionError
2 failed, 43 passed in 51.52s
```

Green on head:
```
45 passed in 53.93s
```

Also updates docs/agent-coordination.md: documents the transport rule and
clarifies that for a human principal the controller derives the sender as
@<username> and forwards no credential to the bus.

Files:
 .../tsk-ivt562-a2a-bus-send-transport-guard.md     |  8 ++
 docs/agent-coordination.md                         | 18 ++--
 tests/test_a2a_bus_agent_auth.py                   | 96 ++++++++++++++++++++++
 tinyagentos/routes/a2a_bus.py                      | 52 +++++++++++-
 4 files changed, 164 insertions(+), 10 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry credentials are now withheld when sending to non-loopback `http://` coordination buses, preventing cleartext transmission.
  * Credentials continue to be forwarded over HTTPS and loopback HTTP destinations.
  * Operators can explicitly opt in to credential forwarding for remote HTTP buses through configuration.

* **Documentation**
  * Updated coordination bus documentation to clarify credential handling and human sender identity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->