### PR TITLE
Chat attachments have no path into project Files: auto-register + tri-state ref-resolve (backend for taOStalk S7, tsk-ndir7g)

### DIFF
--- a/changelog.d/tsk-ctkm6k-chat-attachment-project-register.md
+++ b/changelog.d/tsk-ctkm6k-chat-attachment-project-register.md
@@ -1,0 +1,2 @@
+### Added
+- Chat attachments can auto-register into a project's Files when sent from a project-scoped chat, and a new `/api/chat/attachments/resolve` endpoint returns a tri-state `in_files_state` (`registered`, `not-registered`, `unknown`) so the caller can distinguish "in Files" from "nobody asked".

--- a/desktop/src/apps/chat/__tests__/AttachmentGallery.test.tsx
+++ b/desktop/src/apps/chat/__tests__/AttachmentGallery.test.tsx
@@ -27,6 +27,7 @@ describe("AttachmentGallery", () => {
       filename: "r.pdf", mime_type: "application/pdf",
       size: 1000, url: "/r.pdf", source: "disk",
     }]} />);
-    expect(screen.getByText("r.pdf")).toBeInTheDocument();
+    const link = screen.getByText("r.pdf").closest("a");
+    expect(link).toHaveAttribute("href", "/r.pdf");
   });
 });

