### PR TITLE
fix(desktop): distinguish not-built from not-staged in SPA 404 (#2080)

### DIFF
--- a/changelog.d/2080-desktop-shell-error.md
+++ b/changelog.d/2080-desktop-shell-error.md
@@ -1,0 +1,12 @@
+### Changed
+
+- The desktop SPA 404 error now distinguishes the two failure modes the user can
+  actually act on. When `static/desktop/` exists but has no `index.html`, the
+  message remains "Desktop shell not built — run: cd desktop && npm run build".
+  When the directory is missing entirely, it now reports "Desktop shell not
+  installed (static/desktop missing; not built or staged on this install)"
+  instead of blaming the build. This corrects issue #2080, where a non-editable
+  install (the bundle is a git-ignored artifact staged at install time by
+  `install-server.sh`/`rebuild-desktop.sh` or the CI prebuilt-bundle download)
+  told the user to run `npm run build` on a machine with no Node, when the real
+  cause was that the bundle was never staged.

--- a/tinyagentos/routes/desktop.py
+++ b/tinyagentos/routes/desktop.py
@@ -205,7 +205,9 @@ async def serve_spa_root():
     index = SPA_DIR / "index.html"
     if index.exists():
         return FileResponse(index, media_type="text/html", headers=_HTML_NO_CACHE)
-    return JSONResponse({"error": "Desktop shell not built. Run: cd desktop && npm run build"}, status_code=404)
+    if SPA_DIR.is_dir():
+        return JSONResponse({"error": "Desktop shell not built — run: cd desktop && npm run build"}, status_code=404)
+    return JSONResponse({"error": "Desktop shell not installed (static/desktop missing; not built or staged on this install)"}, status_code=404)
 
 
 @router.get("/desktop/{rest:path}")
@@ -229,4 +231,6 @@ async def serve_spa(rest: str = ""):
     index = SPA_DIR / "index.html"
     if index.exists():
         return FileResponse(index, media_type="text/html", headers=_HTML_NO_CACHE)
-    return JSONResponse({"error": "Desktop shell not built. Run: cd desktop && npm run build"}, status_code=404)
+    if SPA_DIR.is_dir():
+        return JSONResponse({"error": "Desktop shell not built — run: cd desktop && npm run build"}, status_code=404)
+    return JSONResponse({"error": "Desktop shell not installed (static/desktop missing; not built or staged on this install)"}, status_code=404)


### PR DESCRIPTION
Fixes #2080 (the actionable half).

The issue's core ask was that a non-editable install 404s with the misleading `npm run build` hint. `static/desktop/` is a git-ignored build artifact staged at install time by `install-server.sh` → `rebuild-desktop.sh` + systemd unit, or by `desktop_rebuild.py`'s CI prebuilt-bundle download — so shipping it via package-data (the first suggested approach) cannot work and would fight the repo's build-on-install design.

This PR takes the issue's own fallback option: distinguish the two error modes.
- dir exists, no index.html → 'not built — run cd desktop && npm run build'
- dir missing entirely → 'not installed (static/desktop missing; not built or staged on this install)'

The misleading-hint-on-a-Node-less-device problem is what's actually fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application error messages when required files or directories are missing.
  * Separate guidance is now provided for a missing desktop assets directory versus an unavailable application shell.

* **Documentation**
  * Updated desktop application error documentation to reflect the distinct failure scenarios and recommended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->