### PR TITLE
new_id() has no collision retry: a 6-char id space (32**6) makes bulk task creation raise raw sqlite3.IntegrityError - fired in CI on unmodified dev code

### DIFF
--- a/changelog.d/tsk-rsek5i-id-collision-retry.md
+++ b/changelog.d/tsk-rsek5i-id-collision-retry.md
@@ -1,0 +1,2 @@
+### Fixed
+- new_id collisions are now retried up to 5 times at every store insert site, instead of surfacing as a raw sqlite3.IntegrityError and rolling back the transaction

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -712,3 +712,29 @@ async def test_park_closed_task_is_noop(store):
     await store.close_task(t["id"], closed_by="u")
     ok = await store.park_task(t["id"], actor="system")
     assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_create_task_retries_on_id_collision(store, monkeypatch):
+    """new_id collision must be retried, not surfaced as IntegrityError."""
+    import tinyagentos.projects.task_store as task_store_mod
+
+    call_count = 0
+    duplicate_id = "tsk-collision"
+    fresh_id = "tsk-fresh"
+
+    def fake_new_id(prefix):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            return duplicate_id
+        return fresh_id
+
+    monkeypatch.setattr(task_store_mod, "new_id", fake_new_id)
+
+    t1 = await store.create_task(project_id="p", title="T1", created_by="u")
+    assert t1["id"] == duplicate_id
+
+    t2 = await store.create_task(project_id="p", title="T2", created_by="u")
+    assert t2["id"] == fresh_id
+    assert call_count == 3

--- a/tinyagentos/base_store.py
+++ b/tinyagentos/base_store.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sqlite3
 from pathlib import Path
 from enum import Enum
 
@@ -105,3 +106,35 @@ class BaseStore:
         if self._db:
             await self._db.close()
             self._db = None
+
+    async def _insert_with_retry(
+        self,
+        sql: str,
+        params: tuple,
+        id_index: int,
+        new_id_fn,
+        max_attempts: int = 5,
+    ) -> str:
+        params_list = list(params)
+        for attempt in range(max_attempts):
+            try:
+                await self._db.execute(sql, params_list)
+                return params_list[id_index]
+            except sqlite3.IntegrityError as exc:
+                msg = str(exc)
+                if (
+                    "UNIQUE constraint failed:" in msg
+                    and msg.rstrip().endswith(".id")
+                ):
+                    try:
+                        await self._db.rollback()
+                    except Exception:
+                        pass
+                    params_list[id_index] = new_id_fn()
+                    continue
+                raise
+        try:
+            await self._db.rollback()
+        except Exception:
+            pass
+        raise sqlite3.IntegrityError("unique id collision after max retries")

--- a/tinyagentos/coding_sessions/store.py
+++ b/tinyagentos/coding_sessions/store.py
@@ -82,18 +82,19 @@ class CodingSessionStore(BaseStore):
         worker: str | None = None,
         project_id: str | None = None,
     ) -> dict:
-        sid = new_id("cs")
         now = time.time()
         resolved_alias = alias.strip() if alias and alias.strip() else _slugify(workdir.split("/")[-1] or workdir)
