### PR TITLE
[lib-audit] R2-5 projects SSE broker unbounded, replays 32 events with no id, LIVE badge hard-coded

### DIFF
--- a/changelog.d/tsk-dtjaxe-sse-broker-hardening.md
+++ b/changelog.d/tsk-dtjaxe-sse-broker-hardening.md
@@ -1,0 +1,5 @@
+### Fixed
+- Projects SSE broker now assigns a unique `id` to each event, emits it in the SSE stream as `id:`, and honours `Last-Event-ID` on reconnect so stale events are not replayed.
+- Subscriber queue is bounded to 256 events with drop-oldest backpressure, preventing unbounded memory growth on slow consumers.
+- The board live badge now reflects actual connection state via `onopen`/`onerror` callbacks instead of being hard-coded to connected.
+- Client-side SSE deduplication by event `id` prevents re-processing of replayed events.

--- a/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: {
+    subscribeEvents: vi.fn(),
+  },
+}));
+
+import { projectsApi } from "@/lib/projects";
+import { useBoardLive } from "../useBoardLive";
+
+describe("useBoardLive", () => {
+  let unsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    (projectsApi.subscribeEvents as ReturnType<typeof vi.fn>).mockReturnValue(unsubscribe);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets connected=false when the SSE connection errors", async () => {
+    let capturedOnError: (() => void) | undefined;
+    (projectsApi.subscribeEvents as ReturnType<typeof vi.fn>).mockImplementation(
+      (_url: string, _onEvent: (e: unknown) => void, opts?: { onError?: () => void }) => {
+        capturedOnError = opts?.onError;
+        return unsubscribe;
+      },
+    );
+
+    const { result } = renderHook(() => useBoardLive("p1", () => {}));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(capturedOnError).toBeDefined();
+
+    if (capturedOnError) {
+      await act(async () => {
+        capturedOnError();
+      });
+      expect(result.current.connected).toBe(false);
+    }
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.tsx
@@ -24,8 +24,16 @@ describe("useBoardLive", () => {
   });
 
   it("exposes connected status (true after subscribe)", () => {
-    vi.spyOn(projectsApi, "subscribeEvents").mockReturnValue(() => {});
+    let onOpen: (() => void) | undefined;
+    vi.spyOn(projectsApi, "subscribeEvents").mockImplementation((_pid, _cb, opts) => {
+      onOpen = opts?.onOpen;
+      return () => {};
+    });
     const { result } = renderHook(() => useBoardLive("p1", () => {}));
+    expect(result.current.connected).toBe(false);
+    if (onOpen) {
+      act(() => onOpen());
+    }
     expect(result.current.connected).toBe(true);
   });
 });

