### PR TITLE
fix(invite): stop sending fabricated 'lead' scope and drop the lead checkbox

### DIFF
--- a/changelog.d/2064-invite-lead-flag-not-scope.md
+++ b/changelog.d/2064-invite-lead-flag-not-scope.md
@@ -1,0 +1,8 @@
+### Changed
+
+- The invite dialog no longer offers a "Make this agent the project lead"
+  checkbox, and it no longer sends a fabricated `"lead"` scope at mint — `lead`
+  is not a valid scope and previously caused the mint endpoint to reject the
+  invite with a 400. Lead assignment now happens post-registration via
+  `PATCH /api/projects/{id}/lead`; the dialog shows a note pointing the operator
+  there instead.

--- a/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
@@ -82,7 +82,6 @@ export function InviteAgentDialog({
     for (const s of SCOPE_PRESETS) init[s.value] = s.defaultOn;
     return init;
   });
-  const [isLead, setIsLead] = useState(false);
   const [manualApproval, setManualApproval] = useState(false);
   const [intervalSecs, setIntervalSecs] = useState(1800);
   const [submitting, setSubmitting] = useState(false);
@@ -114,7 +113,6 @@ export function InviteAgentDialog({
       if (s.disabled) continue;
       if (scopes[s.value]) out.add(s.value);
     }
-    if (isLead) out.add("lead");
     return [...out];
   };
 
@@ -261,15 +259,10 @@ export function InviteAgentDialog({
                   )}
                 </label>
               ))}
-              <label className="flex items-center gap-2 text-sm py-0.5 mt-1">
-                <input
-                  type="checkbox"
-                  checked={isLead}
-                  onChange={(e) => setIsLead(e.target.checked)}
-                  aria-label="Make this agent the project lead"
-                />
-                <span>Make this agent the project lead</span>
-              </label>
+              <p className="text-[11px] text-zinc-500 mt-1">
+                Lead is assigned after the agent registers — set it from the
+                project&apos;s members view.
+              </p>
             </fieldset>
 
             <fieldset className="border border-zinc-800 p-2 rounded">

--- a/desktop/src/apps/ProjectsApp/__tests__/InviteAgentDialog.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/InviteAgentDialog.test.tsx
@@ -55,15 +55,19 @@ describe("InviteAgentDialog", () => {
     });
   });
 
-  it("adds 'lead' to the posted scopes when the Lead toggle is on", async () => {
+  it("never includes 'lead' in scopes — lead is assigned post-registration", async () => {
     await act(async () => {
       render(<InviteAgentDialog projectId={PID} onClose={() => {}} onMinted={() => {}} />);
     });
-    fireEvent.click(screen.getByLabelText(/make this agent the project lead/i));
+    // The old "Make this agent the project lead" checkbox is gone; in its place
+    // a note tells the operator lead is set post-registration.
+    expect(screen.getByText(/lead is assigned after the agent registers/i)).toBeTruthy();
+    expect(screen.queryByLabelText(/make this agent the project lead/i)).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /mint invite/i }));
 
     await waitFor(() => expect(mintBody).not.toBeNull());
-    expect(mintBody!.scopes).toContain("lead");
+    // "lead" is NOT a valid scope — it is set via PATCH /api/projects/{id}/lead after the agent registers.
+    expect(mintBody!.scopes).not.toContain("lead");
     expect(mintBody!.scopes).toContain("project_tasks");
   });
 


### PR DESCRIPTION
Fixes #2064.

The 'Make this agent the project lead' checkbox injected a literal `"lead"` scope into the mint body. `"lead"` is not in `VALID_SCOPES`, so `mint_invite` rejected every such invite with a 400 (unknown-scope guard from #1993).

Lead is a post-registration concern, not a scope — it is set via `PATCH /api/projects/{id}/lead` (`set_project_lead` → `store.set_lead`). Since the member does not exist at mint time, the checkbox cannot work at mint. This PR removes it and adds a note directing the operator to assign lead after the agent registers.

Test updated: asserts scopes never contain `"lead"` and the note is shown in place of the removed checkbox (fails on the pre-fix code). vitest 5/5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the option to assign a project lead during agent invitation.
  * Invitations no longer include the invalid `lead` permission.
  * Added guidance that project lead assignment is completed after registration from the project’s members view.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->