### PR TITLE
[lib-audit] R2-11 lsof -ti :port also returns clients -- proxy restart kills the incus forkproxy

### DIFF
--- a/changelog.d/tsk-7z2gni-proxy-lsof-listen-filter.md
+++ b/changelog.d/tsk-7z2gni-proxy-lsof-listen-filter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `_pids_listening_on` now adds `-sTCP:LISTEN` to the `lsof` command, so proxy restart only kills actual listeners on the port, not client connections such as the incus forkproxy.

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -9,6 +9,7 @@ import pytest
 from tinyagentos.llm_proxy import (
     EMBEDDING_ALIAS,
     _is_embedding_model,
+    _pids_listening_on,
     generate_litellm_config,
     LLMProxy,
 )
@@ -562,6 +563,72 @@ class TestLLMProxyOwnership:
         key = await p.create_agent_key("routing-only")
         assert key is None
         assert called is False
+
+
+class TestPidsListeningOn:
+    def test_listening_pid_only_returns_listener_not_client(self):
+        """RED test for R2-11: lsof -ti :{port} returns clients too.
+
+        A client socket to the port must not appear in the result.
+        Only the LISTEN socket owner (the server) should be returned.
+        """
+        import os
+        import socket
+        import subprocess
+        import sys
+        import threading
+        import time
+
+        server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server_socket.bind(("127.0.0.1", 0))
+        server_socket.listen(1)
+        port = server_socket.getsockname()[1]
+        server_pid = os.getpid()
+
+        accepted = threading.Event()
+
+        def _accept_and_hold():
+            try:
+                conn, _ = server_socket.accept()
+                accepted.set()
+                time.sleep(3)
+                conn.close()
+            except OSError:
+                pass
+
+        t = threading.Thread(target=_accept_and_hold, daemon=True)
+        t.start()
+
+        client_script = (
+            f"import socket, time\n"
+            f"s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+            f"s.connect(('127.0.0.1', {port}))\n"
+            f"time.sleep(3)\n"
+            f"s.close()\n"
+        )
+        child = subprocess.Popen([sys.executable, "-c", client_script])
+
+        try:
+            for _ in range(50):
+                if accepted.is_set():
+                    break
+                time.sleep(0.1)
+
+            pids = _pids_listening_on(port)
+        finally:
+            child.terminate()
+            try:
+                child.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                child.wait()
+            server_socket.close()
+            t.join(timeout=2)
+
+        assert pids == [server_pid], (
+            f"Expected only server PID {server_pid}, got {pids}"
+        )
 
 
 class TestInhouseKeys:

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -47,13 +47,13 @@ def _pid_alive(pid: int) -> bool:
 def _pids_listening_on(port: int) -> list[int]:
     """Best-effort lookup of PIDs holding a TCP listen on ``port``.
 
-    Uses ``lsof -ti:<port>`` which is available on macOS, most Linux
+    Uses ``lsof -ti :{port} -sTCP:LISTEN`` which is available on macOS, most Linux
     distros, and the Fedora LXC we ship on the Pi. Returns ``[]`` when
     ``lsof`` is missing, errors, or reports nothing.
     """
     try:
         out = subprocess.check_output(
-            ["lsof", "-ti", f":{port}"], text=True, stderr=subprocess.DEVNULL
+            ["lsof", "-ti", f":{port}", "-sTCP:LISTEN"], text=True, stderr=subprocess.DEVNULL
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return []


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-11 lsof -ti :port also returns clients -- proxy restart kills the incus forkproxy

Autonomous build of board card tsk-7z2gni.

_pids_listening_on now passes -sTCP:LISTEN to lsof so proxy restart
only kills the actual listener, not client connections like the incus
forkproxy.

RED test added that opens a client socket to a dummy server from a
child process and asserts only the listener PID is returned.

Failing run before fix:

```
FAILED tests/test_llm_proxy.py::TestPidsListeningOn::test_listening_pid_only_returns_listener_not_client - AssertionError: Expected only server PID 512626, got [512626, 512717]
```

Green after fix: 63 passed in 6.79s

Files:
 changelog.d/tsk-7z2gni-proxy-lsof-listen-filter.md |  3 +
 tests/test_llm_proxy.py                            | 67 ++++++++++++++++++++++
 tinyagentos/llm_proxy.py                           |  4 +-
 3 files changed, 72 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy restarts now target only processes actively listening on the configured TCP port, avoiding termination of connected client processes.

* **Tests**
  * Added coverage to verify that listening server processes are identified without including client connection processes.

* **Documentation**
  * Updated the changelog to document the corrected proxy process filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->