### PR TITLE
ci(dependabot): stop proposing a litellm cap-raise that CI must reject

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,16 @@ updates:
       # proposing the cap-raise until the regression is fixed upstream.
       - dependency-name: "fastapi"
         versions: [">=0.137"]
+      # litellm's specifier must pin the EXACT minor the inlined proxy subset
+      # mirrors (>=1.94.2,<1.95). litellm[proxy] pulls litellm-enterprise, so
+      # the proxy subset is inlined instead, and a wider cap lets a fresh
+      # resolve outrun that subset -- which is why
+      # tests/test_install_licences.py::test_proxy_extra_pins_litellm_to_the_minor_it_mirrors
+      # rejects any ceiling wider than the mirrored minor. Dependabot proposing
+      # a cap-raise (e.g. <1.100 in #2810) can therefore only ever fail CI.
+      # Re-mirroring onto a new minor is a deliberate change, not an auto-bump.
+      - dependency-name: "litellm"
+        versions: [">=1.95"]
 
   # Desktop SPA (Vite/React)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Why

`pyproject.toml` pins litellm to the **exact** minor that the inlined proxy subset mirrors (`>=1.94.2,<1.95`). `litellm[proxy]` pulls `litellm-enterprise`, so the proxy subset is inlined instead of installed via the extra, and any ceiling wider than the mirrored minor lets a fresh resolve outrun that subset.

`tests/test_install_licences.py::test_proxy_extra_pins_litellm_to_the_minor_it_mirrors` enforces this, and a companion test (`test_litellm_cap_helper_rejects_a_ceiling_wider_than_the_mirrored_minor`) proves the check rejects a decoy `<2` ceiling rather than merely looking for *some* upper bound. The gate is doing its job.

`.github/dependabot.yml` has an `ignore` entry for fastapi but none for litellm, so the weekly `python-deps` group keeps widening the specifier. #2810 proposed `litellm>=1.94.2,<1.100` and failed exactly there:

```
FAILED tests/test_install_licences.py::test_proxy_extra_pins_litellm_to_the_minor_it_mirrors - AssertionError: litellm's specifier must pin exactly the mirrored minor (>=1.94.2,<1.95), not merely carry *some* upper bound (got 'litellm>=1.94.2,<1.100')
```

That PR is unmergeable **by construction**, not flaky. Without this, every weekly run re-opens the same doomed bump and burns a CI cycle on it.

## Change

One `ignore` entry mirroring the existing fastapi precedent, with the reasoning inline so the next person does not simply delete it:

```yaml
- dependency-name: "litellm"
  versions: [">=1.95"]
```

Re-mirroring the inlined proxy subset onto a newer litellm minor stays a deliberate, human change — which is the intent the gate already encodes.

## Scope

`.github/dependabot.yml` only. Not under `.github/workflows/`, so no `gate-integrity-allow` is needed. No change under `tinyagentos/` or `desktop/src/`, so no changelog fragment is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiKJuYikvUFHQv1YCrDcUY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to ignore LiteLLM versions 1.95 and later, preserving compatibility with the supported proxy subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->