--- a/desktop/src/apps/ProjectsApp/board/useBoardLive.ts
+++ b/desktop/src/apps/ProjectsApp/board/useBoardLive.ts
@@ -10,10 +10,16 @@ export function useBoardLive(projectId: string, onEvent: (e: BoardLiveEvent) => 
 
   useEffect(() => {
     let active = true;
-    const off = projectsApi.subscribeEvents(projectId, (e) => {
-      if (active) onEventRef.current(e);
-    });
-    setConnected(true);
+    const off = projectsApi.subscribeEvents(
+      projectId,
+      (e) => {
+        if (active) onEventRef.current(e);
+      },
+      {
+        onOpen: () => setConnected(true),
+        onError: () => setConnected(false),
+      },
+    );
     return () => {
       active = false;
       setConnected(false);

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -108,6 +108,7 @@ export type ProjectEvent = {
   kind: string;
   payload: Record<string, unknown>;
   ts: number;
+  id?: string;
 };
 
 export type Routine = {
@@ -449,11 +450,28 @@ export const projectsApi = {
       ),
   },
 
-  subscribeEvents(projectId: string, onEvent: (ev: ProjectEvent) => void): () => void {
+  subscribeEvents(
+    projectId: string,
+    onEvent: (ev: ProjectEvent) => void,
+    opts?: { onOpen?: () => void; onError?: () => void },
+  ): () => void {
     return createSseConnection({
       url: `/api/projects/${projectId}/events`,
       onMessage: (e) => {
-        try { onEvent(JSON.parse(e.data) as ProjectEvent); } catch { /* heartbeat / malformed — skip */ }
+        try {
+          onEvent(JSON.parse(e.data) as ProjectEvent);
+        } catch {
+          /* heartbeat / malformed — skip */
+        }
+      },
+      onOpen: opts?.onOpen,
+      onError: opts?.onError,
+      getMessageId: (msg) => {
+        try {
+          return (JSON.parse(msg.data) as ProjectEvent & { id?: string }).id;
+        } catch {
+          return undefined;
+        }
       },
     });
   },

--- a/tests/projects/test_event_broker.py
+++ b/tests/projects/test_event_broker.py
@@ -4,6 +4,50 @@ from tinyagentos.projects.events import ProjectEventBroker, ProjectEvent
 
 
 @pytest.mark.asyncio
+async def test_publish_assigns_id():
+    broker = ProjectEventBroker()
+    queue = await broker.subscribe("p1")
+    await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": "t1"}))
+    ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+    assert ev.id is not None
+    assert isinstance(ev.id, str)
+
+
+@pytest.mark.asyncio
+async def test_publish_assigns_unique_ids():
+    broker = ProjectEventBroker()
+    queue = await broker.subscribe("p1")
+    ids = []
+    for i in range(10):
+        await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": f"t{i}"}))
+    for _ in range(10):
+        ev = await asyncio.wait_for(queue.get(), timeout=0.5)
+        ids.append(ev.id)
+    assert len(set(ids)) == 10
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_last_event_id_skips_old():
+    broker = ProjectEventBroker()
+    for i in range(5):
+        await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": f"t{i}"}))
+    queue = await broker.subscribe("p1", last_event_id="2")
+    items = []
+    for _ in range(2):
+        items.append(await asyncio.wait_for(queue.get(), timeout=0.5))
+    assert [e.payload["id"] for e in items] == ["t3", "t4"]
+
+
+@pytest.mark.asyncio
+async def test_publish_many_events_queue_stays_bounded():
+    broker = ProjectEventBroker()
+    queue = await broker.subscribe("p1")
+    for i in range(10000):
+        await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": f"t{i}"}))
+    assert queue.qsize() <= 256
+
+
+@pytest.mark.asyncio
 async def test_publish_then_subscribe_replays_recent():
     broker = ProjectEventBroker(replay_size=4)
     await broker.publish("p1", ProjectEvent(kind="task.created", payload={"id": "t1"}))

--- a/tests/projects/test_events_route.py
+++ b/tests/projects/test_events_route.py
@@ -103,3 +103,20 @@ async def test_sse_heartbeat(app, client):
 
     heartbeat_lines = [l for l in lines if l.startswith(":")]
     assert heartbeat_lines, f"No heartbeat lines received; got: {lines}"
+
+
+@pytest.mark.asyncio
+async def test_sse_emits_event_id(app, client):
+    pid = (await client.post("/api/projects", json={"name": "P2", "slug": "p2"})).json()["id"]
+
+    await app.state.project_event_broker.publish(
+        pid, ProjectEvent(kind="task.created", payload={"id": "t1"})
+    )
+
+    cookies = {"taos_session": client.cookies.get("taos_session", "")}
+    lines = await _collect_sse_lines(
+        app, f"/api/projects/{pid}/events", cookies, n_lines=5, timeout=5.0
+    )
+
+    id_lines = [l for l in lines if l.startswith("id:")]
+    assert id_lines, f"No id: lines received; got: {lines}"

--- a/tinyagentos/projects/events.py
+++ b/tinyagentos/projects/events.py
@@ -11,6 +11,7 @@ class ProjectEvent:
     kind: str
     payload: dict[str, Any]
     ts: float = field(default_factory=time.time)
+    id: str | None = None
 
 
 class ProjectEventBroker:
@@ -22,15 +23,22 @@ class ProjectEventBroker:
 
     def __init__(self, replay_size: int = 32) -> None:
         self._replay_size = replay_size
+        self._next_id = 0
         self._queues: dict[str, list[asyncio.Queue[ProjectEvent]]] = {}
         self._replay: dict[str, deque[ProjectEvent]] = {}
         self._lock = asyncio.Lock()
 
-    async def subscribe(self, project_id: str) -> asyncio.Queue[ProjectEvent]:
-        queue: asyncio.Queue[ProjectEvent] = asyncio.Queue(maxsize=self._replay_size)
+    async def subscribe(
+        self,
+        project_id: str,
+        last_event_id: str | None = None,
+    ) -> asyncio.Queue[ProjectEvent]:
+        queue: asyncio.Queue[ProjectEvent] = asyncio.Queue(maxsize=256)
         async with self._lock:
             self._queues.setdefault(project_id, []).append(queue)
             for ev in self._replay.get(project_id, ()):
+                if last_event_id is not None and ev.id is not None and ev.id <= last_event_id:
+                    continue
                 try:
                     queue.put_nowait(ev)
                 except asyncio.QueueFull:
@@ -44,19 +52,14 @@ class ProjectEventBroker:
                 qs.remove(queue)
             if not qs:
                 self._queues.pop(project_id, None)
-                # Keep _replay so a reconnecting subscriber (e.g. a reopened
-                # SSE connection) can catch up on events it missed. The deque
-                # has a fixed maxlen so memory stays bounded.
 
     async def publish(self, project_id: str, event: ProjectEvent) -> None:
         async with self._lock:
+            event.id = str(self._next_id)
+            self._next_id += 1
             buf = self._replay.setdefault(project_id, deque(maxlen=self._replay_size))
             buf.append(event)
             queues = list(self._queues.get(project_id, []))
-        # Backpressure policy: do not block the broker (and every other
-        # subscriber) on a slow consumer. If a subscriber's bounded queue is
-        # full, evict its oldest item and retry so the consumer stays on the
-        # live stream rather than stalling indefinitely.
         for q in queues:
             try:
                 q.put_nowait(event)

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -1629,7 +1629,8 @@ async def project_events(
     if isinstance(project_or_err, JSONResponse):
         return project_or_err
     broker = request.app.state.project_event_broker
-    queue = await broker.subscribe(project_id)
+    last_event_id = request.headers.get("last-event-id")
+    queue = await broker.subscribe(project_id, last_event_id=last_event_id)
 
     async def event_stream():
         try:
@@ -1639,7 +1640,11 @@ async def project_events(
                 try:
                     ev = await _asyncio.wait_for(queue.get(), timeout=15.0)
                     payload = {"kind": ev.kind, "payload": ev.payload, "ts": ev.ts}
-                    yield f"data: {_json.dumps(payload)}\n\n"
+                    lines = [f"data: {_json.dumps(payload)}"]
+                    if ev.id is not None:
+                        lines.append(f"id: {ev.id}")
+                    lines.append("")
+                    yield "\n".join(lines) + "\n"
                 except _asyncio.TimeoutError:
                     yield ": heartbeat\n\n"
         finally:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): [lib-audit] R2-5 projects SSE broker unbounded, replays 32 events with no id, LIVE badge hard-coded

Autonomous build of board card tsk-dtjaxe.

RED test run before fix (4 failed, 8 passed in Python, 1 failed in desktop):
```
FAILED tests/projects/test_event_broker.py::test_publish_assigns_id - AttributeError: ...
FAILED tests/projects/test_event_broker.py::test_publish_assigns_unique_ids - AttributeError: ...
FAILED tests/projects/test_event_broker.py::test_subscribe_with_last_event_id_skips_old - TypeError: ProjectEventBroker.subscribe() got an unexpected keyword argument 'last_event_id'
FAILED tests/projects/test_events_route.py::test_sse_emits_event_id - AssertionError: No id: lines received
FAILED desktop/src/apps/ProjectsApp/board/__tests__/useBoardLive.test.ts - AssertionError: expected undefined to be defined
```

GREEN run after fix (12 passed in Python, 3 passed in desktop):
```
12 passed in 26.29s
3 passed in 1.55s
```

- Assign unique id to each ProjectEvent on publish
- Emit id: in SSE stream and honour Last-Event-ID on reconnect
- Bound subscriber queue to 256 with drop-oldest backpressure
- Wire onopen/onerror in useBoardLive so badge reflects reality
- Deduplicate client-side by event id via getMessageId
- Updated existing useBoardLive.test.tsx for new onopen/onerror contract

Docs-Reviewed: SSE events route is not listed in docs/agent-coordination.md

Files:
 .../board/__tests__/useBoardLive.test.tsx          | 10 ++++-
 desktop/src/apps/ProjectsApp/board/useBoardLive.ts | 14 +++++--
 desktop/src/lib/projects.ts                        | 22 +++++++++-
 tests/projects/test_event_broker.py                | 44 +++++++++++++++++++
 tests/projects/test_events_route.py                | 17 ++++++++
 tinyagentos/projects/events.py                     | 21 ++++++----
 tinyagentos/routes/projects.py                     |  9 +++-
 9 files changed, 173 insertions(+), 18 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved project live updates with unique event IDs and reliable resume behavior after reconnecting.
  * Limited event buffering to prevent excessive queue growth during high activity.
  * Live connection indicators now accurately reflect connection and error states.
  * Prevented duplicate processing of replayed events.

* **Tests**
  * Added coverage for event IDs, reconnection behavior, queue limits, and live connection status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->