-        await self._db.execute(
+        sid = await self._insert_with_retry(
             """INSERT INTO coding_sessions
                (id, alias, cli, launch_target, worker, workdir, repo_source,
                 tmux_session, status, project_id, created_by, created_at, updated_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, NULL, 'starting', ?, ?, ?, ?)""",
             (
-                sid, resolved_alias, cli, launch_target, worker, workdir,
+                new_id("cs"), resolved_alias, cli, launch_target, worker, workdir,
                 json.dumps(repo_source), project_id, created_by, now, now,
             ),
+            id_index=0,
+            new_id_fn=lambda: new_id("cs"),
         )
         await self._db.commit()
         return await self.get_session(sid)

--- a/tinyagentos/container_requests_store.py
+++ b/tinyagentos/container_requests_store.py
@@ -77,14 +77,15 @@ class ContainerRequestStore(BaseStore):
         """Insert a new request in the ``requested`` state and return the row."""
         if canonical_id is None or not canonical_id.strip():
             raise ValueError("canonical_id is required")
-        crq_id = new_id("crq")
         now = time.time()
         config_str = json.dumps(config or {})
-        await self._db.execute(
+        crq_id = await self._insert_with_retry(
             """INSERT INTO container_requests
                (id, canonical_id, image, status, reason, config_json, created_at, updated_at)
                VALUES (?, ?, ?, 'requested', ?, ?, ?, ?)""",
-            (crq_id, canonical_id, image, reason, config_str, now, now),
+            (new_id("crq"), canonical_id, image, reason, config_str, now, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("crq"),
         )
         await self._db.commit()
         return await self.get(crq_id)

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -185,18 +185,19 @@ class DecisionStore(BaseStore):
             raise ValueError(f"invalid decision type: {type!r}")
         if priority not in PRIORITIES:
             raise ValueError(f"invalid priority: {priority!r}")
-        did = new_id("dec")
         now = time.time()
-        await self._db.execute(
+        did = await self._insert_with_retry(
             """INSERT INTO decisions
                (id, from_agent, project_id, user_id, question, type, options, context,
                 priority, status, created_at, deadline, parent_decision_id,
                 checkpoint_ref, timeline_id, metadata)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)""",
-            (did, from_agent, project_id, user_id, question, type,
+            (new_id("dec"), from_agent, project_id, user_id, question, type,
              json.dumps(options or []), context, priority, now, deadline,
              parent_decision_id, checkpoint_ref, timeline_id,
              json.dumps(metadata or {})),
+            id_index=0,
+            new_id_fn=lambda: new_id("dec"),
         )
         await self._db.commit()
         return await self.get(did)

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -118,14 +118,14 @@ class SharedDocsStore(BaseStore):
     async def create_doc(self, owner_user_id: str, kind: str, title: str = "") -> dict:
         if kind not in DOC_KINDS:
             raise ValueError(f"invalid kind {kind!r}; expected one of {DOC_KINDS}")
-        doc_id = new_id("doc")
         now = time.time()
-        await self._db.execute(
+        doc_id = await self._insert_with_retry(
             "INSERT INTO shared_docs (id, owner_user_id, kind, title, created_at, updated_at) "
             "VALUES (?, ?, ?, ?, ?, ?)",
-            (doc_id, owner_user_id, kind, title, now, now),
+            (new_id("doc"), owner_user_id, kind, title, now, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("doc"),
         )
-        # The owner is always a member.
         await self._db.execute(
             "INSERT INTO shared_doc_members (doc_id, member_type, member_id, created_at) "
             "VALUES (?, 'user', ?, ?)",
@@ -184,22 +184,24 @@ class SharedDocsStore(BaseStore):
     async def add_entry(
         self, doc_id: str, text: str, author: str = "", editor_type: str = "user"
     ) -> dict:
-        entry_id = new_id("ent")
         now = time.time()
-        await self._db.execute(
+        entry_id = await self._insert_with_retry(
             "INSERT INTO shared_doc_entries (id, doc_id, text, author, created_at) "
             "VALUES (?, ?, ?, ?, ?)",
-            (entry_id, doc_id, text, author, now),
+            (new_id("ent"), doc_id, text, author, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("ent"),
         )
         await self._db.execute(
             "UPDATE shared_docs SET updated_at = ? WHERE id = ?", (now, doc_id)
         )
-        rev_id = new_id("rev")
-        await self._db.execute(
+        rev_id = await self._insert_with_retry(
             "INSERT INTO shared_doc_entry_revisions "
             "(id, entry_id, rev_index, editor_id, editor_type, op, diff, snapshot, created_at) "
             "VALUES (?, ?, 0, ?, ?, 'create', NULL, ?, ?)",
-            (rev_id, entry_id, author, editor_type, text, now),
+            (new_id("rev"), entry_id, author, editor_type, text, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("rev"),
         )
         await self._db.commit()
         cur = await self._db.execute("SELECT * FROM shared_doc_entries WHERE id = ?", (entry_id,))
@@ -233,13 +235,14 @@ class SharedDocsStore(BaseStore):
 
         snapshot = new_text if next_index % CHECKPOINT_EVERY == 0 else None
 
-        rev_id = new_id("rev")
         now = time.time()
-        await self._db.execute(
+        rev_id = await self._insert_with_retry(
             "INSERT INTO shared_doc_entry_revisions "
             "(id, entry_id, rev_index, editor_id, editor_type, op, diff, snapshot, created_at) "
             "VALUES (?, ?, ?, ?, ?, 'edit', ?, ?, ?)",
-            (rev_id, entry_id, next_index, editor_id, editor_type, diff_text, snapshot, now),
+            (new_id("rev"), entry_id, next_index, editor_id, editor_type, diff_text, snapshot, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("rev"),
         )
         await self._db.execute(
             "UPDATE shared_doc_entries SET text = ? WHERE id = ?", (new_text, entry_id)

--- a/tinyagentos/projects/doc_review_store.py
+++ b/tinyagentos/projects/doc_review_store.py
@@ -75,7 +75,23 @@ class DocReviewStore(ProjectsDBStore):
                         f"invalid transition: (new) -> {new_state}; "
                         f"first state must be awaiting_review or a direct transition target"
                     )
-                review_id = new_id("rev")
+                now = time.time()
+                review_id = await self._insert_with_retry(
+                    """INSERT INTO doc_reviews
+                       (id, project_id, doc_path, review_state,
+                        reviewed_by, reviewed_at,
+                        changes_requested_by, changes_requested_at,
+                        created_at, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        new_id("rev"), project_id, doc_path, new_state,
+                        None, None,
+                        None, None,
+                        now, now,
+                    ),
+                    id_index=0,
+                    new_id_fn=lambda: new_id("rev"),
+                )
                 reviewed_by = None
                 reviewed_at = None
                 changes_requested_by = None
@@ -86,20 +102,6 @@ class DocReviewStore(ProjectsDBStore):
                 elif new_state == "changes_requested":
                     changes_requested_by = actor_id
                     changes_requested_at = now
-                await self._db.execute(
-                    """INSERT INTO doc_reviews
-                       (id, project_id, doc_path, review_state,
-                        reviewed_by, reviewed_at,
-                        changes_requested_by, changes_requested_at,
-                        created_at, updated_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
-                        review_id, project_id, doc_path, new_state,
-                        reviewed_by, reviewed_at,
-                        changes_requested_by, changes_requested_at,
-                        now, now,
-                    ),
-                )
             else:
                 current_state = existing["review_state"]
                 allowed = VALID_TRANSITIONS.get(current_state, [])

--- a/tinyagentos/projects/element_store.py
+++ b/tinyagentos/projects/element_store.py
@@ -99,19 +99,20 @@ class ProjectElementStore(ProjectsDBStore):
         if slug is None or slug == "":
             slug = slugify_element_name(name)
         validate_element_slug(slug)
-        eid = new_id("elm")
         now = time.time()
         try:
             async with self._tx():
-                await self._db.execute(
+                eid = await self._insert_with_retry(
                     """INSERT INTO project_elements
                        (id, project_id, name, slug, type, description, assignee_id,
                         settings, created_at, updated_at)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
-                        eid, project_id, name, slug, type, description, assignee_id,
+                        new_id("elm"), project_id, name, slug, type, description, assignee_id,
                         json.dumps(settings or {}), now, now,
                     ),
+                    id_index=0,
+                    new_id_fn=lambda: new_id("elm"),
                 )
         except sqlite3.IntegrityError as exc:
             # UNIQUE(project_id, slug) is the only uniqueness a caller can

--- a/tinyagentos/projects/lists_store.py
+++ b/tinyagentos/projects/lists_store.py
@@ -36,14 +36,15 @@ class ProjectListsStore(ProjectsDBStore):
         description: str = "",
         status: str = "active",
     ) -> dict:
-        list_id = new_id("lst")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            list_id = await self._insert_with_retry(
                 "INSERT INTO project_lists "
                 "(id, project_id, title, description, status, created_by, created_at, updated_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (list_id, project_id, title, description, status, created_by, now, now),
+                (new_id("lst"), project_id, title, description, status, created_by, now, now),
+                id_index=0,
+                new_id_fn=lambda: new_id("lst"),
             )
         return await self.get_list(list_id)
 
@@ -140,24 +141,25 @@ class ProjectListEntriesStore(ProjectsDBStore):
         category: str | None = None,
         position: int | None = None,
     ) -> dict:
-        entry_id = new_id("ent")
         now = time.time()
 
         async with self._tx():
             if position is not None:
-                await self._db.execute(
+                entry_id = await self._insert_with_retry(
                     "INSERT INTO project_list_entries "
                     "(id, list_id, project_id, text, original_text, category, status, "
                     "done, author_kind, author_id, position, created_at, updated_at) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
-                        entry_id, list_id, project_id, text, original_text,
+                        new_id("ent"), list_id, project_id, text, original_text,
                         category, "new", 0, author_kind, author_id,
                         position, now, now,
                     ),
+                    id_index=0,
+                    new_id_fn=lambda: new_id("ent"),
                 )
             else:
-                await self._db.execute(
+                entry_id = await self._insert_with_retry(
                     "INSERT INTO project_list_entries "
                     "(id, list_id, project_id, text, original_text, category, status, "
                     "done, author_kind, author_id, position, created_at, updated_at) "
@@ -165,10 +167,12 @@ class ProjectListEntriesStore(ProjectsDBStore):
                     "COALESCE((SELECT MAX(position) + 1 FROM project_list_entries "
                     "WHERE list_id = ? AND project_id = ?), 0), ?, ?)",
                     (
-                        entry_id, list_id, project_id, text, original_text,
+                        new_id("ent"), list_id, project_id, text, original_text,
                         category, "new", 0, author_kind, author_id,
                         list_id, project_id, now, now,
                     ),
+                    id_index=0,
+                    new_id_fn=lambda: new_id("ent"),
                 )
         return await self.get_entry(entry_id)
 

--- a/tinyagentos/projects/notes_store.py
+++ b/tinyagentos/projects/notes_store.py
@@ -32,14 +32,15 @@ class ProjectNotesStore(ProjectsDBStore):
         author_id: str,
         author_kind: str = "user",
     ) -> dict:
-        note_id = new_id("note")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            note_id = await self._insert_with_retry(
                 """INSERT INTO project_notes
                    (id, project_id, title, body, author_id, author_kind, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                (note_id, project_id, title, body, author_id, author_kind, now, now),
+                (new_id("note"), project_id, title, body, author_id, author_kind, now, now),
+                id_index=0,
+                new_id_fn=lambda: new_id("note"),
             )
         return await self.get_note(note_id)
 

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -166,7 +166,6 @@ class ProjectStore(ProjectsDBStore):
         settings: dict | None = None,
         user_id: str = "",
     ) -> dict:
-        pid = new_id("prj")
         now = time.time()
         try:
             async with self._tx():
@@ -179,11 +178,13 @@ class ProjectStore(ProjectsDBStore):
                 # creates would both pass and both insert.
                 if await self.get_project_by_name(name) is not None:
                     raise ProjectConflict("name", name)
-                await self._db.execute(
+                pid = await self._insert_with_retry(
                     """INSERT INTO projects
                        (id, name, slug, description, status, created_by, user_id, created_at, updated_at, settings)
                        VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)""",
-                    (pid, name, slug, description, created_by, user_id, now, now, json.dumps(settings or {})),
+                    (new_id("prj"), name, slug, description, created_by, user_id, now, now, json.dumps(settings or {})),
+                    id_index=0,
+                    new_id_fn=lambda: new_id("prj"),
                 )
         except sqlite3.IntegrityError as exc:
             # UNIQUE(slug) is the only schema-level uniqueness a caller can

--- a/tinyagentos/projects/routines_store.py
+++ b/tinyagentos/projects/routines_store.py
@@ -77,21 +77,22 @@ class RoutineStore(BaseStore):
                 raise ValueError("cron_expr is required for trigger_kind='cron'")
             _validate_cron(cron_expr)
 
-        rid = new_id("rtn")
         now = self._clock()
         webhook_token = secrets.token_urlsafe(32) if trigger_kind == "webhook" else None
         next_fire = _compute_next_fire(cron_expr, now) if trigger_kind == "cron" and enabled else None
 
-        await self._db.execute(
+        rid = await self._insert_with_retry(
             """INSERT INTO routines
                (id, project_id, title, body_template, assignee_id, trigger_kind,
                 cron_expr, webhook_token, enabled, last_fired, next_fire,
                 created_by, created_at, updated_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)""",
             (
-                rid, project_id, title, body_template, assignee_id, trigger_kind,
+                new_id("rtn"), project_id, title, body_template, assignee_id, trigger_kind,
                 cron_expr, webhook_token, int(enabled), next_fire, created_by, now, now,
             ),
+            id_index=0,
+            new_id_fn=lambda: new_id("rtn"),
         )
         await self._db.commit()
         return await self.get_routine(rid)

--- a/tinyagentos/projects/strike_store.py
+++ b/tinyagentos/projects/strike_store.py
@@ -49,13 +49,14 @@ class StrikeStore(BaseStore):
         Returns the total strike count for the task after this insert (so the
         caller can decide whether the threshold was just crossed).
         """
-        sid = new_id("str")
         now = time.time()
-        await self._db.execute(
+        sid = await self._insert_with_retry(
             """INSERT INTO task_strikes
                (id, task_id, step, log_tail, actor, created_at)
                VALUES (?, ?, ?, ?, ?, ?)""",
-            (sid, task_id, step, log_tail, actor, now),
+            (new_id("str"), task_id, step, log_tail, actor, now),
+            id_index=0,
+            new_id_fn=lambda: new_id("str"),
         )
         await self._db.commit()
         return await self.count_strikes(task_id)

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -290,18 +290,19 @@ class ProjectTaskStore(ProjectsDBStore):
         parent_task_id: str | None = None,
         element_id: str | None = None,
     ) -> dict:
-        tid = new_id("tsk")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            tid = await self._insert_with_retry(
                 """INSERT INTO project_tasks
                    (id, project_id, parent_task_id, title, body, status, priority, labels,
                     assignee_id, element_id, created_by, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)""",
                 (
-                    tid, project_id, parent_task_id, title, body, priority,
+                    new_id("tsk"), project_id, parent_task_id, title, body, priority,
                     json.dumps(labels or []), assignee_id, element_id, created_by, now, now,
                 ),
+                id_index=0,
+                new_id_fn=lambda: new_id("tsk"),
             )
         new_task = await self.get_task(tid)
         await self._publish(project_id, "task.created", {"id": new_task["id"], "task": new_task})
@@ -771,14 +772,15 @@ class ProjectTaskStore(ProjectsDBStore):
             t = await self.get_task(tid)
             if t is None or t["project_id"] != project_id:
                 raise ValueError(f"task not in project: {tid}")
-        rid = new_id("rel")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            rid = await self._insert_with_retry(
                 """INSERT INTO task_relationships
                    (id, project_id, from_task_id, to_task_id, kind, created_by, created_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (rid, project_id, from_task_id, to_task_id, kind, created_by, now),
+                (new_id("rel"), project_id, from_task_id, to_task_id, kind, created_by, now),
+                id_index=0,
+                new_id_fn=lambda: new_id("rel"),
             )
         await self._publish(project_id, "relationship.added", {"from": from_task_id, "to": to_task_id, "kind": kind})
         return {
@@ -932,14 +934,15 @@ class ProjectTaskStore(ProjectsDBStore):
                 row = await cur.fetchone()
             if row is None or row[0] != task_id:
                 raise ValueError("replies_to_comment_id not in this task")
-        cid = new_id("cmt")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            cid = await self._insert_with_retry(
                 """INSERT INTO task_comments
                    (id, task_id, author_id, body, replies_to_comment_id, created_at)
                    VALUES (?, ?, ?, ?, ?, ?)""",
-                (cid, task_id, author_id, body, replies_to_comment_id, now),
+                (new_id("cmt"), task_id, author_id, body, replies_to_comment_id, now),
+                id_index=0,
+                new_id_fn=lambda: new_id("cmt"),
             )
         new_comment = {
             "id": cid, "task_id": task_id, "author_id": author_id, "body": body,
@@ -977,14 +980,15 @@ class ProjectTaskStore(ProjectsDBStore):
         task = await self.get_task(task_id)
         if task is None:
             raise ValueError(f"task not found: {task_id}")
-        cid = new_id("cki")
         now = time.time()
         async with self._tx():
-            await self._db.execute(
+            cid = await self._insert_with_retry(
                 """INSERT INTO task_checklist_items
                    (id, task_id, text, done, verified, reported, archived, created_by, created_at, updated_at)
                    VALUES (?, ?, ?, 0, 0, 0, 0, ?, ?, ?)""",
-                (cid, task_id, text, created_by, now, now),
+                (new_id("cki"), task_id, text, created_by, now, now),
+                id_index=0,
+                new_id_fn=lambda: new_id("cki"),
             )
         async with self._read(
             "SELECT * FROM task_checklist_items WHERE id = ?", (cid,)

--- a/tinyagentos/projects/tx.py
+++ b/tinyagentos/projects/tx.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 import weakref
 from contextlib import asynccontextmanager
 
@@ -321,3 +322,27 @@ class ProjectsDBStore(BaseStore):
         """
         if not after_commit(self._db, effect):
             await effect()
+
+    async def _insert_with_retry(
+        self,
+        sql: str,
+        params: tuple,
+        id_index: int,
+        new_id_fn,
+        max_attempts: int = 5,
+    ) -> str:
+        params_list = list(params)
+        for attempt in range(max_attempts):
+            try:
+                await self._db.execute(sql, params_list)
+                return params_list[id_index]
+            except sqlite3.IntegrityError as exc:
+                msg = str(exc)
+                if (
+                    "UNIQUE constraint failed:" in msg
+                    and msg.rstrip().endswith(".id")
+                ):
+                    params_list[id_index] = new_id_fn()
+                    continue
+                raise
+        raise sqlite3.IntegrityError("unique id collision after max retries")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): new_id() has no collision retry: a 6-char id space (32**6) makes bulk task creation raise raw sqlite3.IntegrityError - fired in CI on unmodified dev code

Autonomous build of board card tsk-rsek5i.

Give new_id collision-safe insertion at the STORE layer via a bounded
retry (5 attempts) that catches ONLY the UNIQUE-constraint IntegrityError
on the id column, re-mints the id, and retries. Any other IntegrityError
propagates unchanged.

Add _insert_with_retry to BaseStore for non-ProjectDBStore stores
(rollback-managed for implicit transactions) and override in
ProjectsDBStore (tx() manages the transaction, no rollback inside retry).

Updated insert sites (20 total across 15 files):
- tinyagentos/projects/task_store.py: create_task, add_relationship,
  add_comment, create_checklist_item
- tinyagentos/projects/project_store.py: create_project
- tinyagentos/projects/strike_store.py: record_strike
- tinyagentos/projects/doc_review_store.py: set_review_state
- tinyagentos/projects/element_store.py: create_element
- tinyagentos/projects/lists_store.py: create_list, add_entry
- tinyagentos/projects/notes_store.py: create_note
- tinyagentos/projects/routines_store.py: create_routine
- tinyagentos/notes/shared_docs_store.py: create_doc, add_entry,
  edit_entry
- tinyagentos/coding_sessions/store.py: create_session
- tinyagentos/container_requests_store.py: create
- tinyagentos/decisions/decision_store.py: create

canvas/store.py add_element uses ON CONFLICT(id) DO UPDATE SET which
already handles id collisions without raising IntegrityError, so no
retry wrapper is needed there.

Deterministic test added in tests/projects/test_task_store.py:
test_create_task_retries_on_id_collision monkeypatches new_id so the
first two calls return a duplicate id and the third returns a fresh one,
then asserts the second create succeeds with the fresh id.

RED proof (fix removed from task_store.py create_task):

```
FAILED tests/projects/test_task_store.py::test_create_task_retries_on_id_collision - sqlite3.IntegrityError: UNIQUE constraint failed: project_tasks.id
```

GREEN (fix restored):

```
1 passed in 0.23s
```

tests/test_routes_projects.py: 66 passed.

Docs-Reviewed: changelog fragment added, no route changes.

Files:
 tinyagentos/projects/lists_store.py          | 20 ++++++++++-------
 tinyagentos/projects/notes_store.py          |  7 +++---
 tinyagentos/projects/project_store.py        |  7 +++---
 tinyagentos/projects/routines_store.py       |  7 +++---
 tinyagentos/projects/strike_store.py         |  7 +++---
 tinyagentos/projects/task_store.py           | 28 +++++++++++++----------
 tinyagentos/projects/tx.py                   | 25 +++++++++++++++++++++
 16 files changed, 180 insertions(+), 73 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ID collisions during creation of projects, tasks, sessions, notes, documents, decisions, requests, and related records are now retried automatically with a fresh ID.
  - Each collision is retried up to five times, reducing failed creations and preventing raw database errors from surfacing in normal collision scenarios.
  - Other database integrity errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->