### PR TITLE
fix(agents): make scope grants revocable and assign-agent honest (#2148)

### DIFF
--- a/changelog.d/2148-scope-grant-revoke.md
+++ b/changelog.d/2148-scope-grant-revoke.md
@@ -1,0 +1,24 @@
+### Security
+
+- Agent scope grants can now be revoked. `AgentGrantsStore` gained
+  `revoke_grant(canonical_id, scope, project_id=...)` and
+  `revoke_all_for_project(canonical_id, project_id)`, and
+  `POST /api/projects/{id}/members/revoke-agent` is the owner-or-admin route over
+  them (an omitted/empty `scopes` list revokes every grant the agent holds on
+  that project). A revoked scope is refused at check time on the agent's next
+  request, the agent's other scopes and its grants on other projects are
+  untouched, and the revoke is audit-logged as `member.grants_revoked` on the
+  project activity feed. Previously the only removal was revoking the whole
+  identity (`agent_registry_store.revoke`), so least privilege was unachievable
+  (#2148).
+
+### Fixed
+
+- `POST /api/projects/{id}/members/assign-agent` no longer reports a revocation
+  it did not perform. Its `scopes` list is now the agent's complete scope set
+  for the project: a grant on that project which the body does not name is
+  revoked, so `scopes: []` really removes the access instead of answering
+  `{"granted_scopes": []}` while the registry grant stayed live. The response
+  reports `revoked_scopes` and the read-back `active_scopes`, and fails with 500
+  if the reconciliation does not take effect rather than claiming success
+  (#2148).

--- a/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
+++ b/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
@@ -9,6 +9,8 @@ const SCOPE_PRESETS: { value: string; label: string; defaultOn: boolean; disable
   { value: "canvas_write", label: "canvas_write", defaultOn: true },
 ];
 
+type GrantRow = { scope?: string; project_id?: string | null; expires_at?: string | null };
+
 export function AssignAgentToProjectDialog({
   entry,
   onClose,
@@ -31,6 +33,13 @@ export function AssignAgentToProjectDialog({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmation, setConfirmation] = useState<string | null>(null);
+  // Scopes the agent ALREADY holds on the selected project. The server treats
+  // the posted `scopes` list as the agent's COMPLETE set for the project, so a
+  // scope omitted here is REVOKED; anything outside the preset list is shown
+  // (and kept) rather than dropped behind the operator's back (taOS #2148).
+  const [heldScopes, setHeldScopes] = useState<string[]>([]);
+  const [heldLoading, setHeldLoading] = useState(false);
+  const [heldErr, setHeldErr] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -55,8 +64,62 @@ export function AssignAgentToProjectDialog({
     };
   }, []);
 
+  // Load the agent's current grants so the dialog can show (and keep) the
+  // scopes it already holds on the selected project. A failed read leaves us
+  // unable to tell "no grants" from "unknown", so it blocks submission: posting
+  // an incomplete list on top of a failed read is how access disappears.
+  useEffect(() => {
+    if (!selectedProjectId) {
+      setHeldScopes([]);
+      setHeldErr(null);
+      setHeldLoading(false);
+      return;
+    }
+    let active = true;
+    setHeldLoading(true);
+    setHeldErr(null);
+    fetch(
+      `/api/agents/registry/grants?canonical_id=${encodeURIComponent(entry.canonical_id)}`,
+      { credentials: "include" },
+    )
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data: unknown) => {
+        if (!active) return;
+        const rows = (data as { grants?: GrantRow[] } | null)?.grants;
+        const now = Date.now();
+        const held = (Array.isArray(rows) ? rows : [])
+          .filter((row) => {
+            if (!row?.scope || row.project_id !== selectedProjectId) return false;
+            if (row.expires_at && Date.parse(row.expires_at) <= now) return false;
+            return true;
+          })
+          .map((row) => String(row.scope));
+        setHeldScopes([...new Set(held)].sort());
+      })
+      .catch((e: unknown) => {
+        if (active) {
+          setHeldScopes([]);
+          setHeldErr(e instanceof Error ? e.message : "failed to load current scopes");
+        }
+      })
+      .finally(() => {
+        if (active) setHeldLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedProjectId, entry.canonical_id]);
+
+  const presetValues = new Set(SCOPE_PRESETS.map((s) => s.value));
+  const heldExtras = heldScopes.filter((s) => !presetValues.has(s));
+
   const buildScopes = (): string[] => {
     const out = new Set<string>();
+    // Scopes the agent already holds outside the preset list are preserved.
+    for (const s of heldExtras) out.add(s);
     // project_tasks is always granted regardless of its (disabled) checkbox state.
     out.add("project_tasks");
     for (const s of SCOPE_PRESETS) {
@@ -68,7 +131,7 @@ export function AssignAgentToProjectDialog({
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (submitting || !selectedProjectId) return;
+    if (submitting || !selectedProjectId || heldLoading || heldErr) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -178,6 +241,29 @@ export function AssignAgentToProjectDialog({
                 />
                 <span>Lead</span>
               </label>
+              {heldLoading && (
+                <p className="text-[10px] text-zinc-500 mt-1">Loading current scopes…</p>
+              )}
+              {heldErr && (
+                <p className="text-red-400 text-[10px] mt-1">
+                  Could not load this agent&apos;s current scopes ({heldErr}); assigning is
+                  disabled, because a scope it already holds and does not see here would be
+                  revoked. Reopen the dialog to retry.
+                </p>
+              )}
+              {heldExtras.map((s) => (
+                <label key={s} className="flex items-center gap-2 text-sm py-0.5">
+                  <input
+                    type="checkbox"
+                    checked
+                    readOnly
+                    disabled
+                    aria-label={`Scope ${s}`}
+                  />
+                  <span>{s}</span>
+                  <span className="text-[10px] text-zinc-500">(current grant — kept)</span>
+                </label>
+              ))}
             </fieldset>
 
             {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
@@ -192,7 +278,9 @@ export function AssignAgentToProjectDialog({
               </button>
               <button
                 type="submit"
-                disabled={submitting || !selectedProjectId || loadingProjects}
+                disabled={
+                  submitting || !selectedProjectId || loadingProjects || heldLoading || !!heldErr
+                }
                 className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
               >
                 {submitting ? "Assigning…" : "Assign to project"}

--- a/desktop/src/apps/agents/__tests__/AssignAgentToProjectDialog.test.tsx
+++ b/desktop/src/apps/agents/__tests__/AssignAgentToProjectDialog.test.tsx
@@ -14,6 +14,17 @@ function ok(data: unknown, status = 200) {
   return { ok: true, status, json: async () => data };
 }
 
+/**
+ * The dialog reads the agent's current grants before it can be submitted (the
+ * server treats the posted scope list as the complete set for the project),
+ * so a test must wait for the submit button to come back before clicking it.
+ */
+async function waitForAssignEnabled() {
+  const btn = screen.getByRole("button", { name: /assign to project/i });
+  await waitFor(() => expect(btn).not.toBeDisabled());
+  return btn;
+}
+
 describe("AssignAgentToProjectDialog", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let assignBody: Record<string, unknown> | null = null;
@@ -71,7 +82,7 @@ describe("AssignAgentToProjectDialog", () => {
       );
     });
     fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
-    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+    fireEvent.click(await waitForAssignEnabled());
 
     await waitFor(() => expect(assignBody).not.toBeNull());
     expect(assignUrl).toBe("/api/projects/prj_a/members/assign-agent");
@@ -96,7 +107,7 @@ describe("AssignAgentToProjectDialog", () => {
     });
     fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_b" } });
     fireEvent.click(screen.getByLabelText(/make this agent the project lead/i));
-    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+    fireEvent.click(await waitForAssignEnabled());
 
     await waitFor(() => expect(assignBody).not.toBeNull());
     expect(assignUrl).toBe("/api/projects/prj_b/members/assign-agent");
@@ -124,8 +135,85 @@ describe("AssignAgentToProjectDialog", () => {
       );
     });
     fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
-    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+    fireEvent.click(await waitForAssignEnabled());
 
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/not authorized/));
+  });
+
+  it("keeps scopes the agent already holds outside the preset list", async () => {
+    // The server reads the posted `scopes` list as the agent's COMPLETE set for
+    // the project, so an unlisted scope is REVOKED. files_read is not a preset;
+    // it must be shown and re-sent, not dropped (taOS #2148).
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (String(url).includes("/api/agents/registry/grants")) {
+        return Promise.resolve(
+          ok({
+            grants: [
+              { scope: "files_read", project_id: "prj_a", expires_at: null },
+              { scope: "project_tasks", project_id: "prj_a", expires_at: null },
+              { scope: "files_write", project_id: "prj_b", expires_at: null },
+            ],
+          }),
+        );
+      }
+      if (/\/api\/projects\/[^/]+\/members\/assign-agent$/.test(String(url)) && init?.method === "POST") {
+        assignUrl = String(url);
+        assignBody = JSON.parse(String(init.body));
+        return Promise.resolve(ok({ canonical_id: ENTRY.canonical_id }));
+      }
+      return Promise.resolve(ok({}));
+    });
+
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
+
+    await waitFor(() => expect(screen.getByLabelText("Scope files_read")).toBeInTheDocument());
+    // A grant on ANOTHER project is not shown (nor sent).
+    expect(screen.queryByLabelText("Scope files_write")).toBeNull();
+
+    fireEvent.click(await waitForAssignEnabled());
+    await waitFor(() => expect(assignBody).not.toBeNull());
+    const posted = assignBody!.scopes as string[];
+    expect(posted).toContain("files_read");
+    expect(posted).toContain("project_tasks");
+    expect(posted).not.toContain("files_write");
+  });
+
+  it("blocks assigning when the agent's current scopes cannot be read", async () => {
+    // Unknown is not the same as "none": submitting on top of a failed read
+    // would revoke scopes the operator never saw.
+    fetchMock.mockImplementation((url: string) => {
+      if (String(url).includes("/api/agents/registry/grants")) {
+        return Promise.resolve({ ok: false, status: 403, json: async () => ({}) });
+      }
+      return Promise.resolve(ok({}));
+    });
+
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Could not load this agent's current scopes/)).toBeInTheDocument(),
+    );
+    const btn = screen.getByRole("button", { name: /assign to project/i });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(assignBody).toBeNull();
   });
 });

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -154,21 +154,37 @@ to verify it before considering onboarding finished. When you move hosts, confir
 the token works on the new host BEFORE decommissioning the old one. Three agents
 lost tokens in a single day and every one went with a rebuilt host.
 
-Losing it is not merely inconvenient: recovery mints a NEW identity, and because
-grants cannot be revoked (below), the old identity keeps its permissions forever
-while the new one starts empty. One agent spent an evening convinced it lacked a
+Losing it is not merely inconvenient: recovery mints a NEW identity with no
+grants, while the old identity keeps its own unless you revoke them (below) or
+revoke the identity itself. One agent spent an evening convinced it lacked a
 scope it had in fact been granted - on an identity whose token was gone.
 
-**Scope grants are permanent.** `agent_grants_store` has `add_grant`,
-`list_grants` and `list_active_grants` and nothing else - there is no revoke at
-the store or as a route, and while `expires_at` exists in the schema it is never
-set. Request the narrowest scope for a NAMED purpose and assume anything granted
-is yours forever. Tracked as jaylfc/taOS#2148.
+**Scope grants are revocable, per scope and per project.** `agent_grants_store`
+gained `revoke_grant(canonical_id, scope, project_id=...)` and
+`revoke_all_for_project(canonical_id, project_id)` (taOS #2148), and
+`POST /api/projects/{project_id}/members/revoke-agent` is the owner-or-admin
+route over them. Body: `{canonical_id, scopes: [...]}`; an omitted or empty
+`scopes` means every grant the agent holds on that project. A revoke removes
+exactly that one key, so the agent's other scopes and its grants on other
+projects survive, and the identity itself is untouched
+(`agent_registry_store.revoke` is still the whole-identity kill). The response
+reports the store's answer, not the request: `revoked_scopes` plus the read-back
+`active_scopes`. The revoke is audit-logged as `member.grants_revoked` on the
+project activity feed, and when no project-scoped grant is left, the agent's
+member row goes with it. `expires_at` is still never populated - a grant is
+revoked, not time-boxed - though an expired value is already refused at check
+time.
 
-**`assign-agent` with an empty scope list is NOT a revocation.** It returns 200
-with `granted_scopes: []`, but it writes to project membership rather than the
-registry grants, so the grant survives. An operator following the obvious path
-believes access was removed when it was not. Do not rely on it.
+**`assign-agent`'s scope list is authoritative, not a delta.** It returns 200
+with `granted_scopes` echoing the request and, since taOS #2148, reconciles the
+registry grants bound to that project to exactly the list you pass: a grant on
+that project you did not name - including all of them, when you pass
+`scopes: []` - is revoked. `revoked_scopes` reports what was actually removed
+and `active_scopes` is read back from the store, so the response can no longer
+claim a revocation it did not perform; a reconciliation that does not land is a
+500 rather than a success. Grants on the agent's other projects are not touched.
+(Before #2148 this route was additive: `scopes: []` answered
+`{"granted_scopes": []}` while the grant stayed live.)
 
 **The SSE stream proxy requires a channel.** `GET /api/a2a/bus/stream` returns
 400 without `?channel=<thread>`; there is no all-threads mode yet, so watching
@@ -554,7 +570,10 @@ purely from a matching active grant. An already-registered agent is added to a
 further project via `POST /api/projects/{project_id}/members/assign-agent`
 (admin/owner gated) or by redeeming an invite whose handle collides with an
 active identity (the existing canonical_id and token are reused instead of
-409ing).
+409ing). The reverse is
+`POST /api/projects/{project_id}/members/revoke-agent` (taOS #2148), which drops
+the agent's grants on that ONE project and leaves its other projects, its other
+scopes and the identity itself standing.
 
 Deferred binding and an existing active handle are mutually exclusive. Approving
 an auth-request with `defer_binding` mints the token and grants UNBOUND, so the

--- a/tests/test_agent_grants_store.py
+++ b/tests/test_agent_grants_store.py
@@ -185,6 +185,131 @@ class TestAgentGrantsStore:
         finally:
             await store.close()
 
+    # ── revoke_grant (taOS #2148: grants could be granted but never revoked) ──
+    async def test_revoke_grant_removes_the_row(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "files_read", project_id="proj-A")
+            assert (
+                await store.revoke_grant("agent-r", "files_read", project_id="proj-A")
+                is True
+            )
+            assert await store.list_grants("agent-r") == []
+        finally:
+            await store.close()
+
+    async def test_revoke_grant_missing_key_is_false_and_keeps_the_others(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "files_read", project_id="proj-B")
+            assert (
+                await store.revoke_grant("agent-r", "files_read", project_id="proj-A")
+                is False
+            )
+            grants = await store.list_grants("agent-r")
+            assert len(grants) == 1
+            assert grants[0]["project_id"] == "proj-B"
+        finally:
+            await store.close()
+
+    async def test_revoke_grant_spares_other_scopes_and_projects(self, tmp_path):
+        """Acceptance: revoking ONE scope on ONE project must leave the
+        identity's other scopes and other projects intact."""
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "files_read", project_id="proj-A")
+            await store.add_grant("agent-r", "files_read", project_id="proj-B")
+            await store.add_grant("agent-r", "project_tasks", project_id="proj-A")
+            assert (
+                await store.revoke_grant("agent-r", "files_read", project_id="proj-A")
+                is True
+            )
+            pairs = {(g["scope"], g["project_id"]) for g in await store.list_grants("agent-r")}
+            assert pairs == {("files_read", "proj-B"), ("project_tasks", "proj-A")}
+        finally:
+            await store.close()
+
+    async def test_revoke_grant_is_null_safe_for_global_grants(self, tmp_path):
+        """A global grant (project_id NULL) and a project-bound grant of the same
+        scope are distinct keys: revoking one must never remove the other."""
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "files_read")
+            await store.add_grant("agent-r", "files_read", project_id="proj-A")
+            assert await store.revoke_grant("agent-r", "files_read") is True
+            left = [(g["scope"], g["project_id"]) for g in await store.list_grants("agent-r")]
+            assert left == [("files_read", "proj-A")]
+            assert (
+                await store.revoke_grant("agent-r", "files_read", project_id="proj-A")
+                is True
+            )
+            assert await store.list_grants("agent-r") == []
+        finally:
+            await store.close()
+
+    async def test_revoke_grant_uninitialised_raises_runtime_error(self, tmp_path):
+        store = AgentGrantsStore(tmp_path / "grants.db")
+        try:
+            with pytest.raises(RuntimeError, match="not initialised"):
+                await store.revoke_grant("agent-x", "files_read")
+        finally:
+            await store.close()
+
+    # ── revoke_all_for_project ────────────────────────────────────────
+    async def test_revoke_all_for_project_returns_removed_scopes(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "project_tasks", project_id="proj-A")
+            await store.add_grant("agent-r", "canvas_read", project_id="proj-A")
+            removed = await store.revoke_all_for_project("agent-r", "proj-A")
+            assert removed == ["canvas_read", "project_tasks"]
+            assert await store.list_grants("agent-r") == []
+        finally:
+            await store.close()
+
+    async def test_revoke_all_for_project_spares_other_projects_and_globals(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "project_tasks", project_id="proj-A")
+            await store.add_grant("agent-r", "project_tasks", project_id="proj-B")
+            await store.add_grant("agent-r", "memory_read")
+            assert await store.revoke_all_for_project("agent-r", "proj-A") == [
+                "project_tasks"
+            ]
+            left = {(g["scope"], g["project_id"]) for g in await store.list_grants("agent-r")}
+            assert left == {("project_tasks", "proj-B"), ("memory_read", None)}
+        finally:
+            await store.close()
+
+    async def test_revoke_all_for_project_empty_when_none_held(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "project_tasks", project_id="proj-B")
+            assert await store.revoke_all_for_project("agent-r", "proj-A") == []
+            assert len(await store.list_grants("agent-r")) == 1
+        finally:
+            await store.close()
+
+    async def test_revoke_all_for_project_rejects_blank_project_id(self, tmp_path):
+        """Fail closed: a blank project_id would broaden the DELETE to the
+        identity's GLOBAL grants."""
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-r", "memory_read")
+            with pytest.raises(ValueError):
+                await store.revoke_all_for_project("agent-r", "")
+            assert len(await store.list_grants("agent-r")) == 1
+        finally:
+            await store.close()
+
+    async def test_revoke_all_for_project_uninitialised_raises_runtime_error(self, tmp_path):
+        store = AgentGrantsStore(tmp_path / "grants.db")
+        try:
+            with pytest.raises(RuntimeError, match="not initialised"):
+                await store.revoke_all_for_project("agent-x", "proj-A")
+        finally:
+            await store.close()
+
     async def test_existing_db_with_old_unique_upgrades_and_survives(self, tmp_path):
         db_path = tmp_path / "legacy.db"
         # Seed a DB with the OLD 2-column unique constraint and a couple rows.

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -1,4 +1,6 @@
 import asyncio
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -2122,4 +2124,320 @@ class TestConsentApproveHandleCollisionGuard:
         assert brand_rows[0]["canonical_id"] == cid
 
         await self._shutdown(stores)
+
+
+# ---------------------------------------------------------------------------
+# taOS #2148 — scope grants could be granted but never revoked
+#
+# The bug: assign-agent only ever ADDED grants, so calling it with a reduced or
+# empty scope list returned a success response (``granted_scopes: []``) while the
+# registry grant stayed live. These tests pin the honest behaviour: the project's
+# grant set becomes exactly what the caller asked for, the response reports what
+# actually changed, and a reconciliation that does not take effect fails loudly
+# instead of reporting a success it did not perform.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_scope_fixture(client, monkeypatch, tmp_path, prefix):
+    """Wire a registry + grants + project store onto the app under test.
+
+    Mirrors the setup in TestAssignAgentRoute; every caller passes its own
+    ``prefix`` so each test gets independent DB files.
+    """
+    from tinyagentos.agent_registry_store import (
+        AgentRegistryStore,
+        load_or_create_signing_keypair,
+    )
+    from tinyagentos.agent_grants_store import AgentGrantsStore
+    from tinyagentos.projects.project_store import ProjectStore
+
+    registry = AgentRegistryStore(tmp_path / f"reg-{prefix}.db")
+    await registry.init()
+    grants = AgentGrantsStore(tmp_path / f"grants-{prefix}.db")
+    await grants.init()
+    pstore = ProjectStore(tmp_path / f"projects-{prefix}.db")
+    await pstore.init()
+    priv, pub = load_or_create_signing_keypair(tmp_path / f"keys-{prefix}")
+
+    reg = await registry.register(
+        framework="openclaw",
+        display_name="taosmd-dev",
+        user_id="u",
+        origin="external-selfjoin",
+        handle="taosmd-dev",
+    )
+    await registry.set_status(reg["canonical_id"], "active")
+    project = await pstore.create_project(
+        name="P", slug=f"proj-{prefix}", created_by="u"
+    )
+
+    monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+    monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+    monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+    monkeypatch.setattr(
+        client._transport.app.state, "agent_registry_keypair", (priv, pub)
+    )
+    return SimpleNamespace(
+        registry=registry,
+        grants=grants,
+        pstore=pstore,
+        cid=reg["canonical_id"],
+        project=project,
+    )
+
+
+async def _close_scope_fixture(stores):
+    await stores.registry.close()
+    await stores.grants.close()
+    await stores.pstore.close()
+
+
+async def _project_grants(grants, cid, project_id):
+    """The (scope -> grant) map the agent actually holds on ONE project."""
+    return {
+        g["scope"]: g
+        for g in await grants.list_grants(cid)
+        if g.get("project_id") == project_id
+    }
+
+
+async def _assign(client, project_id, cid, scopes, **extra):
+    body = {"canonical_id": cid, "scopes": scopes, **extra}
+    return await client.post(
+        f"/api/projects/{project_id}/members/assign-agent", json=body
+    )
+
+
+class TestAssignAgentReconcilesGrants:
+    """assign-agent must make its report match the grant store."""
+
+    @pytest.mark.asyncio
+    async def test_empty_scopes_revokes_the_projects_grants(
+        self, client, monkeypatch, tmp_path
+    ):
+        """The verified #2148 case: ``scopes: []`` used to answer
+        ``granted_scopes: []`` while the grant stayed live."""
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "revokeall")
+        cid, pid = stores.cid, stores.project["id"]
+
+        first = await _assign(client, pid, cid, ["project_tasks"])
+        assert first.status_code == 200, first.text
+
+        resp = await _assign(client, pid, cid, [])
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["granted_scopes"] == []
+        assert body["revoked_scopes"] == ["project_tasks"]
+        assert body["active_scopes"] == []
+
+        # Read-back from the store: the grant is really gone, and the member row
+        # that access implied went with it.
+        assert await _project_grants(stores.grants, cid, pid) == {}
+        members = await stores.pstore.list_members(pid)
+        assert all(m["member_id"] != cid for m in members)
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_reduced_scopes_revoke_only_the_dropped_scope(
+        self, client, monkeypatch, tmp_path
+    ):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "revokeone")
+        cid, pid = stores.cid, stores.project["id"]
+
+        first = await _assign(client, pid, cid, ["project_tasks", "canvas_read"])
+        assert first.status_code == 200, first.text
+
+        resp = await _assign(client, pid, cid, ["project_tasks"])
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["revoked_scopes"] == ["canvas_read"]
+        assert body["active_scopes"] == ["project_tasks"]
+
+        assert set(await _project_grants(stores.grants, cid, pid)) == {"project_tasks"}
+        # project_tasks is still held, so the membership must survive.
+        members = await stores.pstore.list_members(pid)
+        assert any(m["member_id"] == cid for m in members)
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_spares_the_agents_other_projects(
+        self, client, monkeypatch, tmp_path
+    ):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "revokeother")
+        cid = stores.cid
+        pid_a = stores.project["id"]
+        pid_b = (
+            await stores.pstore.create_project(
+                name="Q", slug="proj-revokeother-b", created_by="u"
+            )
+        )["id"]
+
+        assert (await _assign(client, pid_b, cid, ["project_tasks"])).status_code == 200
+        assert (await _assign(client, pid_a, cid, ["files_read"])).status_code == 200
+
+        resp = await _assign(client, pid_a, cid, [])
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["revoked_scopes"] == ["files_read"]
+        assert await _project_grants(stores.grants, cid, pid_a) == {}
+        assert set(await _project_grants(stores.grants, cid, pid_b)) == {"project_tasks"}
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_that_does_not_take_effect_fails_loudly(
+        self, client, monkeypatch, tmp_path
+    ):
+        """The store refusing the delete must surface as an error, never as a
+        success response claiming the scope is gone."""
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "revokefail")
+        cid, pid = stores.cid, stores.project["id"]
+        assert (await _assign(client, pid, cid, ["project_tasks"])).status_code == 200
+
+        async def _noop_revoke(canonical_id, scope, *, project_id=None):
+            return False
+
+        monkeypatch.setattr(stores.grants, "revoke_grant", _noop_revoke)
+
+        resp = await _assign(client, pid, cid, [])
+        assert resp.status_code == 500, resp.text
+        # And the grant really is still there -- which is exactly why reporting
+        # success would have been a lie.
+        assert set(await _project_grants(stores.grants, cid, pid)) == {"project_tasks"}
+
+        await _close_scope_fixture(stores)
+
+
+class TestRevokeAgentScopesRoute:
+    """Admin route POST /api/projects/{pid}/members/revoke-agent."""
+
+    @pytest.mark.asyncio
+    async def test_revoke_one_scope_leaves_the_rest_intact(
+        self, client, monkeypatch, tmp_path
+    ):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routeone")
+        cid, pid = stores.cid, stores.project["id"]
+        assert (
+            await _assign(client, pid, cid, ["project_tasks", "canvas_read"])
+        ).status_code == 200
+
+        resp = await client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["canvas_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["canonical_id"] == cid
+        assert body["project_id"] == pid
+        assert body["revoked_scopes"] == ["canvas_read"]
+        assert body["active_scopes"] == ["project_tasks"]
+        assert set(await _project_grants(stores.grants, cid, pid)) == {"project_tasks"}
+        # The identity itself is untouched -- only the one scope went.
+        assert (await stores.registry.get(cid))["status"] == "active"
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_revoke_without_scopes_clears_the_project(
+        self, client, monkeypatch, tmp_path
+    ):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routeall")
+        cid, pid = stores.cid, stores.project["id"]
+        assert (
+            await _assign(client, pid, cid, ["project_tasks", "canvas_read"])
+        ).status_code == 200
+
+        resp = await client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["revoked_scopes"] == ["canvas_read", "project_tasks"]
+        assert body["active_scopes"] == []
+        assert await _project_grants(stores.grants, cid, pid) == {}
+        members = await stores.pstore.list_members(pid)
+        assert all(m["member_id"] != cid for m in members)
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_revoke_spares_other_projects(self, client, monkeypatch, tmp_path):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routeother")
+        cid = stores.cid
+        pid_a = stores.project["id"]
+        pid_b = (
+            await stores.pstore.create_project(
+                name="Q", slug="proj-routeother-b", created_by="u"
+            )
+        )["id"]
+        assert (await _assign(client, pid_a, cid, ["files_read"])).status_code == 200
+        assert (await _assign(client, pid_b, cid, ["files_read"])).status_code == 200
+
+        resp = await client.post(
+            f"/api/projects/{pid_a}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["files_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["active_scopes"] == []
+        assert await _project_grants(stores.grants, cid, pid_a) == {}
+        assert set(await _project_grants(stores.grants, cid, pid_b)) == {"files_read"}
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_revoke_is_audit_logged(self, client, monkeypatch, tmp_path):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routeaudit")
+        cid, pid = stores.cid, stores.project["id"]
+        assert (await _assign(client, pid, cid, ["files_read"])).status_code == 200
+
+        resp = await client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["files_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        activity = await stores.pstore.list_activity(pid)
+        revoked = [a for a in activity if a["kind"] == "member.grants_revoked"]
+        assert len(revoked) == 1, activity
+        payload = revoked[0]["payload"]
+        assert payload["canonical_id"] == cid
+        assert payload["scopes"] == ["files_read"]
+
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_revoke_unknown_scope_is_400(self, client, monkeypatch, tmp_path):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routebad")
+        cid, pid = stores.cid, stores.project["id"]
+        resp = await client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["not_a_scope"]},
+        )
+        assert resp.status_code == 400, resp.text
+        await _close_scope_fixture(stores)
+
+    @pytest.mark.asyncio
+    async def test_revoke_requires_admin(self, client, monkeypatch, tmp_path):
+        stores = await _seed_scope_fixture(client, monkeypatch, tmp_path, "routegate")
+        cid, pid = stores.cid, stores.project["id"]
+        assert (await _assign(client, pid, cid, ["project_tasks"])).status_code == 200
+
+        # A non-admin, non-owner caller must be rejected by the admin gate.
+        auth = client._transport.app.state.auth
+        auth.add_user_invite("carol", "admin")
+        carol = auth.find_user("carol")
+        carol_token = auth.create_session(user_id=carol["id"], long_lived=True)
+
+        resp = await client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["project_tasks"]},
+            cookies={"taos_session": carol_token},
+        )
+        assert resp.status_code == 403, resp.text
+        # The grant survived the refused call.
+        assert set(await _project_grants(stores.grants, cid, pid)) == {"project_tasks"}
+
+        await _close_scope_fixture(stores)
 

