### PR TITLE
feat(grant): populate expires_at from duration_secs on approve

### DIFF
--- a/changelog.d/2985-grant-expires-at-duration.md
+++ b/changelog.d/2985-grant-expires-at-duration.md
@@ -1,0 +1,5 @@
+### Changed
+
+- `approve_request_record` now reads `duration_secs` from the auth-request record and passes
+  a computed `expires_at` to every `add_grant` call, so time-boxed grants actually expire.
+  Previously every approval created permanent grants even when `duration_secs > 0`. (taOS #2985)

--- a/tests/test_grant_expiry.py
+++ b/tests/test_grant_expiry.py
@@ -1,0 +1,50 @@
+"""Tests for the approve-path grant expiry: duration_secs -> expires_at.
+
+The store-level persistence of ``expires_at`` is covered by
+``tests/test_agent_grants_store.py`` / ``tests/test_grant_expiry.py``. This
+module asserts the *route-level* mapping injected by issue #2985: a scope
+request carrying ``duration_secs`` must produce a future, timezone-aware expiry
+on approval, and a request without it must stay unbounded.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tinyagentos.routes.agent_auth_requests import _expires_at_from_duration
+
+
+def _parse(iso: str) -> datetime:
+    return datetime.fromisoformat(iso)
+
+
+class TestExpiresAtFromDuration:
+    def test_positive_duration_yields_future_expiry(self):
+        now = datetime.now(timezone.utc)
+        expires = _expires_at_from_duration(3600)
+        assert expires is not None
+        parsed = _parse(expires)
+        assert parsed.tzinfo is not None, "expiry must be timezone-aware"
+        delta = parsed - now
+        # allow a small clock skew window around the intended 1 hour
+        assert timedelta(minutes=59) < delta <= timedelta(hours=1, minutes=1)
+
+    def test_none_duration_is_unbounded(self):
+        assert _expires_at_from_duration(None) is None
+
+    def test_zero_duration_is_unbounded(self):
+        assert _expires_at_from_duration(0) is None
+
+    def test_negative_duration_is_unbounded(self):
+        assert _expires_at_from_duration(-60) is None
+
+    def test_non_int_duration_is_unbounded(self):
+        # a float or string must not produce a bogus expiry
+        assert _expires_at_from_duration(3660.5) is None
+        assert _expires_at_from_duration("3600") is None
+
+    def test_short_duration_still_in_the_future(self):
+        expires = _expires_at_from_duration(30)
+        assert expires is not None
+        parsed = _parse(expires)
+        assert parsed > datetime.now(timezone.utc) - timedelta(seconds=1)

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -23,6 +23,7 @@ Security notes
 
 import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -405,6 +406,17 @@ async def approve_auth_request(
                 locks.pop(request_id, None)
 
 
+def _expires_at_from_duration(duration_secs) -> str | None:
+    """Map a scope request's ``duration_secs`` to a grant expiry timestamp.
+
+    A positive integer yields ``now + duration_secs`` as a timezone-aware ISO
+    string; anything else (None, zero, negative, or a non-int) means the grant
+    is unbounded and returns None."""
+    if isinstance(duration_secs, int) and duration_secs > 0:
+        return (datetime.now(timezone.utc) + timedelta(seconds=duration_secs)).isoformat()
+    return None
+
+
 async def approve_request_record(
     request: Request,
     *,
@@ -485,6 +497,11 @@ async def approve_request_record(
     # regardless of effective_project; project-scoped calls 403 until the agent
     # is bound to a project later via assign-agent.
     binding_project = None if defer_binding else effective_project
+
+    # Compute expires_at from the request's duration_secs so time-boxed grants
+    # actually expire. When duration_secs is None or <= 0, leave it unset so
+    # unbounded grants stay permanent.
+    expires_at = _expires_at_from_duration(record.get("duration_secs"))
 
     registry = _get_registry_store(request)
     private_pem, _public_pem = _get_keypair(request)
@@ -585,6 +602,7 @@ async def approve_request_record(
                 project_id=project_id,
                 granted_scopes=granted_scopes,
                 decided_by=decided_by,
+                expires_at=expires_at,
             )
             result = await auth_store.set_decision(
                 record["id"],
@@ -674,7 +692,9 @@ async def approve_request_record(
     # unbound (project_id=None); assign-agent later writes the project-bound
     # grant that makes project-scoped calls succeed.
     for scope in granted_scopes:
-        await grants_store.add_grant(canonical_id, scope, tier="once", project_id=binding_project)
+        await grants_store.add_grant(
+            canonical_id, scope, tier="once", project_id=binding_project, expires_at=expires_at
+        )
         # Also write a RelationshipManager permission edge so the existing
         # permission-check path (can_communicate etc.) is aware of the agent.
         await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
@@ -756,6 +776,7 @@ async def add_agent_to_project(
     granted_scopes: list[str],
     decided_by: str,
     is_lead: bool = False,
+    expires_at: str | None = None,
 ) -> dict:
     """Add an ALREADY-REGISTERED agent to ANOTHER project (taOS #1862).
 
@@ -775,7 +796,7 @@ async def add_agent_to_project(
     # Write the grants bound to this project and the relationship edge.
     for scope in granted_scopes:
         await grants_store.add_grant(
-            canonical_id, scope, tier="once", project_id=project_id
+            canonical_id, scope, tier="once", project_id=project_id, expires_at=expires_at
         )
         await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
 


### PR DESCRIPTION
Fixes #2985 (item 1 — backend half).

`expires_at` was already honoured by `agent_grants_store.add_grant` and checked by `agent_token_auth._grant_unexpired`, but the approve path never computed it from the request's `duration_secs`, so a time-boxed grant could only be revoked manually and never expired on its own.

This threads `duration_secs` through `approve_request_record`: a positive value produces `now + duration_secs` (timezone-aware ISO) passed to `add_grant`; None/zero/negative stays unbounded. The computation is extracted into a small pure helper `_expires_at_from_duration` and unit-tested directly (6 cases: positive→future, None/zero/negative/non-int→unbounded, short→still future).

Item 2 (Agents-app revoke surface in the desktop SPA) is out of scope here — this PR is the backend time-boxing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approved time-limited access grants now expire according to the requested duration.
  * Grants without a requested duration remain unbounded.
* **Tests**
  * Added coverage verifying expiry calculations and end-to-end approval behavior for both time-limited and unbounded grants.
* **Documentation**
  * Added a changelog entry describing the grant expiration fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->