### PR TITLE
[lib-audit] R2-23 task status and direction unvalidated (vanishing cards, 500)

### DIFF
--- a/changelog.d/tsk-funpc4-task-status-direction-validation.md
+++ b/changelog.d/tsk-funpc4-task-status-direction-validation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- PATCH task status is now validated against the allowed enum (open, claimed, closed), returning 422 on a bogus value instead of silently dropping the write and vanishing the card; GET /api/projects/{pid}/tasks also rejects an invalid status query parameter with 422, and GET /api/projects/{pid}/tasks/{tid}/relationships validates direction up front (422) instead of raising ValueError and returning 500.

--- a/tests/projects/test_routes_task_status_validation.py
+++ b/tests/projects/test_routes_task_status_validation.py
@@ -1,0 +1,83 @@
+"""RED tests for task status and relationship direction validation (tsk-funpc4).
+
+Before the fix:
+  * PATCH /api/projects/{pid}/tasks/{tid} with status="bogus" silently drops
+    the write and returns 200, making the card vanish from every column.
+  * GET /api/projects/{pid}/tasks?status=<anything> is accepted without
+    validation, returning an empty list on a typo.
+  * GET /api/projects/{pid}/tasks/{tid}/relationships?direction=<anything
+    else> raises ValueError inside the store and answers 500.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _project(client, slug: str) -> str:
+    resp = await client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _task(client, pid: str, **payload) -> dict:
+    body = {"title": "T", "body": "orig body", "priority": 1, "labels": ["a"]}
+    body.update(payload)
+    resp = await client.post(f"/api/projects/{pid}/tasks", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestInvalidStatusIsRejected:
+    async def test_patch_bogus_status_returns_422(self, client):
+        pid = await _project(client, "bad-status-patch")
+        t = await _task(client, pid)
+        resp = await client.patch(
+            f"/api/projects/{pid}/tasks/{t['id']}", json={"status": "bogus"}
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_list_tasks_bogus_status_returns_422(self, client):
+        pid = await _project(client, "bad-status-list")
+        await _task(client, pid)
+        resp = await client.get(
+            f"/api/projects/{pid}/tasks", params={"status": "bogus"}
+        )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.parametrize("status", ("open", "claimed", "closed"))
+    async def test_valid_status_still_works(self, client, status):
+        pid = await _project(client, f"valid-status-{status}")
+        t = await _task(client, pid)
+        if status != "open":
+            resp = await client.patch(
+                f"/api/projects/{pid}/tasks/{t['id']}", json={"status": status}
+            )
+            assert resp.status_code == 200, resp.text
+        resp = await client.get(
+            f"/api/projects/{pid}/tasks", params={"status": status}
+        )
+        assert resp.status_code == 200, resp.text
+        assert any(task["id"] == t["id"] for task in resp.json()["items"])
+
+
+class TestInvalidDirectionIsRejected:
+    async def test_list_relationships_bogus_direction_returns_422(self, client):
+        pid = await _project(client, "bad-direction")
+        t = await _task(client, pid)
+        resp = await client.get(
+            f"/api/projects/{pid}/tasks/{t['id']}/relationships",
+            params={"direction": "x"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.parametrize("direction", ("from", "to"))
+    async def test_valid_direction_still_works(self, client, direction):
+        pid = await _project(client, f"valid-direction-{direction}")
+        t = await _task(client, pid)
+        resp = await client.get(
+            f"/api/projects/{pid}/tasks/{t['id']}/relationships",
+            params={"direction": direction},
+        )
+        assert resp.status_code == 200, resp.text

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 import logging
 import time
-
-from typing import TYPE_CHECKING
+from enum import StrEnum
+from typing import TYPE_CHECKING, Literal
 
 from tinyagentos.projects.ids import new_id
 from tinyagentos.projects.strike_store import StrikeStore
@@ -20,6 +20,12 @@ logger = logging.getLogger(__name__)
 # Ancestor-walk depth cap for get_task_context — mirrors the cycle guard in
 # routes/projects.py's parent-chain check.
 _MAX_ANCESTRY_DEPTH = 50
+
+
+class TaskStatus(StrEnum):
+    OPEN = "open"
+    CLAIMED = "claimed"
+    CLOSED = "closed"
 
 TASK_SCHEMA = """
 CREATE TABLE IF NOT EXISTS project_tasks (
@@ -321,7 +327,7 @@ class ProjectTaskStore(ProjectsDBStore):
     async def list_tasks(
         self,
         project_id: str,
-        status: str | None = None,
+        status: TaskStatus | None = None,
         parent_task_id: str | None = None,
         element_id: str | None = None,
     ) -> list[dict]:
@@ -357,7 +363,7 @@ class ProjectTaskStore(ProjectsDBStore):
         body: str | None = None,
         priority: int | None = None,
         labels: list[str] | None = None,
-        status: str | None = None,
+        status: TaskStatus | None = None,
         assignee_id: str | None | object = _UNCHANGED,
         parent_task_id: str | None | object = _UNCHANGED,
         element_id: str | None | object = _UNCHANGED,
@@ -797,7 +803,7 @@ class ProjectTaskStore(ProjectsDBStore):
     async def list_relationships(
         self,
         task_id: str,
-        direction: str = "from",
+        direction: Literal["from", "to"] = "from",
     ) -> list[dict]:
         if direction not in ("from", "to"):
             raise ValueError(f"invalid direction: {direction}")

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -25,6 +25,7 @@ from tinyagentos.projects.folders import (
     write_project_yaml,
 )
 from tinyagentos.projects.project_store import ProjectConflict
+from tinyagentos.projects.task_store import TaskStatus
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -34,7 +35,7 @@ router = APIRouter()
 # ``quarantined``), but the READ/aggregate API surface only advertises these
 # three and must reject anything else rather than silently filter to an empty
 # list (which would hide a caller's typo).
-_TASK_STATUS_ENUM = ("open", "claimed", "closed")
+_TASK_STATUS_ENUM = tuple(member.value for member in TaskStatus)
 
 
 async def _is_field_free(store, field: str, value: str) -> bool:
@@ -526,7 +527,7 @@ class UpdateTaskIn(_TaskRequestModelMixin, BaseModel):
     body: str | None = None
     priority: int | None = None
     labels: list[str] | None = None
-    status: str | None = None
+    status: TaskStatus | None = None
     # Omitted -> unchanged; null -> cleared (the board's "Unassigned" and
     # "Orphans" lanes send exactly that).
     assignee_id: str | None = None
@@ -823,7 +824,7 @@ async def create_task(
 async def list_tasks(
     project_id: str,
     request: Request,
-    status: str | None = None,
+    status: TaskStatus | None = None,
     element_id: str | None = None,
 ):
     pstore = request.app.state.project_store
@@ -1562,7 +1563,7 @@ async def list_relationships(
     project_id: str,
     task_id: str,
     request: Request,
-    direction: str = "from",
+    direction: Literal["from", "to"] = "from",
     user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-23 task status and direction unvalidated (vanishing cards, 500)

Autonomous build of board card tsk-funpc4.

PATCH with a bogus status silently dropped the write and returned 200,
hiding the card from every column. GET /api/projects/{pid}/tasks
accepted any status string, returning an empty list on a typo.
GET /api/projects/{pid}/tasks/{tid}/relationships?direction=<anything
else> raised ValueError inside the store and answered 500.

Fix:
- Add TaskStatus StrEnum (open, claimed, closed) shared by routes and
  the task store.
- UpdateTaskIn.status now uses TaskStatus | None; PATCH rejects bogus
  values with 422.
- list_tasks GET validates the status query parameter with TaskStatus;
  invalid values return 422 instead of an empty board.
- list_relationships GET validates direction as Literal["from", "to"];
  invalid values return 422 instead of 500.
- The store keeps its ValueError guard as defence in depth.

Docs-Reviewed: validation-only change, no route surface change

Proof (RED then GREEN):

```
FAILED tests/projects/test_routes_task_status_validation.py::TestInvalidStatusIsRejected::test_patch_bogus_status_returns_422
FAILED tests/projects/test_routes_task_status_validation.py::TestInvalidStatusIsRejected::test_list_tasks_bogus_status_returns_422
FAILED tests/projects/test_routes_task_status_validation.py::TestInvalidDirectionIsRejected::test_list_relationships_bogus_direction_returns_422
3 failed, 5 passed in 16.89s
```

8 passed in 13.49s

Files:
 .../tsk-funpc4-task-status-direction-validation.md |  3 +
 .../projects/test_routes_task_status_validation.py | 83 ++++++++++++++++++++++
 tinyagentos/projects/task_store.py                 | 16 +++--
 tinyagentos/routes/projects.py                     |  9 +--
 4 files changed, 102 insertions(+), 9 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid task statuses now return a clear 422 error instead of being silently ignored.
  - Invalid task status filters are rejected with a 422 response.
  - Invalid relationship directions now return 422 instead of causing a server error.
  - Valid task statuses and relationship directions continue to work as expected.

- **Documentation**
  - Added a changelog entry describing the validation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->