### PR TITLE
Decisions: an empty multi_select answer is accepted, so a decision records as answered with zero selections

### DIFF
--- a/changelog.d/tsk-zmltwu-empty-multi-select-rejection.md
+++ b/changelog.d/tsk-zmltwu-empty-multi-select-rejection.md
@@ -1,0 +1,2 @@
+### Fixed
+- `POST /api/decisions/{id}/answer` now rejects an empty list for `multi_select` answers with a 400. Previously an empty list was accepted silently, recording the decision as answered while carrying no selection and making it indistinguishable downstream from a real choice.

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -894,6 +894,82 @@ async def test_multi_select_invalid_option_still_rejected(client):
     assert resp.status_code == 400
 
 
+# --------------------------------------------------------------------------- #
+# tsk-zmltwu: empty multi_select answer must be rejected with 400
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_empty_multi_select_answer_is_rejected(client):
+    """An empty list as a multi_select answer is rejected: it would otherwise
+    record the decision as answered with no selections, indistinguishable from
+    a real choice downstream."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "multi_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": []})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "answer must be a subset of the options"
+
+
+@pytest.mark.asyncio
+async def test_multi_select_valid_subset_still_accepted(client):
+    """A valid non-empty subset of multi_select options still returns 200."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "multi_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": ["a"]})
+    assert resp.status_code == 200
+    assert resp.json()["answer"]["value"] == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_multi_select_invalid_option_still_rejected_tsk_zmltwu(client):
+    """A multi_select answer containing a value not in the options is still 400."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "multi_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": ["a", "nope"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_single_select_list_answer_still_rejected(client):
+    """A list submitted as a single_select answer must still 400 (TypeError
+    from unhashable list in set membership is caught and returned as 400)."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "single_select",
+        "options": [{"label": "A", "value": "a"}],
+    })
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": ["a"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_single_select_valid_scalar_still_accepted(client):
+    """A valid scalar single_select answer still returns 200."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "single_select",
+        "options": [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}],
+    })
+    d = resp.json()
+    resp = await client.post(f"/api/decisions/{d['id']}/answer", json={"value": "a"})
+    assert resp.status_code == 200
+    assert resp.json()["answer"]["value"] == "a"
+
+
 @pytest.mark.asyncio
 async def test_other_answer_routes_to_agent_with_note(client, monkeypatch):
     """A free-text Other answer with a note reaches the agent in the same

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -501,7 +501,15 @@ async def decision_history(decision_id: str, request: Request, user: CurrentUser
 
 
 @router.post("/api/decisions/{decision_id}/answer")
-async def answer_decision(decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user_or_device)):
+async def answer_decision(
+    decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user_or_device)
+):
+    """Record an answer for a pending decision.
+
+    For ``multi_select`` decisions, an empty list is rejected with 400: an
+    answer must contain at least one selected option so that a decision cannot
+    silently transition to answered while carrying no choice.
+    """
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     # Authorization check: humans can answer decisions they own or admins; agents are
@@ -547,7 +555,7 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
                     for o in (existing.get("options") or [])
                     if o.get("value") is not None
                 }
-                if valid and any(v not in valid for v in vals):
+                if valid and (not vals or any(v not in valid for v in vals)):
                     return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
         else:
             # Option-only path: existing strict validation.
@@ -563,7 +571,7 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
                             return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
                     else:
                         vals = body.value if isinstance(body.value, list) else None
-                        if vals is None or any(v not in valid for v in vals):
+                        if not vals or any(v not in valid for v in vals):
                             return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
                 except TypeError:
                     return JSONResponse({"error": "invalid answer value shape"}, status_code=400)
@@ -887,7 +895,7 @@ async def answer_decision_as_agent(
                     for o in (existing.get("options") or [])
                     if o.get("value") is not None
                 }
-                if valid and any(v not in valid for v in vals):
+                if valid and (not vals or any(v not in valid for v in vals)):
                     return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
         else:
             valid = {
@@ -902,7 +910,7 @@ async def answer_decision_as_agent(
                             return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
                     else:
                         vals = body.value if isinstance(body.value, list) else None
-                        if vals is None or any(v not in valid for v in vals):
+                        if not vals or any(v not in valid for v in vals):
                             return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
                 except TypeError:
                     return JSONResponse({"error": "invalid answer value shape"}, status_code=400)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Decisions: an empty multi_select answer is accepted, so a decision records as answered with zero selections

Autonomous build of board card tsk-zmltwu.

An empty list passed the subset check because any([]) is False and [] is
a list, so vals is None was False too. The decision recorded as answered
while carrying no selection, indistinguishable downstream from a real
choice. The fix adds not vals to the validation conjunct in both the
human and agent answer paths.

```text
FAILED tests/test_routes_decisions.py::test_empty_multi_select_answer_is_rejected
========================= 1 failed, 4 passed in 9.52s ==========================
```

```text
============================== 5 passed in 9.16s ===============================
```

Docs-Reviewed: validation fix on existing /answer route, no route shape change

Files:
 .../tsk-zmltwu-empty-multi-select-rejection.md     |  2 +
 tests/test_routes_decisions.py                     | 76 ++++++++++++++++++++++
 tinyagentos/routes/decisions.py                    | 18 +++--
 3 files changed, 91 insertions(+), 5 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty multi-select answers are now rejected with a 400 response instead of being recorded as completed without a selection.
  - Validation behavior is consistent for both human and agent-submitted answers.
  - Valid non-empty selections remain accepted, while invalid options and unsupported values continue to be rejected.

- **Tests**
  - Added coverage for empty, valid, and invalid decision answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->