### PR TITLE
fix(projects): set_lead moves role, is_lead, lead_member_id together (#2113)

### DIFF
--- a/changelog.d/2113-lead-flags-cohesion.md
+++ b/changelog.d/2113-lead-flags-cohesion.md
@@ -1,0 +1,7 @@
+### Changed
+
+- Setting a project's lead (`set_lead`) now moves all three lead fields together:
+  `project_members.role = 'lead'`, `project_members.is_lead = 1`, and
+  `projects.lead_member_id` are set in one place on promote, the previous lead's
+  `is_lead` flag is cleared, and clearing the lead resets the flags so the pointer,
+  the flag, and the role label can no longer disagree.

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -187,8 +187,27 @@ async def test_set_lead_and_clear_lead(store):
     await store.add_member(p["id"], member_id="agent-1", member_kind="native")
     await store.set_lead(p["id"], "agent-1")
     assert (await store.get_project(p["id"]))["lead_member_id"] == "agent-1"
+    # Promote: the member row must carry is_lead=1 and role='lead'.
+    m = await store.get_member(p["id"], "agent-1")
+    assert m["is_lead"] == 1
+    assert m["role"] == "lead"
+
+    # Promote a different lead: old lead's is_lead reverts to 0.
+    await store.add_member(p["id"], member_id="agent-2", member_kind="native")
+    await store.set_lead(p["id"], "agent-2")
+    m1 = await store.get_member(p["id"], "agent-1")
+    assert m1["is_lead"] == 0
+    m2 = await store.get_member(p["id"], "agent-2")
+    assert m2["is_lead"] == 1
+
+    # Clear: both is_lead flags reset, lead_member_id None.
     await store.set_lead(p["id"], None)
-    assert (await store.get_project(p["id"]))["lead_member_id"] is None
+    p_after = await store.get_project(p["id"])
+    assert p_after["lead_member_id"] is None
+    m1_final = await store.get_member(p["id"], "agent-1")
+    assert m1_final["is_lead"] == 0
+    m2_final = await store.get_member(p["id"], "agent-2")
+    assert m2_final["is_lead"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -192,22 +192,26 @@ async def test_set_lead_and_clear_lead(store):
     assert m["is_lead"] == 1
     assert m["role"] == "lead"
 
-    # Promote a different lead: old lead's is_lead reverts to 0.
+    # Promote a different lead: old lead's is_lead reverts to 0 AND role resets.
     await store.add_member(p["id"], member_id="agent-2", member_kind="native")
     await store.set_lead(p["id"], "agent-2")
     m1 = await store.get_member(p["id"], "agent-1")
     assert m1["is_lead"] == 0
+    assert m1["role"] == "member"
     m2 = await store.get_member(p["id"], "agent-2")
     assert m2["is_lead"] == 1
+    assert m2["role"] == "lead"
 
-    # Clear: both is_lead flags reset, lead_member_id None.
+    # Clear: both is_lead flags AND roles reset, lead_member_id None.
     await store.set_lead(p["id"], None)
     p_after = await store.get_project(p["id"])
     assert p_after["lead_member_id"] is None
     m1_final = await store.get_member(p["id"], "agent-1")
     assert m1_final["is_lead"] == 0
+    assert m1_final["role"] == "member"
     m2_final = await store.get_member(p["id"], "agent-2")
     assert m2_final["is_lead"] == 0
+    assert m2_final["role"] == "member"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -156,6 +156,26 @@ class ProjectStore(ProjectsDBStore):
                 "UPDATE projects SET lead_member_id = ? WHERE id = ?",
                 (member_id, project_id),
             )
+            if member_id is not None:
+                # Promote the new lead in its member row.
+                await self._db.execute(
+                    "UPDATE project_members SET is_lead = 1, role = 'lead' "
+                    "WHERE project_id = ? AND member_id = ?",
+                    (project_id, member_id),
+                )
+                # Demote any previous lead so the flag stays exclusive.
+                await self._db.execute(
+                    "UPDATE project_members SET is_lead = 0 "
+                    "WHERE project_id = ? AND member_id != ? AND is_lead = 1",
+                    (project_id, member_id),
+                )
+            else:
+                # Clearing lead — unset the flag everywhere on this project.
+                await self._db.execute(
+                    "UPDATE project_members SET is_lead = 0 "
+                    "WHERE project_id = ? AND is_lead = 1",
+                    (project_id,),
+                )
 
     async def create_project(
         self,

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -165,14 +165,14 @@ class ProjectStore(ProjectsDBStore):
                 )
                 # Demote any previous lead so the flag stays exclusive.
                 await self._db.execute(
-                    "UPDATE project_members SET is_lead = 0 "
+                    "UPDATE project_members SET is_lead = 0, role = 'member' "
                     "WHERE project_id = ? AND member_id != ? AND is_lead = 1",
                     (project_id, member_id),
                 )
             else:
                 # Clearing lead — unset the flag everywhere on this project.
                 await self._db.execute(
-                    "UPDATE project_members SET is_lead = 0 "
+                    "UPDATE project_members SET is_lead = 0, role = 'member' "
                     "WHERE project_id = ? AND is_lead = 1",
                     (project_id,),
                 )


### PR DESCRIPTION
Fixes #2113.

Assigning a project lead wrote `projects.lead_member_id` but left the member's `is_lead` flag and `role='lead'` label untouched, so a member the UI presented as lead was refused by any lead-gated action keyed off `is_lead` (e.g. `_authorize_project_lead`).

## Change

In `ProjectStore.set_lead` (the single place the lead pointer is written), the three fields now always move together:

- **Promote** (`member_id` set): sets `role='lead'` + `is_lead=1` on the new lead's member row, clears the previous lead's `is_lead` flag, and sets `projects.lead_member_id`.
- **Clear** (`member_id = None`): sets `lead_member_id = NULL` and resets any `is_lead=1` rows on the project.

Validation semantics (missing project / non-member → KeyError) and `_backfill_lead_member_id` are untouched.

## Tests

Extended `test_set_lead_and_clear_lead` to assert: promote flips `is_lead=1` + `role='lead'`; promoting a second lead demotes the first (`is_lead=0`); clearing resets both members' flags and the pointer. `tests/test_project_store.py` → 23 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Project lead assignments now remain consistent across project and member details.
  - Promoting a new lead automatically removes lead status from the previous lead and restores their standard member status.
  - Clearing a project lead resets all related lead indicators, ensuring no member remains marked as the project lead.
  - Lead changes now provide more reliable project status information across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->