--- a/tests/test_routes_project_files_agent_scope.py
+++ b/tests/test_routes_project_files_agent_scope.py
@@ -153,6 +153,36 @@ class TestAgentFilesProjectBinding:
 
 
 @pytest.mark.asyncio
+class TestGrantRevocationCutsAccess:
+    """taOS #2148: a revoked grant must refuse the agent's NEXT request."""
+
+    async def test_revoke_route_stops_the_next_files_read(self, ctx):
+        pid = await _new_project(ctx, "revokefiles")
+        cid, token = await _mint_agent(ctx, pid, ("files_read",))
+
+        async with _bare(ctx.app) as bare:
+            before = await bare.get(
+                "/api/projects/revokefiles/files", headers=_hdr(token)
+            )
+        assert before.status_code == 200, before.text
+
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/members/revoke-agent",
+            json={"canonical_id": cid, "scopes": ["files_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["revoked_scopes"] == ["files_read"]
+        assert resp.json()["active_scopes"] == []
+
+        async with _bare(ctx.app) as bare:
+            after = await bare.get(
+                "/api/projects/revokefiles/files", headers=_hdr(token)
+            )
+        assert after.status_code == 403, after.text
+        assert after.status_code != 200
+
+
+@pytest.mark.asyncio
 class TestSessionFilesUnchanged:
     async def test_owner_session_list_allowed(self, ctx):
         await _new_project(ctx, "ownerfiles")

--- a/tinyagentos/agent_grants_store.py
+++ b/tinyagentos/agent_grants_store.py
@@ -181,6 +181,83 @@ class AgentGrantsStore(BaseStore):
         return _row_to_dict(row)  # type: ignore[return-value]
 
     # ------------------------------------------------------------------
+    # Revoke
+    # ------------------------------------------------------------------
+
+    async def revoke_grant(
+        self,
+        canonical_id: str,
+        scope: str,
+        *,
+        project_id: Optional[str] = None,
+    ) -> bool:
+        """Delete the grant for the exact (canonical_id, scope, project_id) key.
+
+        NULL-safe on ``project_id`` (``IS``), so a global grant (project_id NULL)
+        and a project-bound grant of the same scope are distinct targets:
+        revoking one never removes the other.
+
+        Returns True when a row was removed and False when no such grant existed,
+        so callers report the real outcome instead of assuming success. Revoking
+        is scoped to this one key: the same scope on another project and the
+        identity's other scopes are left untouched.
+        """
+        if self._db is None:
+            raise RuntimeError(
+                "AgentGrantsStore not initialised — call init() first"
+            )
+        # Same lock as add_grant: a revoke racing an add of the same key must not
+        # interleave with the add's delete+insert+select-back.
+        async with self._write_lock:
+            cursor = await self._db.execute(
+                "DELETE FROM agent_grants "
+                "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
+                (canonical_id, scope, project_id),
+            )
+            await self._db.commit()
+            removed = cursor.rowcount
+        return removed > 0
+
+    async def revoke_all_for_project(
+        self, canonical_id: str, project_id: str
+    ) -> list[str]:
+        """Delete every grant *canonical_id* holds that is bound to *project_id*.
+
+        The common case ("this job is finished, drop the agent from this
+        project"). Grants on OTHER projects and the identity's global grants
+        (project_id NULL) are left alone — a revoke is never an identity-wide
+        wipe; ``agent_registry_store.revoke`` remains the only way to kill the
+        whole identity.
+
+        Returns the sorted scopes actually removed, so the caller can report
+        exactly what it undid. ``project_id`` must be a real project id: a blank
+        value is rejected rather than broadening the DELETE to the identity's
+        global grants (fail closed).
+        """
+        if not project_id:
+            raise ValueError("project_id is required to revoke project grants")
+        if self._db is None:
+            raise RuntimeError(
+                "AgentGrantsStore not initialised — call init() first"
+            )
+        async with self._write_lock:
+            cursor = await self._db.execute(
+                "SELECT DISTINCT scope FROM agent_grants "
+                "WHERE canonical_id = ? AND project_id = ?",
+                (canonical_id, project_id),
+            )
+            scopes = sorted({row[0] for row in await cursor.fetchall()})
+            if not scopes:
+                return []
+            await self._db.execute(
+                "DELETE FROM agent_grants "
+                "WHERE canonical_id = ? AND project_id = ?",
+                (canonical_id, project_id),
+            )
+            await self._db.commit()
+        return scopes
+
+    # ------------------------------------------------------------------
     # Read
     # ------------------------------------------------------------------
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -127,6 +127,17 @@ class AssignAgentBody(BaseModel):
     is_lead: bool = False
 
 
+class RevokeAgentScopesBody(BaseModel):
+    """Body for POST /api/projects/{project_id}/members/revoke-agent.
+
+    ``scopes`` omitted or empty means "every grant this agent holds on this
+    project" — the common "the review is finished, drop it" case.
+    """
+
+    canonical_id: str
+    scopes: list[str] = []
+
+
 class CreateScopeRequest(BaseModel):
     """Body for POST /api/agents/registry/{canonical_id}/scope-requests.
 
@@ -756,6 +767,7 @@ async def add_agent_to_project(
     granted_scopes: list[str],
     decided_by: str,
     is_lead: bool = False,
+    reconcile: bool = False,
 ) -> dict:
     """Add an ALREADY-REGISTERED agent to ANOTHER project (taOS #1862).
 
@@ -766,11 +778,67 @@ async def add_agent_to_project(
     the agent: the identity is reused so one registry JWT spans every project
     the agent holds a grant for.
 
-    Returns ``{"canonical_id": ..., "project_id": ..., "granted_scopes": ...}``.
+    ``reconcile=False`` (the default) is ADDITIVE: grants the agent already
+    holds on the project stay, which is what the consent, invite and
+    scope-request approve paths need (each approves ADDITIONAL scopes and must
+    never drop one already granted). ``reconcile=True`` makes *granted_scopes*
+    the project's exact grant set for this agent: a grant bound to this project
+    that the caller did not name is REVOKED (taOS #2148). Only a caller whose
+    scope list is the operator's complete intent may ask for that — with the
+    additive default a reduced list reports success while the dropped scope
+    stays live.
+
+    Returns ``{"canonical_id": ..., "project_id": ..., "granted_scopes": ...}``
+    plus, when reconciling, ``revoked_scopes`` and ``active_scopes`` (read back
+    from the store, so the response cannot claim a revocation that did not
+    land).
     """
     grants_store = _get_grants_store(request)
     rel_mgr = _get_relationships(request)
 
+    # Revoke BEFORE adding: the project's grant set becomes exactly
+    # ``granted_scopes``. A grant this call does not name is one the operator
+    # asked to remove, and leaving it live while answering "done" is precisely
+    # the #2148 bug (the response read as a revocation and was not one).
+    revoked_scopes: list[str] = []
+    if reconcile:
+        existing_scopes = {
+            g["scope"]
+            for g in await grants_store.list_grants(canonical_id)
+            if g.get("project_id") == project_id
+        }
+        revoked_scopes = sorted(existing_scopes - set(granted_scopes))
+        for scope in revoked_scopes:
+            await grants_store.revoke_grant(canonical_id, scope, project_id=project_id)
+        if revoked_scopes:
+            # Drop the relationship permission edge too — but only when no
+            # grant for that scope survives on another project (or globally).
+            # The edge is NOT project-scoped, so revoking it unconditionally
+            # would strip a scope the agent still legitimately holds elsewhere.
+            remaining_scopes = {
+                g["scope"] for g in await grants_store.list_grants(canonical_id)
+            }
+            for scope in revoked_scopes:
+                if scope not in remaining_scopes:
+                    await rel_mgr.revoke_permission(
+                        canonical_id, "taos-instance", scope
+                    )
+            try:
+                pstore = getattr(request.app.state, "project_store", None)
+                if pstore is not None:
+                    await pstore.log_activity(
+                        project_id,
+                        decided_by,
+                        "member.grants_revoked",
+                        {"canonical_id": canonical_id, "scopes": revoked_scopes},
+                    )
+            except Exception:  # noqa: BLE001 - the revoke already happened
+                logger.warning(
+                    "add_agent_to_project: could not audit-log the revoke of %s on %s",
+                    revoked_scopes,
+                    project_id,
+                    exc_info=True,
+                )
 
     # Write the grants bound to this project and the relationship edge.
     for scope in granted_scopes:
@@ -779,16 +847,39 @@ async def add_agent_to_project(
         )
         await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
 
-    # If a project-scoped scope was granted, add the agent as a project member
-    # (PK (project_id, member_id) makes this naturally idempotent) and sync the
-    # a2a channel. Best-effort: a membership failure never blocks the grant,
-    # which already authorizes the agent for the project.
+    # Read the project's grant set back and refuse to report a reconcile that did
+    # not land. A success response that leaves the old scope live is the lie
+    # #2148 is about; failing here is the honest alternative.
+    active_scopes = sorted(
+        g["scope"]
+        for g in await grants_store.list_grants(canonical_id)
+        if g.get("project_id") == project_id
+    )
+    if reconcile and set(active_scopes) != set(granted_scopes):
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "scope reconciliation did not take effect: expected "
+                f"{sorted(set(granted_scopes))}, store holds {active_scopes}"
+            ),
+        )
+
     result: dict = {
         "canonical_id": canonical_id,
         "project_id": project_id,
         "granted_scopes": list(granted_scopes),
         "is_lead": bool(is_lead),
     }
+    if reconcile:
+        # ``granted_scopes`` keeps its historical meaning (what this call asked
+        # for); the other two are the store's answer, not the request echoed.
+        result["revoked_scopes"] = revoked_scopes
+        result["active_scopes"] = active_scopes
+
+    # If a project-scoped scope was granted, add the agent as a project member
+    # (PK (project_id, member_id) makes this naturally idempotent) and sync the
+    # a2a channel. Best-effort: a membership failure never blocks the grant,
+    # which already authorizes the agent for the project.
     if set(granted_scopes) & _PROJECT_SCOPES:
         try:
             pstore = getattr(request.app.state, "project_store", None)
@@ -841,6 +932,30 @@ async def add_agent_to_project(
                 project_id,
                 exc_info=True,
             )
+    elif reconcile:
+        # Reconciled down to a set with no project-scoped grant: the agent holds
+        # no access here any more, so the member row (and the lead pointer with
+        # it) goes too — otherwise the project keeps listing an agent whose
+        # membership claims an access it does not have.
+        try:
+            pstore = getattr(request.app.state, "project_store", None)
+            if pstore is not None:
+                await pstore.remove_member(project_id, canonical_id)
+                from tinyagentos.projects.a2a import ensure_a2a_channel
+
+                await ensure_a2a_channel(
+                    request.app.state.chat_channels,
+                    pstore,
+                    project_id,
+                    config=getattr(request.app.state, "config", None),
+                )
+        except Exception:  # noqa: BLE001 - membership sync is best-effort
+            logger.warning(
+                "add_agent_to_project: could not drop %s membership for project %s",
+                canonical_id,
+                project_id,
+                exc_info=True,
+            )
     return result
 
 
@@ -857,6 +972,15 @@ async def assign_agent_to_project(
     agent to another project without re-registering it or minting a new token.
     Writes the per-scope grants bound to the project, the idempotent
     project_members row, and ensures a2a channel membership.
+
+    ``body.scopes`` is the agent's COMPLETE scope set for this project, not a
+    delta (taOS #2148): a grant on this project that the body does not name is
+    revoked, so ``scopes: []`` genuinely removes the agent from the project
+    instead of answering ``granted_scopes: []`` while the access stayed live.
+    Grants on the agent's OTHER projects and the identity itself are untouched.
+    The response reports ``revoked_scopes`` and the read-back ``active_scopes``;
+    if the reconciliation does not land the call fails (500) rather than
+    reporting a success it did not perform.
 
     Owner-or-admin gated on the project like the invite mint route.
     """
@@ -893,8 +1017,155 @@ async def assign_agent_to_project(
         granted_scopes=body.scopes,
         decided_by=user.user_id,
         is_lead=body.is_lead,
+        # The operator's scope list is the complete intent for this project
+        # (the UI sends the checked set), so unlisted grants are removed.
+        reconcile=True,
     )
     return result
+
+
+@router.post("/api/projects/{project_id}/members/revoke-agent")
+async def revoke_agent_scopes_from_project(
+    request: Request,
+    project_id: str,
+    body: RevokeAgentScopesBody,
+    user: CurrentUser = Depends(current_user),
+):
+    """Admin route: revoke the scope grants an agent holds on ONE project (taOS #2148).
+
+    The missing half of assign-agent: a grant could be created but never
+    removed, so least privilege was unachievable and the only removal was the
+    nuclear ``agent_registry_store.revoke`` (which kills the entire identity,
+    every scope on every project).
+
+    Revokes the named scopes for *canonical_id* on *project_id* only: the
+    agent's other projects, its other scopes on this project, and the identity
+    itself are untouched. An omitted/empty ``scopes`` list revokes everything
+    the agent holds on this project. When no project-scoped grant survives, the
+    member row (and the lead pointer) go with it, so the project stops listing
+    an agent that holds nothing.
+
+    Deny by default: owner-or-admin gated like assign-agent. Audit-logged as
+    ``member.grants_revoked`` on the project activity feed (the same surface
+    ``member.removed`` uses). The response reports what the store confirms,
+    never what the request asked for.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    pstore = getattr(request.app.state, "project_store", None)
+    if pstore is None:
+        raise HTTPException(status_code=500, detail="project store unavailable")
+    project = await pstore.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="project not found")
+    require_owner_or_admin(user, project["user_id"])
+
+    unknown = sorted(set(body.scopes) - VALID_SCOPES)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
+        )
+
+    registry = _get_registry_store(request)
+    if await registry.get(body.canonical_id) is None:
+        raise HTTPException(
+            status_code=404, detail="agent canonical_id not found in the registry"
+        )
+
+    grants_store = _get_grants_store(request)
+    rel_mgr = _get_relationships(request)
+
+    held = {
+        g["scope"]
+        for g in await grants_store.list_grants(body.canonical_id)
+        if g.get("project_id") == project_id
+    }
+    # An explicit list revokes exactly what it names; an omitted/empty list means
+    # "everything on this project". Unknown-but-valid scopes simply match
+    # nothing and are reported as not revoked.
+    targets = sorted(held) if not body.scopes else sorted(set(body.scopes) & held)
+
+    revoked: list[str] = []
+    for scope in targets:
+        if await grants_store.revoke_grant(
+            body.canonical_id, scope, project_id=project_id
+        ):
+            revoked.append(scope)
+
+    # Report the store's answer, not the request: a revoke that silently did
+    # nothing must not read as a revocation.
+    active_scopes = sorted(
+        g["scope"]
+        for g in await grants_store.list_grants(body.canonical_id)
+        if g.get("project_id") == project_id
+    )
+    expected = sorted(held - set(revoked))
+    if active_scopes != expected:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "revocation did not take effect: expected "
+                f"{expected}, store holds {active_scopes}"
+            ),
+        )
+
+    # Drop the relationship permission edge for a scope that no longer exists
+    # anywhere for this identity (the edge is not project-scoped, so a scope the
+    # agent still holds on another project keeps its edge).
+    remaining_scopes = {
+        g["scope"] for g in await grants_store.list_grants(body.canonical_id)
+    }
+    for scope in revoked:
+        if scope not in remaining_scopes:
+            await rel_mgr.revoke_permission(body.canonical_id, "taos-instance", scope)
+
+    # No project-scoped grant left: the member row now claims an access the
+    # agent does not have. Drop it (and the lead pointer with it).
+    membership_removed = False
+    if not (set(active_scopes) & _PROJECT_SCOPES):
+        try:
+            await pstore.remove_member(project_id, body.canonical_id)
+            membership_removed = True
+            from tinyagentos.projects.a2a import ensure_a2a_channel
+
+            await ensure_a2a_channel(
+                request.app.state.chat_channels,
+                pstore,
+                project_id,
+                config=getattr(request.app.state, "config", None),
+            )
+        except Exception:  # noqa: BLE001 - membership sync is best-effort
+            logger.warning(
+                "revoke-agent: could not drop %s membership for project %s",
+                body.canonical_id,
+                project_id,
+                exc_info=True,
+            )
+
+    try:
+        await pstore.log_activity(
+            project_id,
+            user.user_id,
+            "member.grants_revoked",
+            {"canonical_id": body.canonical_id, "scopes": revoked},
+        )
+    except Exception:  # noqa: BLE001 - the revoke already happened; never 500 on the audit write
+        logger.warning(
+            "revoke-agent: could not audit-log the revoke of %s on %s",
+            revoked,
+            project_id,
+            exc_info=True,
+        )
+
+    return {
+        "canonical_id": body.canonical_id,
+        "project_id": project_id,
+        "revoked_scopes": revoked,
+        "active_scopes": active_scopes,
+        "membership_removed": membership_removed,
+    }
 
 
 async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):


### PR DESCRIPTION
## Summary

Closes the gap flagged in #2148: an agent's scope grants could be granted but never revoked, and the assign-agent flow reported success while leaving stale grants in place.

Two halves, both needed:

1. **Backend — revoke + truthful reconcile.** `agent_grants_store` gains a real revoke path; `add_agent_to_project` reconciles the posted scope list as the agent's *complete* set for that project (with `reconcile=True` scoped to that route only, so consent/invite/scope-request approvals stay additive). Unlisted grants are revoked, and `revoked_scopes` + `active_scopes` are reported. A reconciliation that does not land returns 500 rather than a false success.
2. **Frontend — surface and preserve held scopes.** `AssignAgentToProjectDialog` loads the agent's current grants before submission (a failed read blocks submission, since posting an incomplete list on a failed read is how access disappears), shows any held scopes outside the preset list, and re-sends them so the operator cannot silently drop access.

## Tests

- Backend: 21 new (10 store, 10 route for honest reconcile + revoke, 1 end-to-end — a revoked `files_read` grant makes the agent's next request 403).
- Frontend: 6 passing `AssignAgentToProjectDialog` (vitest) including the "keeps held scopes outside the preset list" case.

Refs #2148.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project owners and administrators can revoke specific or all agent scopes from a project.
  * Revoked permissions take effect on the agent’s next request.
  * Agent assignment now synchronizes project access to exactly the selected scopes and reports active and revoked scopes.
  * The assignment dialog preserves existing scopes and prevents submission if access details cannot be loaded.
  * Scope revocations are recorded in the activity feed.

* **Documentation**
  * Updated agent access documentation to describe project-scoped revocation and synchronized assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->