--- a/desktop/src/lib/chat-attachments-api.ts
+++ b/desktop/src/lib/chat-attachments-api.ts
@@ -4,6 +4,8 @@ export type AttachmentRecord = {
   size: number;
   url: string;
   source: "disk" | "workspace" | "agent-workspace";
+  in_files_state?: "registered" | "not-registered" | "unknown";
+  project_slug?: string;
 };
 
 async function _ensureOk(r: Response): Promise<void> {

--- a/tests/test_chat_files_project_register.py
+++ b/tests/test_chat_files_project_register.py
@@ -1,0 +1,236 @@
+"""Tests for chat attachment auto-registration and ref-resolve.
+
+Covers:
+- attachment appears in project files after from-path with slug
+- same file sent twice yields one project-files entry (idempotent)
+- resolve returns registered / not-registered / unknown
+- non-owner actor gets existence-hiding 404 from both new paths
+- the five original AttachmentRecord fields still round-trip
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from taos_test_csrf import csrf_event_hooks
+
+
+def _make_client(app, user_id: str) -> AsyncClient:
+    token = app.state.auth.create_session(user_id=user_id, long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+        event_hooks=csrf_event_hooks(),
+    )
+
+
+class TestAutoRegister:
+    @pytest.mark.asyncio
+    async def test_attachment_appears_in_project_files(self, client):
+        app = client._transport.app
+        data_dir = app.state.data_dir
+
+        resp = await client.post("/api/projects", json={
+            "name": "AutoRegProj", "slug": "autoregproj", "description": "test",
+        })
+        assert resp.status_code == 200, resp.text
+
+        ws_dir = data_dir / "agent-workspaces" / "user"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        src = ws_dir / "notes.txt"
+        src.write_text("# hello world")
+
+        r = await client.post("/api/chat/attachments/from-path", json={
+            "path": "/workspaces/user/notes.txt",
+            "source": "workspace",
+            "slug": "autoregproj",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["in_files_state"] == "registered"
+        assert body["project_slug"] == "autoregproj"
+
+        r = await client.get("/api/projects/autoregproj/files")
+        assert r.status_code == 200, r.text
+        names = [e["name"] for e in r.json()]
+        assert "notes.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_same_file_twice_yields_one_entry(self, client):
+        app = client._transport.app
+        data_dir = app.state.data_dir
+
+        await client.post("/api/projects", json={
+            "name": "IdemProj", "slug": "idemproj", "description": "test",
+        })
+
+        ws_dir = data_dir / "agent-workspaces" / "user"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        src = ws_dir / "doc.txt"
+        src.write_text("idempotent content")
+
+        for _ in range(2):
+            r = await client.post("/api/chat/attachments/from-path", json={
+                "path": "/workspaces/user/doc.txt",
+                "source": "workspace",
+                "slug": "idemproj",
+            })
+            assert r.status_code == 200, r.text
+
+        r = await client.get("/api/projects/idemproj/files")
+        assert r.status_code == 200, r.text
+        entries = r.json()
+        assert len(entries) == 1
+        assert entries[0]["name"] == "doc.txt"
+
+
+class TestRefResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_registered_for_registered_ref(self, client):
+        app = client._transport.app
+        data_dir = app.state.data_dir
+
+        await client.post("/api/projects", json={
+            "name": "ResolveProj", "slug": "resolveproj", "description": "test",
+        })
+
+        ws_dir = data_dir / "agent-workspaces" / "user"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        src = ws_dir / "resolve_me.txt"
+        src.write_text("resolve content")
+
+        r = await client.post("/api/chat/attachments/from-path", json={
+            "path": "/workspaces/user/resolve_me.txt",
+            "source": "workspace",
+            "slug": "resolveproj",
+        })
+        assert r.status_code == 200, r.text
+        stored_name = r.json()["url"].split("/")[-1]
+
+        r = await client.get(
+            f"/api/chat/attachments/resolve?filename={stored_name}&slug=resolveproj"
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["in_files_state"] == "registered"
+        assert body["filename"] == "resolve_me.txt"
+        assert body["size"] == len("resolve content")
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_not_registered_for_unregistered_ref(self, client):
+        app = client._transport.app
+
+        await client.post("/api/projects", json={
+            "name": "UnregProj", "slug": "unregproj", "description": "test",
+        })
+
+        chat_files = app.state.data_dir / "chat-files"
+        chat_files.mkdir(parents=True, exist_ok=True)
+        stored_name = "unreg-file.txt"
+        (chat_files / stored_name).write_text("unregistered content")
+
+        r = await client.get(
+            f"/api/chat/attachments/resolve?filename={stored_name}&slug=unregproj"
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["in_files_state"] == "not-registered"
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_unknown_for_unresolvable_ref(self, client):
+        await client.post("/api/projects", json={
+            "name": "UnknownProj", "slug": "unknownproj", "description": "test",
+        })
+
+        r = await client.get(
+            "/api/chat/attachments/resolve?filename=nonexistent.txt&slug=unknownproj"
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["in_files_state"] == "unknown"
+
+
+class TestSecurity404:
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_404_from_auto_register(self, client):
+        app = client._transport.app
+
+        await client.post("/api/projects", json={
+            "name": "OwnerProj", "slug": "ownerproj", "description": "test",
+        })
+
+        bob_invite = app.state.auth.add_user_invite("bob", "admin")
+        app.state.auth.complete_invite("bob", bob_invite, "Bob", "", "bobpass12")
+        bob_rec = app.state.auth.find_user("bob")
+        assert bob_rec is not None
+
+        data_dir = app.state.data_dir
+        ws_dir = data_dir / "agent-workspaces" / "user"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        (ws_dir / "secret.txt").write_text("secret")
+
+        async with _make_client(app, bob_rec["id"]) as bob_client:
+            r = await bob_client.post("/api/chat/attachments/from-path", json={
+                "path": "/workspaces/user/secret.txt",
+                "source": "workspace",
+                "slug": "ownerproj",
+            })
+        assert r.status_code == 404, r.text
+        assert r.json()["error"] == "not found"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_404_from_resolve(self, client):
+        app = client._transport.app
+
+        await client.post("/api/projects", json={
+            "name": "ResolveOwner", "slug": "resolveowner", "description": "test",
+        })
+
+        alice_invite = app.state.auth.add_user_invite("alice", "admin")
+        app.state.auth.complete_invite("alice", alice_invite, "Alice", "", "alicepass12")
+        alice_rec = app.state.auth.find_user("alice")
+        assert alice_rec is not None
+
+        chat_files = app.state.data_dir / "chat-files"
+        chat_files.mkdir(parents=True, exist_ok=True)
+        (chat_files / "existing.txt").write_text("data")
+
+        async with _make_client(app, alice_rec["id"]) as alice_client:
+            r = await alice_client.get(
+                "/api/chat/attachments/resolve?filename=existing.txt&slug=resolveowner"
+            )
+        assert r.status_code == 404, r.text
+        assert r.json()["error"] == "not found"
+
+
+class TestAttachmentRecordRoundTrip:
+    @pytest.mark.asyncio
+    async def test_existing_fields_round_trip(self, client):
+        app = client._transport.app
+        data_dir = app.state.data_dir
+
+        await client.post("/api/projects", json={
+            "name": "RoundTrip", "slug": "roundtrip", "description": "test",
+        })
+
+        ws_dir = data_dir / "agent-workspaces" / "user"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        src = ws_dir / "roundtrip.txt"
+        src.write_text("roundtrip")
+
+        r = await client.post("/api/chat/attachments/from-path", json={
+            "path": "/workspaces/user/roundtrip.txt",
+            "source": "workspace",
+            "slug": "roundtrip",
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+        assert body["filename"] == "roundtrip.txt"
+        assert body["mime_type"] == "text/plain"
+        assert body["size"] == len("roundtrip")
+        assert body["url"].startswith("/api/chat/files/")
+        assert body["source"] == "workspace"

--- a/tinyagentos/routes/chat_files.py
+++ b/tinyagentos/routes/chat_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import mimetypes
 import os
 import secrets
@@ -10,9 +11,31 @@ from pathlib import Path
 from fastapi import APIRouter, File, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse
 
+from tinyagentos.routes.project_files import _authorize_files_actor
+
 router = APIRouter()
 
 _MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024  # 100 MB
+_REGISTRY_NAME = "chat-files-project-registry.json"
+
+
+def _registry_path(data_dir: Path) -> Path:
+    return data_dir / _REGISTRY_NAME
+
+
+def _load_registry(data_dir: Path) -> dict:
+    path = _registry_path(data_dir)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_registry(data_dir: Path, registry: dict) -> None:
+    path = _registry_path(data_dir)
+    path.write_text(json.dumps(registry, indent=2))
 
 
 def _resolve_workspace_path(data_dir: Path, source: str, slug: str | None, vfs_path: str) -> Path:
@@ -68,13 +91,32 @@ async def attachment_from_path(body: dict, request: Request):
     dest = chat_files / stored_name
     shutil.copy2(src, dest)
     mime, _ = mimetypes.guess_type(src.name)
-    return JSONResponse({
+    result = {
         "filename": src.name,
         "mime_type": mime or "application/octet-stream",
         "size": src.stat().st_size,
         "url": f"/api/chat/files/{stored_name}",
         "source": source,
-    }, status_code=200)
+    }
+    if slug:
+        auth = await _authorize_files_actor(request, slug, "write")
+        if isinstance(auth, JSONResponse):
+            return auth
+        registry = _load_registry(data_dir)
+        entry = registry.get(stored_name, {})
+        registered_projects = entry.get("projects", [])
+        if slug not in registered_projects:
+            proj_files_root = request.app.state.projects_root / slug / "files"
+            proj_files_root.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, proj_files_root / src.name)
+            entry["original_name"] = src.name
+            entry["size"] = src.stat().st_size
+            entry["projects"] = list(set(registered_projects + [slug]))
+            registry[stored_name] = entry
+            _save_registry(data_dir, registry)
+        result["in_files_state"] = "registered"
+        result["project_slug"] = slug
+    return JSONResponse(result, status_code=200)
 
 
 @router.post("/api/chat/upload")
@@ -113,3 +155,41 @@ async def serve_file(request: Request, filename: str):
     ):
         return JSONResponse({"error": "File not found"}, status_code=404)
     return FileResponse(file_path)
+
+
+@router.get("/api/chat/attachments/resolve")
+async def resolve_attachment(request: Request, filename: str, slug: str):
+    """Resolve a chat file reference to its in-Files state.
+
+    Returns a tri-state ``in_files_state``:
+    - ``registered``: the file exists in chat-files and is registered in the
+      named project's files.
+    - ``not-registered``: the file exists in chat-files but is NOT registered
+      in the named project.
+    - ``unknown``: the stored filename does not resolve to anything in
+      chat-files.
+
+    Authorization follows the same existence-hiding 404 contract as
+    ``tinyagentos.routes.project_files``: a caller who cannot see the project
+    never learns it exists.
+    """
+    data_dir = request.app.state.data_dir
+    auth = await _authorize_files_actor(request, slug, "read")
+    if isinstance(auth, JSONResponse):
+        return auth
+    chat_file = data_dir / "chat-files" / filename
+    if not chat_file.exists() or not chat_file.is_file():
+        return JSONResponse({
+            "filename": filename,
+            "size": 0,
+            "in_files_state": "unknown",
+        }, status_code=200)
+    registry = _load_registry(data_dir)
+    entry = registry.get(filename, {})
+    registered_projects = entry.get("projects", [])
+    in_files_state = "registered" if slug in registered_projects else "not-registered"
+    return JSONResponse({
+        "filename": entry.get("original_name", filename),
+        "size": entry.get("size", chat_file.stat().st_size),
+        "in_files_state": in_files_state,
+    }, status_code=200)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Chat attachments have no path into project Files: auto-register + tri-state ref-resolve (backend for taOStalk S7, tsk-ndir7g)

Autonomous build of board card tsk-ctkm6k.

When POST /api/chat/attachments/from-path receives a slug, copy the file into
that project's files folder and record the registration so the file is
reachable through GET /api/projects/{slug}/files. Re-registering the same
file for the same project is idempotent: the registry prevents a second
Files entry.

Add GET /api/chat/attachments/resolve, which answers with display name,
size in bytes, and a tri-state in_files_state: registered / not-registered /
unknown. Both new paths honour the existence-hiding 404 contract from
project_files._authorize_files_actor.

Extend AttachmentRecord with optional in_files_state and project_slug fields.
Add an anchor-href assertion to AttachmentGallery so the link semantics
cannot be silently removed.

Docs-Reviewed: agent-coordination.md does not enumerate route paths, so no
doc change is required for this routes-level change.

Red-first evidence:

```
FAILED tests/test_chat_files_project_register.py::TestAutoRegister::test_attachment_appears_in_project_files
FAILED tests/test_chat_files_project_register.py::TestAutoRegister::test_same_file_twice_yields_one_entry
FAILED tests/test_chat_files_project_register.py::TestRefResolve::test_resolve_returns_registered_for_registered_ref
FAILED tests/test_chat_files_project_register.py::TestRefResolve::test_resolve_returns_not_registered_for_unregistered_ref
FAILED tests/test_chat_files_project_register.py::TestRefResolve::test_resolve_returns_unknown_for_unresolvable_ref
FAILED tests/test_chat_files_project_register.py::TestSecurity404::test_non_owner_gets_404_from_auto_register
FAILED tests/test_chat_files_project_register.py::TestSecurity404::test_non_owner_gets_404_from_resolve
7 failed, 1 passed in 14.18s
```

Green:

```
8 passed in 16.82s
```

Files:
 .../tsk-ctkm6k-chat-attachment-project-register.md |   2 +
 .../apps/chat/__tests__/AttachmentGallery.test.tsx |   3 +-
 desktop/src/lib/chat-attachments-api.ts            |   2 +
 tests/test_chat_files_project_register.py          | 236 +++++++++++++++++++++
 tinyagentos/routes/chat_files.py                   |  84 +++++++-
 5 files changed, 324 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat attachments sent from a project-scoped chat can be automatically added to the project’s Files.
  - Attachment details now indicate whether a file is registered, not registered, or unknown in project Files.
  - Added attachment resolution support for checking a file’s project registration status.
  - Non-image attachment filenames now link directly to the attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->