### PR TITLE
fix(agents): dedup overlapping handle components in _derive_handle (#2093)

### DIFF
--- a/changelog.d/2995-handle-derivation-dedup.md
+++ b/changelog.d/2995-handle-derivation-dedup.md
@@ -1,0 +1,8 @@
+### Changed
+
+- `_derive_handle` no longer bakes overlapping components into an agent handle
+  twice. When an invite label already contains the project slug or the harness
+  (e.g. project `taosmobile`, harness `claude`, label `taosmobile-dev`), the
+  handle is now `taosmobile-claude-dev` instead of
+  `taosmobile-claude-taosmobile-dev`. Collision-suffix behaviour (`-2`, `-3`)
+  is unchanged.

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -842,3 +842,45 @@ class TestDeriveOsHandleHarnessFallback:
         claude_handle = _derive_os_handle("🎉", "claude", "beta")
         gemini_handle = _derive_os_handle("🎉", "gemini", "beta")
         assert claude_handle != gemini_handle
+
+
+class TestDeriveHandleDedup:
+    """#2093: the label already containing the project name caused double-redeem.
+
+    ``_derive_handle`` must not prepend a component that is already present in
+    the slugified label."""
+
+    def test_label_starts_with_project_slug(self):
+        from tinyagentos.routes.project_invites import _derive_handle
+
+        # taosmobile + claude + taosmobile-dev → taosmobile-claude-dev
+        handle = _derive_handle("taosmobile", "claude", "taosmobile-dev")
+        assert handle == "taosmobile-claude-dev"
+
+    def test_label_equals_project_slug(self):
+        from tinyagentos.routes.project_invites import _derive_handle
+
+        # taosmobile + claude + taosmobile → taosmobile-claude (label stripped)
+        handle = _derive_handle("taosmobile", "claude", "taosmobile")
+        assert handle == "taosmobile-claude"
+
+    def test_label_starts_with_harness(self):
+        from tinyagentos.routes.project_invites import _derive_handle
+
+        # claude + label "claude-code-dev" → must not become "proj-claude-claude-code-dev"
+        handle = _derive_handle("myproj", "claude", "claude-code-dev")
+        assert handle == "myproj-claude-code-dev"
+
+    def test_label_equals_harness(self):
+        from tinyagentos.routes.project_invites import _derive_handle
+
+        # proj + claude + claude → proj-claude (label stripped)
+        handle = _derive_handle("myproj", "claude", "claude")
+        assert handle == "myproj-claude"
+
+    def test_label_without_overlap_unchanged(self):
+        from tinyagentos.routes.project_invites import _derive_handle
+
+        # No overlap → label is appended verbatim (slugified).
+        handle = _derive_handle("taosmobile", "claude", "review-task")
+        assert handle == "taosmobile-claude-review-task"

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -93,6 +93,11 @@ def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:
 
     Each component is slugified independently so an awkward label cannot bleed
     separators into a neighbour; the parts are then joined with single dashes.
+
+    Dedup: if the slugified label starts with (or equals) a prefix already in
+    the handle, strip that overlap from the label before appending — so
+    ``taosmobile`` + ``claude`` + ``taosmobile-dev`` yields
+    ``taosmobile-claude-dev``, not ``taosmobile-claude-taosmobile-dev``.
     """
     slug = _slugify(project_slug)
     hw = _slugify(harness)
@@ -100,7 +105,16 @@ def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:
     if label:
         lbl = _slugify(label)
         if lbl:
-            parts.append(lbl)
+            # Dedup: strip any prefix of the label that duplicates a part.
+            for dedup in (slug, hw):
+                if not lbl:
+                    break
+                if lbl == dedup:
+                    lbl = ""
+                elif lbl.startswith(dedup + "-"):
+                    lbl = lbl[len(dedup) + 1:]
+            if lbl:
+                parts.append(lbl)
     return "-".join(p for p in parts if p)
 
 


### PR DESCRIPTION
Fixes #2093.

## Problem

`_derive_handle` builds `{project_slug}-{harness}[-{label}]` by slugifying each part independently and joining. When the label already contains the project slug or the harness — the natural thing for a person to type — the overlap is baked in twice:

| project | harness | label | before (bug) | after |
|---|---|---|---|---|
| `taosmobile` | `claude` | `taosmobile-dev` | `taosmobile-claude-taosmobile-dev` | `taosmobile-claude-dev` |
| `myproj` | `claude` | `claude-code-dev` | `myproj-claude-claude-code-dev` | `myproj-claude-code-dev` |
| `taosmobile` | `claude` | `taosmobile` | `taosmobile-claude-taosmobile` | `taosmobile-claude` |

## Change

Before joining, strip any label prefix that duplicates the project slug or the harness (exact match, or a `prefix-` boundary match). Collision-suffix behaviour (`-2`, `-3`) from `_dedupe_handle` is unchanged.

The harness-placement design question raised in #2093 (whether the harness should be baked into the handle at all) is intentionally left alone here — it's a separate decision for the maintainer.

## Tests

Added `TestDeriveHandleDedup` (5 cases) covering prefix overlap, exact overlap, harness overlap, harness exact, and the no-overlap passthrough — all passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated project and harness handles by removing duplicated label components and redundant prefixes.
  * Prevented repetitive handle formats when labels overlap with existing project or harness identifiers.
  * Preserved collision suffixes such as `-2` and `-3`.

* **Tests**
  * Added coverage for duplicate, prefixed, and non-overlapping label scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->